### PR TITLE
[deepin-Intel-SIG] MTL spi support

### DIFF
--- a/drivers/spi/spi-intel-pci.c
+++ b/drivers/spi/spi-intel-pci.c
@@ -76,6 +76,7 @@ static const struct pci_device_id intel_spi_pci_ids[] = {
 	{ PCI_VDEVICE(INTEL, 0x7a24), (unsigned long)&cnl_info },
 	{ PCI_VDEVICE(INTEL, 0x7aa4), (unsigned long)&cnl_info },
 	{ PCI_VDEVICE(INTEL, 0x7e23), (unsigned long)&cnl_info },
+	{ PCI_VDEVICE(INTEL, 0x7f24), (unsigned long)&cnl_info },
 	{ PCI_VDEVICE(INTEL, 0x9d24), (unsigned long)&cnl_info },
 	{ PCI_VDEVICE(INTEL, 0x9da4), (unsigned long)&cnl_info },
 	{ PCI_VDEVICE(INTEL, 0xa0a4), (unsigned long)&cnl_info },


### PR DESCRIPTION
commit 8afe3c7fcaf72fca1e7d3dab16a5b7f4201ece17 upstream.

This adds the PCI ID of the Arrow Lake and Meteor Lake-S PCH SPI serial flash controller. This one supports all the necessary commands Linux SPI-NOR stack requires.

deepin-Intel-SIG: commit 8afe3c7fcaf7 spi: intel-pci: Add support for Arrow Lake SPI serial flash.


Link: https://msgid.link/r/20240122120034.2664812-3-mika.westerberg@linux.intel.com

[ Quanxian Wang: amend commit log ]