### PR TITLE
wifi: rtw89: Avoid discarded 'const' qualifier

### DIFF
--- a/drivers/net/wireless/realtek/rtw89/drv_ver.c
+++ b/drivers/net/wireless/realtek/rtw89/drv_ver.c
@@ -1,3 +1,3 @@
-static const char drv_ver[]="v6.8-backport-6.6-1-g809f4dd07";
+static char drv_ver[] = "v6.8-backport-6.6-1-g809f4dd07";
 #include <linux/module.h>
 module_param_string(drv_ver, drv_ver, sizeof(drv_ver), 0444);


### PR DESCRIPTION
module_param_string() does not handle a const ptr perfectly. However, it's also not necessary to be.

Resolve following error when '-Werror' was enabled:

  CC [M]  drivers/net/wireless/realtek/rtw89/drv_ver.o
In file included from ./include/linux/module.h:22,
                 from drivers/net/wireless/realtek/rtw89/drv_ver.c:2:
drivers/net/wireless/realtek/rtw89/drv_ver.c:3:30: error: initialization discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
    3 | module_param_string(drv_ver, drv_ver, sizeof(drv_ver), 0444);
      |                              ^~~~~~~
./include/linux/moduleparam.h:358:26: note: in definition of macro ‘module_param_string’
  358 |                 = { len, string };                                      \
      |                          ^~~~~~
cc1: all warnings being treated as errors