### PR TITLE
net/stmmac: Add phytium old dwmac acpi_device_id

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
@@ -195,6 +195,7 @@ MODULE_DEVICE_TABLE(of, phytium_dwmac_of_match);
 
 #ifdef CONFIG_ACPI
 static const struct acpi_device_id phytium_dwmac_acpi_ids[] = {
+	{ .id = "FTGM0001" }, // compat FT2000/4 id
 	{ .id = "PHYT0004" },
 	{ }
 };


### PR DESCRIPTION
As Phytium ACPI Description Specification document v1.2 p13 Device HID said for old v1.0 Spec,add FTGM0001 for such as some FT2000 device compat.