### PR TITLE
usb:xHCI: add XHCI_RESET_ON_RESUME quirk for phytium 

### DIFF
--- a/Documentation/devicetree/bindings/usb/generic-xhci.yaml
+++ b/Documentation/devicetree/bindings/usb/generic-xhci.yaml
@@ -29,6 +29,11 @@ properties:
         enum:
           - brcm,xhci-brcm-v2
           - brcm,bcm7445-xhci
+      - description: Phytium Pe220x SoC with xHCI
+        items:
+          - enum:
+              - phytium,pe220x-xhci
+          - const: generic-xhci
       - description: Generic xHCI device
         const: xhci-platform
         deprecated: true

--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -61,6 +61,7 @@
 #define PCI_DEVICE_ID_INTEL_MAPLE_RIDGE_XHCI		0x1138
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI		0x51ed
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_N_PCH_XHCI	0x54ed
+#define PCI_DEVICE_ID_PHYTIUM_XHCI			0xdc27
 
 #define PCI_DEVICE_ID_AMD_RENOIR_XHCI			0x1639
 #define PCI_DEVICE_ID_AMD_PROMONTORYA_4			0x43b9
@@ -472,6 +473,10 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 		xhci->quirks |= XHCI_ZERO_64B_REGS;
 	}
 	if (pdev->vendor == PCI_VENDOR_ID_VIA)
+		xhci->quirks |= XHCI_RESET_ON_RESUME;
+
+	if (pdev->vendor == PCI_VENDOR_ID_PHYTIUM ||
+	    pdev->device == PCI_DEVICE_ID_PHYTIUM_XHCI)
 		xhci->quirks |= XHCI_RESET_ON_RESUME;
 
 	/* See https://bugzilla.kernel.org/show_bug.cgi?id=79511 */

--- a/drivers/usb/host/xhci-plat.c
+++ b/drivers/usb/host/xhci-plat.c
@@ -113,6 +113,10 @@ static const struct xhci_plat_priv xhci_plat_brcm = {
 	.quirks = XHCI_RESET_ON_RESUME | XHCI_SUSPEND_RESUME_CLKS,
 };
 
+static const struct xhci_plat_priv xhci_plat_phytium_pe220x = {
+	.quirks = XHCI_RESET_ON_RESUME,
+};
+
 static const struct of_device_id usb_xhci_of_match[] = {
 	{
 		.compatible = "generic-xhci",
@@ -133,6 +137,9 @@ static const struct of_device_id usb_xhci_of_match[] = {
 	}, {
 		.compatible = "brcm,bcm7445-xhci",
 		.data = &xhci_plat_brcm,
+	}, {
+		.compatible = "phytium,pe220x-xhci",
+		.data = &xhci_plat_phytium_pe220x,
 	},
 	{},
 };
@@ -396,6 +403,8 @@ static int xhci_generic_plat_probe(struct platform_device *pdev)
 
 	if (pdev->dev.of_node)
 		priv_match = of_device_get_match_data(&pdev->dev);
+	else if (has_acpi_companion(&pdev->dev))
+		priv_match = acpi_device_get_match_data(&pdev->dev);
 	else
 		priv_match = dev_get_platdata(&pdev->dev);
 
@@ -554,6 +563,7 @@ EXPORT_SYMBOL_GPL(xhci_plat_pm_ops);
 static const struct acpi_device_id usb_xhci_acpi_match[] = {
 	/* XHCI-compliant USB Controller */
 	{ "PNP0D10", },
+	{ "PHYT0039", (kernel_ulong_t)&xhci_plat_phytium_pe220x },
 	{ }
 };
 MODULE_DEVICE_TABLE(acpi, usb_xhci_acpi_match);


### PR DESCRIPTION
add XHCI_RESET_ON_RESUME qurik for phytium xhci controller .for example x100 pci switch and e2000 platform ...
this patch fix usb to work ,after resume from S3.