### PR TITLE
(kernel-rolling) usb: xhci: Avoid use xhci_plat_phytium_pe220x when OF disabled

### DIFF
--- a/drivers/usb/host/xhci-plat.c
+++ b/drivers/usb/host/xhci-plat.c
@@ -100,6 +100,10 @@ static int xhci_plat_start(struct usb_hcd *hcd)
 	return xhci_run(hcd);
 }
 
+static const struct xhci_plat_priv xhci_plat_phytium_pe220x = {
+	.quirks = XHCI_RESET_ON_RESUME,
+};
+
 #ifdef CONFIG_OF
 static const struct xhci_plat_priv xhci_plat_marvell_armada = {
 	.init_quirk = xhci_mvebu_mbus_init_quirk,


### PR DESCRIPTION
Picked and rebased from #151.

From original pull request:

```
xhci_plat_phytium_pe220x is only defined when OF is enabled. This would cause a compile error:

drivers/usb/host/xhci-plat.c:532:33: error: ‘xhci_plat_phytium_pe220x’ undeclared here (not in a function); did you mean ‘xhci_plat_runtime_resume’?
  { "PHYT0039", (kernel_ulong_t)&xhci_plat_phytium_pe220x },
                                 ^~~~~~~~~~~~~~~~~~~~~~~~
                                 xhci_plat_runtime_resume
  CC [M]  drivers/usb/dwc3/core.o

It should be moved.

Reported-by: jianghaoa <jianghaoa@uniontech.com>
```

Builds tested
---

- [x] amd64
- [ ] arm64
- [ ] loong64