### PR TITLE
mtd: Remove an unused-variable adev

### DIFF
--- a/drivers/mtd/mtdpart.c
+++ b/drivers/mtd/mtdpart.c
@@ -581,7 +581,6 @@ static int mtd_part_acpi_parse(struct mtd_info *master,
 						struct mtd_partitions *pparts)
 {
 	struct mtd_part_parser *parser;
-	struct acpi_device *adev;
 	struct fwnode_handle *child;
 	const char *compat;
 	const char *fixed = "acpi-fixed-partitions";


### PR DESCRIPTION
There was an unused-variable 'adev' brings a warning.

Resolve following error when '-Werror' was enabled:

drivers/mtd/mtdpart.c: In function ‘mtd_part_acpi_parse’: drivers/mtd/mtdpart.c:584:29: error: unused variable ‘adev’ [-Werror=unused-variable]
  584 |         struct acpi_device *adev;
      |                             ^~~~
cc1: all warnings being treated as errors

Reported-by: Mingcong Bai <baimingcong@uniontech.com>