### PR TITLE
(kernel-rolling) mtd: rawnand: Add Phytium NAND flash controller support

### DIFF
--- a/Documentation/devicetree/bindings/mtd/phytium,nfc.yaml
+++ b/Documentation/devicetree/bindings/mtd/phytium,nfc.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/mtd/phytium,nfc.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium Nand Flash controller
+
+maintainers:
+  - Chen Baozi <chenbaozi@phytium.com.cn>
+
+properties:
+  compatible:
+    const: phytium,nfc
+
+  reg:
+    maxItems: 1
+
+  interrupts:
+    maxItems: 1
+
+  nand-ecc-strength:
+    const: 8
+
+  nand-ecc-step-size:
+    const: 512
+
+allOf:
+  - $ref: "nand-controller.yaml#"
+
+required:
+  - compatible
+  - reg
+  - interrupts
+
+examples:
+  - |
+    nand0: nand@28002000 {
+      compatible = "phytium,nfc";
+      reg = <0x0 0x28002000 0x0 0x1000>;
+      interrupts = <GIC_SPI 74 IRQ_TYPE_LEVEL_HIGH>;
+    };

--- a/drivers/mtd/nand/raw/Kconfig
+++ b/drivers/mtd/nand/raw/Kconfig
@@ -150,6 +150,25 @@ config MTD_NAND_ORION
 	  No board specific support is done by this driver, each board
 	  must advertise a platform_device for the driver to attach.
 
+config MTD_NAND_PHYTIUM
+	tristate
+
+config MTD_NAND_PHYTIUM_PCI
+	tristate "Support Phytium NAND controller as a PCI device"
+	select MTD_NAND_PHYTIUM
+	depends on PCI
+	help
+	  Enable the driver for NAND flash controller of Phytium Px210 chipset,
+	  using the Phytium NAND controller core.
+
+config MTD_NAND_PHYTIUM_PLAT
+	tristate "Support Phytium NAND controller as a platform device"
+	select MTD_NAND_PHYTIUM
+	depends on ARCH_PHYTIUM
+	help
+	  Enable the driver for NAND flash controller of Phytium CPU chipset,
+	  using the Phytium NAND controller core.
+
 config MTD_NAND_MARVELL
 	tristate "Marvell EBU NAND controller"
 	depends on PXA3xx || ARCH_MMP || PLAT_ORION || ARCH_MVEBU || \

--- a/drivers/mtd/nand/raw/Makefile
+++ b/drivers/mtd/nand/raw/Makefile
@@ -57,6 +57,9 @@ obj-$(CONFIG_MTD_NAND_INTEL_LGM)	+= intel-nand-controller.o
 obj-$(CONFIG_MTD_NAND_ROCKCHIP)		+= rockchip-nand-controller.o
 obj-$(CONFIG_MTD_NAND_PL35X)		+= pl35x-nand-controller.o
 obj-$(CONFIG_MTD_NAND_RENESAS)		+= renesas-nand-controller.o
+obj-$(CONFIG_MTD_NAND_PHYTIUM)		+= phytium_nand.o
+obj-$(CONFIG_MTD_NAND_PHYTIUM_PCI)	+= phytium_nand_pci.o
+obj-$(CONFIG_MTD_NAND_PHYTIUM_PLAT)	+= phytium_nand_plat.o
 
 nand-objs := nand_base.o nand_legacy.o nand_bbt.o nand_timings.o nand_ids.o
 nand-objs += nand_onfi.o

--- a/drivers/mtd/nand/raw/phytium_nand.c
+++ b/drivers/mtd/nand/raw/phytium_nand.c
@@ -1,0 +1,2090 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Core driver for Phytium NAND flash controller
+ *
+ * Copyright (C) 2020-2023, Phytium Technology Co., Ltd.
+ */
+
+#include <linux/module.h>
+#include <linux/mtd/rawnand.h>
+#include <linux/iopoll.h>
+#include <linux/interrupt.h>
+#include <linux/mfd/syscon.h>
+#include <linux/regmap.h>
+#include <linux/dma-mapping.h>
+#include <linux/workqueue.h>
+#include <linux/time.h>
+#include <linux/mutex.h>
+
+#include "phytium_nand.h"
+
+u16 timing_asy_mode0[TIMING_ASY_NUM] = {	/* x100 pass, sample: 1 */
+	0x03, 0x03, 0x28, 0x28, 0x03, 0x03, 0x06, 0x06, 0x28, 0x70, 0x30, 0x50};
+u16 timing_asy_mode1[TIMING_ASY_NUM] = {	/* x100 pass, sample: 1 */
+	0x03, 0x03, 0x14, 0x14, 0x03, 0x03, 0x06, 0x06, 0x14, 0x70, 0x30, 0x28};
+u16 timing_asy_mode2[TIMING_ASY_NUM] = {	/* x100 pass, sample: 7/8 (unlic) */
+	0x03, 0x03, 0x0D, 0x0D, 0x03, 0x03, 0x06, 0x06, 0x0D, 0x70, 0x20, 0x1A};
+u16 timing_asy_mode3[TIMING_ASY_NUM] = {	/* x100 pass, sample: 4-7 */
+	0x03, 0x03, 0x0A, 0x0A, 0x03, 0x03, 0x06, 0x06, 0x0A, 0x70, 0x20, 0x14};
+u16 timing_asy_mode4[TIMING_ASY_NUM] = {	/* x100 1.8v pass */
+	0x03, 0x03, 0x08, 0x08, 0x03, 0x03, 0x06, 0x06, 0x08, 0x70, 0x15, 0x10};
+u16 timing_asy_mode5[TIMING_ASY_NUM] = {	/* x100 1.8v pass */
+	0x03, 0x03, 0x07, 0x07, 0x03, 0x03, 0x06, 0x06, 0x07, 0x20, 0x15, 0x0E};
+u16 timing_syn_mode0[TIMING_SYN_NUM] = {	/* x100 1.8v pass */
+	0x20, 0x41, 0x05, 0x20, 0x10, 0x19, 0x62, 0x40, 0x38, 0x20, 0x00, 0x09,
+	0x50, 0x20};
+u16 timing_syn_mode1[TIMING_SYN_NUM] = {	/* x100 1.8v pass */
+	0x18, 0x32, 0x06, 0x18, 0x0C, 0x10, 0x76, 0x40, 0x2A, 0x1E, 0x00, 0x12,
+	0x24, 0x18};
+u16 timing_syn_mode2[TIMING_SYN_NUM] = {	/* x100 1.8v pass */
+	0x10, 0x0A, 0x04, 0x10, 0x08, 0x0A, 0x6E, 0x50, 0x1D, 0x10, 0x00, 0x0C,
+	0x18, 0x10};
+u16 timing_syn_mode3[TIMING_SYN_NUM] = {	/* x100 1.8v pass */
+	0x0C, 0x1A, 0x02, 0x0C, 0x06, 0x08, 0x78, 0x7C, 0x15, 0x0C, 0x00, 0x08,
+	0x12, 0x0C};
+u16 timing_syn_mode4[TIMING_SYN_NUM] = {	/* x100 1.8v failed */
+	0x08, 0x17, 0x05, 0x08, 0x04, 0x01, 0x73, 0x40, 0x0C, 0x08, 0x00, 0x06,
+	0x0C, 0x10};
+u16 timing_tog_ddr_mode0[TIMING_TOG_NUM] = {	/* 600M clk */
+	0x14, 0x0a, 0x08, 0x08, 0xc8, 0xc8, 0x08, 0x08, 0x20, 0x0a, 0x14, 0x08};
+
+static u32 nfc_ecc_errover;
+static u32 nfc_ecc_err;
+static u32 nfc_irq_st;
+static u32 nfc_irq_en;
+static u32 nfc_irq_complete;
+
+static DECLARE_WAIT_QUEUE_HEAD(wait_done);
+
+/*
+ * Internal helper to conditionnally apply a delay (from the above structure,
+ * most of the time).
+ */
+static void cond_delay(unsigned int ns)
+{
+	if (!ns)
+		return;
+
+	if (ns < 10000)
+		ndelay(ns);
+	else
+		udelay(DIV_ROUND_UP(ns, 1000));
+}
+
+static inline struct phytium_nfc *to_phytium_nfc(struct nand_controller *ctrl)
+{
+	return container_of(ctrl, struct phytium_nfc, controller);
+}
+
+static inline struct phytium_nand_chip *to_phytium_nand(struct nand_chip *chip)
+{
+	return container_of(chip, struct phytium_nand_chip, chip);
+}
+
+static u32 phytium_read(struct phytium_nfc *nfc, u32 reg)
+{
+	return readl_relaxed(nfc->regs + reg);
+}
+
+static void phytium_write(struct phytium_nfc *nfc, u32 reg, u32 value)
+{
+	return writel_relaxed(value, nfc->regs + reg);
+}
+
+static inline int phytium_wait_busy(struct phytium_nfc *nfc)
+{
+	u32 status;
+
+	if (nfc_ecc_errover) {
+		nfc_ecc_errover = 0;
+		return 0;
+	}
+
+	return readl_relaxed_poll_timeout(nfc->regs + NDSR, status,
+			!(status & NDSR_BUSY), 10, 10000);
+}
+
+static void phytium_nfc_disable_int(struct phytium_nfc *nfc, u32 int_mask)
+{
+	u32 reg;
+
+	reg = phytium_read(nfc, NDIR_MASK);
+	phytium_write(nfc, NDIR_MASK, reg | int_mask);
+}
+
+static void phytium_nfc_enable_int(struct phytium_nfc *nfc, u32 int_mask)
+{
+	u32 reg;
+
+	reg = phytium_read(nfc, NDIR_MASK);
+	phytium_write(nfc, NDIR_MASK, reg & (~int_mask));
+}
+
+static void phytium_nfc_clear_int(struct phytium_nfc *nfc, u32 int_mask)
+{
+	phytium_write(nfc, NDIR_MASK, int_mask);
+}
+
+static int phytium_nfc_cmd_correct(struct phytium_nfc_op *nfc_op)
+{
+	if (!nfc_op)
+		return -EINVAL;
+
+	if (nfc_op->cmd_len == 0x01) {
+		nfc_op->cmd[1] = nfc_op->cmd[0];
+		nfc_op->cmd[0] = 0;
+	}
+
+	return 0;
+}
+
+static int phytium_nfc_addr_correct(struct phytium_nfc_op *nfc_op)
+{
+	u32 len;
+	int i, j;
+
+	if (!nfc_op)
+		return -EINVAL;
+
+	len = nfc_op->addr_len > PHYTIUM_NFC_ADDR_MAX_LEN ?
+		  PHYTIUM_NFC_ADDR_MAX_LEN : nfc_op->addr_len;
+
+	if (len == PHYTIUM_NFC_ADDR_MAX_LEN)
+		return 0;
+
+	for (i = len-1, j = PHYTIUM_NFC_ADDR_MAX_LEN - 1; i >= 0; i--, j--) {
+		nfc_op->addr[j] = nfc_op->addr[i];
+		nfc_op->addr[i] = 0;
+	}
+
+	return 0;
+}
+
+static void phytium_nfc_parse_instructions(struct nand_chip *chip,
+					   const struct nand_subop *subop,
+					   struct phytium_nfc_op *nfc_op)
+{
+	struct nand_op_instr *instr = NULL;
+	bool first_cmd = true;
+	u32 op_id;
+	int i;
+
+	/* Reset the input structure as most of its fields will be OR'ed */
+	memset(nfc_op, 0, sizeof(struct phytium_nfc_op));
+
+	for (op_id = 0; op_id < subop->ninstrs; op_id++) {
+		unsigned int offset, naddrs;
+		const u8 *addrs;
+		int len;
+
+		instr = (struct nand_op_instr *)&subop->instrs[op_id];
+
+		switch (instr->type) {
+		case NAND_OP_CMD_INSTR:
+			if (first_cmd) {
+				nfc_op->cmd[0] = instr->ctx.cmd.opcode;
+			} else {
+				nfc_op->cmd[1] = instr->ctx.cmd.opcode;
+				nfc_op->cmd_ctrl.nfc_ctrl.dbc = 1;
+			}
+
+			nfc_op->cle_ale_delay_ns = instr->delay_ns;
+			first_cmd = false;
+			nfc_op->cmd_len++;
+
+			break;
+
+		case NAND_OP_ADDR_INSTR:
+			offset = nand_subop_get_addr_start_off(subop, op_id);
+			naddrs = nand_subop_get_num_addr_cyc(subop, op_id);
+			addrs = &instr->ctx.addr.addrs[offset];
+
+			nfc_op->cmd_ctrl.nfc_ctrl.addr_cyc = naddrs;
+
+			for (i = 0; i < min_t(u32, PHYTIUM_NFC_ADDR_MAX_LEN, naddrs); i++)
+				nfc_op->addr[i] = addrs[i];
+
+			nfc_op->cle_ale_delay_ns = instr->delay_ns;
+
+			nfc_op->addr_len = naddrs;
+			break;
+
+		case NAND_OP_DATA_IN_INSTR:
+			nfc_op->data_instr = instr;
+			nfc_op->data_instr_idx = op_id;
+			nfc_op->cmd_ctrl.nfc_ctrl.dc = 1;
+			len = nand_subop_get_data_len(subop, op_id);
+			nfc_op->page_cnt = len;
+			nfc_op->data_delay_ns = instr->delay_ns;
+
+			break;
+
+		case NAND_OP_DATA_OUT_INSTR:
+			nfc_op->data_instr = instr;
+			nfc_op->data_instr_idx = op_id;
+			nfc_op->cmd_ctrl.nfc_ctrl.dc = 1;
+			len = nand_subop_get_data_len(subop, op_id);
+			nfc_op->page_cnt = len;
+			nfc_op->data_delay_ns = instr->delay_ns;
+			break;
+
+		case NAND_OP_WAITRDY_INSTR:
+			nfc_op->rdy_timeout_ms = instr->ctx.waitrdy.timeout_ms;
+			nfc_op->rdy_delay_ns = instr->delay_ns;
+			break;
+		}
+	}
+}
+
+int phytium_nfc_prepare_cmd(struct nand_chip *chip,
+			    struct phytium_nfc_op *nfc_op,
+			    enum dma_data_direction direction)
+{
+	struct phytium_nand_chip *phytium_nand = to_phytium_nand(chip);
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	int i;
+
+	phytium_nfc_cmd_correct(nfc_op);
+	phytium_nfc_addr_correct(nfc_op);
+
+	nfc_op->cmd_ctrl.nfc_ctrl.csel = 0x0F ^ (0x01 << phytium_nand->selected_die);
+
+	for (i = 0; i < PHYTIUM_NFC_ADDR_MAX_LEN; i++)
+		nfc_op->mem_addr_first[i] = (nfc->dma_phy_addr >> (8 * i)) & 0xFF;
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_prepare_cmd);
+
+int phytium_nfc_send_cmd(struct nand_chip *chip,
+			 struct phytium_nfc_op *nfc_op)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	u32 value = 0;
+
+	memset((u8 *)nfc->dsp_addr, 0, PAGE_SIZE);
+	memcpy((u8 *)nfc->dsp_addr, (u8 *)nfc_op, PHYTIUM_NFC_DSP_SIZE);
+
+	if (phytium_wait_busy(nfc) != 0) {
+		dev_err(nfc->dev, "NFC was always busy\n");
+		dev_err(nfc->dev, "NFC state: %x\n", phytium_read(nfc, NDSR));
+		dev_err(nfc->dev, "NFC debug: %x\n", phytium_read(nfc, ND_DEBUG));
+		return 0;
+	}
+
+	spin_lock(&nfc->spinlock);
+	value = nfc->dsp_phy_addr & 0xFFFFFFFF;
+	phytium_write(nfc, NDAR0, value);
+
+	/* Don't modify NDAR1_DMA_RLEN & NDAR1_DMA_WLEN */
+	value  = phytium_read(nfc, NDAR1);
+	value |= NDAR1_H8((nfc->dsp_phy_addr >> 32) & 0xFF);
+	phytium_write(nfc, NDAR1, value);
+
+	phytium_nfc_enable_int(nfc,  NDIR_CMD_FINISH_MASK);
+
+	value |= NDAR1_DMA_EN;
+	phytium_write(nfc, NDAR1, value);
+	spin_unlock(&nfc->spinlock);
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_send_cmd);
+
+int phytium_nfc_prepare_cmd2(struct nand_chip *chip,
+			     struct phytium_nfc_op *nfc_op,
+			     enum dma_data_direction direction,
+			     u32 cmd_num)
+{
+	struct phytium_nand_chip *phytium_nand = to_phytium_nand(chip);
+	int i;
+
+	for (i = 0; i < cmd_num; i++) {
+		phytium_nfc_cmd_correct(nfc_op);
+		phytium_nfc_addr_correct(nfc_op);
+		nfc_op->cmd_ctrl.nfc_ctrl.csel = 0x0F ^ (0x01 << phytium_nand->selected_die);
+		nfc_op++;
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_prepare_cmd2);
+
+int phytium_nfc_send_cmd2(struct nand_chip *chip,
+			  struct phytium_nfc_op *nfc_op,
+			  u32 cmd_num)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	u32 value = 0;
+	int i;
+
+	memset((u8 *)nfc->dsp_addr, 0, PAGE_SIZE);
+
+	for (i = 0; i < cmd_num; i++) {
+		memcpy((u8 *)nfc->dsp_addr + i*PHYTIUM_NFC_DSP_SIZE,
+			(u8 *)nfc_op, PHYTIUM_NFC_DSP_SIZE);
+		nfc_op++;
+	}
+
+	if (phytium_wait_busy(nfc) != 0) {
+		dev_err(nfc->dev, "NFC was always busy\n");
+		dev_err(nfc->dev, "NFC state: %x\n", phytium_read(nfc, NDSR));
+		dev_err(nfc->dev, "NFC debug: %x\n", phytium_read(nfc, ND_DEBUG));
+		return 0;
+	}
+
+	spin_lock(&nfc->spinlock);
+	value = nfc->dsp_phy_addr & 0xFFFFFFFF;
+	phytium_write(nfc, NDAR0, value);
+
+	/* Don't modify NDAR1_DMA_RLEN & NDAR1_DMA_WLEN */
+	value  = phytium_read(nfc, NDAR1);
+	value |= NDAR1_H8((nfc->dsp_phy_addr >> 32) & 0xFF);
+	phytium_write(nfc, NDAR1, value);
+
+	phytium_nfc_enable_int(nfc, NDIR_DMA_FINISH_MASK | NDIR_ECC_ERR_MASK);
+
+	value |= NDAR1_DMA_EN;
+	phytium_write(nfc, NDAR1, value);
+	spin_unlock(&nfc->spinlock);
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_send_cmd2);
+
+int phytium_nfc_wait_op(struct nand_chip *chip,
+			u32 timeout_ms)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	int ret;
+
+	/* Timeout is expressed in ms */
+	if (!timeout_ms)
+		timeout_ms = IRQ_TIMEOUT;
+	else if (timeout_ms > 1000)
+		timeout_ms = 1000;
+	else if (timeout_ms < 100)
+		timeout_ms = 100;
+
+	ret = wait_event_interruptible_timeout(wait_done, nfc_irq_complete,
+					       msecs_to_jiffies(timeout_ms));
+	nfc_irq_complete = false;
+	if (!ret) {
+		dev_err(nfc->dev, "Timeout waiting for RB signal\n");
+		dev_err(nfc->dev, "NFC state: %x\n", phytium_read(nfc, NDSR));
+		dev_err(nfc->dev, "NFC irq state: %x, irq en:%x\n",
+			phytium_read(nfc, NDIR), phytium_read(nfc, NDIR_MASK));
+		dev_err(nfc->dev, "NFC debug: %x\n", phytium_read(nfc, ND_DEBUG));
+
+		phytium_nfc_clear_int(nfc, NDIR_ALL_INT(nfc->caps->int_mask_bits));
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_wait_op);
+
+static int phytium_nfc_xfer_data_pio(struct phytium_nfc *nfc,
+				     const struct nand_subop *subop,
+				     struct phytium_nfc_op *nfc_op)
+{
+	const struct nand_op_instr *instr = nfc_op->data_instr;
+	unsigned int op_id = nfc_op->data_instr_idx;
+	unsigned int len = nand_subop_get_data_len(subop, op_id);
+	unsigned int offset = nand_subop_get_data_start_off(subop, op_id);
+	bool reading = (instr->type == NAND_OP_DATA_IN_INSTR);
+
+	if (reading) {
+		u8 *in = instr->ctx.data.buf.in + offset;
+
+		memcpy(in, nfc->dma_buf, len);
+
+		nfc->dma_offset = 0;
+	} else {
+		const u8 *out = instr->ctx.data.buf.out + offset;
+
+		memcpy(nfc->dma_buf, out, len);
+	}
+
+	return 0;
+}
+
+static int memcpy_to_reg16(struct phytium_nfc *nfc, u32 reg, u16 *buf, size_t len)
+{
+	int i;
+	u32 val = 0;
+
+	if (!nfc || !buf || (len >= 16))
+		return -EINVAL;
+
+	for (i = 0; i < len; i++) {
+		val = (val << 16) + buf[i];
+		if (i % 2) {
+			phytium_write(nfc, reg, val);
+			val = 0;
+			reg += 4;
+		}
+	}
+
+	return 0;
+}
+
+int phytium_nfc_default_data_interface(struct phytium_nfc *nfc)
+{
+	int value;
+
+	value = phytium_read(nfc, NDCR0);
+	value &= (~NDCR0_IN_MODE(3));
+	value |= NDCR0_IN_MODE(nfc->inter_mode);
+	phytium_write(nfc, NDCR0, value);
+
+	value = phytium_read(nfc, NDCR1);
+	value &= (~NDCR1_SAMPL_PHASE(0xFFFF));
+
+	switch (nfc->inter_mode) {
+	case ASYN_SDR:
+		if (nfc->timing_mode == ASY_MODE4) {
+			memcpy_to_reg16(nfc, NDTR0, timing_asy_mode4, TIMING_ASY_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(4));
+		} else if (nfc->timing_mode == ASY_MODE3) {
+			memcpy_to_reg16(nfc, NDTR0, timing_asy_mode3, TIMING_ASY_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(5));
+		} else if (nfc->timing_mode == ASY_MODE2) {
+			memcpy_to_reg16(nfc, NDTR0, timing_asy_mode2, TIMING_ASY_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(3));
+		} else if (nfc->timing_mode == ASY_MODE1) {
+			memcpy_to_reg16(nfc, NDTR0, timing_asy_mode1, TIMING_ASY_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(2));
+		} else {
+			memcpy_to_reg16(nfc, NDTR0, timing_asy_mode0, TIMING_ASY_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(1));
+		}
+		phytium_write(nfc, ND_INTERVAL_TIME, 0x01);
+		break;
+	case ONFI_DDR:
+		if (nfc->timing_mode == SYN_MODE4) {
+			memcpy_to_reg16(nfc, NDTR6, timing_syn_mode4, TIMING_SYN_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(0x0D));
+			phytium_write(nfc, ND_INTERVAL_TIME, 0x30);
+		} else if (nfc->timing_mode == SYN_MODE3) {
+			memcpy_to_reg16(nfc, NDTR6, timing_syn_mode3, TIMING_SYN_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(0x05));
+			phytium_write(nfc, ND_INTERVAL_TIME, 0x18);
+		} else if (nfc->timing_mode == SYN_MODE2) {
+			memcpy_to_reg16(nfc, NDTR6, timing_syn_mode2, TIMING_SYN_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(0x08));
+			phytium_write(nfc, ND_INTERVAL_TIME, 0x20);
+		} else if (nfc->timing_mode == SYN_MODE1) {
+			memcpy_to_reg16(nfc, NDTR6, timing_syn_mode1, TIMING_SYN_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(0x12));
+			phytium_write(nfc, ND_INTERVAL_TIME, 0x40);
+		} else {
+			memcpy_to_reg16(nfc, NDTR6, timing_syn_mode0, TIMING_SYN_NUM);
+			phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(0x12));
+			phytium_write(nfc, ND_INTERVAL_TIME, 0x40);
+		}
+		break;
+	case TOG_ASYN_DDR:
+		phytium_write(nfc, NDCR1, value | NDCR1_SAMPL_PHASE(8));
+		phytium_write(nfc, ND_INTERVAL_TIME, 0xC8);
+		memcpy_to_reg16(nfc, NDTR13, timing_tog_ddr_mode0, TIMING_TOG_NUM);
+		break;
+	}
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_default_data_interface);
+
+static int phytium_nfc_naked_waitrdy_exec(struct nand_chip *chip,
+					  const struct nand_subop *subop)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	int ret = 0;
+
+	phytium_nfc_parse_instructions(chip, subop, &nfc_op);
+
+	dev_info(nfc->dev, "Phytium nand command 0x%02x 0x%02x.\n",
+		 nfc_op.cmd[0], nfc_op.cmd[1]);
+
+	switch (nfc_op.cmd[0]) {
+	case NAND_CMD_PARAM:
+		memset(nfc->dma_buf, 0, PAGE_SIZE);
+		direction = DMA_FROM_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ_PARAM;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		if (nfc->inter_pro == NAND_ONFI)
+			nfc_op.page_cnt = 3 * sizeof(struct nand_onfi_params);
+		else if (nfc->inter_pro == NAND_JEDEC)
+			nfc_op.page_cnt = 3 * sizeof(struct nand_jedec_params);
+		if (nfc_op.page_cnt)
+			nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+		nfc->dma_offset = 0;
+		break;
+	case NAND_CMD_SET_FEATURES:
+		direction = DMA_TO_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_SET_FTR;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+		if (nfc->inter_mode != ASYN_SDR) {
+			dev_err(nfc->dev, "Not support SET_FEATURES command!\n");
+			return 0;
+		}
+		break;
+	case NAND_CMD_GET_FEATURES:
+		direction = DMA_FROM_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_GET_FTR;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+		break;
+	case NAND_CMD_READ0:
+		if (nfc_op.cmd[1] == NAND_CMD_READSTART) { /* large page */
+			direction = DMA_FROM_DEVICE;
+			nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ;
+			nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		} else if (nfc_op.cmd[1] == NAND_CMD_SEQIN) { /* program page begin */
+			nfc_op.cmd[0] = NAND_CMD_SEQIN;
+			nfc_op.cmd[1] = NAND_CMD_PAGEPROG;
+			direction = DMA_TO_DEVICE;
+			nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_PAGE_PRO;
+			nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		} else {   /* small page */
+			direction = DMA_FROM_DEVICE;
+			nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ;
+			nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		}
+		break;
+	case NAND_CMD_RNDOUT: /* change read column  */
+		direction = DMA_FROM_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_CH_READ_COL;
+		nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+		break;
+	case NAND_CMD_READSTART:   /* large page */
+		direction = DMA_FROM_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		break;
+	case NAND_CMD_RNDOUTSTART:  /* change read column  */
+		direction = DMA_FROM_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_CH_READ_COL;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		nfc->dma_offset = nfc_op.addr[1];
+		nfc->dma_offset = (nfc->dma_offset << 8) + nfc_op.addr[0];
+		break;
+	case NAND_CMD_SEQIN:  /* program begin */
+		if (nfc_op.cmd[0] == NAND_CMD_READ0) {
+			nfc_op.cmd[0] = NAND_CMD_SEQIN;
+			nfc_op.cmd[1] = NAND_CMD_PAGEPROG;
+		}
+		direction = DMA_TO_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_PAGE_PRO;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		break;
+	case NAND_CMD_RNDIN:  /* change write column  */
+		direction = DMA_TO_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_CH_WR_COL;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		break;
+	case NAND_CMD_PAGEPROG: /* program end */
+		nfc_op.cmd[0] = NAND_CMD_RNDIN;
+		nfc_op.cmd[1] = NAND_CMD_PAGEPROG;
+		direction = DMA_TO_DEVICE;
+		nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_PAGE_PRO;
+		nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+		break;
+	default:
+		dev_err(nfc->dev, "Not support cmd %d.\n", nfc_op.cmd[1]);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if ((nfc_op.data_instr) && (direction == DMA_TO_DEVICE))
+		phytium_nfc_xfer_data_pio(nfc, subop, &nfc_op);
+
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+	nfc_op.rdy_timeout_ms = nfc_op.rdy_timeout_ms;
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		goto out;
+
+	cond_delay(nfc_op.rdy_delay_ns);
+
+	if ((nfc_op.data_instr) && (direction == DMA_FROM_DEVICE))
+		phytium_nfc_xfer_data_pio(nfc, subop, &nfc_op);
+
+out:
+	return ret;
+}
+
+static int phytium_nfc_read_id_type_exec(struct nand_chip *chip,
+					 const struct nand_subop *subop)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	u16 read_len = 0;
+	int ret;
+	u8 *buf = nfc->dma_buf;
+
+	memset(nfc->dma_buf, 0, PAGE_SIZE);
+	direction = DMA_FROM_DEVICE;
+
+	phytium_nfc_parse_instructions(chip, subop, &nfc_op);
+	read_len = nfc_op.page_cnt;
+	nfc_op.page_cnt = (read_len & 0x03) ? ((read_len & 0xFFFC) + 4) : read_len;
+
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ_ID;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 0;
+
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		return ret;
+
+	cond_delay(nfc_op.rdy_delay_ns);
+
+	if (!strncmp(nfc->dma_buf, "ONFI", 4)) {
+		nfc->inter_pro = NAND_ONFI;
+	} else if (!strncmp(nfc->dma_buf, "JEDEC", 5)) {
+		nfc->inter_pro = NAND_JEDEC;
+		if (buf[5] == 1)
+			nfc->inter_mode = ASYN_SDR;
+		else if (buf[5] == 2)
+			nfc->inter_mode = TOG_ASYN_DDR;
+		else if (buf[5] == 4)
+			nfc->inter_mode = ASYN_SDR;
+	} else {
+		nfc->inter_pro = NAND_OTHER;
+	}
+
+	dev_info(nfc->dev, "Nand protocol: %d, interface mode: %d\n",
+		 nfc->inter_pro, nfc->inter_mode);
+
+	phytium_nfc_xfer_data_pio(nfc, subop, &nfc_op);
+
+	return 0;
+}
+
+static int phytium_nfc_read_status_exec(struct nand_chip *chip,
+					const struct nand_subop *subop)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	u16 read_len = 0;
+	u32 timeout, count = 0;
+	int ret = 0;
+
+	direction = DMA_FROM_DEVICE;
+
+	phytium_nfc_parse_instructions(chip, subop, &nfc_op);
+	read_len = nfc_op.page_cnt;
+	nfc_op.page_cnt = (read_len & 0x03) ? ((read_len & 0xFFFC) + 4) : read_len;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ_STATUS;
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+
+read_status_retry:
+	count++;
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+	timeout = nfc_op.rdy_timeout_ms ? nfc_op.rdy_timeout_ms : 10;
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		goto out;
+
+	phytium_nfc_xfer_data_pio(nfc, subop, &nfc_op);
+
+	if (0xE0 != *(u8 *)(nfc->dma_buf)) {
+		dev_info(nfc->dev, "Retry to read status (%x)\n", *(u8 *)(nfc->dma_buf));
+
+		if (count < 10)
+			goto read_status_retry;
+	}
+
+out:
+	return ret;
+}
+
+static int phytium_nfc_reset_cmd_type_exec(struct nand_chip *chip,
+					   const struct nand_subop *subop)
+{
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+
+	phytium_nfc_parse_instructions(chip, subop, &nfc_op);
+
+	direction = DMA_NONE;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_RESET;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+
+	return phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+}
+
+static int phytium_nfc_erase_cmd_type_exec(struct nand_chip *chip,
+					   const struct nand_subop *subop)
+{
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+
+	phytium_nfc_parse_instructions(chip, subop, &nfc_op);
+	direction = DMA_NONE;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_ERASE;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs  = 1;
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+
+	return phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+}
+
+static int phytium_nfc_data_in_type_exec(struct nand_chip *chip,
+					 const struct nand_subop *subop)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nfc_op nfc_op;
+	struct nand_op_instr *instr;
+	unsigned int op_id;
+	unsigned int len;
+	unsigned int offset;
+	u8 *in = NULL;
+
+	phytium_nfc_parse_instructions(chip, subop, &nfc_op);
+	if (nfc_op.data_instr->type != NAND_OP_DATA_IN_INSTR) {
+		dev_err(nfc->dev, "Phytium nfc instrs parser failed!\n");
+		return -EINVAL;
+	}
+
+	instr = nfc_op.data_instr;
+	op_id = nfc_op.data_instr_idx;
+	len = nand_subop_get_data_len(subop, op_id);
+	offset = nand_subop_get_data_start_off(subop, op_id);
+	in = instr->ctx.data.buf.in + offset;
+
+	memcpy(in, nfc->dma_buf + nfc->dma_offset, len);
+	nfc->dma_offset += len;
+
+	return 0;
+}
+
+static const struct nand_op_parser phytium_nfc_op_parser = NAND_OP_PARSER(
+	/* Naked commands not supported, use a function for each pattern */
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_read_id_type_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_ADDR_ELEM(false, PHYTIUM_NFC_ADDR_MAX_LEN),
+		NAND_OP_PARSER_PAT_DATA_IN_ELEM(false, 8)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_erase_cmd_type_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_ADDR_ELEM(false, PHYTIUM_NFC_ADDR_MAX_LEN),
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_WAITRDY_ELEM(false)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_read_status_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_DATA_IN_ELEM(false, 1)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_reset_cmd_type_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_WAITRDY_ELEM(false)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_naked_waitrdy_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_ADDR_ELEM(false, PHYTIUM_NFC_ADDR_MAX_LEN),
+		NAND_OP_PARSER_PAT_WAITRDY_ELEM(false),
+		NAND_OP_PARSER_PAT_DATA_IN_ELEM(false, MAX_CHUNK_SIZE)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_naked_waitrdy_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_ADDR_ELEM(false, PHYTIUM_NFC_ADDR_MAX_LEN),
+		NAND_OP_PARSER_PAT_WAITRDY_ELEM(false)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_naked_waitrdy_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_ADDR_ELEM(false, PHYTIUM_NFC_ADDR_MAX_LEN),
+		NAND_OP_PARSER_PAT_DATA_OUT_ELEM(false, 8),
+		NAND_OP_PARSER_PAT_WAITRDY_ELEM(false)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_naked_waitrdy_exec,
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_ADDR_ELEM(false, PHYTIUM_NFC_ADDR_MAX_LEN),
+		NAND_OP_PARSER_PAT_CMD_ELEM(false),
+		NAND_OP_PARSER_PAT_DATA_IN_ELEM(false, MAX_CHUNK_SIZE)),
+	NAND_OP_PARSER_PATTERN(
+		phytium_nfc_data_in_type_exec,
+		NAND_OP_PARSER_PAT_DATA_IN_ELEM(false, MAX_CHUNK_SIZE)),
+	);
+
+static int phytium_nfc_exec_op(struct nand_chip *chip,
+			       const struct nand_operation *op,
+			       bool check_only)
+{
+	return nand_op_parser_exec_op(chip, &phytium_nfc_op_parser,
+				      op, check_only);
+}
+
+static int phytium_nfc_reset(struct phytium_nfc *nfc)
+{
+	u32 value;
+
+	phytium_write(nfc, NDIR_MASK, NDIR_ALL_INT(nfc->caps->int_mask_bits));
+	phytium_write(nfc, NDSR, NDIR_ALL_INT(nfc->caps->int_mask_bits));
+
+	phytium_write(nfc, ND_ERR_CLR, 0x0F);
+	phytium_write(nfc, NDFIFO_CLR, 1);
+
+	value = phytium_read(nfc, NDCR0);
+	phytium_write(nfc, NDCR0, value & ~(NDCR0_ECC_EN | NDCR0_SPARE_EN));
+
+	return 0;
+}
+
+static void phytium_nfc_select_chip(struct nand_chip *chip, int die_nr)
+{
+	struct phytium_nand_chip *phytium_nand = to_phytium_nand(chip);
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+
+	dev_dbg(nfc->dev, "Phytium nand selected chip %d\n", die_nr);
+
+	if (chip == nfc->selected_chip && die_nr == phytium_nand->selected_die)
+		return;
+
+	if (die_nr < 0 || die_nr >= phytium_nand->nsels) {
+		nfc->selected_chip = NULL;
+		phytium_nand->selected_die = -1;
+		return;
+	}
+
+	phytium_nfc_reset(nfc);
+
+	nfc->selected_chip = chip;
+	phytium_nand->selected_die = die_nr;
+}
+
+static int phytium_nand_ooblayout_ecc(struct mtd_info *mtd, int section,
+				      struct mtd_oob_region *oobregion)
+{
+	struct nand_chip *chip = mtd_to_nand(mtd);
+
+	if (section)
+		return -ERANGE;
+
+	oobregion->length = chip->ecc.total;
+	oobregion->offset = mtd->oobsize - oobregion->length;
+
+	return 0;
+}
+
+static int phytium_nand_ooblayout_free(struct mtd_info *mtd, int section,
+				       struct mtd_oob_region *oobregion)
+{
+	struct nand_chip *chip = mtd_to_nand(mtd);
+
+	if (section)
+		return -ERANGE;
+
+	/*
+	 * Bootrom looks in bytes 0 & 5 for bad blocks for the
+	 * 4KB page / 4bit BCH combination.
+	 */
+	if (mtd->writesize >= SZ_4K)
+		oobregion->offset = 6;
+	else
+		oobregion->offset = 2;
+
+	oobregion->length = mtd->oobsize - chip->ecc.total - oobregion->offset;
+
+	return 0;
+}
+
+static const struct mtd_ooblayout_ops phytium_nand_ooblayout_ops = {
+	.ecc = phytium_nand_ooblayout_ecc,
+	.free = phytium_nand_ooblayout_free,
+};
+
+static void phytium_nfc_enable_hw_ecc(struct nand_chip *chip)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	u32 ndcr0 = phytium_read(nfc, NDCR0);
+
+	if (!(ndcr0 & NDCR0_ECC_EN))
+		phytium_write(nfc, NDCR0, ndcr0 | NDCR0_ECC_EN);
+}
+
+static void phytium_nfc_disable_hw_ecc(struct nand_chip *chip)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	u32 ndcr0 = phytium_read(nfc, NDCR0);
+
+	if (ndcr0 & NDCR0_ECC_EN)
+		phytium_write(nfc, NDCR0, ndcr0 & ~NDCR0_ECC_EN);
+}
+
+irqreturn_t phytium_nfc_isr(int irq, void *dev_id)
+{
+	struct phytium_nfc *nfc = dev_id;
+	u32 st = phytium_read(nfc, NDIR);
+	u32 ien = (~phytium_read(nfc, NDIR_MASK)) & NDIR_ALL_INT(nfc->caps->int_mask_bits);
+
+	if (!(st & ien))
+		return IRQ_NONE;
+
+	nfc_irq_st = st;
+	nfc_irq_en = ien;
+	phytium_nfc_disable_int(nfc, st & NDIR_ALL_INT(nfc->caps->int_mask_bits));
+	phytium_write(nfc, 0xFD0, 0);
+
+	if (st & (NDIR_CMD_FINISH | NDIR_DMA_FINISH)) {
+		if (st & NDIR_ECC_ERR)
+			nfc_ecc_err = 1;
+		phytium_write(nfc, NDIR, st);
+		nfc_irq_complete = 1;
+	} else if (st & (NDIR_FIFO_TIMEOUT | NDIR_PGFINISH)) {
+		phytium_write(nfc, NDIR, st);
+		phytium_nfc_enable_int(nfc, (~st) & (NDIR_DMA_FINISH_MASK |
+						     NDIR_PGFINISH_MASK |
+						     NDIR_FIFO_TIMEOUT_MASK |
+						     NDIR_CMD_FINISH_MASK));
+		nfc_irq_complete = 0;
+	} else if (st & NDIR_ECC_ERR) {
+		phytium_write(nfc, ND_ERR_CLR, 0x08);
+		phytium_write(nfc, NDIR, st);
+		phytium_write(nfc, NDFIFO_CLR, 0x01);
+		nfc_irq_complete = 1;
+		nfc_ecc_errover = 1;
+	} else {
+		phytium_write(nfc, NDIR, st);
+		nfc_irq_complete = 1;
+	}
+
+	wake_up(&wait_done);
+
+	return IRQ_HANDLED;
+}
+EXPORT_SYMBOL(phytium_nfc_isr);
+
+static int phytium_nfc_hw_ecc_correct(struct nand_chip *chip,
+				char *buf, int len)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	u32 i, j, value, tmp;
+	u32 ecc_err_reg_nums;
+	int stat = 0;
+
+	if (!buf)
+		return -EINVAL;
+
+	if (nfc->caps->hw_ver == 1)
+		ecc_err_reg_nums = 2;
+	else
+		ecc_err_reg_nums = 4;
+
+	for (i = 0; i < chip->ecc.steps; i++) {
+		for (j = 0; j < ecc_err_reg_nums; j++) {
+			value = phytium_read(nfc, 0xB8 + 4 * (ecc_err_reg_nums * i + j));
+			dev_info(nfc->dev, "ECC_FLAG: offset:%x value:0x%08x\n",
+				 0xB8 + 4 * (2 * i + j), value);
+
+			tmp = value & 0xFFFF;
+			if (tmp && (tmp <= 4096)) {
+				tmp--;
+				stat++;
+				buf[chip->ecc.size * i + (tmp >> 3)] ^= (0x01 << tmp % 8);
+				dev_info(nfc->dev, "ECC_CORRECT %x %02x\n",
+					 chip->ecc.size * i + (tmp >> 3),
+					 buf[chip->ecc.size * i + (tmp >> 3)]);
+				dev_info(nfc->dev, "ECC_CORRECT xor %x %02x\n",
+					 0x01 << (tmp % 8), buf[chip->ecc.size * i + (tmp >> 3)]);
+			} else if (tmp > 4096) {
+				dev_info(nfc->dev, "ECC_CORRECT offset > 4096!\n");
+			}
+
+			tmp = (value >> 16) & 0xFFFF;
+			if (tmp && (tmp <= 4096)) {
+				tmp--;
+				stat++;
+				buf[chip->ecc.size * i + (tmp >> 3)] ^= (0x01 << tmp % 8);
+				dev_info(nfc->dev, "ECC_CORRECT %x %02x\n",
+					 chip->ecc.size * i + (tmp >> 3),
+					 buf[chip->ecc.size * i + (tmp >> 3)]);
+				dev_info(nfc->dev, "ECC_CORRECT xor %x %02x\n",
+					 chip->ecc.size * i + (tmp >> 3),
+					 buf[chip->ecc.size * i + (tmp >> 3)]);
+			} else if (tmp > 4096) {
+				dev_info(nfc->dev, "ECC_CORRECT offset > 4096!\n");
+			}
+		}
+	}
+
+	return stat;
+}
+
+static int phytium_nand_page_read(struct mtd_info *mtd, struct nand_chip *chip,
+				  u8 *buf, u8 *oob_buf, int oob_len, int page,
+				  bool read)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nand_chip *phytium_nand = NULL;
+	const struct nand_sdr_timings *sdr = NULL;
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	int ret = 0;
+
+	memset(&nfc_op, 0, sizeof(nfc_op));
+	phytium_nand = to_phytium_nand(chip);
+	sdr = nand_get_sdr_timings(nand_get_interface_config(&phytium_nand->chip));
+
+	memset(nfc->dma_buf, 0x0, mtd->writesize + mtd->oobsize);
+	direction  = DMA_FROM_DEVICE;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ;
+	nfc_op.cmd[0] = NAND_CMD_READ0;
+	nfc_op.cmd[1] = NAND_CMD_READSTART;
+	nfc_op.cmd_len  = 2;
+	nfc_op.cle_ale_delay_ns = PSEC_TO_NSEC(sdr->tWB_max);
+	nfc_op.rdy_timeout_ms = PSEC_TO_MSEC(sdr->tR_max);
+	nfc_op.rdy_delay_ns = PSEC_TO_NSEC(sdr->tRR_min);
+
+	nfc_op.cmd_ctrl.nfc_ctrl.dbc = 1;
+	nfc_op.addr[2] = page;
+	nfc_op.addr[3] = page >> 8;
+	nfc_op.addr[4] = page >> 16;
+	nfc_op.addr_len = 5;
+	nfc_op.cmd_ctrl.nfc_ctrl.addr_cyc = 0x05;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs = 1;
+
+	nfc_op.page_cnt = mtd->writesize;
+	nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+	nfc_op.cmd_ctrl.nfc_ctrl.ecc_en = 0;
+
+	/* For data read/program */
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		return ret;
+
+	if ((direction == DMA_FROM_DEVICE) && buf)
+		memcpy(buf, nfc->dma_buf, mtd->writesize);
+
+	return ret;
+}
+
+static int phytium_nand_oob_read(struct mtd_info *mtd, struct nand_chip *chip,
+				 u8 *buf, u8 *oob_buf, int oob_len, int page,
+				 bool read)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nand_chip *phytium_nand = NULL;
+	const struct nand_sdr_timings *sdr = NULL;
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	int ret = 0;
+
+	memset(&nfc_op, 0, sizeof(nfc_op));
+	phytium_nand = to_phytium_nand(chip);
+	sdr = nand_get_sdr_timings(nand_get_interface_config(&phytium_nand->chip));
+
+	memset(nfc->dma_buf, 0x00, mtd->writesize + mtd->oobsize);
+	direction  = DMA_FROM_DEVICE;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ;
+	nfc_op.cmd[0] = NAND_CMD_READ0;
+	nfc_op.cmd[1] = NAND_CMD_READSTART;
+	nfc_op.cmd_len  = 2;
+	nfc_op.cle_ale_delay_ns = PSEC_TO_NSEC(sdr->tWB_max);
+	nfc_op.rdy_timeout_ms = PSEC_TO_MSEC(sdr->tR_max);
+	nfc_op.rdy_delay_ns = PSEC_TO_NSEC(sdr->tRR_min);
+
+	nfc_op.cmd_ctrl.nfc_ctrl.dbc = 1;
+	nfc_op.addr[2] = page;
+	nfc_op.addr[3] = page >> 8;
+	nfc_op.addr[4] = page >> 16;
+	nfc_op.addr_len = 5;
+	nfc_op.cmd_ctrl.nfc_ctrl.addr_cyc = 0x05;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs = 1;
+
+	nfc_op.page_cnt = oob_len;
+	nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+	nfc_op.cmd_ctrl.nfc_ctrl.ecc_en = 0;
+	nfc_op.addr[0] = mtd->writesize & 0xFF;
+	nfc_op.addr[1] = (mtd->writesize >> 8) & 0xFF;
+
+	/* For data read/program */
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		return ret;
+
+	cond_delay(nfc_op.rdy_delay_ns);
+
+	if (direction == DMA_FROM_DEVICE)
+		memcpy(oob_buf, nfc->dma_buf, oob_len);
+
+	return ret;
+}
+
+static int phytium_nand_get_ecc_total(struct mtd_info *mtd,
+				      struct nand_ecc_ctrl *ecc)
+{
+	int ecc_total = 0;
+
+	switch (mtd->writesize) {
+	case 0x200:
+		if (ecc->strength == 8)
+			ecc_total = 0x0D;
+		else if (ecc->strength == 4)
+			ecc_total = 7;
+		else if (ecc->strength == 2)
+			ecc_total = 4;
+		else
+			ecc_total = 0;
+		break;
+	case 0x800:
+		if (ecc->strength == 8)
+			ecc_total = 0x34;
+		else if (ecc->strength == 4)
+			ecc_total = 0x1a;
+		else if (ecc->strength == 2)
+			ecc_total = 0xd;
+		else
+			ecc_total = 0;
+	break;
+	case 0x1000:
+		if (ecc->strength == 8)
+			ecc_total = 0x68;
+		else if (ecc->strength == 4)
+			ecc_total = 0x34;
+		else if (ecc->strength == 2)
+			ecc_total = 0x1a;
+		else
+			ecc_total = 0;
+		break;
+	case 0x2000:
+		if (ecc->strength == 8)
+			ecc_total = 0xD0;
+		else if (ecc->strength == 4)
+			ecc_total = 0x68;
+		else if (ecc->strength == 2)
+			ecc_total = 0x34;
+		else
+			ecc_total = 0;
+		break;
+	case 0x4000:
+		if (ecc->strength == 8)
+			ecc_total = 0x1A0;
+		if (ecc->strength == 4)
+			ecc_total = 0xD0;
+		else if (ecc->strength == 2)
+			ecc_total = 0x68;
+		else
+			ecc_total = 0;
+		break;
+	default:
+			ecc_total = 0;
+		break;
+	}
+
+	return ecc_total;
+}
+
+static int phytium_nand_page_read_hwecc(struct mtd_info *mtd, struct nand_chip *chip,
+					u8 *buf, u8 *oob_buf, int oob_len, int page,
+					bool read)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nand_chip *phytium_nand = NULL;
+	const struct nand_sdr_timings *sdr = NULL;
+	struct phytium_nfc_op *nfc_op = NULL;
+	enum dma_data_direction direction;
+	u32 ecc_offset;
+	int max_bitflips = 0;
+	u32 nfc_state = 0;
+	int ret = 0;
+	int i;
+
+	phytium_nand = to_phytium_nand(chip);
+	sdr = nand_get_sdr_timings(nand_get_interface_config(&phytium_nand->chip));
+
+	ecc_offset = phytium_nand->ecc.offset;
+	memset(nfc->dma_buf, 0x00, mtd->writesize + mtd->oobsize);
+	nfc_op = kzalloc(2 * sizeof(struct phytium_nfc_op), GFP_KERNEL);
+	if (!nfc_op) {
+		dev_err(nfc->dev, "Can't malloc space for phytium_nfc_op\n");
+		return 0;
+	}
+
+	nfc_op->cle_ale_delay_ns = PSEC_TO_NSEC(sdr->tWB_max);
+	nfc_op->rdy_timeout_ms = PSEC_TO_MSEC(sdr->tR_max);
+	nfc_op->rdy_delay_ns = PSEC_TO_NSEC(sdr->tRR_min);
+
+	direction  = DMA_FROM_DEVICE;
+	nfc_op->cmd_ctrl.nfc_ctrl.cmd_type = TYPE_READ;
+	nfc_op->cmd[0] = NAND_CMD_READ0;
+	nfc_op->cmd[1] = NAND_CMD_READSTART;
+	nfc_op->cmd_len  = 2;
+	nfc_op->addr_len = 5;
+	nfc_op->cmd_ctrl.nfc_ctrl.dbc = 1;
+	nfc_op->addr[2] = page;
+	nfc_op->addr[3] = page >> 8;
+	nfc_op->addr[4] = page >> 16;
+	nfc_op->cmd_ctrl.nfc_ctrl.addr_cyc = 0x05;
+	nfc_op->cmd_ctrl.nfc_ctrl.dc = 1;
+	nfc_op->cmd_ctrl.nfc_ctrl.auto_rs = 1;
+	nfc_op->page_cnt = mtd->writesize;
+	nfc_op->cmd_ctrl.nfc_ctrl.nc = 1;
+	for (i = 0; i < PHYTIUM_NFC_ADDR_MAX_LEN; i++)
+		nfc_op->mem_addr_first[i] = (nfc->dma_phy_addr >> (8 * i)) & 0xFF;
+
+	nfc_op++;
+	memcpy(nfc_op, nfc_op - 1, sizeof(struct phytium_nfc_op));
+	nfc_op->cmd_ctrl.nfc_ctrl.cmd_type = TYPE_CH_READ_COL;
+	nfc_op->cmd[0] = NAND_CMD_RNDOUT;
+	nfc_op->cmd[1] = NAND_CMD_RNDOUTSTART;
+	memset(&nfc_op->addr, 0, PHYTIUM_NFC_ADDR_MAX_LEN);
+	nfc_op->addr_len = 2;
+	nfc_op->addr[0] = mtd->writesize + phytium_nand->ecc.offset;
+	nfc_op->addr[1] = (mtd->writesize + phytium_nand->ecc.offset) >> 8;
+	nfc_op->cmd_ctrl.nfc_ctrl.addr_cyc = 0x02;
+	nfc_op->page_cnt = phytium_nand_get_ecc_total(mtd, &chip->ecc);
+	nfc_op->cmd_ctrl.nfc_ctrl.nc = 0;
+	nfc_op->cmd_ctrl.nfc_ctrl.auto_rs = 0;
+	nfc_op->cmd_ctrl.nfc_ctrl.ecc_en = 1;
+	for (i = 0; i < PHYTIUM_NFC_ADDR_MAX_LEN; i++)
+		nfc_op->mem_addr_first[i] =
+			((nfc->dma_phy_addr + mtd->writesize) >> (8 * i)) & 0xFF;
+
+	nfc_op--;
+	phytium_nfc_prepare_cmd2(chip, nfc_op, direction, 2);
+	phytium_nfc_send_cmd2(chip, nfc_op, 2);
+	cond_delay(nfc_op->cle_ale_delay_ns);
+
+	ret = phytium_nfc_wait_op(chip, nfc_op->rdy_timeout_ms);
+	if (ret) {
+		kfree(nfc_op);
+		return ret;
+	}
+
+	cond_delay(nfc_op->rdy_delay_ns * 1000);
+
+	if ((direction == DMA_FROM_DEVICE) && buf) {
+		nfc_state = phytium_read(nfc, NDSR);
+		if ((nfc_state & NDSR_ECC_ERROVER) || (nfc_ecc_errover == 1)) {
+			for (i = 0; i < mtd->writesize/16; i++) {
+				if (0xFF != *(u8 *)(nfc->dma_buf + i)) {
+					dev_info(nfc->dev, "NFC: NDSR_ECC_ERROVER %x\n", page);
+					mtd->ecc_stats.failed++;
+					mtd->ecc_stats.corrected += max_bitflips;
+					break;
+				}
+			}
+		} else if (nfc_state & NDSR_ECC_ERR) {
+			max_bitflips = phytium_nfc_hw_ecc_correct(chip,
+						nfc->dma_buf, mtd->writesize);
+			mtd->ecc_stats.corrected += max_bitflips;
+			dev_info(nfc->dev, "NFC: NDSR_ECC_ERR page:%x, bit:%d\n",
+						page, max_bitflips);
+		}
+
+		memcpy(buf, nfc->dma_buf, mtd->writesize);
+	}
+
+	kfree(nfc_op);
+	return max_bitflips;
+}
+
+static int phytium_nand_page_write(struct mtd_info *mtd, struct nand_chip *chip,
+				   const u8 *buf, u8 *oob_buf, int oob_len, int page,
+				   bool read)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nand_chip *phytium_nand = NULL;
+	const struct nand_sdr_timings *sdr = NULL;
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	int ret = 0;
+
+	memset(&nfc_op, 0, sizeof(nfc_op));
+	phytium_nand = to_phytium_nand(chip);
+	sdr = nand_get_sdr_timings(nand_get_interface_config(&phytium_nand->chip));
+
+	memcpy(nfc->dma_buf, buf, mtd->writesize);
+	direction  = DMA_TO_DEVICE;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_PAGE_PRO;
+	nfc_op.cmd[0] = NAND_CMD_SEQIN;
+	nfc_op.cmd[1] = NAND_CMD_PAGEPROG;
+	nfc_op.cmd_len  = 2;
+	nfc_op.addr_len = 5;
+	nfc_op.cle_ale_delay_ns = PSEC_TO_NSEC(sdr->tWB_max);
+	nfc_op.rdy_timeout_ms = PSEC_TO_MSEC(sdr->tPROG_max);
+	nfc_op.rdy_delay_ns = 0;
+
+	nfc_op.cmd_ctrl.nfc_ctrl.dbc = 1;
+	nfc_op.addr[2] = page;
+	nfc_op.addr[3] = page >> 8;
+	nfc_op.addr[4] = page >> 16;
+	nfc_op.cmd_ctrl.nfc_ctrl.addr_cyc = 0x05;
+	nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs = 1;
+	nfc_op.page_cnt = mtd->writesize;
+
+	/* For data read/program */
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		goto out;
+
+	cond_delay(nfc_op.rdy_delay_ns);
+out:
+	return ret;
+}
+
+static int phytium_nand_oob_write(struct mtd_info *mtd, struct nand_chip *chip,
+				  u8 *buf, u8 *oob_buf, int oob_len, int page,
+				  bool read)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nand_chip *phytium_nand = NULL;
+	const struct nand_sdr_timings *sdr = NULL;
+	struct phytium_nfc_op nfc_op;
+	enum dma_data_direction direction;
+	int ret = 0;
+
+	memset(&nfc_op, 0, sizeof(nfc_op));
+	phytium_nand = to_phytium_nand(chip);
+	sdr = nand_get_sdr_timings(nand_get_interface_config(&phytium_nand->chip));
+
+	direction  = DMA_TO_DEVICE;
+	nfc_op.cmd_ctrl.nfc_ctrl.cmd_type = TYPE_PAGE_PRO;
+	nfc_op.cmd[0] = NAND_CMD_SEQIN;
+	nfc_op.cmd[1] = NAND_CMD_PAGEPROG;
+	nfc_op.cmd_len  = 2;
+	nfc_op.addr_len = 5;
+	nfc_op.cle_ale_delay_ns = PSEC_TO_NSEC(sdr->tWB_max);
+	nfc_op.rdy_timeout_ms = PSEC_TO_MSEC(sdr->tPROG_max);
+	nfc_op.rdy_delay_ns = 0;
+
+	nfc_op.cmd_ctrl.nfc_ctrl.dbc = 1;
+	nfc_op.addr[2] = page;
+	nfc_op.addr[3] = page >> 8;
+	nfc_op.addr[4] = page >> 16;
+	nfc_op.cmd_ctrl.nfc_ctrl.addr_cyc = 0x05;
+	nfc_op.cmd_ctrl.nfc_ctrl.dc = 1;
+	nfc_op.cmd_ctrl.nfc_ctrl.auto_rs = 1;
+
+	nfc_op.page_cnt = oob_len;
+	nfc_op.cmd_ctrl.nfc_ctrl.ecc_en = 0;
+	nfc_op.addr[0] = mtd->writesize & 0xFF;
+	nfc_op.addr[1] = (mtd->writesize >> 8) & 0xFF;
+	nfc_op.cmd_ctrl.nfc_ctrl.ecc_en = 0;
+	memcpy(nfc->dma_buf, oob_buf, mtd->oobsize);
+
+	/* For data read/program */
+	phytium_nfc_prepare_cmd(chip, &nfc_op, direction);
+	phytium_nfc_send_cmd(chip, &nfc_op);
+	cond_delay(nfc_op.cle_ale_delay_ns);
+
+	ret = phytium_nfc_wait_op(chip, nfc_op.rdy_timeout_ms);
+	if (ret)
+		goto out;
+
+	cond_delay(nfc_op.rdy_delay_ns);
+out:
+	return ret;
+}
+
+static int phytium_nand_page_write_hwecc(struct mtd_info *mtd, struct nand_chip *chip,
+					 const u8 *buf, u8 *oob_buf, int oob_len, int page,
+					 bool read)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	struct phytium_nand_chip *phytium_nand = NULL;
+	const struct nand_sdr_timings *sdr = NULL;
+	struct phytium_nfc_op *nfc_op;
+	enum dma_data_direction direction;
+	u32 ecc_offset;
+	int ret = 0;
+	int i;
+
+	phytium_nand = to_phytium_nand(chip);
+	sdr = nand_get_sdr_timings(nand_get_interface_config(&phytium_nand->chip));
+	ecc_offset = phytium_nand->ecc.offset;
+
+	nfc_op = kzalloc(2 * sizeof(struct phytium_nfc_op), GFP_KERNEL);
+	if (!nfc_op)
+		return 0;
+
+	nfc_op->cle_ale_delay_ns = PSEC_TO_NSEC(sdr->tWB_max);
+	nfc_op->rdy_timeout_ms = PSEC_TO_MSEC(sdr->tR_max);
+	nfc_op->rdy_delay_ns = PSEC_TO_NSEC(sdr->tRR_min);
+
+	direction = DMA_TO_DEVICE;
+	nfc_op->cmd_ctrl.nfc_ctrl.cmd_type = TYPE_CH_ROW_ADDR;
+	nfc_op->cmd[0] = NAND_CMD_SEQIN;
+	nfc_op->cmd_len  = 1;
+	nfc_op->addr_len = 5;
+	nfc_op->cmd_ctrl.nfc_ctrl.dbc = 0;
+	nfc_op->addr[2] = page;
+	nfc_op->addr[3] = page >> 8;
+	nfc_op->addr[4] = page >> 16;
+	nfc_op->cmd_ctrl.nfc_ctrl.addr_cyc = 0x05;
+	nfc_op->cmd_ctrl.nfc_ctrl.auto_rs = 0;
+	nfc_op->cmd_ctrl.nfc_ctrl.nc = 1;
+	for (i = 0; i < PHYTIUM_NFC_ADDR_MAX_LEN; i++)
+		nfc_op->mem_addr_first[i] = (nfc->dma_phy_addr >> (8 * i)) & 0xFF;
+
+	/* The first dsp must have data to transfer */
+	memcpy(nfc->dma_buf, buf, mtd->writesize);
+	nfc_op->page_cnt = mtd->writesize;
+	nfc_op->cmd_ctrl.nfc_ctrl.dc = 1;
+
+	nfc_op++;
+	memcpy(nfc_op, nfc_op - 1, sizeof(struct phytium_nfc_op));
+	nfc_op->cmd_ctrl.nfc_ctrl.cmd_type = TYPE_PAGE_PRO;
+	nfc_op->cmd_ctrl.nfc_ctrl.dbc = 1;
+	nfc_op->cmd_ctrl.nfc_ctrl.auto_rs = 1;
+	nfc_op->cmd[0] = NAND_CMD_RNDIN;
+	nfc_op->cmd[1] = NAND_CMD_PAGEPROG;
+	memset(&nfc_op->addr, 0, PHYTIUM_NFC_ADDR_MAX_LEN);
+	nfc_op->addr_len = 2;
+	nfc_op->cmd_len = 2;
+	nfc_op->addr[0] = mtd->writesize + ecc_offset;
+	nfc_op->addr[1] = (mtd->writesize + ecc_offset) >> 8;
+	nfc_op->cmd_ctrl.nfc_ctrl.addr_cyc = 0x02;
+	nfc_op->page_cnt = phytium_nand_get_ecc_total(mtd, &chip->ecc);
+	nfc_op->cmd_ctrl.nfc_ctrl.nc = 0;
+	nfc_op->cmd_ctrl.nfc_ctrl.dc = 1;
+	nfc_op->cmd_ctrl.nfc_ctrl.ecc_en = 1;
+	for (i = 0; i < PHYTIUM_NFC_ADDR_MAX_LEN; i++)
+		nfc_op->mem_addr_first[i] =
+			((nfc->dma_phy_addr + mtd->writesize + ecc_offset) >> (8 * i)) & 0xFF;
+
+	/* when enable ECC, must offer ecc_offset of oob, but no oobdata */
+	nfc_op--;
+	phytium_nfc_prepare_cmd2(chip, nfc_op, direction, 2);
+	phytium_nfc_send_cmd2(chip, nfc_op, 2);
+	cond_delay(nfc_op->cle_ale_delay_ns);
+
+	ret = phytium_nfc_wait_op(chip, nfc_op->rdy_timeout_ms);
+	if (ret)
+		goto out;
+
+	cond_delay(nfc_op->rdy_delay_ns * 1000);
+out:
+	kfree(nfc_op);
+	return ret;
+}
+
+static int phytium_nfc_hw_ecc_bch_read_page_raw(struct nand_chip *chip,
+						u8 *buf, int oob_required,
+						int page)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	u32 oob_len = oob_required ? mtd->oobsize : 0;
+	int ret;
+
+	ret = phytium_nand_page_read(mtd, chip, buf, NULL, 0, page, true);
+	if (oob_required)
+		ret = phytium_nand_oob_read(mtd, chip, NULL, chip->oob_poi,
+					    oob_len, page, true);
+
+	return ret;
+}
+
+static int phytium_nfc_hw_ecc_bch_read_oob_raw(struct nand_chip *chip, int page)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	int ret;
+
+	/* Invalidate page cache */
+	chip->pagecache.page = -1;
+	memset(chip->oob_poi, 0xFF, mtd->oobsize);
+
+	ret = phytium_nand_oob_read(mtd, chip, NULL, chip->oob_poi,
+				    mtd->oobsize, page, true);
+
+	return ret;
+}
+
+static int phytium_nfc_hw_ecc_bch_read_page(struct nand_chip *chip,
+					    u8 *buf, int oob_required,
+					    int page)
+{
+	int ret;
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	u32  oob_len = oob_required ? mtd->oobsize : 0;
+	struct phytium_nand_chip *phytium_nand = NULL;
+
+	phytium_nand = to_phytium_nand(chip);
+
+	phytium_nfc_enable_hw_ecc(chip);
+	cond_delay(20*1000);
+
+	ret = phytium_nand_page_read_hwecc(mtd, chip, buf, NULL,
+					   0, page, true);
+
+	phytium_nfc_disable_hw_ecc(chip);
+
+	if (oob_required) {
+		oob_len = mtd->oobsize;
+		ret = phytium_nand_oob_read(mtd, chip, NULL, chip->oob_poi,
+					    oob_len, page, true);
+	}
+
+	return ret;
+}
+
+static int phytium_nfc_hw_ecc_bch_read_oob(struct nand_chip *chip,
+					   int page)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	u32 oob_len = mtd->oobsize;
+	int ret;
+
+	ret = phytium_nand_oob_read(mtd, chip, NULL, chip->oob_poi,
+				    oob_len, page, true);
+
+	return ret;
+}
+
+static int phytium_nfc_hw_ecc_bch_write_page_raw(struct nand_chip *chip,
+						 const u8 *buf,
+						 int oob_required, int page)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	void *oob_buf = oob_required ? chip->oob_poi : NULL;
+
+	if (oob_required)
+		phytium_nand_oob_write(mtd, chip, NULL, oob_buf,
+				       mtd->oobsize, page, false);
+
+	return phytium_nand_page_write(mtd, chip, buf, NULL,
+				       0, page, false);
+}
+
+static int phytium_nfc_hw_ecc_bch_write_page(struct nand_chip *chip,
+					     const u8 *buf,
+					     int oob_required, int page)
+{
+	int ret;
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	void *oob_buf = oob_required ? chip->oob_poi : NULL;
+	u32 oob_len;
+
+	if (oob_required) {
+		oob_len = mtd->oobsize;
+		phytium_nand_oob_write(mtd, chip, NULL, oob_buf,
+				       oob_len, page, false);
+	}
+
+	phytium_nfc_enable_hw_ecc(chip);
+	cond_delay(20*1000);
+	ret = phytium_nand_page_write_hwecc(mtd, chip, buf, NULL,
+					    0, page, false);
+	phytium_nfc_disable_hw_ecc(chip);
+
+	return ret;
+}
+
+static int phytium_nfc_hw_ecc_bch_write_oob_raw(struct nand_chip *chip, int page)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+
+	return phytium_nand_oob_write(mtd, chip, NULL, chip->oob_poi,
+				      mtd->oobsize, page, false);
+}
+
+static int phytium_nfc_hw_ecc_bch_write_oob(struct nand_chip *chip, int page)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	struct phytium_nand_chip *phytium_nand = to_phytium_nand(chip);
+	u32 oob_len = mtd->oobsize - phytium_nand->ecc.length;
+
+	return phytium_nand_oob_write(mtd, chip, NULL, chip->oob_poi,
+				      oob_len, page, false);
+}
+
+static int phytium_nand_hw_ecc_ctrl_init(struct mtd_info *mtd,
+					 struct nand_ecc_ctrl *ecc)
+{
+	struct nand_chip *chip = mtd_to_nand(mtd);
+
+	if ((mtd->writesize + mtd->oobsize > MAX_CHUNK_SIZE))
+		return -EOPNOTSUPP;
+
+	chip->ecc.algo = NAND_ECC_ALGO_BCH;
+	ecc->read_page_raw = phytium_nfc_hw_ecc_bch_read_page_raw;
+	ecc->read_page = phytium_nfc_hw_ecc_bch_read_page;
+	ecc->read_oob_raw = phytium_nfc_hw_ecc_bch_read_oob_raw;
+	ecc->read_oob = phytium_nfc_hw_ecc_bch_read_oob;
+	ecc->write_page_raw = phytium_nfc_hw_ecc_bch_write_page_raw;
+	ecc->write_page = phytium_nfc_hw_ecc_bch_write_page;
+	ecc->write_oob_raw = phytium_nfc_hw_ecc_bch_write_oob_raw;
+	ecc->write_oob = phytium_nfc_hw_ecc_bch_write_oob;
+
+	return 0;
+}
+
+static int phytium_nand_ecc_init(struct mtd_info *mtd,
+				 struct nand_ecc_ctrl *ecc)
+{
+	int ret = 0;
+
+	mtd_set_ooblayout(mtd, &phytium_nand_ooblayout_ops);
+
+	switch (ecc->engine_type) {
+	case NAND_ECC_ENGINE_TYPE_ON_HOST:
+		ret = phytium_nand_hw_ecc_ctrl_init(mtd, ecc);
+		break;
+	case NAND_ECC_ENGINE_TYPE_NONE:
+		ecc->read_page_raw = phytium_nfc_hw_ecc_bch_read_page_raw;
+		ecc->read_oob_raw = phytium_nfc_hw_ecc_bch_read_oob;
+		ecc->write_page_raw = phytium_nfc_hw_ecc_bch_write_page_raw;
+		ecc->write_oob_raw = phytium_nfc_hw_ecc_bch_write_oob_raw;
+		ecc->read_page = ecc->read_page_raw;
+		ecc->read_oob = ecc->read_oob_raw;
+		ecc->write_page = ecc->write_page_raw;
+		ecc->write_oob = ecc->write_oob_raw;
+		break;
+	case NAND_ECC_ENGINE_TYPE_SOFT:
+	case NAND_ECC_ENGINE_TYPE_ON_DIE:
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
+static u8 bbt_pattern[] = {'P', 'H', 'Y', 'b', 't', '0' };
+static u8 bbt_mirror_pattern[] = {'1', 't', 'b', 'Y', 'H', 'P' };
+
+static struct nand_bbt_descr bbt_main_descr = {
+	.options = NAND_BBT_LASTBLOCK | NAND_BBT_CREATE | NAND_BBT_WRITE |
+		   NAND_BBT_2BIT | NAND_BBT_VERSION,
+	.offs =	8,
+	.len = 6,
+	.veroffs = 14,
+	.maxblocks = 8,	/* Last 8 blocks in each chip */
+	.pattern = bbt_pattern
+};
+
+static struct nand_bbt_descr bbt_mirror_descr = {
+	.options = NAND_BBT_LASTBLOCK | NAND_BBT_CREATE | NAND_BBT_WRITE |
+		   NAND_BBT_2BIT | NAND_BBT_VERSION,
+	.offs =	8,
+	.len = 6,
+	.veroffs = 14,
+	.maxblocks = 8,	/* Last 8 blocks in each chip */
+	.pattern = bbt_mirror_pattern
+};
+
+static int phytium_nand_attach_chip(struct nand_chip *chip)
+{
+	struct mtd_info *mtd = nand_to_mtd(chip);
+	struct phytium_nand_chip *phytium_nand = to_phytium_nand(chip);
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	u32 value;
+	int ret = 0;
+
+	if (nfc->caps->flash_bbt)
+		chip->bbt_options |= NAND_BBT_USE_FLASH;
+
+	if (chip->bbt_options & NAND_BBT_USE_FLASH) {
+		/*
+		 * We'll use a bad block table stored in-flash and don't
+		 * allow writing the bad block marker to the flash.
+		 */
+		chip->bbt_options |= NAND_BBT_NO_OOB_BBM;
+		chip->bbt_td = &bbt_main_descr;
+		chip->bbt_md = &bbt_mirror_descr;
+	}
+
+	if (chip->options & NAND_BUSWIDTH_16)
+		phytium_nand->ndcr |= NDCR0_WIDTH;
+
+	/*
+	 * On small page NANDs, only one cycle is needed to pass the
+	 * column address.
+	 */
+	if (mtd->writesize <= 512)
+		phytium_nand->addr_cyc = 1;
+	else
+		phytium_nand->addr_cyc = 2;
+
+	/*
+	 * Now add the number of cycles needed to pass the row
+	 * address.
+	 *
+	 * Addressing a chip using CS 2 or 3 should also need the third row
+	 * cycle but due to inconsistance in the documentation and lack of
+	 * hardware to test this situation, this case is not supported.
+	 */
+	if (chip->options & NAND_ROW_ADDR_3)
+		phytium_nand->addr_cyc += 3;
+	else
+		phytium_nand->addr_cyc += 2;
+
+	if (nfc->caps) {
+		if (chip->ecc.engine_type == NAND_ECC_ENGINE_TYPE_ON_HOST) {
+			chip->ecc.size = nfc->caps->ecc_step_size ?
+					 nfc->caps->ecc_step_size :
+					 chip->ecc.size;
+			chip->ecc.strength = nfc->caps->ecc_strength ?
+					     nfc->caps->ecc_strength :
+					     chip->ecc.strength;
+			chip->ecc.strength = nfc->caps->ecc_strength;
+			chip->ecc.bytes = 7;
+		} else {
+			chip->ecc.size = 512;
+			chip->ecc.strength = 1;
+			chip->ecc.bytes = 0;
+		}
+		chip->ecc.engine_type = NAND_ECC_ENGINE_TYPE_ON_HOST;
+	}
+
+	if (nfc->caps->hw_ver == 1) {
+		if (chip->ecc.strength == 0x04)
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(4);
+		else if (chip->ecc.strength == 0x02)
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(2);
+		else
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(0);
+	} else {
+		if (chip->ecc.strength == 0x08)
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(7);
+		else if (chip->ecc.strength == 0x04)
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(3);
+		else if (chip->ecc.strength == 0x02)
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(1);
+		else
+			phytium_nand->ndcr |= NDCR0_ECC_STREN(0);
+	}
+
+	value = phytium_read(nfc, NDCR0);
+	value &= ~NDCR0_EN;
+	phytium_write(nfc, NDCR0, value);
+
+	value &= ~NDCR0_ECC_STREN(7);
+	value |= phytium_nand->ndcr;
+	phytium_write(nfc, NDCR0, value | NDCR0_EN);
+
+	ret = phytium_nand_ecc_init(mtd, &chip->ecc);
+	if (ret) {
+		dev_err(nfc->dev, "ECC init failed: %d\n", ret);
+		goto out;
+	}
+
+	/*
+	 * Subpage write not available with hardware ECC, prohibit also
+	 * subpage read as in userspace subpage access would still be
+	 * allowed and subpage write, if used, would lead to numerous
+	 * uncorrectable ECC errors.
+	 */
+	if (chip->ecc.engine_type == NAND_ECC_ENGINE_TYPE_ON_HOST)
+		chip->options |= NAND_NO_SUBPAGE_WRITE;
+
+	/*
+	 * We keep the MTD name unchanged to avoid breaking platforms
+	 * where the MTD cmdline parser is used and the bootloader
+	 * has not been updated to use the new naming scheme.
+	 */
+	if (nfc->caps->legacy_of_bindings)
+		mtd->name = "phytium_nand-0";
+
+out:
+	return ret;
+}
+
+static void phytium_nand_chips_cleanup(struct phytium_nfc *nfc)
+{
+	struct phytium_nand_chip *entry, *temp;
+
+	list_for_each_entry_safe(entry, temp, &nfc->chips, node) {
+		/* Unregister device */
+		WARN_ON(mtd_device_unregister(nand_to_mtd(&entry->chip)));
+		nand_cleanup(&entry->chip);
+		list_del(&entry->node);
+	}
+}
+
+static int phytium_nfc_init_dma(struct phytium_nfc *nfc)
+{
+	int ret;
+
+	ret = dma_set_mask_and_coherent(nfc->dev, DMA_BIT_MASK(64));
+	if (ret)
+		return ret;
+
+	nfc->dsp_addr = dma_alloc_coherent(nfc->dev, PAGE_SIZE,
+					&nfc->dsp_phy_addr, GFP_KERNEL | GFP_DMA);
+	if (!nfc->dsp_addr)
+		return -ENOMEM;
+
+	nfc->dma_buf = dma_alloc_coherent(nfc->dev, MAX_CHUNK_SIZE,
+					&nfc->dma_phy_addr, GFP_KERNEL | GFP_DMA);
+	if (!nfc->dma_buf)
+		return -ENOMEM;
+
+	dev_info(nfc->dev, "NFC address dsp_phy_addr:%llx, dma_phy_addr:%llx\n",
+					nfc->dsp_phy_addr, nfc->dma_phy_addr);
+
+	return 0;
+}
+
+int phytium_nfc_init(struct phytium_nfc *nfc)
+{
+	u32 value;
+
+	nfc->inter_mode = ASYN_SDR;
+	nfc->timing_mode = ASY_MODE0;
+
+	value = phytium_read(nfc, NDCR1);
+	value &= (~NDCR1_SAMPL_PHASE(0xFFFF));
+	value &= ~NDCR1_ECC_DATA_FIRST_EN;
+	value |= NDCR1_SAMPL_PHASE(1);
+	value |= NDCR1_ECC_BYPASS;
+	phytium_write(nfc, NDCR1, value);
+	phytium_write(nfc, ND_INTERVAL_TIME, 1);
+	phytium_write(nfc, NDFIFO_LEVEL0, 4);
+	phytium_write(nfc, NDFIFO_LEVEL1, 4);
+	phytium_write(nfc, NDFIFO_CLR, 1);
+	phytium_write(nfc, ND_ERR_CLR, 1);
+
+	/* Configure the DMA  */
+	phytium_nfc_init_dma(nfc);
+
+	phytium_nfc_reset(nfc);
+
+	value = phytium_read(nfc, NDCR0);
+	value &= (~NDCR0_IN_MODE(3));
+	value |= NDCR0_IN_MODE(nfc->inter_mode);
+	value |= NDCR0_EN;
+
+	phytium_write(nfc, NDCR0, value);
+
+	nfc_ecc_errover = 0;
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nfc_init);
+
+static int phytium_nfc_setup_interface(struct nand_chip *chip, int chipnr,
+				       const struct nand_interface_config *conf)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	unsigned int period_ns = 2;
+	const struct nand_sdr_timings *sdr;
+	struct phytium_nfc_timings nfc_tmg;
+	int read_delay;
+
+	sdr = nand_get_sdr_timings(conf);
+	if (IS_ERR(sdr))
+		return PTR_ERR(sdr);
+
+	nfc_tmg.tRP = TO_CYCLES(DIV_ROUND_UP(sdr->tRC_min, 2), period_ns) - 1;
+	nfc_tmg.tRH = nfc_tmg.tRP;
+	nfc_tmg.tWP = TO_CYCLES(DIV_ROUND_UP(sdr->tWC_min, 2), period_ns) - 1;
+	nfc_tmg.tWH = nfc_tmg.tWP;
+	nfc_tmg.tCS = TO_CYCLES(sdr->tCS_min, period_ns);
+	nfc_tmg.tCH = TO_CYCLES(sdr->tCH_min, period_ns) - 1;
+	nfc_tmg.tADL = TO_CYCLES(sdr->tADL_min, period_ns);
+	dev_info(nfc->dev, "[nfc_tmg]tRP: %d, tRH:%d, tWP:%d tWH:%d\n",
+		nfc_tmg.tRP, nfc_tmg.tRH, nfc_tmg.tWP, nfc_tmg.tWH);
+	dev_info(nfc->dev, "[nfc_tmg]tCS: %d, tCH:%d, tADL:%d\n",
+		nfc_tmg.tCS, nfc_tmg.tCH, nfc_tmg.tADL);
+
+	read_delay = sdr->tRC_min >= 30000 ?
+		MIN_RD_DEL_CNT : MIN_RD_DEL_CNT + nfc_tmg.tRH;
+
+	nfc_tmg.tAR = TO_CYCLES(sdr->tAR_min, period_ns);
+	nfc_tmg.tWHR = TO_CYCLES(max_t(int, sdr->tWHR_min, sdr->tCCS_min),
+				 period_ns) - 2,
+	nfc_tmg.tRHW = TO_CYCLES(max_t(int, sdr->tRHW_min, sdr->tCCS_min),
+				 period_ns);
+	dev_info(nfc->dev, "[nfc_tmg]tAR: %d, tWHR:%d, tRHW:%d\n",
+		nfc_tmg.tAR, nfc_tmg.tWHR, nfc_tmg.tRHW);
+
+	nfc_tmg.tR = TO_CYCLES(sdr->tWB_max, period_ns);
+
+	if (chipnr < 0)
+		return 0;
+
+	if (nfc_tmg.tWP > 0x10)
+		nfc->timing_mode = ASY_MODE1;
+	else if (nfc_tmg.tWP < 0x0D)
+		nfc->timing_mode = ASY_MODE3;
+
+	if (nfc->inter_mode == ONFI_DDR)
+		nfc->timing_mode = SYN_MODE3;
+
+	phytium_nfc_default_data_interface(nfc);
+
+	return 0;
+}
+
+static int phytium_nand_chip_init(struct phytium_nfc *nfc)
+{
+	struct device *dev = nfc->dev;
+	struct phytium_nand_chip *phytium_nand;
+	struct mtd_info *mtd;
+	struct nand_chip *chip;
+	int ret;
+
+	/* Alloc the nand chip structure */
+	phytium_nand = devm_kzalloc(dev, sizeof(*phytium_nand), GFP_KERNEL);
+	if (!phytium_nand)
+		return -ENOMEM;
+
+	phytium_nand->nsels = 1;
+	phytium_nand->selected_die = -1;
+
+	chip = &phytium_nand->chip;
+	chip->controller = &nfc->controller;
+	chip->legacy.select_chip = phytium_nfc_select_chip;
+	phytium_nfc_default_data_interface(nfc);
+
+	mtd = nand_to_mtd(chip);
+	mtd->dev.parent = dev;
+	mtd->owner = THIS_MODULE;
+
+	/*
+	 * Default to HW ECC engine mode. If the nand-ecc-mode property is given
+	 * in the DT node, this entry will be overwritten in nand_scan_ident().
+	 */
+	chip->ecc.engine_type = NAND_ECC_ENGINE_TYPE_ON_HOST;
+
+	chip->options |= NAND_BUSWIDTH_AUTO;
+	chip->options |= NAND_SKIP_BBTSCAN;
+	chip->bbt_options |= NAND_BBT_NO_OOB;
+
+	ret = nand_scan(chip, phytium_nand->nsels);
+	if (ret) {
+		dev_err(dev, "could not scan the nand chip\n");
+		goto out;
+	}
+
+	if (nfc->caps->parts) {
+		ret = mtd_device_register(mtd, nfc->caps->parts, nfc->caps->nr_parts - 1);
+	} else if (dev->of_node) {
+		nand_set_flash_node(chip, dev->of_node);
+		ret = mtd_device_register(mtd, NULL, 0);
+	} else {
+		ret = -EINVAL;
+	}
+
+	if (ret) {
+		dev_err(dev, "failed to register mtd device: %d\n", ret);
+		/* Unregister device */
+		WARN_ON(mtd_device_unregister(mtd));
+		nand_cleanup(mtd_to_nand(mtd));
+		return ret;
+	}
+
+	phytium_nand->ecc.length = phytium_nand_get_ecc_total(mtd, &chip->ecc);
+	phytium_nand->ecc.offset = mtd->oobsize - phytium_nand->ecc.length;
+	chip->ecc.total = phytium_nand_get_ecc_total(mtd, &chip->ecc);
+
+	mtd_ooblayout_ecc(mtd, 0, &phytium_nand->ecc);
+
+	dev_info(dev, "ooblayout ecc offset: %x, length: %x\n",
+		 phytium_nand->ecc.offset, phytium_nand->ecc.length);
+
+out:
+	list_add_tail(&phytium_nand->node, &nfc->chips);
+	return 0;
+}
+
+static const struct nand_controller_ops phytium_nand_controller_ops = {
+	.attach_chip = phytium_nand_attach_chip,
+	.exec_op = phytium_nfc_exec_op,
+	.setup_interface = phytium_nfc_setup_interface,
+};
+
+int phytium_nand_init(struct phytium_nfc *nfc)
+{
+	int ret;
+
+	nand_controller_init(&nfc->controller);
+	nfc->controller.ops = &phytium_nand_controller_ops;
+	INIT_LIST_HEAD(&nfc->chips);
+
+	/* Init the controller and then probe the chips */
+	ret = phytium_nfc_init(nfc);
+	if (ret)
+		goto out;
+
+	ret = phytium_nand_chip_init(nfc);
+	if (ret)
+		goto out;
+
+	spin_lock_init(&nfc->spinlock);
+
+out:
+	return ret;
+}
+EXPORT_SYMBOL_GPL(phytium_nand_init);
+
+int phytium_nand_remove(struct phytium_nfc *nfc)
+{
+	phytium_nand_chips_cleanup(nfc);
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nand_remove);
+
+static int phytium_nfc_wait_ndrun(struct nand_chip *chip)
+{
+	struct phytium_nfc *nfc = to_phytium_nfc(chip->controller);
+	int ret = 0;
+	u32 val;
+
+	ret = readl_relaxed_poll_timeout(nfc->regs + NDSR, val,
+					 (val & NDSR_RB) == 0,
+					 0, 100 * 1000);
+	if (ret) {
+		dev_err(nfc->dev, "Timeout on NAND controller run mode\n");
+		ret = -EAGAIN;
+	}
+
+	return ret;
+}
+
+int phytium_nand_prepare(struct phytium_nfc *nfc)
+{
+	struct phytium_nand_chip *chip = NULL;
+
+	list_for_each_entry(chip, &nfc->chips, node)
+		phytium_nfc_wait_ndrun(&chip->chip);
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nand_prepare);
+
+int phytium_nand_resume(struct phytium_nfc *nfc)
+{
+	nfc->selected_chip = NULL;
+	phytium_nfc_init(nfc);
+	phytium_nfc_default_data_interface(nfc);
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(phytium_nand_resume);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium NAND controller platform driver");
+MODULE_AUTHOR("Zhu Mingshuai <zhumingshuai@phytium.com.cn>");

--- a/drivers/mtd/nand/raw/phytium_nand.h
+++ b/drivers/mtd/nand/raw/phytium_nand.h
@@ -1,0 +1,449 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Phytium NAND flash controller driver
+ *
+ * Copyright (C) 2020-2023, Phytium Technology, Co., Ltd.
+ */
+#ifndef PHYTIUM_NAND_H
+#define PHYTIUM_NAND_H
+
+#include <linux/module.h>
+#include <linux/clk.h>
+#include <linux/mtd/rawnand.h>
+#include <linux/of_platform.h>
+#include <linux/iopoll.h>
+#include <linux/interrupt.h>
+#include <linux/slab.h>
+#include <linux/mfd/syscon.h>
+#include <linux/regmap.h>
+#include <asm/unaligned.h>
+#include <linux/dma-mapping.h>
+#include <linux/workqueue.h>
+#include <linux/mtd/partitions.h>
+
+/* NFC does not support transfers of larger chunks at a time */
+#define MAX_PAGE_NUM		16
+#define MAX_CHUNK_SIZE		((1024 + 76) * 16)
+
+#define POLL_PERIOD		0
+#define POLL_TIMEOUT		100000
+/* Interrupt maximum wait period in ms */
+#define IRQ_TIMEOUT		1000
+
+/* Latency in clock cycles between SoC pins and NFC logic */
+#define MIN_RD_DEL_CNT		3
+
+#define PHYTIUM_NFC_ADDR_MAX_LEN 5
+#define PHYTIUM_NFC_DSP_SIZE    16
+
+/* NAND controller flash control register */
+#define NDCR0			0x00
+#define NDCR0_EN		BIT(0)
+#define NDCR0_WIDTH		BIT(1)
+#define NDCR0_IN_MODE(x)	(min_t(u32, x, 0x3) << 2)
+#define NDCR0_ECC_EN		BIT(4)
+#define NDCR0_ECC_STREN(x)	(min_t(u32, x, 0x7) << 5)
+#define NDCR0_SPARE_EN		BIT(8)
+#define NDCR0_SPARE_SIZE(x)	(min_t(u32, x, 0xFFF) << 9)
+#define NDCR0_GENERIC_FIELDS_MASK
+
+#define NDCR1			0x04
+#define NDCR1_SAMPL_PHASE(x)	min_t(u32, x, 0xFFFF)
+#define NDCR1_ECC_DATA_FIRST_EN BIT(16)
+#define NDCR1_RB_SHARE_EN       BIT(17)
+#define NDCR1_ECC_BYPASS        BIT(18)
+
+#define NDAR0			0x08
+
+#define NDAR1			0x0C
+#define NDAR1_H8(x)		min_t(u32, x, 0xFF)
+#define NDAR1_DMA_EN		BIT(8)
+#define NDAR1_EMPTY(x)		(min_t(u32, x, 0x7F) << 9)
+#define NDAR1_DMA_RLEN(x)	(min_t(u32, x, 0xFF) << 9)
+#define NDAR1_DMA_WLEN(x)	(min_t(u32, x, 0xFF) << 9)
+
+#define NDTR0			0x10
+#define NDTR0_TCS_TCLS(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR0_TCLS_TWP(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR1			0x14
+#define NDTR1_TWH(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR1_TWP(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR2			0x18
+#define NDTR2_TCH_TCLH(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR2_TCLH_TWH(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR3			0x1c
+#define NDTR3_TDQ_EN(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR3_TCH_TWH(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR4			0x20
+#define NDTR4_TWHR_SMX(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR4_TREH(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR5			0x24
+#define NDTR5_TRC(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR5_TADL_SMX(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR6			0x28
+#define NDTR6_TCAD_TCS_SMX(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR6_RES(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR7			0x2c
+#define NDTR7_TCK(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR7_TDQ_EN(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR8			0x30
+#define NDTR8_TCAD_TCK_SMX(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR8_HF_TCK(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR9			0x34
+#define NDTR9_TWHR(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR9_TCCS_TCALS_SMX(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR10			0x38
+#define NDTR10_TCK(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR10_MTCK(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR11			0x3c
+#define NDTR11_TCK_TCALS(x)	(min_t(u32, x, 0xFFFF) << 16)
+#define NDTR11_RES(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR12			0x40
+#define NDTR12_TWRCK(x)		(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR12_RES(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR13			0x44
+#define NDTR13_TWRHCA(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR13_TRLCA(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR14			0x48
+#define NDTR14_TWRHCE(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR14_RES(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR15			0x4c
+#define NDTR15_TCDQSS_TWPRE_TDS(x) (min_t(u32, x, 0xFFFF) << 0)
+#define NDTR15_HFTDSC(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR16			0x50
+#define NDTR16_TWPST_TDH(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR16_TWPSTH(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR17			0x54
+#define NDTR17_TCS_TRPRE(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR17_TRELDQS(x)	(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDTR18			0x58
+#define NDTR18_TRPST_TDQSRE(x)	(min_t(u32, x, 0xFFFF) << 0)
+#define NDTR18_RES(x)		(min_t(u32, x, 0xFFFF) << 16)
+
+#define NDFIFO			0x5c
+#define NDFIFO_REV		(min_t(u32, x, 0) << 12)
+#define NDFIFO_FULL		BIT(11)
+#define NDFIFO_EMP		BIT(10)
+#define NDFIFO_CNT(x)		(min_t(u32, x, 0x3F) << 0)
+
+#define ND_INTERVAL_TIME	0x60
+#define NDCMD_INTERVAL_TIME	0x64
+#define NDFIFO_TIMEOUT		0x68
+#define NDFIFO_LEVEL0		0x6c
+#define NDFIFO_LEVEL1		0x70
+#define NDWP			0x74
+#define NDFIFO_CLR		0x78
+
+#define NDSR			0x7c
+#define NDSR_BUSY		BIT(0)
+#define NDSR_DMA_BUSY		BIT(1)
+#define NDSR_DMA_PGFINISH	BIT(2)
+#define NDSR_DMA_FINISH		BIT(3)
+#define NDSR_FIFO_EMP		BIT(4)
+#define NDSR_FIFO_FULL		BIT(5)
+#define NDSR_FIFO_TIMEOUT	BIT(6)
+#define NDSR_CS(x)		(min_t(u32, x, 0xF) << 7)
+#define NDSR_CMD_PGFINISH	BIT(11)
+#define NDSR_PG_PGFINISH	BIT(12)
+#define NDSR_RE			BIT(13)
+#define NDSR_DQS		BIT(14)
+#define NDSR_RB			BIT(15)
+#define NDSR_ECC_BUSY		BIT(16)
+#define NDSR_ECC_FINISH		BIT(17)
+#define NDSR_ECC_RIGHT		BIT(18)
+#define NDSR_ECC_ERR		BIT(19)
+#define NDSR_ECC_ERROVER	BIT(20)
+#define NDSR_AXI_DSP_ERR	BIT(21)
+#define NDSR_AXI_RD_ERR		BIT(22)
+#define NDSR_AXI_WR_ERR		BIT(23)
+#define NDSR_RB_STATUS(x)       (min_t(u32, x, 0xF) << 24)
+#define NDSR_PROT_ERR           BIT(28)
+#define NDSR_ECC_BYPASS         BIT(29)
+
+#define NDIR_MASK		0x80
+#define NDIR_BUSY_MASK		BIT(0)
+#define NDIR_DMA_BUSY_MASK	BIT(1)
+#define NDIR_DMA_PGFINISH_MASK	BIT(2)
+#define NDIR_DMA_FINISH_MASK	BIT(3)
+#define NDIR_FIFO_EMP_MASK	BIT(4)
+#define NDIR_FIFO_FULL_MASK	BIT(5)
+#define NDIR_FIFO_TIMEOUT_MASK	BIT(6)
+#define NDIR_CMD_FINISH_MASK	BIT(7)
+#define NDIR_PGFINISH_MASK	BIT(8)
+#define NDIR_RE_MASK		BIT(9)
+#define NDIR_DQS_MASK		BIT(10)
+#define NDIR_RB_MASK		BIT(11)
+#define NDIR_ECC_FINISH_MASK	BIT(12)
+#define NDIR_ECC_ERR_MASK	BIT(13)
+
+#define NDIR			0x84
+#define NDIR_ALL_INT(x)		GENMASK(x, 0)
+#define NDIR_BUSY		BIT(0)
+#define NDIR_DMA_BUSY		BIT(1)
+#define NDIR_DMA_PGFINISH	BIT(2)
+#define NDIR_DMA_FINISH		BIT(3)
+#define NDIR_FIFO_EMP		BIT(4)
+#define NDIR_FIFO_FULL		BIT(5)
+#define NDIR_FIFO_TIMEOUT	BIT(6)
+#define NDIR_CMD_FINISH		BIT(7)
+#define NDIR_PGFINISH		BIT(8)
+#define NDIR_RE			BIT(9)
+#define NDIR_DQS		BIT(10)
+#define NDIR_RB			BIT(11)
+#define NDIR_ECC_FINISH		BIT(12)
+#define NDIR_ECC_ERR		BIT(13)
+
+#define ND_DEBUG		0x88
+
+#define ND_ERR_CLR		0x8c
+#define ND_DSP_ERR_CLR		BIT(0)
+#define ND_AXI_RD_ERR_CLR	BIT(1)
+#define ND_AXI_WR_ERR_CLR	BIT(2)
+#define ND_ECC_ERR_CLR		BIT(3)
+
+#define NDCR_PAGE_SZ(x)		(x >= 2048 ? BIT(24) : 0)
+
+enum nand_inter_pro {
+	NAND_ONFI,
+	NAND_JEDEC,
+	NAND_OTHER,
+};
+
+enum nand_inter_mode {
+	ASYN_SDR,
+	ONFI_DDR,
+	TOG_ASYN_DDR,
+};
+
+enum asy_timing_mode {
+	ASY_MODE0,
+	ASY_MODE1,
+	ASY_MODE2,
+	ASY_MODE3,
+	ASY_MODE4,
+};
+
+enum onfi_syn_timing_mode {
+	SYN_MODE0 = 0x10,
+	SYN_MODE1,
+	SYN_MODE2,
+	SYN_MODE3,
+	SYN_MODE4,
+};
+
+/**
+ * NAND controller timings expressed in NAND Controller clock cycles
+ *
+ * @tRP:	ND_nRE pulse width
+ * @tRH:	ND_nRE high duration
+ * @tWP:	ND_nWE pulse time
+ * @tWH:	ND_nWE high duration
+ * @tCS:	Enable signal setup time
+ * @tCH:	Enable signal hold time
+ * @tADL:	Address to write data delay
+ * @tAR:	ND_ALE low to ND_nRE low delay
+ * @tWHR:	ND_nWE high to ND_nRE low for status read
+ * @tRHW:	ND_nRE high duration, read to write delay
+ * @tR:		ND_nWE high to ND_nRE low for read
+ */
+struct phytium_nfc_timings {
+	u16 tRP;
+	u16 tRH;
+	u16 tWP;       /* NDTR1_TWP */
+	u16 tWH;       /* NDTR1_TWH */
+	u16 tCS;
+	u16 tCH;
+	u16 tADL;
+	u16 tAR;
+	u16 tWHR;
+	u16 tRHW;
+	u16 tR;
+};
+
+/**
+ * NAND chip structure: stores NAND chip device related information
+ *
+ * @chip:		Base NAND chip structure
+ * @node:		Used to store NAND chips into a list
+ * @ndcr:		Controller register value for this NAND chip
+ * @ndtr0:		Timing registers 0 value for this NAND chip
+ * @ndtr1:		Timing registers 1 value for this NAND chip
+ * @selected_die:	Current active CS
+ * @nsels:		Number of CS lines required by the NAND chip
+ */
+struct phytium_nand_chip {
+	struct nand_chip chip;
+	struct list_head node;
+	u32 ndcr;
+	u32 ndtr0;
+	u32 ndtr1;
+	int addr_cyc;
+	int selected_die;
+	unsigned int nsels;
+	struct mtd_oob_region ecc;
+};
+
+/**
+ * NAND controller capabilities for distinction between compatible strings
+ *
+ * @max_cs_nb:		Number of Chip Select lines available
+ * @max_rb_nb:		Number of Ready/Busy lines available
+ * @legacy_of_bindings:	Indicates if DT parsing must be done using the old
+ *			fashion way
+ * @flash_bbt:
+ * @ecc_strength:
+ * @ecc_step_size:
+ * @parts:
+ * @nr_parts:
+ */
+struct phytium_nfc_caps {
+	unsigned int hw_ver;
+	unsigned int int_mask_bits;
+	unsigned int max_cs_nb;
+	unsigned int max_rb_nb;
+	bool legacy_of_bindings;
+	bool flash_bbt;
+	int ecc_strength;
+	int ecc_step_size;
+	struct mtd_partition *parts;
+	unsigned int nr_parts;
+};
+
+/**
+ * NAND controller structure: stores Marvell NAND controller information
+ *
+ * @controller:		Base controller structure
+ * @dev:		Parent device (used to print error messages)
+ * @regs:		NAND controller registers
+ * @reg_clk:		Regiters clock
+ * @complete:		Completion object to wait for NAND controller events
+ * @chips:		List containing all the NAND chips attached to
+ *			this NAND controller
+ * @caps:		NAND controller capabilities for each compatible string
+ * @dma_buf:		32-bit aligned buffer for DMA transfers (NFCv1 only)
+ */
+struct phytium_nfc {
+	struct nand_controller controller;
+	struct device *dev;
+	void __iomem *regs;
+	int irq;
+	struct list_head chips;
+	struct nand_chip *selected_chip;
+	struct phytium_nfc_caps *caps;
+
+	void *dsp_addr;
+	dma_addr_t dsp_phy_addr;
+
+	void *dma_buf;
+	u32 dma_offset;
+	dma_addr_t dma_phy_addr;
+
+	enum nand_inter_pro inter_pro;
+	enum nand_inter_mode inter_mode;
+	u32 timing_mode;
+
+	spinlock_t spinlock;
+};
+
+/**
+ * Derives a duration in numbers of clock cycles.
+ *
+ * @ps: Duration in pico-seconds
+ * @period_ns:  Clock period in nano-seconds
+ *
+ * Convert the duration in nano-seconds, then divide by the period and
+ * return the number of clock periods.
+ */
+#define TO_CYCLES(ps, period_ns) (DIV_ROUND_UP(ps / 1000, period_ns))
+#define TO_CYCLES64(ps, period_ns) (DIV_ROUND_UP_ULL(div_u64(ps, 1000), \
+						     period_ns))
+
+struct phytium_nfc_cmd_ctrl {
+	u16 csel:4;
+	u16 dbc:1;
+	u16 addr_cyc:3;
+	u16 nc:1;
+#define TYPE_RESET         0x00
+#define TYPE_SET_FTR       0x01
+#define TYPE_GET_FTR       0x02
+#define TYPE_READ_ID       0x03
+#define TYPE_PAGE_PRO      0x04
+#define TYPE_ERASE         0x05
+#define TYPE_READ          0x06
+#define TYPE_TOGGLE        0x07
+#define TYPE_READ_PARAM    0x02
+#define TYPE_READ_STATUS   0x03
+#define TYPE_CH_READ_COL   0x03
+#define TYPE_CH_ROW_ADDR   0x01
+#define TYPE_CH_WR_COL     0x01
+	u16 cmd_type:4;
+	u16 dc:1;
+	u16 auto_rs:1;
+	u16 ecc_en:1;
+};
+
+/**
+ * NAND driver structure filled during the parsing of the ->exec_op() subop
+ * subset of instructions.
+ *
+ * @cle_ale_delay_ns:	Optional delay after the last CMD or ADDR cycle
+ * @rdy_timeout_ms:	Timeout for waits on Ready/Busy pin
+ * @rdy_delay_ns:	Optional delay after waiting for the RB pin
+ * @data_delay_ns:	Optional delay after the data xfer
+ * @data_instr_idx:	Index of the data instruction in the subop
+ * @data_instr:		Pointer to the data instruction in the subop
+ */
+struct phytium_nfc_op {
+	u8 cmd[2];
+	union {
+		u16 ctrl;
+		struct phytium_nfc_cmd_ctrl nfc_ctrl;
+	} cmd_ctrl;
+	u8 addr[PHYTIUM_NFC_ADDR_MAX_LEN];
+	u16 page_cnt;
+	u8 mem_addr_first[PHYTIUM_NFC_ADDR_MAX_LEN];
+
+	u32 cmd_len;
+	u32 addr_len;
+
+	u32 cle_ale_delay_ns;
+	u32 rdy_timeout_ms;
+	u32 rdy_delay_ns;
+	u32 data_delay_ns;
+	u32 data_instr_idx;
+	struct nand_op_instr *data_instr;
+} __packed;
+
+#define TIMING_ASY_NUM 12
+#define TIMING_SYN_NUM 14
+#define TIMING_TOG_NUM 12
+
+#define TMP_DMA_DEBUG 0    /* Temporary dma space */
+
+int phytium_nand_init(struct phytium_nfc *nfc);
+int phytium_nand_remove(struct phytium_nfc *nfc);
+int phytium_nand_prepare(struct phytium_nfc *nfc);
+int phytium_nand_suspend(struct phytium_nfc *nfc);
+int phytium_nand_resume(struct phytium_nfc *nfc);
+
+irqreturn_t phytium_nfc_isr(int irq, void *dev_id);
+
+#endif /* NAND_PHYTIUM_NAND_H */

--- a/drivers/mtd/nand/raw/phytium_nand_pci.c
+++ b/drivers/mtd/nand/raw/phytium_nand_pci.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * PCI driver for Phytium NAND flash controller
+ *
+ * Copyright (C) 2021-2023, Phytium Technology Co., Ltd.
+ */
+#include <linux/module.h>
+#include <linux/pci.h>
+#include <linux/device.h>
+
+#include "phytium_nand.h"
+
+#define DRV_NAME	"phytium_nand_pci"
+
+static struct mtd_partition partition_info[] = {
+	{
+		.name = "Flash partition 1",
+		.offset =  0x0000000,
+		.size =    0x4000000 },
+	{
+		.name = "Flash partition 2",
+		.offset =  0x4000000,
+		.size =    0x8000000 },
+	{
+		.name = "Flash partition 3",
+		.offset =  0x8000000,
+		.size =    0x10000000 },
+	{
+		.name = "Flash partition 4",
+		.offset =  0x10000000,
+		.size =    0x12000000 },
+	{
+		.name = "Flash partition 5",
+		.offset =  0x12000000,
+		.size =    0x14000000 },
+};
+
+static struct phytium_nfc_caps x100_nfc_caps = {
+	.hw_ver = 1,
+	.int_mask_bits = 13,
+	.max_cs_nb = 2,
+	.max_rb_nb = 1,
+	.legacy_of_bindings = true,
+	.ecc_strength = 4,
+	.ecc_step_size = 512,
+	.nr_parts = 5,
+	.parts = partition_info,
+};
+
+static int phytium_pci_probe(struct pci_dev *pdev, const struct pci_device_id *pid)
+{
+	struct phytium_nfc *nfc;
+	int ret;
+
+	ret = pcim_enable_device(pdev);
+	if (ret)
+		return ret;
+
+	ret = pcim_iomap_regions(pdev, 0x1, pci_name(pdev));
+	if (ret) {
+		dev_err(&pdev->dev, "I/O memory remapping failed\n");
+		return ret;
+	}
+
+	pci_set_master(pdev);
+	pci_try_set_mwi(pdev);
+
+	nfc = devm_kzalloc(&pdev->dev, sizeof(struct phytium_nfc),
+			   GFP_KERNEL);
+	if (!nfc)
+		return -ENOMEM;
+
+	nfc->dev = &pdev->dev;
+	nfc->regs = pcim_iomap_table(pdev)[0];
+	nfc->irq = pdev->irq;
+	nfc->caps = &x100_nfc_caps;
+
+	ret = devm_request_irq(nfc->dev, nfc->irq, phytium_nfc_isr,
+			       IRQF_SHARED, "phytium-nfc-pci", nfc);
+	if (ret) {
+		dev_err(nfc->dev, "Failed to register NFC interrupt.\n");
+		return ret;
+	}
+
+	ret = phytium_nand_init(nfc);
+	if (ret)
+		return ret;
+
+	pci_set_drvdata(pdev, nfc);
+
+	return ret;
+}
+
+static void phytium_pci_remove(struct pci_dev *pdev)
+{
+	struct phytium_nfc *nfc = pci_get_drvdata(pdev);
+	int ret;
+
+	ret = phytium_nand_remove(nfc);
+	if (ret)
+		dev_warn(&pdev->dev, "can't remove device properly: %d\n", ret);
+}
+
+static int __maybe_unused phytium_nfc_prepare(struct device *dev)
+{
+	struct pci_dev *pci = to_pci_dev(dev);
+	struct phytium_nfc *nfc = pci_get_drvdata(pci);
+	int ret;
+
+	ret = phytium_nand_prepare(nfc);
+
+	return 0;
+}
+
+static int __maybe_unused phytium_nfc_resume(struct device *dev)
+{
+	struct pci_dev *pci = to_pci_dev(dev);
+	struct phytium_nfc *nfc = pci_get_drvdata(pci);
+	int ret;
+
+	ret = phytium_nand_resume(nfc);
+
+	return ret;
+}
+
+static const struct dev_pm_ops phytium_pci_dev_pm_ops = {
+	.prepare = phytium_nfc_prepare,
+	.resume = phytium_nfc_resume,
+};
+
+static const struct pci_device_id phytium_pci_id_table[] = {
+	{ PCI_VDEVICE(PHYTIUM, 0xdc29) },
+	{ }
+};
+MODULE_DEVICE_TABLE(pci, phytium_pci_id_table);
+
+static struct pci_driver phytium_pci_driver = {
+	.name		= DRV_NAME,
+	.id_table	= phytium_pci_id_table,
+	.probe		= phytium_pci_probe,
+	.remove		= phytium_pci_remove,
+	.driver	= {
+		.pm	= &phytium_pci_dev_pm_ops,
+	},
+};
+module_pci_driver(phytium_pci_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("PCI driver for Phytium NAND controller");
+MODULE_AUTHOR("Zhu Mingshuai <zhumingshuai@phytium.com.cn>");

--- a/drivers/mtd/nand/raw/phytium_nand_plat.c
+++ b/drivers/mtd/nand/raw/phytium_nand_plat.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Core driver for Phytium NAND flash controller
+ *
+ * Copyright (C) 2020-2023, Phytium Technology Co., Ltd.
+ */
+
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/clk.h>
+#include <linux/pm_runtime.h>
+#include <linux/platform_device.h>
+#include <linux/dmaengine.h>
+#include <linux/dma-mapping.h>
+#include <linux/of.h>
+#include <linux/of_dma.h>
+#include <linux/acpi.h>
+#include <linux/acpi_dma.h>
+
+#include "phytium_nand.h"
+
+#define DRV_NAME	"phytium_nand_plat"
+
+static int phytium_nfc_plat_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct resource *r;
+	struct phytium_nfc *nfc;
+	unsigned int ecc_strength;
+	unsigned int ecc_step_size;
+	int ret;
+
+	nfc = devm_kzalloc(&pdev->dev, sizeof(struct phytium_nfc),
+			   GFP_KERNEL);
+	if (!nfc)
+		return -ENOMEM;
+
+	nfc->dev = dev;
+
+	r = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	nfc->regs = devm_ioremap_resource(dev, r);
+	if (IS_ERR(nfc->regs))
+		return PTR_ERR(nfc->regs);
+
+	dev_info(nfc->dev, "NFC register address :%p, phy address:%llx\n",
+				nfc->regs, r->start);
+
+	nfc->irq = platform_get_irq(pdev, 0);
+	if (nfc->irq < 0) {
+		dev_err(dev, "failed to retrieve irq\n");
+		return nfc->irq;
+	}
+
+	ret = devm_request_irq(dev, nfc->irq, phytium_nfc_isr, 0,
+			       "phytium-nfc-plat", nfc);
+	if (ret) {
+		dev_err(nfc->dev, "Failed to register NFC interrupt.\n");
+		return ret;
+	}
+
+	nfc->caps = devm_kzalloc(dev, sizeof(struct phytium_nfc_caps), GFP_KERNEL);
+	if (!nfc->caps)
+		return -ENOMEM;
+
+	/* Currently hard-coded parameters */
+	nfc->caps->hw_ver = 2;
+	nfc->caps->int_mask_bits = 17;
+	nfc->caps->max_cs_nb = 4;
+	nfc->caps->max_rb_nb = 4;
+	nfc->caps->nr_parts = 0;
+	nfc->caps->parts = NULL;
+
+	device_property_read_u32(&pdev->dev, "nand-ecc-strength", &ecc_strength);
+	nfc->caps->ecc_strength = ecc_strength ? ecc_strength : 8;
+
+	device_property_read_u32(&pdev->dev, "nand-ecc-step-size", &ecc_step_size);
+	nfc->caps->ecc_step_size = ecc_step_size ? ecc_step_size : 512;
+
+	ret = phytium_nand_init(nfc);
+	if (ret)
+		return ret;
+
+	platform_set_drvdata(pdev, nfc);
+
+	return ret;
+}
+
+static int phytium_nfc_plat_remove(struct platform_device *pdev)
+{
+	struct phytium_nfc *nfc = platform_get_drvdata(pdev);
+
+	return phytium_nand_remove(nfc);
+}
+
+static int __maybe_unused phytium_nfc_plat_prepare(struct device *dev)
+{
+	struct phytium_nfc *nfc = dev_get_drvdata(dev);
+
+	return phytium_nand_prepare(nfc);
+}
+
+static int __maybe_unused phytium_nfc_plat_resume(struct device *dev)
+{
+	struct phytium_nfc *nfc = dev_get_drvdata(dev);
+	int ret;
+
+	ret = phytium_nand_resume(nfc);
+
+	return ret;
+}
+
+static const struct dev_pm_ops phytium_dev_pm_ops = {
+	.prepare = phytium_nfc_plat_prepare,
+	.resume = phytium_nfc_plat_resume,
+};
+
+#ifdef CONFIG_OF
+static const struct of_device_id phytium_nfc_of_ids[] = {
+	{ .compatible = "phytium,nfc", },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, phytium_nfc_of_ids);
+#endif
+
+static struct platform_driver phytium_nfc_plat_driver = {
+	.driver	= {
+		.name		= DRV_NAME,
+		.of_match_table = phytium_nfc_of_ids,
+		.pm		= &phytium_dev_pm_ops,
+	},
+	.probe = phytium_nfc_plat_probe,
+	.remove	= phytium_nfc_plat_remove,
+};
+module_platform_driver(phytium_nfc_plat_driver)
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium NAND controller Platform driver");
+MODULE_AUTHOR("Zhu Mingshuai <zhumingshuai@phytium.com.cn>");


### PR DESCRIPTION
Picked and rebased from #199.

From original pull request:

> "This patch implements a device driver of NAND flash controller for both Phytium PCIe chipset and SoCs. Since interrupt flags depends on the bus implementation, e.g., PCI vs platform, we extract the interrupt register function from NFC driver core."

Builds tested
---

- [x] amd64
- [ ] arm64
- [x] loong64