### PR TITLE
[Intel-SIG] MTL ACPI driver updates sync with upstream (6.9)

### DIFF
--- a/drivers/acpi/scan.c
+++ b/drivers/acpi/scan.c
@@ -794,6 +794,7 @@ static const char * const acpi_honor_dep_ids[] = {
 	"INTC1059", /* IVSC (TGL) driver must be loaded to allow i2c access to camera sensors */
 	"INTC1095", /* IVSC (ADL) driver must be loaded to allow i2c access to camera sensors */
 	"INTC100A", /* IVSC (RPL) driver must be loaded to allow i2c access to camera sensors */
+	"INTC10CF", /* IVSC (MTL) driver must be loaded to allow i2c access to camera sensors */
 	NULL
 };
 


### PR DESCRIPTION
1e518e8333ca,ACPI: scan: Defer enumeration of devices with a _DEP pointing to IVSC device,2024-02-12 18:55:40 +0100,Wentong Wu <wentong.wu@intel.com>,v6.9-rc1
