### PR TITLE
[linux-6.6.y] Add support for Zhaoxin Processors

### DIFF
--- a/arch/x86/include/asm/cpufeatures.h
+++ b/arch/x86/include/asm/cpufeatures.h
@@ -150,6 +150,8 @@
 #define X86_FEATURE_SM2_EN		( 5*32+ 1) /* SM2 Zhaoxin GMI enabled */
 #define X86_FEATURE_XSTORE		( 5*32+ 2) /* "rng" RNG present (xstore) */
 #define X86_FEATURE_XSTORE_EN		( 5*32+ 3) /* "rng_en" RNG enabled */
+#define X86_FEATURE_CCS			( 5*32+ 4) /*  "sm3 sm4" present */
+#define X86_FEATURE_CCS_EN		( 5*32+ 5) /*  "sm3_en sm4_en" enabled */
 #define X86_FEATURE_XCRYPT		( 5*32+ 6) /* "ace" on-CPU crypto (xcrypt) */
 #define X86_FEATURE_XCRYPT_EN		( 5*32+ 7) /* "ace_en" on-CPU crypto enabled */
 #define X86_FEATURE_ACE2		( 5*32+ 8) /* Advanced Cryptography Engine v2 */
@@ -158,6 +160,23 @@
 #define X86_FEATURE_PHE_EN		( 5*32+11) /* PHE enabled */
 #define X86_FEATURE_PMM			( 5*32+12) /* PadLock Montgomery Multiplier */
 #define X86_FEATURE_PMM_EN		( 5*32+13) /* PMM enabled */
+#define X86_FEATURE_ZX_FMA		( 5*32+15) /* FMA supported */
+#define X86_FEATURE_PARALLAX		( 5*32+16) /* Adaptive P-state control present */
+#define X86_FEATURE_PARALLAX_EN		( 5*32+17) /* Adaptive P-state control enabled */
+#define X86_FEATURE_OVERSTRESS		( 5*32+18) /* Overstress for auto overclock present */
+#define X86_FEATURE_OVERSTRESS_EN	( 5*32+19) /* Overstress for auto overclock enabled */
+#define X86_FEATURE_TM3			( 5*32+20) /* Thermal Monitor 3 present */
+#define X86_FEATURE_TM3_EN		( 5*32+21) /* Thermal Monitor 3 enabled */
+#define X86_FEATURE_RNG2		( 5*32+22) /* 2nd generation of RNG present */
+#define X86_FEATURE_RNG2_EN		( 5*32+23) /* 2nd generation of RNG enabled */
+#define X86_FEATURE_SEM			( 5*32+24) /* SME feature present */
+#define X86_FEATURE_PHE2		( 5*32+25) /* SHA384 and SHA 512 present */
+#define X86_FEATURE_PHE2_EN		( 5*32+26) /* SHA384 and SHA 512 enabled */
+#define X86_FEATURE_XMODX		( 5*32+27) /* "rsa" XMODEXP and MONTMUL2 are present */
+#define X86_FEATURE_XMODX_EN		( 5*32+28) /* "rsa_en" XMODEXP and MONTMUL2 are enabled */
+#define X86_FEATURE_VEX			( 5*32+29) /* VEX instructions are present */
+#define X86_FEATURE_VEX_EN		( 5*32+30) /* VEX instructions are enabled */
+#define X86_FEATURE_STK			( 5*32+31) /* STK are present */
 
 /* More extended AMD flags: CPUID level 0x80000001, ECX, word 6 */
 #define X86_FEATURE_LAHF_LM		( 6*32+ 0) /* LAHF/SAHF in long mode */

--- a/arch/x86/kernel/cpu/centaur.c
+++ b/arch/x86/kernel/cpu/centaur.c
@@ -112,6 +112,9 @@ static void early_init_centaur(struct cpuinfo_x86 *c)
 
 	if (cpuid_eax(0xC0000000) >= 0xC0000006)
 		c->x86_capability[CPUID_C000_0006_EAX] = cpuid_eax(0xC0000006);
+
+	if (detect_extended_topology_early(c) < 0)
+		detect_ht_early(c);
 }
 
 static void init_centaur(struct cpuinfo_x86 *c)
@@ -130,11 +133,14 @@ static void init_centaur(struct cpuinfo_x86 *c)
 	clear_cpu_cap(c, 0*32+31);
 #endif
 	early_init_centaur(c);
+	detect_extended_topology(c);
 	init_intel_cacheinfo(c);
-	detect_num_cpu_cores(c);
+	if (!cpu_has(c, X86_FEATURE_XTOPOLOGY)) {
+		detect_num_cpu_cores(c);
 #ifdef CONFIG_X86_32
 	detect_ht(c);
 #endif
+	}
 
 	if (c->cpuid_level > 9) {
 		unsigned int eax = cpuid_eax(10);

--- a/arch/x86/kernel/cpu/zhaoxin.c
+++ b/arch/x86/kernel/cpu/zhaoxin.c
@@ -66,16 +66,21 @@ static void early_init_zhaoxin(struct cpuinfo_x86 *c)
 		set_cpu_cap(c, X86_FEATURE_NONSTOP_TSC);
 	}
 
+	if (detect_extended_topology_early(c) < 0)
+		detect_ht_early(c);
 }
 
 static void init_zhaoxin(struct cpuinfo_x86 *c)
 {
 	early_init_zhaoxin(c);
+	detect_extended_topology(c);
 	init_intel_cacheinfo(c);
-	detect_num_cpu_cores(c);
+	if (!cpu_has(c, X86_FEATURE_XTOPOLOGY)) {
+		detect_num_cpu_cores(c);
 #ifdef CONFIG_X86_32
 	detect_ht(c);
 #endif
+	}
 
 	if (c->cpuid_level > 9) {
 		unsigned int eax = cpuid_eax(10);


### PR DESCRIPTION
Let Linux supports new Zhaoxin CPU features and " Shanghai " CPU vendor ID;
let related drivers supports new Zhaoxin CPU FMS.
Fix a CPU topo limitation of Installed kernel use CPUID B leaf to get CPU topo as default,
add 4leaf get CPU cacheinfo additionally.

Note：
Support for the Zhaoxin processor includes two vendor IDs, zhaoxin and centaur, so we will synchronously modify centaur.c and zhaoxin.c.

Include:

1. x86/cpufeatures: Add Zhaoxin feature bits
2. x86/cpu: Add detect extended topology for Zhaoxin CPUs