### PR TITLE
[linux-6.6.y] x86/mce: Add Centaur MCA support

### DIFF
--- a/arch/x86/kernel/cpu/mce/intel.c
+++ b/arch/x86/kernel/cpu/mce/intel.c
@@ -93,6 +93,7 @@ static int cmci_supported(int *banks)
 	 * makes sure none of the backdoors are entered otherwise.
 	 */
 	if (boot_cpu_data.x86_vendor != X86_VENDOR_INTEL &&
+	    boot_cpu_data.x86_vendor != X86_VENDOR_CENTAUR &&
 	    boot_cpu_data.x86_vendor != X86_VENDOR_ZHAOXIN)
 		return 0;
 


### PR DESCRIPTION
zhaoxin inclusion
category: feature

-------------------
Add MCA support for some Zhaoxin CPUs which use X86_VENDOR_CENTAUR as vendor ID.