### PR TITLE
[linux-6.6.y] Driver for Zhaoxin AES and SHA algorithm

### DIFF
--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -79,6 +79,21 @@ config CRYPTO_DEV_ZHAOXIN_AES
 	  If unsure say M. The compiled module will be
 	  called zhaoxin-aes.
 
+config CRYPTO_DEV_ZHAOXIN_SHA
+	tristate "Zhaoxin ACE driver for SHA1 and SHA256 algorithms"
+	depends on CRYPTO_DEV_ZHAOXIN
+	default CRYPTO_DEV_ZHAOXIN
+	select CRYPTO_HASH
+	select CRYPTO_SHA1
+	select CRYPTO_SHA256
+	help
+	  Use Zhaoxin ACE for SHA1/SHA256 algorithms.
+
+	  Available in Zhaoxin processors.
+
+	  If unsure say M. The compiled module will be
+	  called zhaoxin-sha.
+
 config CRYPTO_DEV_GEODE
 	tristate "Support for the Geode LX AES engine"
 	depends on X86_32 && PCI

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -52,6 +52,33 @@ config CRYPTO_DEV_PADLOCK_SHA
 	  If unsure say M. The compiled module will be
 	  called padlock-sha.
 
+config CRYPTO_DEV_ZHAOXIN
+	tristate "Support for Zhaoxin ACE"
+	depends on X86 && !UML
+	default m
+	help
+	  Some Zhaoxin processors come with an integrated crypto engine
+	  (so called Zhaoxin ACE, Advanced Cryptography Engine)
+	  that provides instructions for very fast cryptographic
+	  operations with supported algorithms.
+
+	  The instructions are used only when the CPU supports them.
+	  Otherwise software encryption is used.
+
+config CRYPTO_DEV_ZHAOXIN_AES
+	tristate "Zhaoxin ACE driver for AES algorithm"
+	depends on CRYPTO_DEV_ZHAOXIN
+	default CRYPTO_DEV_ZHAOXIN
+	select CRYPTO_BLKCIPHER
+	select CRYPTO_AES
+	help
+	  Use Zhaoxin ACE for AES algorithm.
+
+	  Available in Zhaoxin CPUs.
+
+	  If unsure say M. The compiled module will be
+	  called zhaoxin-aes.
+
 config CRYPTO_DEV_GEODE
 	tristate "Support for the Geode LX AES engine"
 	depends on X86_32 && PCI

--- a/drivers/crypto/Makefile
+++ b/drivers/crypto/Makefile
@@ -31,6 +31,7 @@ obj-$(CONFIG_CRYPTO_DEV_OMAP_DES) += omap-des.o
 obj-$(CONFIG_CRYPTO_DEV_OMAP_SHAM) += omap-sham.o
 obj-$(CONFIG_CRYPTO_DEV_PADLOCK_AES) += padlock-aes.o
 obj-$(CONFIG_CRYPTO_DEV_PADLOCK_SHA) += padlock-sha.o
+obj-$(CONFIG_CRYPTO_DEV_ZHAOXIN_AES) += zhaoxin-aes.o
 obj-$(CONFIG_CRYPTO_DEV_PPC4XX) += amcc/
 obj-$(CONFIG_CRYPTO_DEV_QCE) += qce/
 obj-$(CONFIG_CRYPTO_DEV_QCOM_RNG) += qcom-rng.o

--- a/drivers/crypto/Makefile
+++ b/drivers/crypto/Makefile
@@ -32,6 +32,7 @@ obj-$(CONFIG_CRYPTO_DEV_OMAP_SHAM) += omap-sham.o
 obj-$(CONFIG_CRYPTO_DEV_PADLOCK_AES) += padlock-aes.o
 obj-$(CONFIG_CRYPTO_DEV_PADLOCK_SHA) += padlock-sha.o
 obj-$(CONFIG_CRYPTO_DEV_ZHAOXIN_AES) += zhaoxin-aes.o
+obj-$(CONFIG_CRYPTO_DEV_ZHAOXIN_SHA) += zhaoxin-sha.o
 obj-$(CONFIG_CRYPTO_DEV_PPC4XX) += amcc/
 obj-$(CONFIG_CRYPTO_DEV_QCE) += qce/
 obj-$(CONFIG_CRYPTO_DEV_QCOM_RNG) += qcom-rng.o

--- a/drivers/crypto/padlock-sha.c
+++ b/drivers/crypto/padlock-sha.c
@@ -491,7 +491,7 @@ static struct shash_alg sha256_alg_nano = {
 };
 
 static const struct x86_cpu_id padlock_sha_ids[] = {
-	X86_MATCH_FEATURE(X86_FEATURE_PHE, NULL),
+	{ X86_VENDOR_CENTAUR, 6, X86_MODEL_ANY, X86_FEATURE_PHE },
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, padlock_sha_ids);

--- a/drivers/crypto/zhaoxin-aes.c
+++ b/drivers/crypto/zhaoxin-aes.c
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
-/* 
- * Cryptographic API.
- *
- * Support for VIA PadLock hardware crypto engine.
- *
- * Copyright (c) 2004  Michal Ludvig <michal@logix.cz>
- *
+/*
+ * Support for ACE hardware crypto engine.
  */
 
 #include <crypto/algapi.h>
@@ -22,10 +17,12 @@
 #include <linux/percpu.h>
 #include <linux/smp.h>
 #include <linux/slab.h>
+#include <linux/processor.h>
 #include <asm/cpu_device_id.h>
 #include <asm/byteorder.h>
-#include <asm/processor.h>
 #include <asm/fpu/api.h>
+
+#define DRIVER_VERSION "1.0.0"
 
 /*
  * Number of data blocks actually fetched for each xcrypt insn.
@@ -41,27 +38,23 @@ static unsigned int cbc_fetch_blocks = 1;
 
 /* Control word. */
 struct cword {
-	unsigned int __attribute__ ((__packed__))
+	unsigned int __packed
 		rounds:4,
 		algo:3,
 		keygen:1,
 		interm:1,
 		encdec:1,
 		ksize:2;
-} __attribute__ ((__aligned__(PADLOCK_ALIGNMENT)));
+} __aligned(PADLOCK_ALIGNMENT);
 
-/* Whenever making any changes to the following
- * structure *make sure* you keep E, d_data
- * and cword aligned on 16 Bytes boundaries and
- * the Hardware can access 16 * 16 bytes of E and d_data
- * (only the first 15 * 16 bytes matter but the HW reads
- * more).
+/*
+ * Whenever making any changes to the following structure *make sure* you keep E, d_data and cword
+ * aligned on 16 Bytes boundaries and the Hardware can access 16 * 16 bytes of E and d_data (only
+ * the first 15 * 16 bytes matter but the HW reads more).
  */
 struct aes_ctx {
-	u32 E[AES_MAX_KEYLENGTH_U32]
-		__attribute__ ((__aligned__(PADLOCK_ALIGNMENT)));
-	u32 d_data[AES_MAX_KEYLENGTH_U32]
-		__attribute__ ((__aligned__(PADLOCK_ALIGNMENT)));
+	u32 E[AES_MAX_KEYLENGTH_U32] __aligned(PADLOCK_ALIGNMENT);
+	u32 d_data[AES_MAX_KEYLENGTH_U32] __aligned(PADLOCK_ALIGNMENT);
 	struct {
 		struct cword encrypt;
 		struct cword decrypt;
@@ -71,14 +64,13 @@ struct aes_ctx {
 
 static DEFINE_PER_CPU(struct cword *, paes_last_cword);
 
-/* Tells whether the ACE is capable to generate
-   the extended key for a given key_len. */
-static inline int
-aes_hw_extkey_available(uint8_t key_len)
+/* Tells whether the ACE is capable to generate the extended key for a given key_len. */
+static inline int aes_hw_extkey_available(uint8_t key_len)
 {
-	/* TODO: We should check the actual CPU model/stepping
-	         as it's possible that the capability will be
-	         added in the next CPU revisions. */
+	/*
+	 * TODO: We should check the actual CPU model/stepping as it's possible that the
+	 * capability will be added in the next CPU revisions.
+	 */
 	if (key_len == 16)
 		return 1;
 	return 0;
@@ -104,8 +96,7 @@ static inline struct aes_ctx *skcipher_aes_ctx(struct crypto_skcipher *tfm)
 	return aes_ctx_common(crypto_skcipher_ctx(tfm));
 }
 
-static int aes_set_key(struct crypto_tfm *tfm, const u8 *in_key,
-		       unsigned int key_len)
+static int aes_set_key(struct crypto_tfm *tfm, const u8 *in_key, unsigned int key_len)
 {
 	struct aes_ctx *ctx = aes_ctx(tfm);
 	const __le32 *key = (const __le32 *)in_key;
@@ -116,9 +107,8 @@ static int aes_set_key(struct crypto_tfm *tfm, const u8 *in_key,
 		return -EINVAL;
 
 	/*
-	 * If the hardware is capable of generating the extended key
-	 * itself we must supply the plain key for both encryption
-	 * and decryption.
+	 * If the hardware is capable of generating the extended key itself we must supply the
+	 * plain key for both encryption and decryption.
 	 */
 	ctx->D = ctx->E;
 
@@ -153,7 +143,7 @@ static int aes_set_key(struct crypto_tfm *tfm, const u8 *in_key,
 ok:
 	for_each_online_cpu(cpu)
 		if (&ctx->cword.encrypt == per_cpu(paes_last_cword, cpu) ||
-		    &ctx->cword.decrypt == per_cpu(paes_last_cword, cpu))
+			&ctx->cword.decrypt == per_cpu(paes_last_cword, cpu))
 			per_cpu(paes_last_cword, cpu) = NULL;
 
 	return 0;
@@ -186,30 +176,27 @@ static inline void padlock_store_cword(struct cword *cword)
 }
 
 /*
- * While the padlock instructions don't use FP/SSE registers, they
- * generate a spurious DNA fault when CR0.TS is '1'.  Fortunately,
- * the kernel doesn't use CR0.TS.
+ * While the padlock instructions don't use FP/SSE registers, they generate a spurious DNA fault
+ * when CR0.TS is '1'. Fortunately, the kernel doesn't use CR0.TS.
  */
-
 static inline void rep_xcrypt_ecb(const u8 *input, u8 *output, void *key,
-				  struct cword *control_word, int count)
+				struct cword *control_word, int count)
 {
 	asm volatile (".byte 0xf3,0x0f,0xa7,0xc8"	/* rep xcryptecb */
-		      : "+S"(input), "+D"(output)
-		      : "d"(control_word), "b"(key), "c"(count));
+	: "+S"(input), "+D"(output)
+	: "d"(control_word), "b"(key), "c"(count));
 }
 
-static inline u8 *rep_xcrypt_cbc(const u8 *input, u8 *output, void *key,
-				 u8 *iv, struct cword *control_word, int count)
+static inline u8 *rep_xcrypt_cbc(const u8 *input, u8 *output, void *key, u8 *iv,
+				struct cword *control_word, int count)
 {
 	asm volatile (".byte 0xf3,0x0f,0xa7,0xd0"	/* rep xcryptcbc */
-		      : "+S" (input), "+D" (output), "+a" (iv)
-		      : "d" (control_word), "b" (key), "c" (count));
+	: "+S" (input), "+D" (output), "+a" (iv)
+	: "d" (control_word), "b" (key), "c" (count));
 	return iv;
 }
 
-static void ecb_crypt_copy(const u8 *in, u8 *out, u32 *key,
-			   struct cword *cword, int count)
+static void ecb_crypt_copy(const u8 *in, u8 *out, u32 *key, struct cword *cword, int count)
 {
 	/*
 	 * Padlock prefetches extra data so we must provide mapped input buffers.
@@ -222,8 +209,7 @@ static void ecb_crypt_copy(const u8 *in, u8 *out, u32 *key,
 	rep_xcrypt_ecb(tmp, out, key, cword, count);
 }
 
-static u8 *cbc_crypt_copy(const u8 *in, u8 *out, u32 *key,
-			   u8 *iv, struct cword *cword, int count)
+static u8 *cbc_crypt_copy(const u8 *in, u8 *out, u32 *key, u8 *iv, struct cword *cword, int count)
 {
 	/*
 	 * Padlock prefetches extra data so we must provide mapped input buffers.
@@ -236,10 +222,10 @@ static u8 *cbc_crypt_copy(const u8 *in, u8 *out, u32 *key,
 	return rep_xcrypt_cbc(tmp, out, key, iv, cword, count);
 }
 
-static inline void ecb_crypt(const u8 *in, u8 *out, u32 *key,
-			     struct cword *cword, int count)
+static inline void ecb_crypt(const u8 *in, u8 *out, u32 *key, struct cword *cword, int count)
 {
-	/* Padlock in ECB mode fetches at least ecb_fetch_bytes of data.
+	/*
+	 * Padlock in ECB mode fetches at least ecb_fetch_bytes of data.
 	 * We could avoid some copying here but it's probably not worth it.
 	 */
 	if (unlikely(offset_in_page(in) + ecb_fetch_bytes > PAGE_SIZE)) {
@@ -250,8 +236,8 @@ static inline void ecb_crypt(const u8 *in, u8 *out, u32 *key,
 	rep_xcrypt_ecb(in, out, key, cword, count);
 }
 
-static inline u8 *cbc_crypt(const u8 *in, u8 *out, u32 *key,
-			    u8 *iv, struct cword *cword, int count)
+static inline u8 *cbc_crypt(const u8 *in, u8 *out, u32 *key, u8 *iv, struct cword *cword,
+				int count)
 {
 	/* Padlock in CBC mode fetches at least cbc_fetch_bytes of data. */
 	if (unlikely(offset_in_page(in) + cbc_fetch_bytes > PAGE_SIZE))
@@ -260,8 +246,8 @@ static inline u8 *cbc_crypt(const u8 *in, u8 *out, u32 *key,
 	return rep_xcrypt_cbc(in, out, key, iv, cword, count);
 }
 
-static inline void padlock_xcrypt_ecb(const u8 *input, u8 *output, void *key,
-				      void *control_word, u32 count)
+static inline void padlock_xcrypt_ecb(const u8 *input, u8 *output, void *key, void *control_word,
+				u32 count)
 {
 	u32 initial = count & (ecb_fetch_blocks - 1);
 
@@ -274,16 +260,16 @@ static inline void padlock_xcrypt_ecb(const u8 *input, u8 *output, void *key,
 
 	if (initial)
 		asm volatile (".byte 0xf3,0x0f,0xa7,0xc8"	/* rep xcryptecb */
-			      : "+S"(input), "+D"(output)
-			      : "d"(control_word), "b"(key), "c"(initial));
+		: "+S"(input), "+D"(output)
+		: "d"(control_word), "b"(key), "c"(initial));
 
 	asm volatile (".byte 0xf3,0x0f,0xa7,0xc8"	/* rep xcryptecb */
-		      : "+S"(input), "+D"(output)
-		      : "d"(control_word), "b"(key), "c"(count));
+	: "+S"(input), "+D"(output)
+	: "d"(control_word), "b"(key), "c"(count));
 }
 
-static inline u8 *padlock_xcrypt_cbc(const u8 *input, u8 *output, void *key,
-				     u8 *iv, void *control_word, u32 count)
+static inline u8 *padlock_xcrypt_cbc(const u8 *input, u8 *output, void *key, u8 *iv,
+				void *control_word, u32 count)
 {
 	u32 initial = count & (cbc_fetch_blocks - 1);
 
@@ -294,12 +280,12 @@ static inline u8 *padlock_xcrypt_cbc(const u8 *input, u8 *output, void *key,
 
 	if (initial)
 		asm volatile (".byte 0xf3,0x0f,0xa7,0xd0"	/* rep xcryptcbc */
-			      : "+S" (input), "+D" (output), "+a" (iv)
-			      : "d" (control_word), "b" (key), "c" (initial));
+		: "+S" (input), "+D" (output), "+a" (iv)
+		: "d" (control_word), "b" (key), "c" (initial));
 
 	asm volatile (".byte 0xf3,0x0f,0xa7,0xd0"	/* rep xcryptcbc */
-		      : "+S" (input), "+D" (output), "+a" (iv)
-		      : "d" (control_word), "b" (key), "c" (count));
+	: "+S" (input), "+D" (output), "+a" (iv)
+	: "d" (control_word), "b" (key), "c" (count));
 	return iv;
 }
 
@@ -322,21 +308,21 @@ static void padlock_aes_decrypt(struct crypto_tfm *tfm, u8 *out, const u8 *in)
 }
 
 static struct crypto_alg aes_alg = {
-	.cra_name		=	"aes",
+	.cra_name			=	"aes",
 	.cra_driver_name	=	"aes-padlock",
 	.cra_priority		=	PADLOCK_CRA_PRIORITY,
-	.cra_flags		=	CRYPTO_ALG_TYPE_CIPHER,
+	.cra_flags			=	CRYPTO_ALG_TYPE_CIPHER,
 	.cra_blocksize		=	AES_BLOCK_SIZE,
 	.cra_ctxsize		=	sizeof(struct aes_ctx),
 	.cra_alignmask		=	PADLOCK_ALIGNMENT - 1,
-	.cra_module		=	THIS_MODULE,
-	.cra_u			=	{
+	.cra_module			=	THIS_MODULE,
+	.cra_u = {
 		.cipher = {
 			.cia_min_keysize	=	AES_MIN_KEY_SIZE,
 			.cia_max_keysize	=	AES_MAX_KEY_SIZE,
-			.cia_setkey	   	= 	aes_set_key,
-			.cia_encrypt	 	=	padlock_aes_encrypt,
-			.cia_decrypt	  	=	padlock_aes_decrypt,
+			.cia_setkey			=	aes_set_key,
+			.cia_encrypt		=	padlock_aes_encrypt,
+			.cia_decrypt		=	padlock_aes_decrypt,
 		}
 	}
 };
@@ -355,8 +341,8 @@ static int ecb_aes_encrypt(struct skcipher_request *req)
 
 	while ((nbytes = walk.nbytes) != 0) {
 		padlock_xcrypt_ecb(walk.src.virt.addr, walk.dst.virt.addr,
-				   ctx->E, &ctx->cword.encrypt,
-				   nbytes / AES_BLOCK_SIZE);
+					ctx->E, &ctx->cword.encrypt,
+					nbytes / AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
 	}
@@ -380,8 +366,8 @@ static int ecb_aes_decrypt(struct skcipher_request *req)
 
 	while ((nbytes = walk.nbytes) != 0) {
 		padlock_xcrypt_ecb(walk.src.virt.addr, walk.dst.virt.addr,
-				   ctx->D, &ctx->cword.decrypt,
-				   nbytes / AES_BLOCK_SIZE);
+					ctx->D, &ctx->cword.decrypt,
+					nbytes / AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
 	}
@@ -420,9 +406,9 @@ static int cbc_aes_encrypt(struct skcipher_request *req)
 
 	while ((nbytes = walk.nbytes) != 0) {
 		u8 *iv = padlock_xcrypt_cbc(walk.src.virt.addr,
-					    walk.dst.virt.addr, ctx->E,
-					    walk.iv, &ctx->cword.encrypt,
-					    nbytes / AES_BLOCK_SIZE);
+						walk.dst.virt.addr, ctx->E,
+						walk.iv, &ctx->cword.encrypt,
+						nbytes / AES_BLOCK_SIZE);
 		memcpy(walk.iv, iv, AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
@@ -447,8 +433,8 @@ static int cbc_aes_decrypt(struct skcipher_request *req)
 
 	while ((nbytes = walk.nbytes) != 0) {
 		padlock_xcrypt_cbc(walk.src.virt.addr, walk.dst.virt.addr,
-				   ctx->D, walk.iv, &ctx->cword.decrypt,
-				   nbytes / AES_BLOCK_SIZE);
+				ctx->D, walk.iv, &ctx->cword.decrypt,
+				nbytes / AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
 	}
@@ -474,41 +460,38 @@ static struct skcipher_alg cbc_aes_alg = {
 	.decrypt		=	cbc_aes_decrypt,
 };
 
-static const struct x86_cpu_id padlock_cpu_id[] = {
-	{ X86_VENDOR_CENTAUR, 6, X86_MODEL_ANY, X86_FEATURE_XCRYPT },
+static const struct x86_cpu_id zhaoxin_cpu_id[] = {
+	{ X86_VENDOR_CENTAUR, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_XCRYPT },
+	{ X86_VENDOR_ZHAOXIN, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_XCRYPT },
 	{}
 };
-MODULE_DEVICE_TABLE(x86cpu, padlock_cpu_id);
+MODULE_DEVICE_TABLE(x86cpu, zhaoxin_cpu_id);
 
 static int __init padlock_init(void)
 {
 	int ret;
-	struct cpuinfo_x86 *c = &cpu_data(0);
 
-	if (!x86_match_cpu(padlock_cpu_id))
+	if (!x86_match_cpu(zhaoxin_cpu_id))
 		return -ENODEV;
 
 	if (!boot_cpu_has(X86_FEATURE_XCRYPT_EN)) {
-		printk(KERN_NOTICE PFX "VIA PadLock detected, but not enabled. Hmm, strange...\n");
+		pr_notice("ACE detected, but not enabled. Hmm, strange...\n");
 		return -ENODEV;
 	}
 
-	if ((ret = crypto_register_alg(&aes_alg)) != 0)
+	ret = crypto_register_alg(&aes_alg);
+	if (!!ret)
 		goto aes_err;
 
-	if ((ret = crypto_register_skcipher(&ecb_aes_alg)) != 0)
+	ret = crypto_register_skcipher(&ecb_aes_alg);
+	if (!!ret)
 		goto ecb_aes_err;
 
-	if ((ret = crypto_register_skcipher(&cbc_aes_alg)) != 0)
+	ret = crypto_register_skcipher(&cbc_aes_alg);
+	if (!!ret)
 		goto cbc_aes_err;
 
-	printk(KERN_NOTICE PFX "Using VIA PadLock ACE for AES algorithm.\n");
-
-	if (c->x86 == 6 && c->x86_model == 15 && c->x86_stepping == 2) {
-		ecb_fetch_blocks = MAX_ECB_FETCH_BLOCKS;
-		cbc_fetch_blocks = MAX_CBC_FETCH_BLOCKS;
-		printk(KERN_NOTICE PFX "VIA Nano stepping 2 detected: enabling workaround.\n");
-	}
+	pr_notice("Using ACE for AES algorithm.\n");
 
 out:
 	return ret;
@@ -518,7 +501,7 @@ cbc_aes_err:
 ecb_aes_err:
 	crypto_unregister_alg(&aes_alg);
 aes_err:
-	printk(KERN_ERR PFX "VIA PadLock AES initialization failed.\n");
+	pr_err("ACE AES initialization failed.\n");
 	goto out;
 }
 
@@ -532,8 +515,9 @@ static void __exit padlock_fini(void)
 module_init(padlock_init);
 module_exit(padlock_fini);
 
-MODULE_DESCRIPTION("VIA PadLock AES algorithm support");
+MODULE_DESCRIPTION("ACE AES algorithm support");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Michal Ludvig");
+MODULE_VERSION(DRIVER_VERSION);
 
 MODULE_ALIAS_CRYPTO("aes");

--- a/drivers/crypto/zhaoxin-sha.c
+++ b/drivers/crypto/zhaoxin-sha.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Support for ACE hardware crypto engine.
+ */
+
+#include <crypto/internal/hash.h>
+#include <crypto/padlock.h>
+#include <crypto/sha1.h>
+#include <crypto/sha2.h>
+#include <linux/err.h>
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/errno.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/scatterlist.h>
+#include <asm/cpu_device_id.h>
+#include <asm/fpu/api.h>
+
+#define DRIVER_VERSION "1.0.0"
+
+static inline void padlock_output_block(uint32_t *src, uint32_t *dst, size_t count)
+{
+	while (count--)
+		*dst++ = swab32(*src++);
+}
+
+/*
+ * Add two shash_alg instance for hardware-implemented multiple-parts hash
+ * supported by Zhaoxin Processor.
+ */
+static int padlock_sha1_init_zhaoxin(struct shash_desc *desc)
+{
+	struct sha1_state *sctx = shash_desc_ctx(desc);
+
+	*sctx = (struct sha1_state){
+		.state = { SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4 },
+	};
+
+	return 0;
+}
+
+static int padlock_sha1_update_zhaoxin(struct shash_desc *desc, const u8 *data,	unsigned int len)
+{
+	struct sha1_state *sctx = shash_desc_ctx(desc);
+	unsigned int partial, done;
+	const u8 *src;
+
+	/* The PHE require the out buffer must 128 bytes and 16-bytes aligned */
+	u8 buf[128 + PADLOCK_ALIGNMENT - STACK_ALIGN] __aligned(STACK_ALIGN);
+	u8 *dst = PTR_ALIGN(&buf[0], PADLOCK_ALIGNMENT);
+
+	partial = sctx->count & 0x3f;
+	sctx->count += len;
+	done = 0;
+	src = data;
+	memcpy(dst, (u8 *)(sctx->state), SHA1_DIGEST_SIZE);
+
+	if ((partial + len) >= SHA1_BLOCK_SIZE) {
+		/* Append the bytes in state's buffer to a block to handle */
+		if (partial) {
+			done = -partial;
+			memcpy(sctx->buffer + partial, data, done + SHA1_BLOCK_SIZE);
+			src = sctx->buffer;
+			asm volatile (".byte 0xf3,0x0f,0xa6,0xc8"
+			: "+S"(src), "+D"(dst)
+			: "a"((long)-1), "c"((unsigned long)1));
+			done += SHA1_BLOCK_SIZE;
+			src = data + done;
+		}
+
+		/* Process the left bytes from the input data */
+		if (len - done >= SHA1_BLOCK_SIZE) {
+			asm volatile (".byte 0xf3,0x0f,0xa6,0xc8"
+			: "+S"(src), "+D"(dst)
+			: "a"((long)-1), "c"((unsigned long)((len - done) / SHA1_BLOCK_SIZE)));
+			done += ((len - done) - (len - done) % SHA1_BLOCK_SIZE);
+			src = data + done;
+		}
+		partial = 0;
+	}
+	memcpy((u8 *)(sctx->state), dst, SHA1_DIGEST_SIZE);
+	memcpy(sctx->buffer + partial, src, len - done);
+
+	return 0;
+}
+
+static int padlock_sha1_final_zhaoxin(struct shash_desc *desc, u8 *out)
+{
+	struct sha1_state *state = (struct sha1_state *)shash_desc_ctx(desc);
+	unsigned int partial, padlen;
+	__be64 bits;
+	static const u8 padding[64] = { 0x80, };
+
+	bits = cpu_to_be64(state->count << 3);
+
+	/* Pad out to 56 mod 64 */
+	partial = state->count & 0x3f;
+	padlen = (partial < 56) ? (56 - partial) : ((64+56) - partial);
+	padlock_sha1_update_zhaoxin(desc, padding, padlen);
+
+	/* Append length field bytes */
+	padlock_sha1_update_zhaoxin(desc, (const u8 *)&bits, sizeof(bits));
+
+	/* Swap to output */
+	padlock_output_block((uint32_t *)(state->state), (uint32_t *)out, 5);
+
+	return 0;
+}
+
+static int padlock_sha256_init_zhaoxin(struct shash_desc *desc)
+{
+	struct sha256_state *sctx = shash_desc_ctx(desc);
+
+	*sctx = (struct sha256_state) {
+		.state = {
+			SHA256_H0, SHA256_H1, SHA256_H2, SHA256_H3,
+			SHA256_H4, SHA256_H5, SHA256_H6, SHA256_H7
+		},
+	};
+
+	return 0;
+}
+
+static int padlock_sha256_update_zhaoxin(struct shash_desc *desc, const u8 *data, unsigned int len)
+{
+	struct sha256_state *sctx = shash_desc_ctx(desc);
+	unsigned int partial, done;
+	const u8 *src;
+
+	/* The PHE require the out buffer must 128 bytes and 16-bytes aligned */
+	u8 buf[128 + PADLOCK_ALIGNMENT - STACK_ALIGN] __aligned(STACK_ALIGN);
+	u8 *dst = PTR_ALIGN(&buf[0], PADLOCK_ALIGNMENT);
+
+	partial = sctx->count & 0x3f;
+	sctx->count += len;
+	done = 0;
+	src = data;
+	memcpy(dst, (u8 *)(sctx->state), SHA256_DIGEST_SIZE);
+
+	if ((partial + len) >= SHA256_BLOCK_SIZE) {
+
+		/* Append the bytes in state's buffer to a block to handle */
+		if (partial) {
+			done = -partial;
+			memcpy(sctx->buf + partial, data, done + SHA256_BLOCK_SIZE);
+			src = sctx->buf;
+			asm volatile (".byte 0xf3,0x0f,0xa6,0xd0"
+			: "+S"(src), "+D"(dst)
+			: "a"((long)-1), "c"((unsigned long)1));
+			done += SHA256_BLOCK_SIZE;
+			src = data + done;
+		}
+
+		/* Process the left bytes from input data */
+		if (len - done >= SHA256_BLOCK_SIZE) {
+			asm volatile (".byte 0xf3,0x0f,0xa6,0xd0"
+			: "+S"(src), "+D"(dst)
+			: "a"((long)-1), "c"((unsigned long)((len - done) / 64)));
+			done += ((len - done) - (len - done) % 64);
+			src = data + done;
+		}
+		partial = 0;
+	}
+	memcpy((u8 *)(sctx->state), dst, SHA256_DIGEST_SIZE);
+	memcpy(sctx->buf + partial, src, len - done);
+
+	return 0;
+}
+
+static int padlock_sha256_final_zhaoxin(struct shash_desc *desc, u8 *out)
+{
+	struct sha256_state *state = (struct sha256_state *)shash_desc_ctx(desc);
+	unsigned int partial, padlen;
+	__be64 bits;
+	static const u8 padding[64] = { 0x80, };
+
+	bits = cpu_to_be64(state->count << 3);
+
+	/* Pad out to 56 mod 64 */
+	partial = state->count & 0x3f;
+	padlen = (partial < 56) ? (56 - partial) : ((64+56) - partial);
+	padlock_sha256_update_zhaoxin(desc, padding, padlen);
+
+	/* Append length field bytes */
+	padlock_sha256_update_zhaoxin(desc, (const u8 *)&bits, sizeof(bits));
+
+	/* Swap to output */
+	padlock_output_block((uint32_t *)(state->state), (uint32_t *)out, 8);
+
+	return 0;
+}
+
+static int padlock_sha_export_zhaoxin(struct shash_desc *desc, void *out)
+{
+	int statesize = crypto_shash_statesize(desc->tfm);
+	void *sctx = shash_desc_ctx(desc);
+
+	memcpy(out, sctx, statesize);
+	return 0;
+}
+
+static int padlock_sha_import_zhaoxin(struct shash_desc *desc, const void *in)
+{
+	int statesize = crypto_shash_statesize(desc->tfm);
+	void *sctx = shash_desc_ctx(desc);
+
+	memcpy(sctx, in, statesize);
+	return 0;
+}
+
+static struct shash_alg sha1_alg_zhaoxin = {
+	.digestsize	=	SHA1_DIGEST_SIZE,
+	.init		=	padlock_sha1_init_zhaoxin,
+	.update		=	padlock_sha1_update_zhaoxin,
+	.final		=	padlock_sha1_final_zhaoxin,
+	.export		=	padlock_sha_export_zhaoxin,
+	.import		=	padlock_sha_import_zhaoxin,
+	.descsize	=	sizeof(struct sha1_state),
+	.statesize	=	sizeof(struct sha1_state),
+	.base = {
+		.cra_name			=	"sha1",
+		.cra_driver_name	=	"sha1-padlock-zhaoxin",
+		.cra_priority		=	PADLOCK_CRA_PRIORITY,
+		.cra_blocksize		=	SHA1_BLOCK_SIZE,
+		.cra_module			=	THIS_MODULE,
+	}
+};
+
+static struct shash_alg sha256_alg_zhaoxin = {
+	.digestsize	=	SHA256_DIGEST_SIZE,
+	.init		=	padlock_sha256_init_zhaoxin,
+	.update		=	padlock_sha256_update_zhaoxin,
+	.final		=	padlock_sha256_final_zhaoxin,
+	.export		=	padlock_sha_export_zhaoxin,
+	.import		=	padlock_sha_import_zhaoxin,
+	.descsize	=	sizeof(struct sha256_state),
+	.statesize	=	sizeof(struct sha256_state),
+	.base = {
+		.cra_name			=	"sha256",
+		.cra_driver_name	=	"sha256-padlock-zhaoxin",
+		.cra_priority		=	PADLOCK_CRA_PRIORITY,
+		.cra_blocksize		=	SHA256_BLOCK_SIZE,
+		.cra_module			=	THIS_MODULE,
+	}
+};
+
+static const struct x86_cpu_id zhaoxin_sha_ids[] = {
+	{ X86_VENDOR_CENTAUR, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_PHE },
+	{ X86_VENDOR_ZHAOXIN, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_PHE },
+	{}
+};
+MODULE_DEVICE_TABLE(x86cpu, zhaoxin_sha_ids);
+
+static int __init padlock_init(void)
+{
+	int rc = -ENODEV;
+	struct shash_alg *sha1;
+	struct shash_alg *sha256;
+
+	if (!x86_match_cpu(zhaoxin_sha_ids) || !boot_cpu_has(X86_FEATURE_PHE_EN))
+		return -ENODEV;
+
+	sha1 = &sha1_alg_zhaoxin;
+	sha256 = &sha256_alg_zhaoxin;
+
+	rc = crypto_register_shash(sha1);
+	if (rc)
+		goto out;
+
+	rc = crypto_register_shash(sha256);
+	if (rc)
+		goto out_unreg1;
+
+	pr_notice("Using ACE for SHA1/SHA256 algorithms.\n");
+
+	return 0;
+
+out_unreg1:
+	crypto_unregister_shash(sha1);
+
+out:
+	pr_err("ACE SHA1/SHA256 initialization failed.\n");
+	return rc;
+}
+
+static void __exit padlock_fini(void)
+{
+	crypto_unregister_shash(&sha1_alg_zhaoxin);
+	crypto_unregister_shash(&sha256_alg_zhaoxin);
+}
+
+module_init(padlock_init);
+module_exit(padlock_fini);
+
+MODULE_DESCRIPTION("ACE SHA1/SHA256 algorithms support.");
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Michal Ludvig");
+MODULE_VERSION(DRIVER_VERSION);
+
+MODULE_ALIAS_CRYPTO("sha1-all");
+MODULE_ALIAS_CRYPTO("sha256-all");
+MODULE_ALIAS_CRYPTO("sha1-padlock");
+MODULE_ALIAS_CRYPTO("sha256-padlock");


### PR DESCRIPTION
Includes:
1. Add support for Zhaoxin AES algorithm
Some Zhaoxin processors come with an integrated crypto engine (so called
Zhaoxin ACE, Advanced Cryptography Engine) that provides instructions for
very fast cryptographic operations with supported AES algorithms.
2. Add support for Zhaoxin SHA algorithm
Some Zhaoxin processors come with an integrated crypto engine (so called
Zhaoxin ACE, Advanced Cryptography Engine) that provides instructions for
very fast cryptographic operations with supportedSHA1/SHA256 algorithms.