### PR TITLE
[linux-6.6.y] ata: libata: disabling PhyRdy Change Interrupt based on actual LPM capability

### DIFF
--- a/drivers/ata/libata-eh.c
+++ b/drivers/ata/libata-eh.c
@@ -3374,6 +3374,8 @@ static int ata_eh_set_lpm(struct ata_link *link, enum ata_lpm_policy policy,
 			  struct ata_device **r_failed_dev)
 {
 	struct ata_port *ap = ata_is_host_link(link) ? link->ap : NULL;
+	struct device *device = ap ? ap->host->dev : NULL;
+	struct pci_dev *pdev = (!device || !dev_is_pci(device)) ? NULL : to_pci_dev(device);
 	struct ata_eh_context *ehc = &link->eh_context;
 	struct ata_device *dev, *link_dev = NULL, *lpm_dev = NULL;
 	enum ata_lpm_policy old_policy = link->lpm_policy;
@@ -3381,6 +3383,11 @@ static int ata_eh_set_lpm(struct ata_link *link, enum ata_lpm_policy policy,
 	unsigned int hints = ATA_LPM_EMPTY | ATA_LPM_HIPM;
 	unsigned int err_mask;
 	int rc;
+
+	/* if controller does not support lpm, then sets no LPM flags*/
+	if ((pdev && pdev->vendor == PCI_VENDOR_ID_ZHAOXIN) &&
+	    !(~ap->host->flags & (ATA_HOST_NO_PART | ATA_HOST_NO_SSC | ATA_HOST_NO_DEVSLP)))
+		link->flags |= ATA_LFLAG_NO_LPM;
 
 	/* if the link or host doesn't do LPM, noop */
 	if (!IS_ENABLED(CONFIG_SATA_HOST) ||


### PR DESCRIPTION
zhaoxin inclusion
category: bugfix
CVE: NA

-----------------

The ahci spec mentions that PhyRdy Change Interrupt and Link Power Management (LPM) do not coexist.

However, before enabling LPM, the driver did not check whether the host supports LPM, but directly disabled PhyRdy Change Interrupt.

Increase the judgment on the actual support of LPM, and disable PhyRdy Change Interrupt only when it is supported.