### PR TITLE
[linux-6.6.y] Turning off Zhaoxin ahci controller runtime pm from sysfs

### DIFF
--- a/drivers/ata/ahci.c
+++ b/drivers/ata/ahci.c
@@ -895,6 +895,11 @@ static int ahci_pci_device_runtime_suspend(struct device *dev)
 	struct pci_dev *pdev = to_pci_dev(dev);
 	struct ata_host *host = pci_get_drvdata(pdev);
 
+	if (pdev->vendor == PCI_VENDOR_ID_ZHAOXIN && pdev->revision <= 0x20) {
+		dev_err(&pdev->dev, "zx ahci controller does not support runtime pm!\n");
+		return -EIO;
+	}
+
 	ahci_pci_disable_interrupts(host);
 	return 0;
 }


### PR DESCRIPTION
zhaoxin inclusion
category: bugfix

-------------------

There exits some problems with enabling ahci controller runtime pm on various Zhaoxin platforms.

For some Zhaoxin CPUs, link into listen mode, and PHY into P2, which will cause the device to continuously send comminit. When the controller is in D3, the comminit will continuously wake up the controller, resulting in the controller being unable to stabilize at D3;

For another Zhaoxin CPUs, after entering and exiting runtime pm for a certain number of times, ahci controller reset accumulates for many times, which will make ahci and PXPTRF P2CW think that the other party can no longer receive requests and block the P2CW path, resulting in failure to recognize the device;

There are alse some Zhaoxin CPUs, the test is normal, but considering that the server platform is not sensitive to power consumption, and this part has very little impact on power consumption;

In summary, it is recommended to close the zx ahci controller runtime pm.