### PR TITLE
[linux-6.6.y] Add MWAIT Cx support for Zhaoxin CPUs

### DIFF
--- a/arch/x86/include/asm/acpi.h
+++ b/arch/x86/include/asm/acpi.h
@@ -102,7 +102,8 @@ static inline bool arch_has_acpi_pdc(void)
 {
 	struct cpuinfo_x86 *c = &cpu_data(0);
 	return (c->x86_vendor == X86_VENDOR_INTEL ||
-		c->x86_vendor == X86_VENDOR_CENTAUR);
+		c->x86_vendor == X86_VENDOR_CENTAUR ||
+		c->x86_vendor == X86_VENDOR_ZHAOXIN);
 }
 
 static inline void arch_acpi_set_proc_cap_bits(u32 *cap)

--- a/arch/x86/kernel/acpi/cstate.c
+++ b/arch/x86/kernel/acpi/cstate.c
@@ -221,7 +221,9 @@ static int __init ffh_cstate_init(void)
 
 	if (c->x86_vendor != X86_VENDOR_INTEL &&
 	    c->x86_vendor != X86_VENDOR_AMD &&
-	    c->x86_vendor != X86_VENDOR_HYGON)
+	    c->x86_vendor != X86_VENDOR_HYGON &&
+	    c->x86_vendor != X86_VENDOR_CENTAUR &&
+	    c->x86_vendor != X86_VENDOR_ZHAOXIN)
 		return -1;
 
 	cpu_cstate_entry = alloc_percpu(struct cstate_entry);


### PR DESCRIPTION
zhaoxin inclusion
category: bugfix
CVE: NA

-----------------

When the processor is idle，low-power idle states (C-states) can be used to save power. For Zhaoxin processors，there are two methods to enter idle states. One is HLT instruction and legacy method of I/O reads from the ACPI-defined register (known as P_LVLx)，the other one is MWAIT instruction with idle states hints.

Default for legacy operating system，HLT and P_LVLx I/O reads are used for Zhaoxin Processors to enter idle states, but we have checked on some Zhaoxin platform that MWAIT instruction is more efficient than P_LVLx I/O reads and HLT, so we add MWAIT Cx support for Zhaoxin Processors.