### PR TITLE
[linux-6.6.y] cpufreq: ACPI: add ITMT support when CPPC enabled

### DIFF
--- a/arch/x86/kernel/itmt.c
+++ b/arch/x86/kernel/itmt.c
@@ -122,6 +122,7 @@ int sched_set_itmt_support(void)
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(sched_set_itmt_support);
 
 /**
  * sched_clear_itmt_support() - Revoke platform's support of ITMT
@@ -181,3 +182,4 @@ void sched_set_itmt_core_prio(int prio, int cpu)
 {
 	per_cpu(sched_core_priority, cpu) = prio;
 }
+EXPORT_SYMBOL_GPL(sched_set_itmt_core_prio);

--- a/kernel/sched/topology.c
+++ b/kernel/sched/topology.c
@@ -2469,6 +2469,17 @@ build_sched_domains(const struct cpumask *cpu_map, struct sched_domain_attr *att
 		}
 	}
 
+#if IS_ENABLED(CONFIG_X86)
+	if ((boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR ||
+	     boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN) &&
+	    (boot_cpu_data.x86 == 7 && boot_cpu_data.x86_model == 0x5b)) {
+		for_each_cpu(i, cpu_map) {
+			for (sd = *per_cpu_ptr(d.sd, i); sd; sd = sd->parent)
+				sd->flags |= SD_ASYM_PACKING;
+		}
+	}
+#endif
+
 	/* Calculate CPU capacity for physical packages and nodes */
 	for (i = nr_cpumask_bits-1; i >= 0; i--) {
 		if (!cpumask_test_cpu(i, cpu_map))


### PR DESCRIPTION
The _CPC method can get per-core highest frequency.
The highest frequency may varies between cores which mean cores can running at different max frequency, so can use it as a core priority and give a hint to scheduler in order to put critical task to the higher priority core.