### PR TITLE
[linux-6.6.y] x86/mce: Set bios_cmci_threshold for CMCI threshold

### DIFF
--- a/arch/x86/kernel/cpu/mce/core.c
+++ b/arch/x86/kernel/cpu/mce/core.c
@@ -1941,6 +1941,7 @@ static int __mcheck_cpu_apply_quirks(struct cpuinfo_x86 *c)
 			if (cfg->monarch_timeout < 0)
 				cfg->monarch_timeout = USEC_PER_SEC;
 		}
+		mca_cfg.bios_cmci_threshold = 1;
 	}
 
 	if (cfg->monarch_timeout < 0)


### PR DESCRIPTION
zhaoxin inclusion
category: bugfix
CVE: NA

-----------------

In the Linux kernel, the CMCI threshold is set to 1 by default. This patch prevents Linux from overwriting the CMCI threshold set by the bios. With this patch, the CMCI threshold can be set through the BIOS, which can also avoid CMCI storms, on Zhaoxin/Centaur CPUs.