### PR TITLE
[linux-6.6.y] x86/mce/zhaoxin: Enable mcelog to decode PCIE, ZDI/ZPI, and DRAM errors

### DIFF
--- a/arch/x86/include/asm/mce.h
+++ b/arch/x86/include/asm/mce.h
@@ -295,6 +295,12 @@ struct cper_sec_mem_err;
 extern void apei_mce_report_mem_error(int corrected,
 				      struct cper_sec_mem_err *mem_err);
 
+extern void zx_apei_mce_report_mem_error(int corrected, struct cper_sec_mem_err *mem_err);
+struct cper_sec_pcie;
+extern void zx_apei_mce_report_pcie_error(int corrected, struct cper_sec_pcie *pcie_err);
+struct cper_sec_proc_generic;
+extern void zx_apei_mce_report_zdi_error(int corrected, struct cper_sec_proc_generic *zdi_err);
+
 /*
  * Enumerate new IP types and HWID values in AMD processors which support
  * Scalable MCA.

--- a/arch/x86/kernel/acpi/apei.c
+++ b/arch/x86/kernel/acpi/apei.c
@@ -40,7 +40,29 @@ int arch_apei_enable_cmcff(struct acpi_hest_header *hest_hdr, void *data)
 void arch_apei_report_mem_error(int sev, struct cper_sec_mem_err *mem_err)
 {
 #ifdef CONFIG_X86_MCE
-	apei_mce_report_mem_error(sev, mem_err);
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN ||
+	    boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR)
+		zx_apei_mce_report_mem_error(sev, mem_err);
+	else
+		apei_mce_report_mem_error(sev, mem_err);
+#endif
+}
+
+void arch_apei_report_pcie_error(int sev, struct cper_sec_pcie *pcie_err)
+{
+#ifdef CONFIG_X86_MCE
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN ||
+	    boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR)
+		zx_apei_mce_report_pcie_error(sev, pcie_err);
+#endif
+}
+
+void arch_apei_report_zdi_error(int sev, struct cper_sec_proc_generic *zdi_err)
+{
+#ifdef CONFIG_X86_MCE
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN ||
+	    boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR)
+		zx_apei_mce_report_zdi_error(sev, zdi_err);
 #endif
 }
 

--- a/drivers/acpi/apei/apei-base.c
+++ b/drivers/acpi/apei/apei-base.c
@@ -773,6 +773,16 @@ void __weak arch_apei_report_mem_error(int sev,
 }
 EXPORT_SYMBOL_GPL(arch_apei_report_mem_error);
 
+void __weak arch_apei_report_pcie_error(int sev, struct cper_sec_pcie *pcie_err)
+{
+}
+EXPORT_SYMBOL_GPL(arch_apei_report_pcie_error);
+
+void __weak arch_apei_report_zdi_error(int sev, struct cper_sec_proc_generic *zdi_err)
+{
+}
+EXPORT_SYMBOL_GPL(arch_apei_report_zdi_error);
+
 int apei_osc_setup(void)
 {
 	static u8 whea_uuid_str[] = "ed855e0c-6c90-47bf-a62a-26de0fc5ad5c";

--- a/drivers/acpi/apei/ghes.c
+++ b/drivers/acpi/apei/ghes.c
@@ -699,7 +699,7 @@ static bool ghes_do_proc(struct ghes *ghes,
 
 			atomic_notifier_call_chain(&ghes_report_chain, sev, mem_err);
 
-			arch_apei_report_mem_error(sev, mem_err);
+			arch_apei_report_mem_error(sec_sev, mem_err);
 			queued = ghes_handle_memory_failure(gdata, sev, sync);
 		}
 		else if (guid_equal(sec_type, &CPER_SEC_PCIE)) {

--- a/drivers/acpi/apei/ghes.c
+++ b/drivers/acpi/apei/ghes.c
@@ -703,10 +703,17 @@ static bool ghes_do_proc(struct ghes *ghes,
 			queued = ghes_handle_memory_failure(gdata, sev, sync);
 		}
 		else if (guid_equal(sec_type, &CPER_SEC_PCIE)) {
+			struct cper_sec_pcie *pcie_err = acpi_hest_get_payload(gdata);
+
+			arch_apei_report_pcie_error(sec_sev, pcie_err);
 			ghes_handle_aer(gdata);
 		}
 		else if (guid_equal(sec_type, &CPER_SEC_PROC_ARM)) {
 			queued = ghes_handle_arm_hw_error(gdata, sev, sync);
+		} else if (guid_equal(sec_type, &CPER_SEC_PROC_GENERIC)) {
+			struct cper_sec_proc_generic *zdi_err = acpi_hest_get_payload(gdata);
+
+			arch_apei_report_zdi_error(sec_sev, zdi_err);
 		} else {
 			void *err = acpi_hest_get_payload(gdata);
 
@@ -1091,6 +1098,8 @@ static int ghes_in_nmi_queue_one_entry(struct ghes *ghes,
 	u32 len, node_len;
 	u64 buf_paddr;
 	int sev, rc;
+	struct acpi_hest_generic_data *gdata;
+	guid_t *sec_type;
 
 	if (!IS_ENABLED(CONFIG_ARCH_HAVE_NMI_SAFE_CMPXCHG))
 		return -EOPNOTSUPP;
@@ -1126,6 +1135,23 @@ static int ghes_in_nmi_queue_one_entry(struct ghes *ghes,
 
 	sev = ghes_severity(estatus->error_severity);
 	if (sev >= GHES_SEV_PANIC) {
+		apei_estatus_for_each_section(estatus, gdata) {
+			sec_type = (guid_t *)gdata->section_type;
+			if (guid_equal(sec_type, &CPER_SEC_PLATFORM_MEM)) {
+				struct cper_sec_mem_err *mem_err = acpi_hest_get_payload(gdata);
+
+				arch_apei_report_mem_error(sev, mem_err);
+			} else if (guid_equal(sec_type, &CPER_SEC_PCIE)) {
+				struct cper_sec_pcie *pcie_err = acpi_hest_get_payload(gdata);
+
+				arch_apei_report_pcie_error(sev, pcie_err);
+			} else if (guid_equal(sec_type, &CPER_SEC_PROC_GENERIC)) {
+				struct cper_sec_proc_generic *zdi_err =
+							acpi_hest_get_payload(gdata);
+
+				arch_apei_report_zdi_error(sev, zdi_err);
+			}
+		}
 		ghes_print_queued_estatus();
 		__ghes_panic(ghes, estatus, buf_paddr, fixmap_idx);
 	}

--- a/include/acpi/apei.h
+++ b/include/acpi/apei.h
@@ -52,6 +52,8 @@ int erst_clear(u64 record_id);
 
 int arch_apei_enable_cmcff(struct acpi_hest_header *hest_hdr, void *data);
 void arch_apei_report_mem_error(int sev, struct cper_sec_mem_err *mem_err);
+void arch_apei_report_pcie_error(int sev, struct cper_sec_pcie *pcie_err);
+void arch_apei_report_zdi_error(int sev, struct cper_sec_proc_generic *zdi_err);
 
 #endif
 #endif


### PR DESCRIPTION
zhaoxin inclusion
category: bugfix

-------------------

The mcelog cannot decode PCIE, ZDI/ZPI, and DRAM errors in the FFM (Firmware First Mode).
The purpose of this patch is to enable mcelog to decode PCIE, ZDI/ZPI, and DRAM errors that occur on Zhaoxin processors, so that the cause of these errors can be quickly located.