### PR TITLE
[linux-6.6.y] efi: cper: Add Zhaoxin/Centaur ZDI/ZPI error decode

### DIFF
--- a/include/linux/cper.h
+++ b/include/linux/cper.h
@@ -578,4 +578,5 @@ void cper_estatus_print(const char *pfx,
 int cper_estatus_check_header(const struct acpi_hest_generic_status *estatus);
 int cper_estatus_check(const struct acpi_hest_generic_status *estatus);
 
+const char *cper_zdi_zpi_err_type_str(unsigned int etype);
 #endif


### PR DESCRIPTION
zhaoxin inclusion
category: feature

-------------------

ZPI is the interconnection interface between sockets, ZDI is the interconnection interface between dies.

ZPI is the interconnection interface between sockets, ZDI is the interconnection interface between dies.

When either zdi or zpi occurs error, it will trigger smi interrput, the smi handler will read error information from the zdi/zpi configuration space, fill it in the cper structure asscoiated with error and produce a sci or nmi interrput to notify the OS ,the OS driver will decode the cper structure to help user to annalyze the error.

Because UEFI spec does not define the section type of ZDI/ZPI error. Zhaoxin defines ZDI/ZPI errors according to the error format defined by the Generic Processor Error Section type.When the error occurs, The BIOS will fill error information  in the data structure corresponding to the Generic Processor Error Section type in the smi handler.However,the error information printed by default  apei driver is not easy to read.

The software has added some printed logs to make the ZDI/ZPI error information on the Zhaoxin/Centaur cpu vendor easier to read.