### PR TITLE
net: macb: Add support for Phytium gem1.0 and gem 2.0

### DIFF
--- a/Documentation/devicetree/bindings/net/cdns,macb.yaml
+++ b/Documentation/devicetree/bindings/net/cdns,macb.yaml
@@ -58,8 +58,8 @@ properties:
           - cdns,emac                 # Generic
           - cdns,gem                  # Generic
           - cdns,macb                 # Generic
-	  - cdns,phytium-gem-1.0    # GEM version 1.0 on Phytium SoCs
-	  - cdns,phytium-gem-2.0    # GEM version 2.0 on Phytium SoCs
+          - cdns,phytium-gem-1.0      # GEM version 1.0 on Phytium SoCs
+          - cdns,phytium-gem-2.0      # GEM version 2.0 on Phytium SoCs
 
   reg:
     minItems: 1

--- a/Documentation/devicetree/bindings/net/cdns,macb.yaml
+++ b/Documentation/devicetree/bindings/net/cdns,macb.yaml
@@ -58,6 +58,8 @@ properties:
           - cdns,emac                 # Generic
           - cdns,gem                  # Generic
           - cdns,macb                 # Generic
+	  - cdns,phytium-gem-1.0    # GEM version 1.0 on Phytium SoCs
+	  - cdns,phytium-gem-2.0    # GEM version 2.0 on Phytium SoCs
 
   reg:
     minItems: 1


### PR DESCRIPTION
This patch modify macb driver to support the Phytium gem1.0 and gem2.0 controller.