### PR TITLE
drm: amdgpu: radeon: disable cache flush workaround for LoongArch and Loongson64

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
@@ -2117,6 +2117,14 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 {
 	bool write64bit = flags & AMDGPU_FENCE_FLAG_64BIT;
 	bool int_sel = flags & AMDGPU_FENCE_FLAG_INT;
+
+/* This workaround causes instability for LoongArch/Loongson (MIPS)
+ * devices based on the 7A1000/2000 chipset under heavy I/O load.
+ *
+ * FIXME: Disable this workaround until we find a better fix (possibly in
+ * the platform-specific PCI code).
+ */
+#ifndef CONFIG_MACH_LOONGSON64
 	/* Workaround for cache flush problems. First send a dummy EOP
 	 * event down the pipe with seq one below.
 	 */
@@ -2130,6 +2138,7 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 				DATA_SEL(1) | INT_SEL(0));
 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
+#endif
 
 	/* Then send the real EOP event down the pipe. */
 	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
@@ -6154,6 +6154,13 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 	bool write64bit = flags & AMDGPU_FENCE_FLAG_64BIT;
 	bool int_sel = flags & AMDGPU_FENCE_FLAG_INT;
 
+/* This workaround causes instability for LoongArch/Loongson (MIPS)
+ * devices based on the 7A1000/2000 chipset under heavy I/O load.
+ *
+ * FIXME: Disable this workaround until we find a better fix (possibly in
+ * the platform-specific PCI code).
+ */
+#ifndef CONFIG_MACH_LOONGSON64
 	/* Workaround for cache flush problems. First send a dummy EOP
 	 * event down the pipe with seq one below.
 	 */
@@ -6168,6 +6175,7 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 				DATA_SEL(1) | INT_SEL(0));
 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
+#endif
 
 	/* Then send the real EOP event down the pipe:
 	 * EVENT_WRITE_EOP - flush caches, send int */

--- a/drivers/gpu/drm/radeon/cik.c
+++ b/drivers/gpu/drm/radeon/cik.c
@@ -3543,6 +3543,13 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
 	struct radeon_ring *ring = &rdev->ring[fence->ring];
 	u64 addr = rdev->fence_drv[fence->ring].gpu_addr;
 
+/* This workaround causes instability for LoongArch/Loongson (MIPS)
+ * devices based on the 7A1000/2000 chipset under heavy I/O load.
+ *
+ * FIXME: Disable this workaround until we find a better fix (possibly in
+ * the platform-specific PCI code).
+ */
+#ifndef CONFIG_MACH_LOONGSON64
 	/* Workaround for cache flush problems. First send a dummy EOP
 	 * event down the pipe with seq one below.
 	 */
@@ -3556,6 +3563,7 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
 				DATA_SEL(1) | INT_SEL(0));
 	radeon_ring_write(ring, fence->seq - 1);
 	radeon_ring_write(ring, 0);
+#endif
 
 	/* Then send the real EOP event down the pipe. */
 	radeon_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));


### PR DESCRIPTION
This workaround causes instability for LoongArch/Loongson (MIPS) devices based on the 7A1000/2000 chipset under heavy I/O load.

FIXME: Disable this workaround until we find a better fix (possibly in the platform-specific PCI code).