### PR TITLE
[linux-6.6.y] hwmon: zhaoxin-cputemp: modify HWMON_THERMAL import

### DIFF
--- a/drivers/hwmon/hwmon.c
+++ b/drivers/hwmon/hwmon.c
@@ -1194,4 +1194,3 @@ module_exit(hwmon_exit);
 MODULE_AUTHOR("Mark M. Hoffman <mhoffman@lightlink.com>");
 MODULE_DESCRIPTION("hardware monitoring sysfs/class support");
 MODULE_LICENSE("GPL");
-MODULE_IMPORT_NS(HWMON_THERMAL);

--- a/drivers/hwmon/zhaoxin-cputemp.c
+++ b/drivers/hwmon/zhaoxin-cputemp.c
@@ -329,3 +329,5 @@ MODULE_LICENSE("GPL");
 
 module_init(zhaoxin_cputemp_init)
 module_exit(zhaoxin_cputemp_exit)
+
+MODULE_IMPORT_NS(HWMON_THERMAL);


### PR DESCRIPTION
Since the driver utilizes the hwmon_device_register_for_thermal function, it is necessary to add "MODULE_IMPORT_NS(HWMON_THERMAL)" to the zhaoxin-cputemp.c.