### PR TITLE
[linux-6.6.y] hwmon: zhaoxin-rng: remove log when CPU mismatch

### DIFF
--- a/drivers/char/hw_random/zhaoxin-rng.c
+++ b/drivers/char/hw_random/zhaoxin-rng.c
@@ -69,10 +69,8 @@ static int __init zhaoxin_rng_mod_init(void)
 {
 	int err;
 
-	if (!x86_match_cpu(zhaoxin_rng_cpu_ids)) {
-		pr_err(PFX "The CPU isn't support XSTORE.\n");
+	if (!x86_match_cpu(zhaoxin_rng_cpu_ids))
 		return -ENODEV;
-	}
 
 	pr_info("Zhaoxin RNG detected\n");
 


### PR DESCRIPTION
Delete this sentence "The CPU isn't support XSTORE" to avoid unnecessary redundant information.