### PR TITLE
[6.6]HYGON: Support identify Hygon pspccp on C86-2G/C86-3G/C86-4G cpus

### DIFF
--- a/drivers/crypto/ccp/Makefile
+++ b/drivers/crypto/ccp/Makefile
@@ -7,12 +7,14 @@ ccp-$(CONFIG_CRYPTO_DEV_SP_CCP) += ccp-dev.o \
 	    ccp-dev-v5.o \
 	    ccp-dmaengine.o
 ccp-$(CONFIG_CRYPTO_DEV_CCP_DEBUGFS) += ccp-debugfs.o
-ccp-$(CONFIG_PCI) += sp-pci.o
+ccp-$(CONFIG_PCI) += sp-pci.o \
+                     hygon/sp-pci.o
 ccp-$(CONFIG_CRYPTO_DEV_SP_PSP) += psp-dev.o \
                                    sev-dev.o \
                                    tee-dev.o \
                                    platform-access.o \
-                                   dbc.o
+                                   dbc.o \
+                                   hygon/psp-dev.o
 
 obj-$(CONFIG_CRYPTO_DEV_CCP_CRYPTO) += ccp-crypto.o
 ccp-crypto-objs := ccp-crypto-main.o \

--- a/drivers/crypto/ccp/hygon/psp-dev.c
+++ b/drivers/crypto/ccp/hygon/psp-dev.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * HYGON Platform Security Processor (PSP) interface
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/psp-hygon.h>
+
+#include "psp-dev.h"
+
+/* Function and variable pointers for hooks */
+struct hygon_psp_hooks_table hygon_psp_hooks;

--- a/drivers/crypto/ccp/hygon/psp-dev.c
+++ b/drivers/crypto/ccp/hygon/psp-dev.c
@@ -17,3 +17,14 @@
 
 /* Function and variable pointers for hooks */
 struct hygon_psp_hooks_table hygon_psp_hooks;
+
+int fixup_hygon_psp_caps(struct psp_device *psp)
+{
+	/* the hygon psp is unavailable if bit0 is cleared in feature reg */
+	if (!(psp->capability & PSP_CAPABILITY_SEV))
+		return -ENODEV;
+
+	psp->capability &= ~(PSP_CAPABILITY_TEE |
+			     PSP_CAPABILITY_PSP_SECURITY_REPORTING);
+	return 0;
+}

--- a/drivers/crypto/ccp/hygon/psp-dev.h
+++ b/drivers/crypto/ccp/hygon/psp-dev.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * HYGON Platform Security Processor (PSP) driver interface
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ */
+
+#ifndef __CCP_HYGON_PSP_DEV_H__
+#define __CCP_HYGON_PSP_DEV_H__
+
+#include <linux/mutex.h>
+
+#include "sp-dev.h"
+
+#include "../psp-dev.h"
+#include "../sev-dev.h"
+
+/*
+ * Hooks table: a table of function and variable pointers filled in
+ * when psp init.
+ */
+extern struct hygon_psp_hooks_table {
+	bool sev_dev_hooks_installed;
+	struct mutex *sev_cmd_mutex;
+	int (*__sev_do_cmd_locked)(int cmd, void *data, int *psp_ret);
+} hygon_psp_hooks;
+
+#endif	/* __CCP_HYGON_PSP_DEV_H__ */

--- a/drivers/crypto/ccp/hygon/psp-dev.h
+++ b/drivers/crypto/ccp/hygon/psp-dev.h
@@ -27,4 +27,6 @@ extern struct hygon_psp_hooks_table {
 	int (*__sev_do_cmd_locked)(int cmd, void *data, int *psp_ret);
 } hygon_psp_hooks;
 
+int fixup_hygon_psp_caps(struct psp_device *psp);
+
 #endif	/* __CCP_HYGON_PSP_DEV_H__ */

--- a/drivers/crypto/ccp/hygon/sp-dev.h
+++ b/drivers/crypto/ccp/hygon/sp-dev.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * HYGON Secure Processor interface
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ */
+
+#ifndef __CCP_HYGON_SP_DEV_H__
+#define __CCP_HYGON_SP_DEV_H__
+
+#include <linux/processor.h>
+#include <linux/ccp.h>
+
+#include "../ccp-dev.h"
+#include "../sp-dev.h"
+
+#ifdef CONFIG_X86_64
+static inline bool is_vendor_hygon(void)
+{
+	return boot_cpu_data.x86_vendor == X86_VENDOR_HYGON;
+}
+#else
+static inline bool is_vendor_hygon(void) { return false; }
+#endif
+
+extern const struct sp_dev_vdata hygon_dev_vdata[];
+
+#endif	/* __CCP_HYGON_SP_DEV_H__ */

--- a/drivers/crypto/ccp/hygon/sp-pci.c
+++ b/drivers/crypto/ccp/hygon/sp-pci.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * HYGON Secure Processor interface driver
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include "sp-dev.h"
+
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
+static const struct sev_vdata csvv1 = {
+	.cmdresp_reg		= 0x10580,	/* C2PMSG_32 */
+	.cmdbuff_addr_lo_reg	= 0x105e0,	/* C2PMSG_56 */
+	.cmdbuff_addr_hi_reg	= 0x105e4,	/* C2PMSG_57 */
+};
+
+static const struct psp_vdata pspv1 = {
+	.sev			= &csvv1,
+	.bootloader_info_reg	= 0x105ec,	/* C2PMSG_59 */
+	.feature_reg		= 0x105fc,	/* C2PMSG_63 */
+	.inten_reg		= 0x10610,	/* P2CMSG_INTEN */
+	.intsts_reg		= 0x10614,	/* P2CMSG_INTSTS */
+};
+
+#endif
+
+const struct sp_dev_vdata hygon_dev_vdata[] = {
+	{	/* 0 */
+		.bar = 2,
+#ifdef CONFIG_CRYPTO_DEV_SP_CCP
+		.ccp_vdata = &ccpv5a,
+#endif
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
+		.psp_vdata = &pspv1,
+#endif
+	},
+	{	/* 1 */
+		.bar = 2,
+#ifdef CONFIG_CRYPTO_DEV_SP_CCP
+		.ccp_vdata = &ccpv5b,
+#endif
+	},
+};

--- a/drivers/crypto/ccp/hygon/sp-pci.c
+++ b/drivers/crypto/ccp/hygon/sp-pci.c
@@ -28,6 +28,13 @@ static const struct psp_vdata pspv1 = {
 	.intsts_reg		= 0x10614,	/* P2CMSG_INTSTS */
 };
 
+static const struct psp_vdata pspv2 = {
+	.sev			= &csvv1,
+	.feature_reg		= 0x105fc,
+	.inten_reg		= 0x10670,
+	.intsts_reg		= 0x10674,
+};
+
 #endif
 
 const struct sp_dev_vdata hygon_dev_vdata[] = {
@@ -44,6 +51,15 @@ const struct sp_dev_vdata hygon_dev_vdata[] = {
 		.bar = 2,
 #ifdef CONFIG_CRYPTO_DEV_SP_CCP
 		.ccp_vdata = &ccpv5b,
+#endif
+	},
+	{	/* 2 */
+		.bar = 2,
+#ifdef CONFIG_CRYPTO_DEV_SP_CCP
+		.ccp_vdata = &ccpv5a,
+#endif
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
+		.psp_vdata = &pspv2,
 #endif
 	},
 };

--- a/drivers/crypto/ccp/psp-dev.c
+++ b/drivers/crypto/ccp/psp-dev.c
@@ -17,6 +17,8 @@
 #include "platform-access.h"
 #include "dbc.h"
 
+#include "hygon/psp-dev.h"
+
 struct psp_device *psp_master;
 
 static struct psp_device *psp_alloc_struct(struct sp_device *sp)
@@ -72,6 +74,17 @@ static unsigned int psp_get_capability(struct psp_device *psp)
 		return -ENODEV;
 	}
 	psp->capability = val;
+
+	/*
+	 * Fix capability of Hygon psp, the meaning of Hygon psp feature
+	 * register is not exactly the same as AMD.
+	 * Return -ENODEV directly if hygon psp not configured with CSV
+	 * capability.
+	 */
+	if (is_vendor_hygon()) {
+		if (fixup_hygon_psp_caps(psp))
+			return -ENODEV;
+	}
 
 	/* Detect if TSME and SME are both enabled */
 	if (psp->capability & PSP_CAPABILITY_PSP_SECURITY_REPORTING &&

--- a/drivers/crypto/ccp/sev-dev.c
+++ b/drivers/crypto/ccp/sev-dev.c
@@ -33,6 +33,8 @@
 #include "psp-dev.h"
 #include "sev-dev.h"
 
+#include "hygon/psp-dev.h"
+
 #define DEVICE_NAME		"sev"
 #define SEV_FW_FILE		"amd/sev.fw"
 #define SEV_FW_NAME_SIZE	64
@@ -1216,11 +1218,28 @@ static int sev_misc_init(struct sev_device *sev)
 	return 0;
 }
 
+/* Code to set all of the function and variable pointers */
+static void sev_dev_install_hooks(void)
+{
+	hygon_psp_hooks.sev_cmd_mutex = &sev_cmd_mutex;
+	hygon_psp_hooks.__sev_do_cmd_locked = __sev_do_cmd_locked;
+
+	hygon_psp_hooks.sev_dev_hooks_installed = true;
+}
+
 int sev_dev_init(struct psp_device *psp)
 {
 	struct device *dev = psp->dev;
 	struct sev_device *sev;
 	int ret = -ENOMEM;
+
+	/*
+	 * Install sev-dev related function and variable pointers hooks only
+	 * for Hygon vendor, install these hooks here, even though the
+	 * following initialization fails.
+	 */
+	if (is_vendor_hygon())
+		sev_dev_install_hooks();
 
 	if (!boot_cpu_has(X86_FEATURE_SEV)) {
 		dev_info_once(dev, "SEV: memory encryption not enabled by BIOS\n");

--- a/drivers/crypto/ccp/sp-pci.c
+++ b/drivers/crypto/ccp/sp-pci.c
@@ -580,6 +580,9 @@ static const struct pci_device_id sp_pci_table[] = {
 	{ PCI_VDEVICE(AMD, 0x156E), (kernel_ulong_t)&dev_vdata[8] },
 	{ PCI_VDEVICE(HYGON, 0x1456), (kernel_ulong_t)&hygon_dev_vdata[0] },
 	{ PCI_VDEVICE(HYGON, 0x1468), (kernel_ulong_t)&hygon_dev_vdata[1] },
+	{ PCI_VDEVICE(HYGON, 0x1486), (kernel_ulong_t)&hygon_dev_vdata[2] },
+	{ PCI_VDEVICE(HYGON, 0x14b8), (kernel_ulong_t)&hygon_dev_vdata[1] },
+	{ PCI_VDEVICE(HYGON, 0x14a6), (kernel_ulong_t)&hygon_dev_vdata[2] },
 	/* Last entry must be zero */
 	{ 0, }
 };

--- a/drivers/crypto/ccp/sp-pci.c
+++ b/drivers/crypto/ccp/sp-pci.c
@@ -25,6 +25,8 @@
 #include "ccp-dev.h"
 #include "psp-dev.h"
 
+#include "hygon/sp-dev.h"
+
 /* used for version string AA.BB.CC.DD */
 #define AA				GENMASK(31, 24)
 #define BB				GENMASK(23, 16)
@@ -576,6 +578,8 @@ static const struct pci_device_id sp_pci_table[] = {
 	{ PCI_VDEVICE(AMD, 0x1649), (kernel_ulong_t)&dev_vdata[6] },
 	{ PCI_VDEVICE(AMD, 0x17E0), (kernel_ulong_t)&dev_vdata[7] },
 	{ PCI_VDEVICE(AMD, 0x156E), (kernel_ulong_t)&dev_vdata[8] },
+	{ PCI_VDEVICE(HYGON, 0x1456), (kernel_ulong_t)&hygon_dev_vdata[0] },
+	{ PCI_VDEVICE(HYGON, 0x1468), (kernel_ulong_t)&hygon_dev_vdata[1] },
 	/* Last entry must be zero */
 	{ 0, }
 };

--- a/include/linux/psp-hygon.h
+++ b/include/linux/psp-hygon.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * HYGON Platform Security Processor (PSP) driver interface
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ */
+
+#ifndef __PSP_HYGON_H__
+#define __PSP_HYGON_H__
+
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
+#else	/* !CONFIG_CRYPTO_DEV_SP_PSP */
+#endif	/* CONFIG_CRYPTO_DEV_SP_PSP */
+
+#endif	/* __PSP_HYGON_H__ */

--- a/include/uapi/linux/psp-hygon.h
+++ b/include/uapi/linux/psp-hygon.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note */
+/*
+ * Userspace interface for HYGON Platform Security Processor (PSP)
+ * commands.
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ */
+
+#ifndef __PSP_HYGON_USER_H__
+#define __PSP_HYGON_USER_H__
+
+#endif	/* __PSP_HYGON_USER_H__ */


### PR DESCRIPTION
PSPCCP is the device which includes Platform Secure Processor and Cryptographic Co-Processor
in Hygon CPU, NTBCCP is Cryptographic Co-Processor in Hygon CPU. There are various device
IDs for PSPCCP/NTBCCP on Hygon C86-2G/C86-3G/C86-4G cpus. In order to avoid code intrusion
as much as possible, we introduce many files specific to Hygon.

Link: https://gitee.com/deepin-kernelsig/kernel/pulls/2