### PR TITLE
crypto: ccp: Implement CSV_HGSC_CERT_IMPORT ioctl command

### DIFF
--- a/drivers/crypto/ccp/Makefile
+++ b/drivers/crypto/ccp/Makefile
@@ -14,7 +14,8 @@ ccp-$(CONFIG_CRYPTO_DEV_SP_PSP) += psp-dev.o \
                                    tee-dev.o \
                                    platform-access.o \
                                    dbc.o \
-                                   hygon/psp-dev.o
+                                   hygon/psp-dev.o \
+                                   hygon/csv-dev.o
 
 obj-$(CONFIG_CRYPTO_DEV_CCP_CRYPTO) += ccp-crypto.o
 ccp-crypto-objs := ccp-crypto-main.o \

--- a/drivers/crypto/ccp/hygon/csv-dev.c
+++ b/drivers/crypto/ccp/hygon/csv-dev.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * HYGON CSV interface
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/psp.h>
+#include <linux/psp-hygon.h>
+#include <uapi/linux/psp-hygon.h>
+
+#include "psp-dev.h"
+
+int csv_cmd_buffer_len(int cmd)
+{
+	switch (cmd) {
+	case CSV_CMD_HGSC_CERT_IMPORT:		return sizeof(struct csv_data_hgsc_cert_import);
+	default:				return 0;
+	}
+}
+
+static int csv_ioctl_do_hgsc_import(struct sev_issue_cmd *argp)
+{
+	struct csv_user_data_hgsc_cert_import input;
+	struct csv_data_hgsc_cert_import *data;
+	void *hgscsk_blob, *hgsc_blob;
+	int ret;
+
+	if (copy_from_user(&input, (void __user *)argp->data, sizeof(input)))
+		return -EFAULT;
+
+	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	/* copy HGSCSK certificate blobs from userspace */
+	hgscsk_blob = psp_copy_user_blob(input.hgscsk_cert_address, input.hgscsk_cert_len);
+	if (IS_ERR(hgscsk_blob)) {
+		ret = PTR_ERR(hgscsk_blob);
+		goto e_free;
+	}
+
+	data->hgscsk_cert_address = __psp_pa(hgscsk_blob);
+	data->hgscsk_cert_len = input.hgscsk_cert_len;
+
+	/* copy HGSC certificate blobs from userspace */
+	hgsc_blob = psp_copy_user_blob(input.hgsc_cert_address, input.hgsc_cert_len);
+	if (IS_ERR(hgsc_blob)) {
+		ret = PTR_ERR(hgsc_blob);
+		goto e_free_hgscsk;
+	}
+
+	data->hgsc_cert_address = __psp_pa(hgsc_blob);
+	data->hgsc_cert_len = input.hgsc_cert_len;
+
+	ret = hygon_psp_hooks.__sev_do_cmd_locked(CSV_CMD_HGSC_CERT_IMPORT,
+						  data, &argp->error);
+
+	kfree(hgsc_blob);
+e_free_hgscsk:
+	kfree(hgscsk_blob);
+e_free:
+	kfree(data);
+	return ret;
+}
+
+static long csv_ioctl(struct file *file, unsigned int ioctl, unsigned long arg)
+{
+	void __user *argp = (void __user *)arg;
+	struct sev_issue_cmd input;
+	int ret = -EFAULT;
+
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
+
+	if (!psp_master || !psp_master->sev_data)
+		return -ENODEV;
+
+	if (ioctl != SEV_ISSUE_CMD)
+		return -EINVAL;
+
+	if (copy_from_user(&input, argp, sizeof(struct sev_issue_cmd)))
+		return -EFAULT;
+
+	if (input.cmd > CSV_MAX)
+		return -EINVAL;
+
+	mutex_lock(hygon_psp_hooks.sev_cmd_mutex);
+
+	switch (input.cmd) {
+	case CSV_HGSC_CERT_IMPORT:
+		ret = csv_ioctl_do_hgsc_import(&input);
+		break;
+	default:
+		/*
+		 * If the command is compatible between CSV and SEV, the
+		 * native implementation of the driver is invoked.
+		 * Release the mutex before calling the native ioctl function
+		 * because it will acquires the mutex.
+		 */
+		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
+		return hygon_psp_hooks.sev_ioctl(file, ioctl, arg);
+	}
+
+	if (copy_to_user(argp, &input, sizeof(struct sev_issue_cmd)))
+		ret = -EFAULT;
+
+	mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
+
+	return ret;
+}
+
+const struct file_operations csv_fops = {
+	.owner = THIS_MODULE,
+	.unlocked_ioctl = csv_ioctl,
+};

--- a/drivers/crypto/ccp/hygon/csv-dev.h
+++ b/drivers/crypto/ccp/hygon/csv-dev.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * HYGON CSV driver interface
+ *
+ * Copyright (C) 2024 Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ */
+
+#ifndef __CCP_HYGON_CSV_DEV_H__
+#define __CCP_HYGON_CSV_DEV_H__
+
+#include <linux/fs.h>
+
+extern const struct file_operations csv_fops;
+
+int csv_cmd_buffer_len(int cmd);
+
+#endif	/* __CCP_HYGON_CSV_DEV_H__ */

--- a/drivers/crypto/ccp/hygon/psp-dev.h
+++ b/drivers/crypto/ccp/hygon/psp-dev.h
@@ -25,6 +25,7 @@ extern struct hygon_psp_hooks_table {
 	bool sev_dev_hooks_installed;
 	struct mutex *sev_cmd_mutex;
 	int (*__sev_do_cmd_locked)(int cmd, void *data, int *psp_ret);
+	long (*sev_ioctl)(struct file *file, unsigned int ioctl, unsigned long arg);
 } hygon_psp_hooks;
 
 int fixup_hygon_psp_caps(struct psp_device *psp);

--- a/drivers/crypto/ccp/sev-dev.c
+++ b/drivers/crypto/ccp/sev-dev.c
@@ -34,6 +34,7 @@
 #include "sev-dev.h"
 
 #include "hygon/psp-dev.h"
+#include "hygon/csv-dev.h"
 
 #define DEVICE_NAME		"sev"
 #define SEV_FW_FILE		"amd/sev.fw"
@@ -129,6 +130,18 @@ static int sev_wait_cmd_ioc(struct sev_device *sev,
 
 static int sev_cmd_buffer_len(int cmd)
 {
+	/*
+	 * The Hygon CSV command may conflict with AMD SEV command, so it's
+	 * preferred to check whether it's a CSV-specific command for Hygon
+	 * psp.
+	 */
+	if (is_vendor_hygon()) {
+		int r = csv_cmd_buffer_len(cmd);
+
+		if (r)
+			return r;
+	}
+
 	switch (cmd) {
 	case SEV_CMD_INIT:			return sizeof(struct sev_data_init);
 	case SEV_CMD_INIT_EX:                   return sizeof(struct sev_data_init_ex);
@@ -1200,7 +1213,11 @@ static int sev_misc_init(struct sev_device *sev)
 		misc = &misc_dev->misc;
 		misc->minor = MISC_DYNAMIC_MINOR;
 		misc->name = DEVICE_NAME;
-		misc->fops = &sev_fops;
+
+		if (is_vendor_hygon())
+			misc->fops = &csv_fops;
+		else
+			misc->fops = &sev_fops;
 
 		ret = misc_register(misc);
 		if (ret)
@@ -1223,6 +1240,7 @@ static void sev_dev_install_hooks(void)
 {
 	hygon_psp_hooks.sev_cmd_mutex = &sev_cmd_mutex;
 	hygon_psp_hooks.__sev_do_cmd_locked = __sev_do_cmd_locked;
+	hygon_psp_hooks.sev_ioctl = sev_ioctl;
 
 	hygon_psp_hooks.sev_dev_hooks_installed = true;
 }
@@ -1330,7 +1348,8 @@ void sev_dev_destroy(struct psp_device *psp)
 int sev_issue_cmd_external_user(struct file *filep, unsigned int cmd,
 				void *data, int *error)
 {
-	if (!filep || filep->f_op != &sev_fops)
+	if (!filep || filep->f_op != (is_vendor_hygon()
+				      ? &csv_fops : &sev_fops))
 		return -EBADF;
 
 	return sev_do_cmd(cmd, data, error);

--- a/include/linux/psp-hygon.h
+++ b/include/linux/psp-hygon.h
@@ -10,6 +10,36 @@
 #ifndef __PSP_HYGON_H__
 #define __PSP_HYGON_H__
 
+#include <linux/types.h>
+
+/*****************************************************************************/
+/***************************** CSV interface *********************************/
+/*****************************************************************************/
+
+/**
+ * Guest/platform management commands for CSV
+ */
+enum csv_cmd {
+	CSV_CMD_HGSC_CERT_IMPORT        = 0x300,
+	CSV_CMD_MAX,
+};
+
+/**
+ * struct csv_data_hgsc_cert_import - HGSC_CERT_IMPORT command parameters
+ *
+ * @hgscsk_cert_address: HGSCSK certificate chain
+ * @hgscsk_cert_len: len of HGSCSK certificate
+ * @hgsc_cert_address: HGSC certificate chain
+ * @hgsc_cert_len: len of HGSC certificate
+ */
+struct csv_data_hgsc_cert_import {
+	u64 hgscsk_cert_address;        /* In */
+	u32 hgscsk_cert_len;            /* In */
+	u32 reserved;                   /* In */
+	u64 hgsc_cert_address;          /* In */
+	u32 hgsc_cert_len;              /* In */
+} __packed;
+
 #ifdef CONFIG_CRYPTO_DEV_SP_PSP
 #else	/* !CONFIG_CRYPTO_DEV_SP_PSP */
 #endif	/* CONFIG_CRYPTO_DEV_SP_PSP */

--- a/include/uapi/linux/psp-hygon.h
+++ b/include/uapi/linux/psp-hygon.h
@@ -11,4 +11,34 @@
 #ifndef __PSP_HYGON_USER_H__
 #define __PSP_HYGON_USER_H__
 
+#include <linux/types.h>
+
+/*****************************************************************************/
+/***************************** CSV interface *********************************/
+/*****************************************************************************/
+
+/**
+ * CSV guest/platform commands
+ */
+enum {
+	CSV_HGSC_CERT_IMPORT = 201,
+
+	CSV_MAX,
+};
+
+/**
+ * struct csv_user_data_hgsc_cert_import - HGSC_CERT_IMPORT command parameters
+ *
+ * @hgscsk_cert_address: HGSCSK certificate chain
+ * @hgscsk_cert_len: length of HGSCSK certificate
+ * @hgsc_cert_address: HGSC certificate chain
+ * @hgsc_cert_len: length of HGSC certificate
+ */
+struct csv_user_data_hgsc_cert_import {
+	__u64 hgscsk_cert_address;              /* In */
+	__u32 hgscsk_cert_len;                  /* In */
+	__u64 hgsc_cert_address;                /* In */
+	__u32 hgsc_cert_len;                    /* In */
+} __packed;
+
 #endif	/* __PSP_HYGON_USER_H__ */


### PR DESCRIPTION
Hygon General Security Certificates (HGSC) are the basic certificates that enable Hygon CPUs' security functions. The security functions, such as CSV, will not work until the HGSC is imported.

Test reference: see the comments in https://gitee.com/openeuler/kernel/issues/I98M2W

hygon inclusion
category: feature
CVE: NA

---------------------------

The CSV_HGSC_CERT_IMPORT command can be used to import hygon general secure cert to the Secure Proccessor, to enable Hygon Secure Functions, such as CSV, TPM, TPCM, TDM.

Link: https://gitee.com/deepin-kernelsig/kernel/pulls/3