### PR TITLE
crypto: ccp: Fix compile error on csv_cmd_buffer_len()

### DIFF
--- a/drivers/crypto/ccp/hygon/csv-dev.c
+++ b/drivers/crypto/ccp/hygon/csv-dev.c
@@ -15,6 +15,7 @@
 #include <linux/psp-hygon.h>
 #include <uapi/linux/psp-hygon.h>
 
+#include "csv-dev.h"
 #include "psp-dev.h"
 
 /*


### PR DESCRIPTION
hygon inclusion
category: bugfix
CVE: NA

---------------------------

The error messages is shown as following:

drivers/crypto/ccp/hygon/csv-dev.c:21:5: error: no previous prototype for ‘csv_cmd_buffer_len’ [-Werror=missing-prototypes]
   21 | int csv_cmd_buffer_len(int cmd)
      |     ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Reported-by: WangYuli <wangyuli@uniontech.com>