### PR TITLE
spi: phytium: fix 'Disabling IRQ #18'

### DIFF
--- a/drivers/spi/spi-phytium.c
+++ b/drivers/spi/spi-phytium.c
@@ -405,13 +405,6 @@ int phytium_spi_add_host(struct device *dev, struct phytium_spi *fts)
 	fts->dma_addr = (dma_addr_t)(fts->paddr + DR);
 	snprintf(fts->name, sizeof(fts->name), "phytium_spi%d", fts->bus_num);
 
-	ret = request_irq(fts->irq, phytium_spi_irq, IRQF_SHARED,
-			fts->name, master);
-	if (ret < 0) {
-		dev_err(dev, "can not get IRQ\n");
-		goto err_free_master;
-	}
-
 	master->use_gpio_descriptors = true;
 	master->mode_bits = SPI_CPOL | SPI_CPHA | SPI_LOOP;
 	master->bits_per_word_mask = SPI_BPW_MASK(8) | SPI_BPW_MASK(16);
@@ -440,6 +433,14 @@ int phytium_spi_add_host(struct device *dev, struct phytium_spi *fts)
 	}
 
 	spi_master_set_devdata(master, fts);
+
+	ret = request_irq(fts->irq, phytium_spi_irq, IRQF_SHARED,
+			fts->name, master);
+	if (ret < 0) {
+		dev_err(dev, "can not get IRQ\n");
+		goto err_free_master;
+	}
+
 	ret = spi_register_controller(master);
 	if (ret) {
 		dev_err(&master->dev, "problem registering spi master\n");


### PR DESCRIPTION
It also casue FT-D3000 board m70f
request_irq register a handler 'phytium_spi_irq',
which calls spi_master_get_devdata.
so it should be called after spi_master_set_devdata, where the handler can really get the fts structure.

Log:
[    1.535532] irq 18: nobody cared (try booting with the "irqpoll" option)
[    1.542258] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 4.19.0-arm64-desktop #5300
[    1.542260] Hardware name: N/A N/A/L21K-2041K, BIOS KL4.27.BD.D.062.D 03/10/2022
[    1.542261] Call trace:
[    1.542267]  dump_backtrace+0x0/0x190
[    1.542269]  show_stack+0x14/0x20
[    1.542273]  dump_stack+0xa8/0xcc
[    1.542277]  __report_bad_irq+0x48/0x100
[    1.542279]  note_interrupt+0x280/0x2e4
[    1.542281]  handle_irq_event_percpu+0x54/0x68
[    1.542283]  handle_irq_event+0x40/0x98
[    1.542285]  handle_fasteoi_irq+0xd4/0x1a0
[    1.542287]  generic_handle_irq+0x2c/0x40
[    1.542289]  __handle_domain_irq+0x60/0xb8
[    1.542291]  gic_handle_irq+0x7c/0x178
[    1.542292]  el1_irq+0xb0/0x140
[    1.542294]  __do_softirq+0x84/0x2e8
[    1.542297]  irq_exit+0x9c/0xb8
[    1.542298]  __handle_domain_irq+0x64/0xb8
[    1.542300]  gic_handle_irq+0x7c/0x178
[    1.542301]  el1_irq+0xb0/0x140
[    1.542303]  __setup_irq+0x478/0x6d8
[    1.542305]  request_threaded_irq+0xdc/0x198
[    1.542308]  phytium_spi_add_host+0x70/0x198
[    1.542310]  phytium_spi_probe+0x2ec/0x328
[    1.542313]  platform_drv_probe+0x50/0xa0
[    1.542315]  really_probe+0x23c/0x3c8
[    1.542317]  driver_probe_device+0xdc/0x130
[    1.542318]  __driver_attach+0x128/0x150
[    1.542320]  bus_for_each_dev+0x60/0x98
[    1.542322]  driver_attach+0x20/0x28
[    1.542323]  bus_add_driver+0x1a0/0x280
[    1.542325]  driver_register+0x60/0x110
[    1.542327]  __platform_driver_register+0x44/0x50
[    1.542330]  phytium_spi_driver_init+0x18/0x20
[    1.542332]  do_one_initcall+0x30/0x19c
[    1.542335]  kernel_init_freeable+0x27c/0x320
[    1.542338]  kernel_init+0x10/0x100
[    1.542340]  ret_from_fork+0x10/0x18
[    1.542341] handlers:
[    1.544611] [<0000000057fd3891>] phytium_spi_irq
[    1.549235] Disabling IRQ #18

same problem link:
https://gitee.com/openeuler/kernel/commit/7e9c59f90e0d0b78aa3ad27fc2baf37b9333b41f

![IMG_20240806_210904(1)](https://github.com/user-attachments/assets/8669279d-1060-472d-a4c9-9af8b2ee6965)
