### PR TITLE
[linux-6.6.y] x86/mce: Add NMIs setup in machine_check func

### DIFF
--- a/arch/x86/kernel/cpu/mce/core.c
+++ b/arch/x86/kernel/cpu/mce/core.c
@@ -2122,11 +2122,17 @@ static __always_inline void exc_machine_check_kernel(struct pt_regs *regs)
 
 static __always_inline void exc_machine_check_user(struct pt_regs *regs)
 {
+	irqentry_state_t irq_state;
+
+	irq_state = irqentry_nmi_enter(regs);
+
 	irqentry_enter_from_user_mode(regs);
 
 	do_machine_check(regs);
 
 	irqentry_exit_to_user_mode(regs);
+
+	irqentry_nmi_exit(regs, irq_state);
 }
 
 #ifdef CONFIG_X86_64


### PR DESCRIPTION
#MC is a NMI-like exception. But do not do any setup that NMIs need.
This will lead to console_owner_lock issue and HPET dead loop issue.

![输入图片说明](https://foruda.gitee.com/images/1718073570333896489/97468637_8868386.png "屏幕截图")
This may lead to read_hpet dead loops.

The console_owner_lock issue is similar.

To avoid these issues, add NMIs setup When Handling #MC Exceptions.