### PR TITLE
[linux-6.6.y] x86/hpet: Read HPET directly if panic in progress

### DIFF
--- a/arch/x86/kernel/hpet.c
+++ b/arch/x86/kernel/hpet.c
@@ -805,6 +805,12 @@ static u64 read_hpet(struct clocksource *cs)
 		return (u64)hpet_readl(HPET_COUNTER);
 
 	/*
+	 * Read HPET directly if panic in progress.
+	 */
+	if (unlikely(atomic_read(&panic_cpu) != PANIC_CPU_INVALID))
+		return (u64)hpet_readl(HPET_COUNTER);
+
+	/*
 	 * Read the current state of the lock and HPET value atomically.
 	 */
 	old.lockval = READ_ONCE(hpet.lockval);


### PR DESCRIPTION
When the clocksource of the system is HPET，a CPU executing read_hpet might
be interrupted by #GP/#PF to executing the panic，this may lead to
read_hpet dead loops:

![输入图片说明](https://foruda.gitee.com/images/1718074657676425361/81c9bc12_8868386.png "屏幕截图")

To avoid this dead loops, read HPET directly if panic in progress.