### PR TITLE
[6.6]Hygon: Some enhancement and bugfixes for HYGON SME/CSV/CSV2

### DIFF
--- a/arch/x86/kernel/head_64.S
+++ b/arch/x86/kernel/head_64.S
@@ -375,6 +375,14 @@ SYM_INNER_LABEL(secondary_startup_64_no_verify, SYM_L_GLOBAL)
 	shrq	$32, %rdx
 	wrmsr
 
+#ifdef CONFIG_AMD_MEM_ENCRYPT
+	/*
+	 * Ensure .bss.decrypted memory's stale caches which lived in earlier
+	 * stage to be flushed.
+	 */
+	call	early_clflush_bss_decrypted_section
+#endif
+
 	/* Setup and Load IDT */
 	call	early_setup_idt
 
@@ -511,6 +519,8 @@ SYM_CODE_END(vc_boot_ghcb)
 SYM_DATA(initial_code,	.quad x86_64_start_kernel)
 #ifdef CONFIG_AMD_MEM_ENCRYPT
 SYM_DATA(initial_vc_handler,	.quad handle_vc_boot_ghcb)
+SYM_DATA(bsp_flush_bss_decrypted_section_handled,	.byte 0x0)
+	.balign	8
 #endif
 
 SYM_DATA(trampoline_lock, .quad 0);

--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -2467,6 +2467,9 @@ void sev_free_vcpu(struct kvm_vcpu *vcpu)
 
 	__free_page(virt_to_page(svm->sev_es.vmsa));
 
+	if (svm->sev_es.ghcb)
+		kvm_vcpu_unmap(vcpu, &svm->sev_es.ghcb_map, false);
+
 	if (svm->sev_es.ghcb_sa_free)
 		kvfree(svm->sev_es.ghcb_sa);
 

--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -159,6 +159,13 @@ static int sev_asid_new(struct kvm_sev_info *sev)
 	bool retry = true;
 	int ret;
 
+	/*
+	 * No matter what the min_sev_asid is, all asids in range
+	 * [1, max_sev_asid] can be used for CSV2 guest on Hygon CPUs.
+	 */
+	if (is_x86_vendor_hygon())
+		max_asid = max_sev_asid;
+
 	if (min_asid > max_asid)
 		return -ENOTTY;
 
@@ -2308,11 +2315,19 @@ void __init sev_hardware_setup(void)
 		goto out;
 	}
 
-	/* Has the system been allocated ASIDs for SEV-ES? */
-	if (min_sev_asid == 1)
-		goto out;
+	if (is_x86_vendor_hygon()) {
+		/*
+		 * Ths ASIDs from 1 to max_sev_asid are available for hygon
+		 * CSV2 guest.
+		 */
+		sev_es_asid_count = max_sev_asid;
+	} else {
+		/* Has the system been allocated ASIDs for SEV-ES? */
+		if (min_sev_asid == 1)
+			goto out;
 
-	sev_es_asid_count = min_sev_asid - 1;
+		sev_es_asid_count = min_sev_asid - 1;
+	}
 	WARN_ON_ONCE(misc_cg_set_capacity(MISC_CG_RES_SEV_ES, sev_es_asid_count));
 	sev_es_supported = true;
 
@@ -2328,7 +2343,8 @@ out:
 		pr_info("%s %s (ASIDs %u - %u)\n",
 			is_x86_vendor_hygon() ? "CSV2" : "SEV-ES",
 			sev_es_supported ? "enabled" : "disabled",
-			min_sev_asid > 1 ? 1 : 0, min_sev_asid - 1);
+			is_x86_vendor_hygon() ? 1 : (min_sev_asid > 1 ? 1 : 0),
+			is_x86_vendor_hygon() ? max_sev_asid : min_sev_asid - 1);
 
 	sev_enabled = sev_supported;
 	sev_es_enabled = sev_es_supported;

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -1709,22 +1709,17 @@ static int do_get_msr_feature(struct kvm_vcpu *vcpu, unsigned index, u64 *data)
 	struct kvm_msr_entry msr;
 	int r;
 
+	/* Unconditionally clear the output for simplicity */
+	msr.data = 0;
 	msr.index = index;
 	r = kvm_get_msr_feature(&msr);
 
-	if (r == KVM_MSR_RET_INVALID) {
-		/* Unconditionally clear the output for simplicity */
-		*data = 0;
-		if (kvm_msr_ignored_check(index, 0, false))
-			r = 0;
-	}
-
-	if (r)
-		return r;
+	if (r == KVM_MSR_RET_INVALID && kvm_msr_ignored_check(index, 0, false))
+		r = 0;
 
 	*data = msr.data;
 
-	return 0;
+	return r;
 }
 
 static bool __kvm_valid_efer(struct kvm_vcpu *vcpu, u64 efer)

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -9855,8 +9855,13 @@ static int complete_hypercall_exit(struct kvm_vcpu *vcpu)
 {
 	u64 ret = vcpu->run->hypercall.ret;
 
-	if (!is_64_bit_mode(vcpu))
+	/* Use is_64_bit_hypercall() instead of is_64_bit_mode() for Hygon CPUs */
+	if (is_x86_vendor_hygon()) {
+		if (!is_64_bit_hypercall(vcpu))
+			ret = (u32)ret;
+	} else if (!is_64_bit_mode(vcpu)) {
 		ret = (u32)ret;
+	}
 	kvm_rax_write(vcpu, ret);
 	++vcpu->stat.hypercalls;
 	return kvm_skip_emulated_instruction(vcpu);


### PR DESCRIPTION
Description:
1. Fix the asid range for CSV2 guest
2. Keep CSV2 #VC handling for user-space NAE event in atomic context
3. Fix unexpected hypercall warning messages
4. Fix cache coherency issue in the CSV/CSV2 guest
5. Fix the return value and emulated MSRs info to user space
6. Fix memleak on mapped GHCB pages