### PR TITLE
spi: Introduce dependencise for Phytium to avoid warnings

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -780,6 +780,7 @@ config SPI_PHYTIUM
 
 config SPI_PHYTIUM_PLAT
 	tristate "Phytium SPI controller platform support"
+	depends on ARCH_PHYTIUM || COMPILE_TEST
 	select SPI_PHYTIUM
 	help
 	  This selects a platform driver for Phytium SPI controller.
@@ -789,6 +790,7 @@ config SPI_PHYTIUM_PLAT
 
 config SPI_PHYTIUM_PCI
 	tristate "Phytium SPI controller PCI support"
+	depends on ARCH_PHYTIUM || COMPILE_TEST
 	depends on PCI
 	select SPI_PHYTIUM
 	help


### PR DESCRIPTION
Fix follow warnings in Kconfig:

WARNING: unmet direct dependencies detected for SPI_PHYTIUM
  Depends on [n]: SPI [=y] && SPI_MASTER [=y] && (ARCH_PHYTIUM || COMPILE_TEST [=n])
  Selected by [m]:
  - SPI_PHYTIUM_PLAT [=m] && SPI [=y] && SPI_MASTER [=y]
  - SPI_PHYTIUM_PCI [=m] && SPI [=y] && SPI_MASTER [=y] && PCI [=y]

WARNING: unmet direct dependencies detected for SPI_PHYTIUM
  Depends on [n]: SPI [=y] && SPI_MASTER [=y] && (ARCH_PHYTIUM || COMPILE_TEST [=n])
  Selected by [m]:
  - SPI_PHYTIUM_PLAT [=m] && SPI [=y] && SPI_MASTER [=y]
  - SPI_PHYTIUM_PCI [=m] && SPI [=y] && SPI_MASTER [=y] && PCI [=y]