### PR TITLE
[Deepin-Kernel-SIG] [FROMLIST] net: phy: fix may not suspend when phy has WoL

### DIFF
--- a/drivers/net/phy/phy_device.c
+++ b/drivers/net/phy/phy_device.c
@@ -288,6 +288,18 @@ static bool mdio_bus_phy_may_suspend(struct phy_device *phydev)
 	if (netdev->wol_enabled)
 		return false;
 
+	/* Ethernet and phy device wol state may not same, netdev->wol_enabled
+	 * disabled,and phydev set wol_enabled enabled, so netdev->wol_enabled
+	 * is not enough, so check phydev->wol_enabled.
+	 */
+	struct ethtool_wolinfo wol = { .cmd = ETHTOOL_GWOL };
+
+	phy_ethtool_get_wol(phydev, &wol);
+	if (wol.wolopts) {
+		phydev_warn(phydev, "Phy and mac wol are not compatible\n");
+		return false;
+	}
+
 	/* As long as not all affected network drivers support the
 	 * wol_enabled flag, let's check for hints that WoL is enabled.
 	 * Don't suspend PHY if the attached netdev parent may wake up.


### PR DESCRIPTION
When system suspend, and mdio_bus_phy goes to suspend,
if the phy enabled wol, phy_suspend will returned -EBUSY,
and break system suspend.

93f41e67(net: phy: fix WoL handling when suspending the PHY)
Fix the case when netdev->wol_enabled=1, but some case,
netdev->wol_enabled=0 and phydev set wol_enabled enabled,
so check phydev->wol_enabled.

I dont know why
481b5d93(net: phy: provide phy_resume/phy_suspend helpers)
think that it should return -EBUSY when WoL.

Log:
YT8531S Gigabit Ethernet phytmac_mii_bus-PHYT0046:00:07: PM: dpm_run_callback(): mdio_bus_phy_suspend+0x0/0x10c returns -16
YT8531S Gigabit Ethernet phytmac_mii_bus-PHYT0046:00:07: PM: failed to suspend: error -16
PM: Some devices failed to suspend, or early wake event detected
YT8531S Gigabit Ethernet phytmac_mii_bus-PHYT0046:00:07: PM: dpm_run_callback(): mdio_bus_phy_suspend+0x0/0x10c returns -16
YT8531S Gigabit Ethernet phytmac_mii_bus-PHYT0046:00:07: PM: failed to suspend: error -16
PM: Some devices failed to suspend, or early wake event detected
YT8531S Gigabit Ethernet phytmac_mii_bus-PHYT0046:00:07: PM: dpm_run_callback(): mdio_bus_phy_suspend+0x0/0x10c returns -16
YT8531S Gigabit Ethernet phytmac_mii_bus-PHYT0046:00:07: PM: failed to freeze: error -16