### PR TITLE
[Deepin-Kernel-SIG] [linux-6.6.y] printk: show build commitid in the front of dmesg

### DIFF
--- a/include/linux/printk.h
+++ b/include/linux/printk.h
@@ -11,6 +11,7 @@
 
 extern const char linux_banner[];
 extern const char linux_proc_banner[];
+extern const char linux_commitid_banner[];
 
 extern int oops_in_progress;	/* If set, an oops, panic(), BUG() or die() is in progress */
 

--- a/init/main.c
+++ b/init/main.c
@@ -894,7 +894,7 @@ void start_kernel(void)
 	 */
 	boot_cpu_init();
 	page_address_init();
-	pr_notice("%s", linux_banner);
+	pr_notice("%s", linux_commitid_banner);
 	early_security_init();
 	setup_arch(&command_line);
 	setup_boot_config();

--- a/init/version-timestamp.c
+++ b/init/version-timestamp.c
@@ -28,3 +28,7 @@ struct uts_namespace init_uts_ns = {
 const char linux_banner[] =
 	"Linux version " UTS_RELEASE " (" LINUX_COMPILE_BY "@"
 	LINUX_COMPILE_HOST ") (" LINUX_COMPILER ") " UTS_VERSION "\n";
+
+const char linux_commitid_banner[] =
+	"Linux version " UTS_RELEASE " (" LINUX_COMPILE_BY "@"
+	LINUX_COMPILE_HOST ") (" LINUX_COMPILER ") (" GIT_COMMITID ") " UTS_VERSION "\n";

--- a/init/version.c
+++ b/init/version.c
@@ -48,6 +48,7 @@ BUILD_LTO_INFO;
 
 struct uts_namespace init_uts_ns __weak;
 const char linux_banner[] __weak;
+const char linux_commitid_banner[] __weak;
 
 #include "version-timestamp.c"
 

--- a/scripts/mkcompile_h
+++ b/scripts/mkcompile_h
@@ -19,9 +19,12 @@ fi
 LD_VERSION=$(LC_ALL=C $LD -v | head -n1 |
 		sed -e 's/(compatible with [^)]*)//' -e 's/[[:space:]]*$//')
 
+GIT_COMMITID=$(git log -1 --pretty=format:%h 2>/dev/null)
+
 cat <<EOF
 #define UTS_MACHINE		"${UTS_MACHINE}"
 #define LINUX_COMPILE_BY	"${LINUX_COMPILE_BY}"
 #define LINUX_COMPILE_HOST	"${LINUX_COMPILE_HOST}"
 #define LINUX_COMPILER		"${CC_VERSION}, ${LD_VERSION}"
+#define GIT_COMMITID		"${GIT_COMMITID}"
 EOF

--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -184,6 +184,7 @@ cat <<EOF > debian/changelog
 $sourcename ($packageversion) $distribution; urgency=low
 
   * Custom built Linux kernel.
+  * Git:$(git symbolic-ref --short HEAD 2>/dev/null || true) $(git rev-parse --short HEAD) $(git diff --quiet HEAD || echo "dirty")
 
  -- $maintainer  $(date -R)
 EOF


### PR DESCRIPTION
This can help us find source code version when troubleshooting.