### PR TITLE
[Deepin Kernel SIG] kABI: Introduce generic kABI macros to use for kABI workarounds

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5773,6 +5773,14 @@ M:	"WangYuli" <wangyuli@uniontech.com>
 S:	Maintained
 F:	lib/fonts/font_cjk*
 
+DEEPIN KABI-HELPERS
+M:	"Lugang He" <helugang@uniontech.com>
+M:	"WangYuli" <wangyuli@uniontech.com>
+M:	"Wentao Guan" <guanwentao@uniontech.com>
+M:	"Winston Wen" <wentao@uniontech.com>
+S:	Maintained
+F:	include/linux/deepin_kabi.h
+
 DEEPIN OWNERS
 M:	"WangYuli" <wangyuli@uniontech.com>
 S:	Maintained

--- a/drivers/pci/pci.h
+++ b/drivers/pci/pci.h
@@ -310,6 +310,15 @@ struct pci_sriov {
 	u16		subsystem_device; /* VF subsystem device */
 	resource_size_t	barsz[PCI_SRIOV_NUM_BARS];	/* VF BAR size */
 	bool		drivers_autoprobe; /* Auto probing of VFs by driver */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 #ifdef CONFIG_PCI_DOE

--- a/include/crypto/akcipher.h
+++ b/include/crypto/akcipher.h
@@ -10,6 +10,7 @@
 
 #include <linux/atomic.h>
 #include <linux/crypto.h>
+#include <linux/deepin_kabi.h>
 
 /**
  * struct akcipher_request - public key request
@@ -126,6 +127,10 @@ struct akcipher_alg {
 	unsigned int (*max_size)(struct crypto_akcipher *tfm);
 	int (*init)(struct crypto_akcipher *tfm);
 	void (*exit)(struct crypto_akcipher *tfm);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 
 #ifdef CONFIG_CRYPTO_STATS
 	struct crypto_istat_akcipher stat;

--- a/include/crypto/public_key.h
+++ b/include/crypto/public_key.h
@@ -12,6 +12,7 @@
 
 #include <linux/keyctl.h>
 #include <linux/oid_registry.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Cryptographic data for the public-key subtype of the asymmetric key type.
@@ -32,6 +33,10 @@ struct public_key {
 #define KEY_EFLAG_CA		0	/* set if the CA basic constraints is set */
 #define KEY_EFLAG_DIGITALSIG	1	/* set if the digitalSignature usage is set */
 #define KEY_EFLAG_KEYCERTSIGN	2	/* set if the keyCertSign usage is set */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 extern void public_key_free(struct public_key *key);

--- a/include/linux/can/core.h
+++ b/include/linux/can/core.h
@@ -17,6 +17,7 @@
 #include <linux/can.h>
 #include <linux/skbuff.h>
 #include <linux/netdevice.h>
+#include <linux/deepin_kabi.h>
 
 #define DNAME(dev) ((dev) ? (dev)->name : "any")
 
@@ -32,6 +33,9 @@ struct can_proto {
 	int protocol;
 	const struct proto_ops *ops;
 	struct proto *prot;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* required_size

--- a/include/linux/can/dev.h
+++ b/include/linux/can/dev.h
@@ -22,6 +22,7 @@
 #include <linux/can/skb.h>
 #include <linux/ethtool.h>
 #include <linux/netdevice.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * CAN mode
@@ -85,6 +86,11 @@ struct can_priv {
 	int (*do_get_berr_counter)(const struct net_device *dev,
 				   struct can_berr_counter *bec);
 	int (*do_get_auto_tdcv)(const struct net_device *dev, u32 *tdcv);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static inline bool can_tdc_is_enabled(const struct can_priv *priv)

--- a/include/linux/can/rx-offload.h
+++ b/include/linux/can/rx-offload.h
@@ -11,6 +11,7 @@
 
 #include <linux/netdevice.h>
 #include <linux/can.h>
+#include <linux/deepin_kabi.h>
 
 struct can_rx_offload {
 	struct net_device *dev;
@@ -29,6 +30,9 @@ struct can_rx_offload {
 	struct napi_struct napi;
 
 	bool inc;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 int can_rx_offload_add_timestamp(struct net_device *dev,

--- a/include/linux/cred.h
+++ b/include/linux/cred.h
@@ -14,6 +14,7 @@
 #include <linux/atomic.h>
 #include <linux/uidgid.h>
 #include <linux/sched.h>
+#include <linux/deepin_kabi.h>
 #include <linux/sched/user.h>
 
 struct cred;
@@ -143,6 +144,10 @@ struct cred {
 		int non_rcu;			/* Can we skip RCU deletion? */
 		struct rcu_head	rcu;		/* RCU deletion hook */
 	};
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } __randomize_layout;
 
 extern void __put_cred(struct cred *);

--- a/include/linux/deepin_kabi.h
+++ b/include/linux/deepin_kabi.h
@@ -443,6 +443,7 @@
 # define _DEEPIN_KABI_DEPRECATE(_type, _orig)	_type deepin_reserved_##_orig
 # define _DEEPIN_KABI_DEPRECATE_FN(_type, _orig, _args...)  \
 	_type (* deepin_reserved_##_orig)(_args)
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
 # define _DEEPIN_KABI_REPLACE(_orig, _new)			  \
 	union {						  \
 		_new;					  \
@@ -451,6 +452,9 @@
 		} DEEPIN_KABI_UNIQUE_ID;			  \
 		__DEEPIN_KABI_CHECK_SIZE_ALIGN(_orig, _new);  \
 	}
+#else
+# define _DEEPIN_KABI_REPLACE(_orig, _new)		_new;
+#endif /* CONFIG_DEEPIN_KABI_RESERVE */
 
 # define _DEEPIN_KABI_EXCLUDE(_elem)		_elem
 
@@ -497,7 +501,11 @@
 
 # define DEEPIN_KABI_USE_SPLIT(n, ...)	DEEPIN_KABI_REPLACE_SPLIT(_DEEPIN_KABI_RESERVE(n), __VA_ARGS__)
 
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
 # define _DEEPIN_KABI_RESERVE(n)		unsigned long deepin_reserved##n
+#else
+# define _DEEPIN_KABI_RESERVE(n)
+#endif /* CONFIG_DEEPIN_KABI_RESERVE */
 
 #define DEEPIN_KABI_EXCLUDE(_elem)		_DEEPIN_KABI_EXCLUDE(_elem);
 

--- a/include/linux/deepin_kabi.h
+++ b/include/linux/deepin_kabi.h
@@ -1,0 +1,546 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * deepin_kabi.h - deepin kABI abstraction header
+ *
+ * Copyright (c) 2014 Don Zickus
+ * Copyright (c) 2015-2020 Jiri Benc
+ * Copyright (c) 2015 Sabrina Dubroca, Hannes Frederic Sowa
+ * Copyright (c) 2016-2018 Prarit Bhargava
+ * Copyright (c) 2017 Paolo Abeni, Larry Woodman
+ * Copyright (c) 2023-2024 Lugang He
+ * Copyright (c) 2024 WangYuli
+ *
+ * This file is released under the GPLv2.
+ * See the file COPYING for more details.
+ *
+ * These kabi macros hide the changes from the kabi checker and from the
+ * process that computes the exported symbols' checksums.
+ * They have 2 variants: one (defined under __GENKSYMS__) used when
+ * generating the checksums, and the other used when building the kernel's
+ * binaries.
+ *
+ * The use of these macros does not guarantee that the usage and modification
+ * of code is correct.  As with all Red Hat only changes, an engineer must
+ * explain why the use of the macro is valid in the patch containing the
+ * changes.
+ *
+ * The macro helpers are derived from RHEL "include/linux/rh_kabi.h"
+ * Mostly debrand from RHEL.
+ */
+
+#ifndef _LINUX_DEEPIN_KABI_H
+#define _LINUX_DEEPIN_KABI_H
+
+#include <linux/kconfig.h>
+#include <linux/compiler.h>
+#include <linux/stringify.h>
+
+/*
+ * NOTE
+ *   Unless indicated otherwise, don't use ';' after these macros as it
+ *   messes up the kABI checker by changing what the resulting token string
+ *   looks like.  Instead let the macros add the ';' so it can be properly
+ *   hidden from the kABI checker (mainly for DEEPIN_KABI_EXTEND, but applied to
+ *   most macros for uniformity).
+ *
+ *
+ * DEEPIN_KABI_CONST
+ *   Adds a new const modifier to a function parameter preserving the old
+ *   checksum.
+ *
+ * DEEPIN_KABI_ADD_MODIFIER
+ *   Adds a new modifier to a function parameter or a typedef, preserving
+ *   the old checksum.  Useful e.g. for adding rcu annotations or changing
+ *   int to unsigned.  Beware that this may change the semantics; if you're
+ *   sure this is safe, always explain why binary compatibility with 3rd
+ *   party modules is retained.
+ *
+ * DEEPIN_KABI_DEPRECATE
+ *   Marks the element as deprecated and make it unusable by modules while
+ *   keeping a hole in its place to preserve binary compatibility.
+ *
+ * DEEPIN_KABI_DEPRECATE_FN
+ *   Marks the function pointer as deprecated and make it unusable by modules
+ *   while keeping a hole in its place to preserve binary compatibility.
+ *
+ * DEEPIN_KABI_EXTEND
+ *   Adds a new field to a struct.  This must always be added to the end of
+ *   the struct.  Before using this macro, make sure this is actually safe
+ *   to do - there is a number of conditions under which it is *not* safe.
+ *   In particular (but not limited to), this macro cannot be used:
+ *   - if the struct in question is embedded in another struct, or
+ *   - if the struct is allocated by drivers either statically or
+ *     dynamically, or
+ *   - if the struct is allocated together with driver data (an example of
+ *     such behavior is struct net_device or struct request).
+ *
+ * DEEPIN_KABI_EXTEND_WITH_SIZE
+ *   Adds a new element (usually a struct) to a struct and reserves extra
+ *   space for the new element.  The provided 'size' is the total space to
+ *   be added in longs (i.e. it's 8 * 'size' bytes), including the size of
+ *   the added element.  It is automatically checked that the new element
+ *   does not overflow the reserved space, now nor in the future. However,
+ *   no attempt is done to check the content of the added element (struct)
+ *   for kABI conformance - kABI checking inside the added element is
+ *   effectively switched off.
+ *   For any struct being added by DEEPIN_KABI_EXTEND_WITH_SIZE, it is
+ *   recommended its content to be documented as not covered by kABI
+ *   guarantee.
+ *
+ * DEEPIN_KABI_FILL_HOLE
+ *   Fills a hole in a struct.
+ *
+ *   Warning: only use if a hole exists for _all_ arches.  Use pahole to verify.
+ *
+ * DEEPIN_KABI_RENAME
+ *   Renames an element without changing its type.  This macro can be used in
+ *   bitfields, for example.
+ *
+ *   NOTE: this macro does not add the final ';'
+ *
+ * DEEPIN_KABI_REPLACE
+ *   Replaces the _orig field by the _new field.  The size of the occupied
+ *   space is preserved, it's fine if the _new field is smaller than the
+ *   _orig field.  If a _new field is larger or has a different alignment,
+ *   compilation will abort.
+ *
+ * DEEPIN_KABI_REPLACE_SPLIT
+ *   Works the same as DEEPIN_KABI_REPLACE but replaces a single _orig field by
+ *   multiple new fields.  The checks for size and alignment done by
+ *   DEEPIN_KABI_REPLACE are still applied.
+ *
+ * DEEPIN_KABI_HIDE_INCLUDE
+ *   Hides the given include file from kABI checksum computations.  This is
+ *   used when a newly added #include makes a previously opaque struct
+ *   visible.
+ *
+ *   Example usage:
+ *   #include DEEPIN_KABI_HIDE_INCLUDE(<linux/poll.h>)
+ *
+ * DEEPIN_KABI_FAKE_INCLUDE
+ *   Pretends inclusion of the given file for kABI checksum computations.
+ *   This is used when upstream removed a particular #include but that made
+ *   some structures opaque that were previously visible and is causing kABI
+ *   checker failures.
+ *
+ *   Example usage:
+ *   #include DEEPIN_KABI_FAKE_INCLUDE(<linux/rhashtable.h>)
+ *
+ * DEEPIN_KABI_RESERVE
+ *   Adds a reserved field to a struct.  This is done prior to kABI freeze
+ *   for structs that cannot be expanded later using DEEPIN_KABI_EXTEND (for
+ *   example because they are embedded in another struct or because they are
+ *   allocated by drivers or because they use unusual memory layout).  The
+ *   size of the reserved field is 'unsigned long' and is assumed to be
+ *   8 bytes.
+ *
+ *   The argument is a number unique for the given struct; usually, multiple
+ *   DEEPIN_KABI_RESERVE macros are added to a struct with numbers starting from
+ *   one.
+ *
+ *   Example usage:
+ *   struct foo {
+ *           int a;
+ *           DEEPIN_KABI_RESERVE(1)
+ *           DEEPIN_KABI_RESERVE(2)
+ *           DEEPIN_KABI_RESERVE(3)
+ *           DEEPIN_KABI_RESERVE(4)
+ *   };
+ *
+ * DEEPIN_KABI_USE
+ *   Uses a previously reserved field or multiple fields.  The arguments are
+ *   one or more numbers assigned to DEEPIN_KABI_RESERVE, followed by a field to
+ *   be put in their place.  The compiler ensures that the new field is not
+ *   larger than the reserved area.
+ *
+ *   Example usage:
+ *   struct foo {
+ *           int a;
+ *           DEEPIN_KABI_USE(1, int b)
+ *           DEEPIN_KABI_USE(2, 3, int c[3])
+ *           DEEPIN_KABI_RESERVE(4)
+ *   };
+ *
+ * DEEPIN_KABI_USE_SPLIT
+ *   Works the same as DEEPIN_KABI_USE but replaces a single reserved field by
+ *   multiple new fields.
+ *
+ * DEEPIN_KABI_AUX_EMBED
+ * DEEPIN_KABI_AUX_PTR
+ *   Adds an extenstion of a struct in the form of "auxiliary structure".
+ *   This is done prior to kABI freeze for structs that cannot be expanded
+ *   later using DEEPIN_KABI_EXTEND.  See also DEEPIN_KABI_RESERVED, these two
+ *   approaches can (and often are) combined.
+ *
+ *   To use this for 'struct foo' (the "base structure"), define a new
+ *   structure called 'struct foo_deepin'; this new struct is called "auxiliary
+ *   structure".  Then add DEEPIN_KABI_AUX_EMBED or DEEPIN_KABI_AUX_PTR to the end
+ *   of the base structure.  The argument is the name of the base structure,
+ *   without the 'struct' keyword.
+ *
+ *   DEEPIN_KABI_AUX_PTR stores a pointer to the aux structure in the base
+ *   struct.  The lifecycle of the aux struct needs to be properly taken
+ *   care of.
+ *
+ *   DEEPIN_KABI_AUX_EMBED embeds the aux struct into the base struct.  This
+ *   cannot be used when the base struct is itself embedded into another
+ *   struct, allocated in an array, etc.
+ *
+ *   Both approaches (ptr and embed) work correctly even when the aux struct
+ *   is allocated by modules.  To ensure this, the code responsible for
+ *   allocation/assignment of the aux struct has to properly set the size of
+ *   the aux struct; see the DEEPIN_KABI_AUX_SET_SIZE and DEEPIN_KABI_AUX_INIT_SIZE
+ *   macros.
+ *
+ *   New fields can be later added to the auxiliary structure, always to its
+ *   end.  Note the auxiliary structure cannot be shrunk in size later (i.e.,
+ *   fields cannot be removed, only deprecated).  Any code accessing fields
+ *   from the aux struct must guard the access using the DEEPIN_KABI_AUX macro.
+ *   The access itself is then done via a '_deepin' field in the base struct.
+ *
+ *   The auxiliary structure is not guaranteed for access by modules unless
+ *   explicitly commented as such in the declaration of the aux struct
+ *   itself or some of its elements.
+ *
+ *   Example:
+ *
+ *   struct foo_deepin {
+ *           int newly_added;
+ *   };
+ *
+ *   struct foo {
+ *           bool big_hammer;
+ *           DEEPIN_KABI_AUX_PTR(foo)
+ *   };
+ *
+ *   void use(struct foo *f)
+ *   {
+ *           if (DEEPIN_KABI_AUX(f, foo, newly_added))
+ *                   f->_deepin->newly_added = 123;
+ *	     else
+ *	             // the field 'newly_added' is not present in the passed
+ *	             // struct, fall back to old behavior
+ *	             f->big_hammer = true;
+ *   }
+ *
+ *   static struct foo_deepin my_foo_deepin {
+ *           .newly_added = 0;
+ *   }
+ *
+ *   static struct foo my_foo = {
+ *           .big_hammer = false,
+ *           ._deepin = &my_foo_deepin,
+ *           DEEPIN_KABI_AUX_INIT_SIZE(foo)
+ *   };
+ *
+ * DEEPIN_KABI_USE_AUX_PTR
+ *   Creates an auxiliary structure post kABI freeze.  This works by using
+ *   two reserved fields (thus there has to be two reserved fields still
+ *   available) and converting them to DEEPIN_KABI_AUX_PTR.
+ *
+ *   Example:
+ *
+ *   struct foo_deepin {
+ *   };
+ *
+ *   struct foo {
+ *           int a;
+ *           DEEPIN_KABI_RESERVE(1)
+ *           DEEPIN_KABI_USE_AUX_PTR(2, 3, foo)
+ *   };
+ *
+ * DEEPIN_KABI_AUX_SET_SIZE
+ * DEEPIN_KABI_AUX_INIT_SIZE
+ *   Calculates and stores the size of the auxiliary structure.
+ *
+ *   DEEPIN_KABI_AUX_SET_SIZE is for dynamically allocated base structs,
+ *   DEEPIN_KABI_AUX_INIT_SIZE is for statically allocated case structs.
+ *
+ *   These macros must be called from the allocation (DEEPIN_KABI_AUX_SET_SIZE)
+ *   or declaration (DEEPIN_KABI_AUX_INIT_SIZE) site, regardless of whether
+ *   that happens in the kernel or in a module.  Without calling one of
+ *   these macros, the aux struct will appear to have no fields to the
+ *   kernel.
+ *
+ *   Note: since DEEPIN_KABI_AUX_SET_SIZE is intended to be invoked outside of
+ *   a struct definition, it does not add the semicolon and must be
+ *   terminated by semicolon by the caller.
+ *
+ * DEEPIN_KABI_AUX
+ *   Verifies that the given field exists in the given auxiliary structure.
+ *   This MUST be called prior to accessing that field; failing to do that
+ *   may lead to invalid memory access.
+ *
+ *   The first argument is a pointer to the base struct, the second argument
+ *   is the name of the base struct (without the 'struct' keyword), the
+ *   third argument is the field name.
+ *
+ *   This macro works for structs extended by either of DEEPIN_KABI_AUX_EMBED,
+ *   DEEPIN_KABI_AUX_PTR and DEEPIN_KABI_USE_AUX_PTR.
+ *
+ * DEEPIN_KABI_FORCE_CHANGE
+ *   Force change of the symbol checksum.  The argument of the macro is a
+ *   version for cases we need to do this more than once.
+ *
+ *   This macro does the opposite: it changes the symbol checksum without
+ *   actually changing anything about the exported symbol.  It is useful for
+ *   symbols that are not whitelisted, we're changing them in an
+ *   incompatible way and want to prevent 3rd party modules to silently
+ *   corrupt memory.  Instead, by changing the symbol checksum, such modules
+ *   won't be loaded by the kernel.  This macro should only be used as a
+ *   last resort when all other KABI workarounds have failed.
+ *
+ * DEEPIN_KABI_EXCLUDE
+ *   !!! WARNING: DANGEROUS, DO NOT USE unless you are aware of all the !!!
+ *   !!! implications. This should be used ONLY EXCEPTIONALLY and only  !!!
+ *   !!! under specific circumstances. Very likely, this macro does not !!!
+ *   !!! do what you expect it to do. Note that any usage of this macro !!!
+ *   !!! MUST be paired with a DEEPIN_KABI_FORCE_CHANGE annotation of       !!!
+ *   !!! a suitable symbol (or an equivalent safeguard) and the commit  !!!
+ *   !!! log MUST explain why the chosen solution is appropriate.       !!!
+ *
+ *   Exclude the element from checksum generation.  Any such element is
+ *   considered not to be part of the kABI whitelist and may be changed at
+ *   will.  Note however that it's the responsibility of the developer
+ *   changing the element to ensure 3rd party drivers using this element
+ *   won't panic, for example by not allowing them to be loaded.  That can
+ *   be achieved by changing another, non-whitelisted symbol they use,
+ *   either by nature of the change or by using DEEPIN_KABI_FORCE_CHANGE.
+ *
+ *   Also note that any change to the element must preserve its size. Change
+ *   of the size is not allowed and would constitute a silent kABI breakage.
+ *   Beware that the DEEPIN_KABI_EXCLUDE macro does not do any size checks.
+ *
+ * DEEPIN_KABI_EXCLUDE_WITH_SIZE
+ *   Like DEEPIN_KABI_EXCLUDE, this macro excludes the element from
+ *   checksum generation.  The same warnings as for DEEPIN_KABI_EXCLUDE
+ *   apply: use DEEPIN_KABI_FORCE_CHANGE.
+ *
+ *   This macro is intended to be used for elements embedded inside
+ *   kABI-protected structures (struct, array). In contrast with
+ *   DEEPIN_KABI_EXCLUDE, this macro reserves extra space, so that the
+ *   embedded element can grow without changing the offsets of the
+ *   fields that follow. The provided 'size' is the total space to be
+ *   added in longs (i.e. it's 8 * 'size' bytes), including the size
+ *   of the added element.  It is automatically checked that the new
+ *   element does not overflow the reserved space, now nor in the
+ *   future. The size is also included in the checksum via the
+ *   reserved space, to ensure that we don't accidentally change it,
+ *   which would change the offsets of the fields that follow.
+ *
+ * DEEPIN_KABI_BROKEN_INSERT
+ * DEEPIN_KABI_BROKEN_REMOVE
+ *   Insert a field to the middle of a struct / delete a field from a struct.
+ *   Note that this breaks kABI! It can be done only when it's certain that
+ *   no 3rd party driver can validly reach into the struct.  A typical
+ *   example is a struct that is:  both (a) referenced only through a long
+ *   chain of pointers from another struct that is part of a whitelisted
+ *   symbol and (b) kernel internal only, it should have never been visible
+ *   to genksyms in the first place.
+ *
+ *   Another example are structs that are explicitly exempt from kABI
+ *   guarantee but we did not have enough foresight to use DEEPIN_KABI_EXCLUDE.
+ *   In this case, the warning for DEEPIN_KABI_EXCLUDE applies.
+ *
+ *   A detailed explanation of correctness of every DEEPIN_KABI_BROKEN_* macro
+ *   use is especially important.
+ *
+ * DEEPIN_KABI_BROKEN_INSERT_BLOCK
+ * DEEPIN_KABI_BROKEN_REMOVE_BLOCK
+ *   A version of DEEPIN_KABI_BROKEN_INSERT / REMOVE that allows multiple fields
+ *   to be inserted or removed together.  All fields need to be terminated
+ *   by ';' inside(!) the macro parameter.  The macro itself must not be
+ *   terminated by ';'.
+ *
+ * DEEPIN_KABI_BROKEN_REPLACE
+ *   Replace a field by a different one without doing any checking.  This
+ *   allows replacing a field by another with a different size.  Similarly
+ *   to other DEEPIN_KABI_BROKEN macros, use of this indicates a kABI breakage.
+ *
+ * DEEPIN_KABI_BROKEN_INSERT_ENUM
+ * DEEPIN_KABI_BROKEN_REMOVE_ENUM
+ *   Insert a field to the middle of an enumaration type / delete a field from
+ *   an enumaration type. Note that this can break kABI especially if the
+ *   number of enum fields is used in an array within a structure. It can be
+ *   done only when it is certain that no 3rd party driver will use the
+ *   enumeration type or a structure that embeds an array with size determined
+ *   by an enumeration type.
+ *
+ * DEEPIN_KABI_EXTEND_ENUM
+ *   Adds a new field to an enumeration type.  This must always be added to
+ *   the end of the enum.  Before using this macro, make sure this is actually
+ *   safe to do.
+ */
+
+#undef linux
+#define linux linux
+
+#ifdef __GENKSYMS__
+
+# define DEEPIN_KABI_CONST
+# define DEEPIN_KABI_ADD_MODIFIER(_new)
+# define DEEPIN_KABI_EXTEND(_new)
+# define DEEPIN_KABI_FILL_HOLE(_new)
+# define DEEPIN_KABI_FORCE_CHANGE(ver)		__attribute__((deepin_kabi_change ## ver))
+# define DEEPIN_KABI_RENAME(_orig, _new)		_orig
+# define DEEPIN_KABI_HIDE_INCLUDE(_file)		<linux/deepin_kabi.h>
+# define DEEPIN_KABI_FAKE_INCLUDE(_file)		_file
+# define DEEPIN_KABI_BROKEN_INSERT(_new)
+# define DEEPIN_KABI_BROKEN_REMOVE(_orig)		_orig;
+# define DEEPIN_KABI_BROKEN_INSERT_BLOCK(_new)
+# define DEEPIN_KABI_BROKEN_REMOVE_BLOCK(_orig)	_orig
+# define DEEPIN_KABI_BROKEN_REPLACE(_orig, _new)	_orig;
+# define DEEPIN_KABI_BROKEN_INSERT_ENUM(_new)
+# define DEEPIN_KABI_BROKEN_REMOVE_ENUM(_orig)	_orig,
+# define DEEPIN_KABI_EXTEND_ENUM(_new)
+
+# define _DEEPIN_KABI_DEPRECATE(_type, _orig)	_type _orig
+# define _DEEPIN_KABI_DEPRECATE_FN(_type, _orig, _args...)	_type (*_orig)(_args)
+# define _DEEPIN_KABI_REPLACE(_orig, _new)		_orig
+# define _DEEPIN_KABI_EXCLUDE(_elem)
+
+# define __DEEPIN_KABI_CHECK_SIZE(_item, _size)
+
+#else
+
+# define DEEPIN_KABI_ALIGN_WARNING ".  Disable CONFIG_DEEPIN_KABI_SIZE_ALIGN_CHECKS if debugging."
+
+# define DEEPIN_KABI_CONST				const
+# define DEEPIN_KABI_ADD_MODIFIER(_new)		_new
+# define DEEPIN_KABI_EXTEND(_new)			_new;
+# define DEEPIN_KABI_FILL_HOLE(_new)		_new;
+# define DEEPIN_KABI_FORCE_CHANGE(ver)
+# define DEEPIN_KABI_RENAME(_orig, _new)		_new
+# define DEEPIN_KABI_HIDE_INCLUDE(_file)		_file
+# define DEEPIN_KABI_FAKE_INCLUDE(_file)		<linux/deepin_kabi.h>
+# define DEEPIN_KABI_BROKEN_INSERT(_new)		_new;
+# define DEEPIN_KABI_BROKEN_REMOVE(_orig)
+# define DEEPIN_KABI_BROKEN_INSERT_BLOCK(_new)	_new
+# define DEEPIN_KABI_BROKEN_REMOVE_BLOCK(_orig)
+# define DEEPIN_KABI_BROKEN_REPLACE(_orig, _new)	_new;
+# define DEEPIN_KABI_BROKEN_INSERT_ENUM(_new)	_new,
+# define DEEPIN_KABI_BROKEN_REMOVE_ENUM(_orig)
+# define DEEPIN_KABI_EXTEND_ENUM(_new)		_new,
+
+#if IS_BUILTIN(CONFIG_DEEPIN_KABI_SIZE_ALIGN_CHECKS)
+# define __DEEPIN_KABI_CHECK_SIZE_ALIGN(_orig, _new)			\
+	union {								\
+		_Static_assert(sizeof(struct{_new;}) <= sizeof(struct{_orig;}), \
+			       __FILE__ ":" __stringify(__LINE__) ": "  __stringify(_new) " is larger than " __stringify(_orig) DEEPIN_KABI_ALIGN_WARNING); \
+		_Static_assert(__alignof__(struct{_new;}) <= __alignof__(struct{_orig;}), \
+			       __FILE__ ":" __stringify(__LINE__) ": "  __stringify(_orig) " is not aligned the same as " __stringify(_new) DEEPIN_KABI_ALIGN_WARNING); \
+	}
+# define __DEEPIN_KABI_CHECK_SIZE(_item, _size)				\
+	_Static_assert(sizeof(struct{_item;}) <= _size,			\
+		       __FILE__ ":" __stringify(__LINE__) ": " __stringify(_item) " is larger than the reserved size (" __stringify(_size) " bytes)" DEEPIN_KABI_ALIGN_WARNING);
+#else
+# define __DEEPIN_KABI_CHECK_SIZE_ALIGN(_orig, _new)
+# define __DEEPIN_KABI_CHECK_SIZE(_item, _size)
+#endif
+
+#define DEEPIN_KABI_UNIQUE_ID	__PASTE(deepin_kabi_hidden_, __LINE__)
+
+# define _DEEPIN_KABI_DEPRECATE(_type, _orig)	_type deepin_reserved_##_orig
+# define _DEEPIN_KABI_DEPRECATE_FN(_type, _orig, _args...)  \
+	_type (* deepin_reserved_##_orig)(_args)
+# define _DEEPIN_KABI_REPLACE(_orig, _new)			  \
+	union {						  \
+		_new;					  \
+		struct {				  \
+			_orig;				  \
+		} DEEPIN_KABI_UNIQUE_ID;			  \
+		__DEEPIN_KABI_CHECK_SIZE_ALIGN(_orig, _new);  \
+	}
+
+# define _DEEPIN_KABI_EXCLUDE(_elem)		_elem
+
+#endif /* __GENKSYMS__ */
+
+# define DEEPIN_KABI_DEPRECATE(_type, _orig)	_DEEPIN_KABI_DEPRECATE(_type, _orig);
+# define DEEPIN_KABI_DEPRECATE_FN(_type, _orig, _args...)  \
+	_DEEPIN_KABI_DEPRECATE_FN(_type, _orig, _args);
+# define DEEPIN_KABI_REPLACE(_orig, _new)		_DEEPIN_KABI_REPLACE(_orig, _new);
+
+#define _DEEPIN_KABI_REPLACE1(_new)		_new;
+#define _DEEPIN_KABI_REPLACE2(_new, ...)	_new; _DEEPIN_KABI_REPLACE1(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE3(_new, ...)	_new; _DEEPIN_KABI_REPLACE2(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE4(_new, ...)	_new; _DEEPIN_KABI_REPLACE3(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE5(_new, ...)	_new; _DEEPIN_KABI_REPLACE4(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE6(_new, ...)	_new; _DEEPIN_KABI_REPLACE5(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE7(_new, ...)	_new; _DEEPIN_KABI_REPLACE6(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE8(_new, ...)	_new; _DEEPIN_KABI_REPLACE7(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE9(_new, ...)	_new; _DEEPIN_KABI_REPLACE8(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE10(_new, ...)	_new; _DEEPIN_KABI_REPLACE9(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE11(_new, ...)	_new; _DEEPIN_KABI_REPLACE10(__VA_ARGS__)
+#define _DEEPIN_KABI_REPLACE12(_new, ...)	_new; _DEEPIN_KABI_REPLACE11(__VA_ARGS__)
+
+#define DEEPIN_KABI_REPLACE_SPLIT(_orig, ...)	_DEEPIN_KABI_REPLACE(_orig, \
+		struct { __PASTE(_DEEPIN_KABI_REPLACE, COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__) });
+
+# define DEEPIN_KABI_RESERVE(n)		_DEEPIN_KABI_RESERVE(n);
+
+#define _DEEPIN_KABI_USE1(n, _new)	_DEEPIN_KABI_RESERVE(n), _new
+#define _DEEPIN_KABI_USE2(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE1(__VA_ARGS__)
+#define _DEEPIN_KABI_USE3(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE2(__VA_ARGS__)
+#define _DEEPIN_KABI_USE4(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE3(__VA_ARGS__)
+#define _DEEPIN_KABI_USE5(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE4(__VA_ARGS__)
+#define _DEEPIN_KABI_USE6(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE5(__VA_ARGS__)
+#define _DEEPIN_KABI_USE7(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE6(__VA_ARGS__)
+#define _DEEPIN_KABI_USE8(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE7(__VA_ARGS__)
+#define _DEEPIN_KABI_USE9(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE8(__VA_ARGS__)
+#define _DEEPIN_KABI_USE10(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE9(__VA_ARGS__)
+#define _DEEPIN_KABI_USE11(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE10(__VA_ARGS__)
+#define _DEEPIN_KABI_USE12(n, ...)	_DEEPIN_KABI_RESERVE(n); _DEEPIN_KABI_USE11(__VA_ARGS__)
+
+#define _DEEPIN_KABI_USE(...)	_DEEPIN_KABI_REPLACE(__VA_ARGS__)
+#define DEEPIN_KABI_USE(n, ...)	_DEEPIN_KABI_USE(__PASTE(_DEEPIN_KABI_USE, COUNT_ARGS(__VA_ARGS__))(n, __VA_ARGS__));
+
+# define DEEPIN_KABI_USE_SPLIT(n, ...)	DEEPIN_KABI_REPLACE_SPLIT(_DEEPIN_KABI_RESERVE(n), __VA_ARGS__)
+
+# define _DEEPIN_KABI_RESERVE(n)		unsigned long deepin_reserved##n
+
+#define DEEPIN_KABI_EXCLUDE(_elem)		_DEEPIN_KABI_EXCLUDE(_elem);
+
+#define DEEPIN_KABI_EXCLUDE_WITH_SIZE(_new, _size)				\
+	union {								\
+		DEEPIN_KABI_EXCLUDE(_new)					\
+		unsigned long DEEPIN_KABI_UNIQUE_ID[_size];			\
+		__DEEPIN_KABI_CHECK_SIZE(_new, 8 * (_size))			\
+	};
+
+#define DEEPIN_KABI_EXTEND_WITH_SIZE(_new, _size)				\
+	DEEPIN_KABI_EXTEND(union {						\
+		_new;							\
+		unsigned long DEEPIN_KABI_UNIQUE_ID[_size];			\
+		__DEEPIN_KABI_CHECK_SIZE(_new, 8 * (_size))			\
+	})
+
+#define _DEEPIN_KABI_AUX_PTR(_struct)					\
+	size_t _struct##_size_deepin;					\
+	_DEEPIN_KABI_EXCLUDE(struct _struct##_deepin *_deepin)
+#define DEEPIN_KABI_AUX_PTR(_struct)					\
+	_DEEPIN_KABI_AUX_PTR(_struct);
+
+#define _DEEPIN_KABI_AUX_EMBED(_struct)					\
+	size_t _struct##_size_deepin;					\
+	_DEEPIN_KABI_EXCLUDE(struct _struct##_deepin _deepin)
+#define DEEPIN_KABI_AUX_EMBED(_struct)					\
+	_DEEPIN_KABI_AUX_EMBED(_struct);
+
+#define DEEPIN_KABI_USE_AUX_PTR(n1, n2, _struct)				\
+	DEEPIN_KABI_USE(n1, n2,						\
+		     struct { DEEPIN_KABI_AUX_PTR(_struct) })
+
+#define DEEPIN_KABI_AUX_SET_SIZE(_name, _struct) ({				\
+	(_name)->_struct##_size_deepin = sizeof(struct _struct##_deepin);	\
+})
+
+#define DEEPIN_KABI_AUX_INIT_SIZE(_struct)					\
+	._struct##_size_deepin = sizeof(struct _struct##_deepin),
+
+#define DEEPIN_KABI_AUX(_ptr, _struct, _field) ({				\
+	size_t __off = offsetof(struct _struct##_deepin, _field);		\
+	(_ptr)->_struct##_size_deepin > __off ? true : false;		\
+})
+
+#endif /* _LINUX_DEEPIN_KABI_H */

--- a/include/linux/device.h
+++ b/include/linux/device.h
@@ -12,6 +12,7 @@
 #ifndef _DEVICE_H_
 #define _DEVICE_H_
 
+#include <linux/deepin_kabi.h>
 #include <linux/dev_printk.h>
 #include <linux/energy_model.h>
 #include <linux/ioport.h>
@@ -805,6 +806,15 @@ struct device {
 #ifdef CONFIG_DMA_OPS_BYPASS
 	bool			dma_ops_bypass : 1;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+
 };
 
 /**

--- a/include/linux/device/class.h
+++ b/include/linux/device/class.h
@@ -18,6 +18,7 @@
 #include <linux/klist.h>
 #include <linux/pm.h>
 #include <linux/device/bus.h>
+#include <linux/deepin_kabi.h>
 
 struct device;
 struct fwnode_handle;
@@ -69,6 +70,11 @@ struct class {
 	void (*get_ownership)(const struct device *dev, kuid_t *uid, kgid_t *gid);
 
 	const struct dev_pm_ops *pm;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct class_dev_iter {

--- a/include/linux/device/driver.h
+++ b/include/linux/device/driver.h
@@ -14,6 +14,7 @@
 #ifndef _DEVICE_DRIVER_H_
 #define _DEVICE_DRIVER_H_
 
+#include <linux/deepin_kabi.h>
 #include <linux/kobject.h>
 #include <linux/klist.h>
 #include <linux/pm.h>
@@ -119,6 +120,11 @@ struct device_driver {
 	void (*coredump) (struct device *dev);
 
 	struct driver_private *p;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 

--- a/include/linux/dma-map-ops.h
+++ b/include/linux/dma-map-ops.h
@@ -9,6 +9,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/pgtable.h>
 #include <linux/slab.h>
+#include <linux/deepin_kabi.h>
 
 struct cma;
 
@@ -82,6 +83,12 @@ struct dma_map_ops {
 	size_t (*max_mapping_size)(struct device *dev);
 	size_t (*opt_mapping_size)(void);
 	unsigned long (*get_merge_boundary)(struct device *dev);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 #ifdef CONFIG_DMA_OPS

--- a/include/linux/ethtool.h
+++ b/include/linux/ethtool.h
@@ -18,6 +18,7 @@
 #include <linux/if_ether.h>
 #include <linux/netlink.h>
 #include <uapi/linux/ethtool.h>
+#include <linux/deepin_kabi.h>
 
 struct compat_ethtool_rx_flow_spec {
 	u32		flow_type;
@@ -912,6 +913,11 @@ struct ethtool_ops {
 	int	(*set_mm)(struct net_device *dev, struct ethtool_mm_cfg *cfg,
 			  struct netlink_ext_ack *extack);
 	void	(*get_mm_stats)(struct net_device *dev, struct ethtool_mm_stats *stats);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 int ethtool_check_ops(const struct ethtool_ops *ops);

--- a/include/linux/fwnode.h
+++ b/include/linux/fwnode.h
@@ -13,6 +13,7 @@
 #include <linux/list.h>
 #include <linux/bits.h>
 #include <linux/err.h>
+#include <linux/deepin_kabi.h>
 
 struct fwnode_operations;
 struct device;
@@ -42,9 +43,13 @@ struct fwnode_handle {
 	struct fwnode_handle *secondary;
 	const struct fwnode_operations *ops;
 	struct device *dev;
+
 	struct list_head suppliers;
 	struct list_head consumers;
 	u8 flags;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*
@@ -164,6 +169,11 @@ struct fwnode_operations {
 	void __iomem *(*iomap)(struct fwnode_handle *fwnode, int index);
 	int (*irq_get)(const struct fwnode_handle *fwnode, unsigned int index);
 	int (*add_links)(struct fwnode_handle *fwnode);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define fwnode_has_op(fwnode, op)					\

--- a/include/linux/i2c.h
+++ b/include/linux/i2c.h
@@ -22,6 +22,7 @@
 #include <linux/of.h>		/* for struct device_node */
 #include <linux/swab.h>		/* for swab16 */
 #include <uapi/linux/i2c.h>
+#include <linux/deepin_kabi.h>
 
 extern struct bus_type i2c_bus_type;
 extern struct device_type i2c_adapter_type;
@@ -433,6 +434,8 @@ struct i2c_board_info {
 	const struct resource *resources;
 	unsigned int	num_resources;
 	int		irq;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /**
@@ -566,6 +569,9 @@ struct i2c_algorithm {
 	int (*reg_slave)(struct i2c_client *client);
 	int (*unreg_slave)(struct i2c_client *client);
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -655,6 +661,9 @@ struct i2c_bus_recovery_info {
 	struct pinctrl *pinctrl;
 	struct pinctrl_state *pins_default;
 	struct pinctrl_state *pins_gpio;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 int i2c_recover_bus(struct i2c_adapter *adap);
@@ -746,6 +755,9 @@ struct i2c_adapter {
 
 	struct irq_domain *host_notify_domain;
 	struct regulator *bus_regulator;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #define to_i2c_adapter(d) container_of(d, struct i2c_adapter, dev)
 

--- a/include/linux/inetdevice.h
+++ b/include/linux/inetdevice.h
@@ -13,6 +13,7 @@
 #include <linux/sysctl.h>
 #include <linux/rtnetlink.h>
 #include <linux/refcount.h>
+#include <linux/deepin_kabi.h>
 
 struct ipv4_devconf {
 	void	*sysctl;
@@ -50,6 +51,9 @@ struct in_device {
 	struct neigh_parms	*arp_parms;
 	struct ipv4_devconf	cnf;
 	struct rcu_head		rcu_head;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define IPV4_DEVCONF(cnf, attr) ((cnf).data[IPV4_DEVCONF_ ## attr - 1])

--- a/include/linux/input.h
+++ b/include/linux/input.h
@@ -20,6 +20,7 @@
 #include <linux/fs.h>
 #include <linux/timer.h>
 #include <linux/mod_devicetable.h>
+#include <linux/deepin_kabi.h>
 
 struct input_dev_poller;
 
@@ -209,6 +210,8 @@ struct input_dev {
 	ktime_t timestamp[INPUT_CLK_MAX];
 
 	bool inhibited;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #define to_input_dev(d) container_of(d, struct input_dev, dev)
 

--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -14,6 +14,7 @@
 #include <linux/err.h>
 #include <linux/of.h>
 #include <uapi/linux/iommu.h>
+#include <linux/deepin_kabi.h>
 
 #define IOMMU_READ	(1 << 0)
 #define IOMMU_WRITE	(1 << 1)
@@ -111,6 +112,11 @@ struct iommu_domain {
 			int users;
 		};
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static inline bool iommu_is_dma_domain(struct iommu_domain *domain)
@@ -294,6 +300,14 @@ struct iommu_ops {
 	const struct iommu_domain_ops *default_domain_ops;
 	unsigned long pgsize_bitmap;
 	struct module *owner;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /**

--- a/include/linux/ioport.h
+++ b/include/linux/ioport.h
@@ -14,6 +14,7 @@
 #include <linux/compiler.h>
 #include <linux/minmax.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 /*
  * Resources are tree-like, allowing
  * nesting etc..
@@ -25,6 +26,10 @@ struct resource {
 	unsigned long flags;
 	unsigned long desc;
 	struct resource *parent, *sibling, *child;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*

--- a/include/linux/ipv6.h
+++ b/include/linux/ipv6.h
@@ -3,6 +3,7 @@
 #define _IPV6_H
 
 #include <uapi/linux/ipv6.h>
+#include <linux/deepin_kabi.h>
 
 #define ipv6_optlen(p)  (((p)->hdrlen+1) << 3)
 #define ipv6_authlen(p) (((p)->hdrlen+2) << 2)
@@ -84,6 +85,11 @@ struct ipv6_devconf {
 	__u8		ndisc_evict_nocarrier;
 
 	struct ctl_table_header *sysctl_header;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct ipv6_params {

--- a/include/linux/key-type.h
+++ b/include/linux/key-type.h
@@ -10,6 +10,7 @@
 
 #include <linux/key.h>
 #include <linux/errno.h>
+#include <linux/deepin_kabi.h>
 
 #ifdef CONFIG_KEYS
 
@@ -56,6 +57,8 @@ struct key_match_data {
 	unsigned	lookup_type;	/* Type of lookup for this search. */
 #define KEYRING_SEARCH_LOOKUP_DIRECT	0x0000	/* Direct lookup by description. */
 #define KEYRING_SEARCH_LOOKUP_ITERATE	0x0001	/* Iterative search. */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*

--- a/include/linux/key.h
+++ b/include/linux/key.h
@@ -20,6 +20,7 @@
 #include <linux/assoc_array.h>
 #include <linux/refcount.h>
 #include <linux/time64.h>
+#include <linux/deepin_kabi.h>
 
 #ifdef __KERNEL__
 #include <linux/uidgid.h>
@@ -278,6 +279,8 @@ struct key {
 	 * restriction.
 	 */
 	struct key_restriction *restrict_link;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern struct key *key_alloc(struct key_type *type,

--- a/include/linux/keyctl.h
+++ b/include/linux/keyctl.h
@@ -8,6 +8,8 @@
 #ifndef __LINUX_KEYCTL_H
 #define __LINUX_KEYCTL_H
 
+#include <linux/deepin_kabi.h>
+
 #include <uapi/linux/keyctl.h>
 
 struct kernel_pkey_query {
@@ -37,6 +39,8 @@ struct kernel_pkey_params {
 		__u32	in2_len;	/* 2nd input data size (verify) */
 	};
 	enum kernel_pkey_operation op : 8;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif /* __LINUX_KEYCTL_H */

--- a/include/linux/kobject.h
+++ b/include/linux/kobject.h
@@ -15,6 +15,7 @@
 #ifndef _KOBJECT_H_
 #define _KOBJECT_H_
 
+#include <linux/deepin_kabi.h>
 #include <linux/types.h>
 #include <linux/list.h>
 #include <linux/sysfs.h>
@@ -75,6 +76,10 @@ struct kobject {
 	unsigned int state_add_uevent_sent:1;
 	unsigned int state_remove_uevent_sent:1;
 	unsigned int uevent_suppress:1;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 
 #ifdef CONFIG_DEBUG_KOBJECT_RELEASE
 	struct delayed_work	release;
@@ -120,6 +125,10 @@ struct kobj_type {
 	const struct kobj_ns_type_operations *(*child_ns_type)(const struct kobject *kobj);
 	const void *(*namespace)(const struct kobject *kobj);
 	void (*get_ownership)(const struct kobject *kobj, kuid_t *uid, kgid_t *gid);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct kobj_uevent_env {
@@ -170,6 +179,10 @@ struct kset {
 	spinlock_t list_lock;
 	struct kobject kobj;
 	const struct kset_uevent_ops *uevent_ops;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } __randomize_layout;
 
 void kset_init(struct kset *kset);

--- a/include/linux/lsm_hooks.h
+++ b/include/linux/lsm_hooks.h
@@ -29,6 +29,7 @@
 #include <linux/init.h>
 #include <linux/rculist.h>
 #include <linux/xattr.h>
+#include <linux/deepin_kabi.h>
 
 union security_list_options {
 	#define LSM_HOOK(RET, DEFAULT, NAME, ...) RET (*NAME)(__VA_ARGS__);
@@ -65,6 +66,10 @@ struct lsm_blob_sizes {
 	int	lbs_msg_msg;
 	int	lbs_task;
 	int	lbs_xattr_count; /* number of xattr slots in new_xattrs array */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /**

--- a/include/linux/memcontrol.h
+++ b/include/linux/memcontrol.h
@@ -21,6 +21,7 @@
 #include <linux/vmstat.h>
 #include <linux/writeback.h>
 #include <linux/page-flags.h>
+#include <linux/deepin_kabi.h>
 
 struct mem_cgroup;
 struct obj_cgroup;
@@ -65,6 +66,7 @@ struct mem_cgroup_reclaim_cookie {
 struct mem_cgroup_id {
 	int id;
 	refcount_t ref;
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /*
@@ -139,6 +141,11 @@ struct mem_cgroup_per_node {
 	bool			on_tree;
 	struct mem_cgroup	*memcg;		/* Back pointer, we cannot */
 						/* use container_of	   */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct mem_cgroup_threshold {
@@ -333,6 +340,14 @@ struct mem_cgroup {
 	struct lru_gen_mm_list mm_list;
 #endif
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 	struct mem_cgroup_per_node *nodeinfo[];
 };
 

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -30,6 +30,7 @@
 #include <linux/kasan.h>
 #include <linux/memremap.h>
 #include <linux/slab.h>
+#include <linux/deepin_kabi.h>
 
 struct mempolicy;
 struct anon_vma;
@@ -549,6 +550,10 @@ struct vm_fault {
 					 * page table to avoid allocation from
 					 * atomic context.
 					 */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*
@@ -628,6 +633,10 @@ struct vm_operations_struct {
 	 */
 	struct page *(*find_special_page)(struct vm_area_struct *vma,
 					  unsigned long addr);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #ifdef CONFIG_NUMA_BALANCING

--- a/include/linux/mm_types.h
+++ b/include/linux/mm_types.h
@@ -19,6 +19,7 @@
 #include <linux/workqueue.h>
 #include <linux/seqlock.h>
 #include <linux/percpu_counter.h>
+#include <linux/deepin_kabi.h>
 
 #include <asm/mmu.h>
 
@@ -660,6 +661,11 @@ struct vm_area_struct {
 	struct vma_numab_state *numab_state;	/* NUMA Balancing state */
 #endif
 	struct vm_userfaultfd_ctx vm_userfaultfd_ctx;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } __randomize_layout;
 
 #ifdef CONFIG_SCHED_MM_CID
@@ -919,6 +925,11 @@ struct mm_struct {
 #endif /* CONFIG_LRU_GEN */
 	} __randomize_layout;
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 	/*
 	 * The mm_cpumask needs to be at the end of mm_struct, because it
 	 * is dynamically sized based on nr_cpu_ids.

--- a/include/linux/mmu_notifier.h
+++ b/include/linux/mmu_notifier.h
@@ -8,6 +8,7 @@
 #include <linux/mmap_lock.h>
 #include <linux/srcu.h>
 #include <linux/interval_tree.h>
+#include <linux/deepin_kabi.h>
 
 struct mmu_notifier_subscriptions;
 struct mmu_notifier;
@@ -221,6 +222,11 @@ struct mmu_notifier_ops {
 	 */
 	struct mmu_notifier *(*alloc_notifier)(struct mm_struct *mm);
 	void (*free_notifier)(struct mmu_notifier *subscription);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*
@@ -240,6 +246,9 @@ struct mmu_notifier {
 	struct mm_struct *mm;
 	struct rcu_head rcu;
 	unsigned int users;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -22,6 +22,7 @@
 #include <linux/mm_types.h>
 #include <linux/page-flags.h>
 #include <linux/local_lock.h>
+#include <linux/deepin_kabi.h>
 #include <asm/page.h>
 
 /* Free memory management - zoned buddy allocator.  */
@@ -982,6 +983,11 @@ struct zone {
 	bool			contiguous;
 
 	CACHELINE_PADDING(_pad3_);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 	/* Zone statistics */
 	atomic_long_t		vm_stat[NR_VM_ZONE_STAT_ITEMS];
 	atomic_long_t		vm_numa_event[NR_VM_NUMA_EVENT_ITEMS];
@@ -1394,6 +1400,9 @@ typedef struct pglist_data {
 
 	CACHELINE_PADDING(_pad2_);
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 	/* Per-node vmstats */
 	struct per_cpu_nodestat __percpu *per_cpu_nodestats;
 	atomic_long_t		vm_stat[NR_VM_NODE_STAT_ITEMS];

--- a/include/linux/net.h
+++ b/include/linux/net.h
@@ -25,6 +25,7 @@
 #include <linux/sockptr.h>
 
 #include <uapi/linux/net.h>
+#include <linux/deepin_kabi.h>
 
 struct poll_table_struct;
 struct pipe_inode_info;
@@ -223,6 +224,11 @@ struct proto_ops {
 	int		(*sendmsg_locked)(struct sock *sk, struct msghdr *msg,
 					  size_t size);
 	int		(*set_rcvlowat)(struct sock *sk, int val);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define DECLARE_SOCKADDR(type, dst, src)	\

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -52,6 +52,7 @@
 #include <net/net_trackers.h>
 #include <net/net_debug.h>
 #include <net/dropreason-core.h>
+#include <linux/deepin_kabi.h>
 
 struct netpoll_info;
 struct device;
@@ -319,6 +320,9 @@ struct header_ops {
 				const unsigned char *haddr);
 	bool	(*validate)(const char *ll_header, unsigned int len);
 	__be16	(*parse_protocol)(const struct sk_buff *skb);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* These flag bits are private to the generic network queueing
@@ -380,6 +384,11 @@ struct napi_struct {
 	/* control-path-only fields follow */
 	struct list_head	dev_list;
 	struct hlist_node	napi_hash_node;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 enum {
@@ -658,6 +667,11 @@ struct netdev_queue {
 #ifdef CONFIG_BQL
 	struct dql		dql;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } ____cacheline_aligned_in_smp;
 
 extern int sysctl_fb_tunnels_only_for_init_net;
@@ -1038,6 +1052,11 @@ struct xfrmdev_ops {
 	int	(*xdo_dev_policy_add) (struct xfrm_policy *x, struct netlink_ext_ack *extack);
 	void	(*xdo_dev_policy_delete) (struct xfrm_policy *x);
 	void	(*xdo_dev_policy_free) (struct xfrm_policy *x);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 #endif
 
@@ -1645,6 +1664,16 @@ struct net_device_ops {
 	int			(*ndo_hwtstamp_set)(struct net_device *dev,
 						    struct kernel_hwtstamp_config *kernel_config,
 						    struct netlink_ext_ack *extack);
+
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /**
@@ -2417,6 +2446,14 @@ struct net_device {
 	struct rtnl_hw_stats64	*offload_xstats_l3;
 
 	struct devlink_port	*devlink_port;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 #define to_net_dev(d) container_of(d, struct net_device, dev)
 
@@ -2711,6 +2748,11 @@ struct packet_type {
 	struct net		*af_packet_net;
 	void			*af_packet_priv;
 	struct list_head	list;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct offload_callbacks {

--- a/include/linux/netfilter.h
+++ b/include/linux/netfilter.h
@@ -16,6 +16,7 @@
 #include <linux/netdevice.h>
 #include <linux/sockptr.h>
 #include <net/net_namespace.h>
+#include <linux/deepin_kabi.h>
 
 static inline int NF_DROP_GETERR(int verdict)
 {
@@ -179,6 +180,8 @@ struct nf_sockopt_ops {
 	int (*get)(struct sock *sk, int optval, void __user *user, int *len);
 	/* Use the module struct to lock set/get code in place */
 	struct module *owner;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /* Function to register/unregister hook points. */
@@ -377,6 +380,8 @@ struct nf_nat_hook {
 				  enum nf_nat_manip_type mtype,
 				  enum ip_conntrack_dir dir);
 	void (*remove_nat_bysrc)(struct nf_conn *ct);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 extern const struct nf_nat_hook __rcu *nf_nat_hook;
@@ -465,6 +470,9 @@ struct nf_ct_hook {
 	void (*attach)(struct sk_buff *nskb, const struct sk_buff *skb);
 	void (*set_closing)(struct nf_conntrack *nfct);
 	int (*confirm)(struct sk_buff *skb);
+
+	DEEPIN_KABI_RESERVE(1)
+
 };
 extern const struct nf_ct_hook __rcu *nf_ct_hook;
 
@@ -480,6 +488,8 @@ struct nfnl_ct_hook {
 			     u32 portid, u32 report);
 	void (*seq_adjust)(struct sk_buff *skb, struct nf_conn *ct,
 			   enum ip_conntrack_info ctinfo, s32 off);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 extern const struct nfnl_ct_hook __rcu *nfnl_ct_hook;
 

--- a/include/linux/netfilter/ipset/ip_set.h
+++ b/include/linux/netfilter/ipset/ip_set.h
@@ -16,6 +16,7 @@
 #include <linux/vmalloc.h>
 #include <net/netlink.h>
 #include <uapi/linux/netfilter/ipset/ip_set.h>
+#include <linux/deepin_kabi.h>
 
 #define _IP_SET_MODULE_DESC(a, b, c)		\
 	MODULE_DESCRIPTION(a " type of IP sets, revisions " b "-" c)
@@ -190,6 +191,8 @@ struct ip_set_type_variant {
 	void (*cancel_gc)(struct ip_set *set);
 	/* Region-locking is used */
 	bool region_lock;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct ip_set_region {
@@ -236,6 +239,8 @@ struct ip_set_type {
 
 	/* Set this to THIS_MODULE if you are a module, otherwise NULL */
 	struct module *me;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /* register and unregister set type */
@@ -280,6 +285,8 @@ struct ip_set {
 	size_t offset[IPSET_EXT_ID_MAX];
 	/* The type specific data */
 	void *data;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 static inline void

--- a/include/linux/netfilter/nfnetlink.h
+++ b/include/linux/netfilter/nfnetlink.h
@@ -6,6 +6,7 @@
 #include <linux/capability.h>
 #include <net/netlink.h>
 #include <uapi/linux/netfilter/nfnetlink.h>
+#include <linux/deepin_kabi.h>
 
 struct nfnl_info {
 	struct net		*net;
@@ -28,6 +29,8 @@ struct nfnl_callback {
 	const struct nla_policy	*policy;
 	enum nfnl_callback_type	type;
 	__u16			attr_count;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 enum nfnl_abort_action {
@@ -46,6 +49,8 @@ struct nfnetlink_subsystem {
 	int (*abort)(struct net *net, struct sk_buff *skb,
 		     enum nfnl_abort_action action);
 	bool (*valid_genid)(struct net *net, u32 genid);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 int nfnetlink_subsys_register(const struct nfnetlink_subsystem *n);

--- a/include/linux/netfilter_ipv6.h
+++ b/include/linux/netfilter_ipv6.h
@@ -9,6 +9,7 @@
 
 #include <uapi/linux/netfilter_ipv6.h>
 #include <net/tcp.h>
+#include <linux/deepin_kabi.h>
 
 /* Check for an extension */
 static inline int
@@ -65,6 +66,8 @@ struct nf_ipv6_ops {
 					 const struct nf_bridge_frag_data *data,
 					 struct sk_buff *));
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #ifdef CONFIG_NETFILTER

--- a/include/linux/nsproxy.h
+++ b/include/linux/nsproxy.h
@@ -4,6 +4,7 @@
 
 #include <linux/spinlock.h>
 #include <linux/sched.h>
+#include <linux/deepin_kabi.h>
 
 struct mnt_namespace;
 struct uts_namespace;
@@ -38,6 +39,10 @@ struct nsproxy {
 	struct time_namespace *time_ns;
 	struct time_namespace *time_ns_for_children;
 	struct cgroup_namespace *cgroup_ns;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 extern struct nsproxy init_nsproxy;
 

--- a/include/linux/pci.h
+++ b/include/linux/pci.h
@@ -529,6 +529,15 @@ struct pci_dev {
 
 	/* These methods index pci_reset_fn_methods[] */
 	u8 reset_methods[PCI_NUM_RESET_METHODS]; /* In priority order */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 static inline struct pci_dev *pci_physfn(struct pci_dev *dev)
@@ -678,6 +687,14 @@ struct pci_bus {
 	struct bin_attribute	*legacy_mem;	/* Legacy mem */
 	unsigned int		is_added:1;
 	unsigned int		unsafe_warn:1;	/* warned about RW1C config write */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
 };
 
 #define to_pci_bus(n)	container_of(n, struct pci_bus, dev)
@@ -933,6 +950,15 @@ struct pci_driver {
 	struct device_driver	driver;
 	struct pci_dynids	dynids;
 	bool driver_managed_dma;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 static inline struct pci_driver *to_pci_driver(struct device_driver *drv)

--- a/include/linux/pci_hotplug.h
+++ b/include/linux/pci_hotplug.h
@@ -45,6 +45,15 @@ struct hotplug_slot_ops {
 	int (*get_latch_status)		(struct hotplug_slot *slot, u8 *value);
 	int (*get_adapter_status)	(struct hotplug_slot *slot, u8 *value);
 	int (*reset_slot)		(struct hotplug_slot *slot, bool probe);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /**
@@ -63,6 +72,15 @@ struct hotplug_slot {
 	struct pci_slot			*pci_slot;
 	struct module			*owner;
 	const char			*mod_name;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 static inline const char *hotplug_slot_name(const struct hotplug_slot *slot)

--- a/include/linux/pm.h
+++ b/include/linux/pm.h
@@ -16,6 +16,7 @@
 #include <linux/timer.h>
 #include <linux/hrtimer.h>
 #include <linux/completion.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Callbacks for platform drivers to implement.
@@ -640,6 +641,13 @@ struct pm_subsys_data {
 #ifdef CONFIG_PM_GENERIC_DOMAINS
 	struct pm_domain_data *domain_data;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 /*
@@ -720,6 +728,9 @@ struct dev_pm_info {
 	struct pm_subsys_data	*subsys_data;  /* Owned by the subsystem. */
 	void (*set_latency_tolerance)(struct device *, s32);
 	struct dev_pm_qos	*qos;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern int dev_pm_get_subsys_data(struct device *dev);
@@ -746,6 +757,9 @@ struct dev_pm_domain {
 	int (*activate)(struct device *dev);
 	void (*sync)(struct device *dev);
 	void (*dismiss)(struct device *dev);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*

--- a/include/linux/pm_domain.h
+++ b/include/linux/pm_domain.h
@@ -110,6 +110,9 @@ struct genpd_power_state {
 	struct fwnode_handle *fwnode;
 	u64 idle_time;
 	void *data;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct genpd_lock_ops;
@@ -166,6 +169,11 @@ struct generic_pm_domain {
 			unsigned long lock_flags;
 		};
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 
 };
 

--- a/include/linux/pm_qos.h
+++ b/include/linux/pm_qos.h
@@ -112,6 +112,9 @@ struct dev_pm_qos_request {
 		struct freq_qos_request freq;
 	} data;
 	struct device *dev;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct dev_pm_qos {
@@ -122,6 +125,9 @@ struct dev_pm_qos {
 	struct dev_pm_qos_request *resume_latency_req;
 	struct dev_pm_qos_request *latency_tolerance_req;
 	struct dev_pm_qos_request *flags_req;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* Action requested to pm_qos_update_target */

--- a/include/linux/pm_wakeup.h
+++ b/include/linux/pm_wakeup.h
@@ -14,6 +14,7 @@
 #endif
 
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 struct wake_irq;
 
@@ -61,6 +62,9 @@ struct wakeup_source {
 	struct device		*dev;
 	bool			active:1;
 	bool			autosleep_enabled:1;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define for_each_wakeup_source(ws) \

--- a/include/linux/ptp_clock_kernel.h
+++ b/include/linux/ptp_clock_kernel.h
@@ -193,6 +193,11 @@ struct ptp_clock_info {
 	int (*verify)(struct ptp_clock_info *ptp, unsigned int pin,
 		      enum ptp_pin_function func, unsigned int chan);
 	long (*do_aux_work)(struct ptp_clock_info *ptp);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct ptp_clock;

--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -32,6 +32,8 @@
 #include <linux/if_packet.h>
 #include <linux/llist.h>
 #include <net/flow.h>
+#include <linux/deepin_kabi.h>
+
 #if IS_ENABLED(CONFIG_NF_CONNTRACK)
 #include <linux/netfilter/nf_conntrack_common.h>
 #endif
@@ -1043,6 +1045,10 @@ struct sk_buff {
 
 	); /* end headers group */
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 	/* These elements must be at the end, see alloc_skb() for details.  */
 	sk_buff_data_t		tail;
 	sk_buff_data_t		end;

--- a/include/linux/skmsg.h
+++ b/include/linux/skmsg.h
@@ -12,6 +12,7 @@
 #include <net/sock.h>
 #include <net/tcp.h>
 #include <net/strparser.h>
+#include <linux/deepin_kabi.h>
 
 #define MAX_MSG_FRAGS			MAX_SKB_FRAGS
 #define NR_MSG_FRAG_IDS			(MAX_MSG_FRAGS + 1)
@@ -58,6 +59,11 @@ struct sk_psock_progs {
 	struct bpf_prog			*stream_parser;
 	struct bpf_prog			*stream_verdict;
 	struct bpf_prog			*skb_verdict;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 enum sk_psock_state_bits {
@@ -108,6 +114,11 @@ struct sk_psock {
 	struct delayed_work		work;
 	struct sock			*sk_pair;
 	struct rcu_work			rwork;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 int sk_msg_alloc(struct sock *sk, struct sk_msg *msg, int len,

--- a/include/linux/sunrpc/cache.h
+++ b/include/linux/sunrpc/cache.h
@@ -16,6 +16,7 @@
 #include <linux/atomic.h>
 #include <linux/kstrtox.h>
 #include <linux/proc_fs.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Each cache requires:
@@ -123,6 +124,9 @@ struct cache_detail {
 		struct dentry		*pipefs;
 	};
 	struct net		*net;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* this must be embedded in any request structure that

--- a/include/linux/sunrpc/clnt.h
+++ b/include/linux/sunrpc/clnt.h
@@ -28,6 +28,7 @@
 #include <linux/path.h>
 #include <net/ipv6.h>
 #include <linux/sunrpc/xprtmultipath.h>
+#include <linux/deepin_kabi.h>
 
 struct rpc_inode;
 struct rpc_sysfs_client {
@@ -93,6 +94,11 @@ struct rpc_clnt {
 	const struct cred	*cl_cred;
 	unsigned int		cl_max_connect; /* max number of transports not to the same IP */
 	struct super_block *pipefs_sb;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*
@@ -106,6 +112,8 @@ struct rpc_program {
 	const struct rpc_version **	version;	/* version array */
 	struct rpc_stat *	stats;		/* statistics */
 	const char *		pipe_dir_name;	/* path to rpc_pipefs dir */
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct rpc_version {
@@ -148,10 +156,13 @@ struct rpc_create_args {
 	char			*client_name;
 	struct svc_xprt		*bc_xprt;	/* NFSv4.1 backchannel */
 	const struct cred	*cred;
+
 	unsigned int		max_connect;
 	struct xprtsec_parms	xprtsec;
 	unsigned long		connect_timeout;
 	unsigned long		reconnect_timeout;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct rpc_add_xprt_test {

--- a/include/linux/sunrpc/sched.h
+++ b/include/linux/sunrpc/sched.h
@@ -17,6 +17,7 @@
 #include <linux/wait_bit.h>
 #include <linux/workqueue.h>
 #include <linux/sunrpc/xdr.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * This is the actual RPC procedure call info.
@@ -27,6 +28,8 @@ struct rpc_message {
 	void *			rpc_argp;	/* Arguments */
 	void *			rpc_resp;	/* Result */
 	const struct cred *	rpc_cred;	/* Credentials */
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct rpc_call_ops;
@@ -91,6 +94,11 @@ struct rpc_task {
 	unsigned char		tk_priority : 2,/* Task priority */
 				tk_garb_retry : 2,
 				tk_cred_retry : 2;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 typedef void			(*rpc_action)(struct rpc_task *);
@@ -100,6 +108,9 @@ struct rpc_call_ops {
 	void (*rpc_call_done)(struct rpc_task *, void *);
 	void (*rpc_count_stats)(struct rpc_task *, void *);
 	void (*rpc_release)(void *);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rpc_task_setup {
@@ -113,6 +124,9 @@ struct rpc_task_setup {
 	struct workqueue_struct *workqueue;
 	unsigned short flags;
 	signed char priority;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*

--- a/include/linux/sunrpc/stats.h
+++ b/include/linux/sunrpc/stats.h
@@ -11,6 +11,7 @@
 #define _LINUX_SUNRPC_STATS_H
 
 #include <linux/proc_fs.h>
+#include <linux/deepin_kabi.h>
 
 struct rpc_stat {
 	const struct rpc_program *program;
@@ -24,6 +25,8 @@ struct rpc_stat {
 				rpcretrans,
 				rpcauthrefresh,
 				rpcgarbage;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct svc_stat {
@@ -37,6 +40,8 @@ struct svc_stat {
 				rpcbadfmt,
 				rpcbadauth,
 				rpcbadclnt;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct net;

--- a/include/linux/sunrpc/xprt.h
+++ b/include/linux/sunrpc/xprt.h
@@ -18,6 +18,7 @@
 #include <linux/sunrpc/sched.h>
 #include <linux/sunrpc/xdr.h>
 #include <linux/sunrpc/msg_prot.h>
+#include <linux/deepin_kabi.h>
 
 #define RPC_MIN_SLOT_TABLE	(2U)
 #define RPC_DEF_SLOT_TABLE	(16U)
@@ -39,6 +40,9 @@ struct rpc_timeout {
 				to_increment;		/* if !exponential */
 	unsigned int		to_retries;		/* max # of retries */
 	unsigned char		to_exponential;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum rpc_display_format_t {
@@ -125,6 +129,11 @@ struct rpc_rqst {
 	unsigned long		rq_bc_pa_state;	/* Backchannel prealloc state */
 	struct list_head	rq_bc_pa_list;	/* Backchannel prealloc list */
 #endif /* CONFIG_SUNRPC_BACKCHANEL */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 #define rq_svec			rq_snd_buf.head
 #define rq_slen			rq_snd_buf.len
@@ -315,6 +324,11 @@ struct rpc_xprt {
 	const struct xprt_class	*xprt_class;
 	struct rpc_sysfs_xprt	*xprt_sysfs;
 	bool			main; /*mark if this is the 1st transport */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #if defined(CONFIG_SUNRPC_BACKCHANNEL)
@@ -353,6 +367,9 @@ struct xprt_create {
 	struct xprtsec_parms	xprtsec;
 	unsigned long		connect_timeout;
 	unsigned long		reconnect_timeout;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct xprt_class {

--- a/include/linux/swap.h
+++ b/include/linux/swap.h
@@ -14,6 +14,7 @@
 #include <linux/atomic.h>
 #include <linux/page-flags.h>
 #include <uapi/linux/mempolicy.h>
+#include <linux/deepin_kabi.h>
 #include <asm/page.h>
 
 struct notifier_block;
@@ -321,6 +322,9 @@ struct swap_info_struct {
 					 */
 	struct work_struct discard_work; /* discard worker */
 	struct swap_cluster_list discard_clusters; /* discard clusters list */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 	struct plist_node avail_lists[]; /*
 					   * entries in swap_avail_heads, one
 					   * entry per node.

--- a/include/net/dcbnl.h
+++ b/include/net/dcbnl.h
@@ -9,6 +9,7 @@
 #define __NET_DCBNL_H__
 
 #include <linux/dcbnl.h>
+#include <linux/deepin_kabi.h>
 
 struct net_device;
 
@@ -131,6 +132,15 @@ struct dcbnl_rtnl_ops {
 	/* rewrite */
 	int (*dcbnl_setrewr)(struct net_device *dev, struct dcb_app *app);
 	int (*dcbnl_delrewr)(struct net_device *dev, struct dcb_app *app);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 #endif /* __NET_DCBNL_H__ */

--- a/include/net/dst.h
+++ b/include/net/dst.h
@@ -20,6 +20,7 @@
 #include <net/neighbour.h>
 #include <asm/processor.h>
 #include <linux/indirect_call_wrapper.h>
+#include <linux/deepin_kabi.h>
 
 struct sk_buff;
 
@@ -92,6 +93,15 @@ struct dst_entry {
 #ifdef CONFIG_64BIT
 	struct lwtunnel_state   *lwtstate;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 struct dst_metrics {

--- a/include/net/dst_ops.h
+++ b/include/net/dst_ops.h
@@ -4,6 +4,7 @@
 #include <linux/types.h>
 #include <linux/percpu_counter.h>
 #include <linux/cache.h>
+#include <linux/deepin_kabi.h>
 
 struct dst_entry;
 struct kmem_cachep;
@@ -41,6 +42,15 @@ struct dst_ops {
 	struct kmem_cache	*kmem_cachep;
 
 	struct percpu_counter	pcpuc_entries ____cacheline_aligned_in_smp;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 static inline int dst_entries_get_fast(struct dst_ops *dst)

--- a/include/net/fib_rules.h
+++ b/include/net/fib_rules.h
@@ -11,6 +11,7 @@
 #include <net/rtnetlink.h>
 #include <net/fib_notifier.h>
 #include <linux/indirect_call_wrapper.h>
+#include <linux/deepin_kabi.h>
 
 struct fib_kuid_range {
 	kuid_t start;
@@ -44,6 +45,15 @@ struct fib_rule {
 	struct fib_rule_port_range	sport_range;
 	struct fib_rule_port_range	dport_range;
 	struct rcu_head		rcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 struct fib_lookup_arg {

--- a/include/net/flow.h
+++ b/include/net/flow.h
@@ -12,6 +12,7 @@
 #include <linux/atomic.h>
 #include <linux/container_of.h>
 #include <linux/uidgid.h>
+#include <linux/deepin_kabi.h>
 
 struct flow_keys;
 
@@ -42,6 +43,9 @@ struct flowi_common {
 	kuid_t  flowic_uid;
 	__u32		flowic_multipath_hash;
 	struct flowi_tunnel flowic_tun_key;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 union flowi_uli {
@@ -88,6 +92,9 @@ struct flowi4 {
 #define fl4_icmp_code		uli.icmpt.code
 #define fl4_mh_type		uli.mht.type
 #define fl4_gre_key		uli.gre_key
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } __attribute__((__aligned__(BITS_PER_LONG/8)));
 
 static inline void flowi4_init_output(struct flowi4 *fl4, int oif,

--- a/include/net/genetlink.h
+++ b/include/net/genetlink.h
@@ -5,6 +5,7 @@
 #include <linux/genetlink.h>
 #include <net/netlink.h>
 #include <net/net_namespace.h>
+#include <linux/deepin_kabi.h>
 
 #define GENLMSG_DEFAULT_SIZE (NLMSG_DEFAULT_SIZE - GENL_HDRLEN)
 
@@ -89,6 +90,8 @@ struct genl_family {
 	int			id;
 	/* starting number of multicast group IDs in this family */
 	unsigned int		mcgrp_offset;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /**
@@ -113,6 +116,8 @@ struct genl_info {
 	possible_net_t		_net;
 	void *			user_ptr[2];
 	struct netlink_ext_ack *extack;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 static inline struct net *genl_info_net(const struct genl_info *info)
@@ -195,6 +200,11 @@ struct genl_ops {
 	u8			internal_flags;
 	u8			flags;
 	u8			validate;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /**

--- a/include/net/inet_connection_sock.h
+++ b/include/net/inet_connection_sock.h
@@ -20,6 +20,7 @@
 
 #include <net/inet_sock.h>
 #include <net/request_sock.h>
+#include <linux/deepin_kabi.h>
 
 /* Cancel timers, when they are not required. */
 #undef INET_CSK_CLEAR_TIMERS
@@ -52,6 +53,8 @@ struct inet_connection_sock_af_ops {
 				  char __user *optval, int __user *optlen);
 	void	    (*addr2sockaddr)(struct sock *sk, struct sockaddr *);
 	void	    (*mtu_reduced)(struct sock *sk);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /** inet_connection_sock - INET connection oriented sock
@@ -134,6 +137,8 @@ struct inet_connection_sock {
 	} icsk_mtup;
 	u32			  icsk_probes_tstamp;
 	u32			  icsk_user_timeout;
+
+	DEEPIN_KABI_RESERVE(1)
 
 	u64			  icsk_ca_priv[104 / sizeof(u64)];
 #define ICSK_CA_PRIV_SIZE	  sizeof_field(struct inet_connection_sock, icsk_ca_priv)

--- a/include/net/ip6_fib.h
+++ b/include/net/ip6_fib.h
@@ -68,6 +68,8 @@ struct fib6_config {
 	struct nlattr	*fc_encap;
 	u16		fc_encap_type;
 	bool		fc_is_fdb;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct fib6_node {
@@ -84,6 +86,8 @@ struct fib6_node {
 	int			fn_sernum;
 	struct fib6_info __rcu	*rr_ptr;
 	struct rcu_head		rcu;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct fib6_gc_args {
@@ -203,6 +207,9 @@ struct fib6_info {
 
 	struct rcu_head			rcu;
 	struct nexthop			*nh;
+
+	DEEPIN_KABI_RESERVE(1)
+
 	struct fib6_nh			fib6_nh[];
 };
 
@@ -219,6 +226,8 @@ struct rt6_info {
 
 	/* more non-fragment space at head required */
 	unsigned short			rt6i_nfheader_len;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct fib6_result {

--- a/include/net/l3mdev.h
+++ b/include/net/l3mdev.h
@@ -9,6 +9,7 @@
 
 #include <net/dst.h>
 #include <net/fib_rules.h>
+#include <linux/deepin_kabi.h>
 
 enum l3mdev_type {
 	L3MDEV_TYPE_UNSPEC,
@@ -43,6 +44,11 @@ struct l3mdev_ops {
 	/* IPv6 ops */
 	struct dst_entry * (*l3mdev_link_scope_lookup)(const struct net_device *dev,
 						 struct flowi6 *fl6);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #ifdef CONFIG_NET_L3_MASTER_DEV

--- a/include/net/lwtunnel.h
+++ b/include/net/lwtunnel.h
@@ -7,6 +7,7 @@
 #include <linux/skbuff.h>
 #include <linux/types.h>
 #include <net/route.h>
+#include <linux/deepin_kabi.h>
 
 #define LWTUNNEL_HASH_BITS   7
 #define LWTUNNEL_HASH_SIZE   (1 << LWTUNNEL_HASH_BITS)
@@ -33,6 +34,12 @@ struct lwtunnel_state {
 	int		(*orig_output)(struct net *net, struct sock *sk, struct sk_buff *skb);
 	int		(*orig_input)(struct sk_buff *);
 	struct		rcu_head rcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+
 	__u8            data[];
 };
 

--- a/include/net/neighbour.h
+++ b/include/net/neighbour.h
@@ -29,6 +29,7 @@
 #include <linux/sysctl.h>
 #include <linux/workqueue.h>
 #include <net/rtnetlink.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * NUD stands for "neighbor unreachability detection"
@@ -86,6 +87,8 @@ struct neigh_parms {
 	u32	qlen;
 	int	data[NEIGH_VAR_DATA_MAX];
 	DECLARE_BITMAP(data_state, NEIGH_VAR_DATA_MAX);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 static inline void neigh_var_set(struct neigh_parms *p, int index, int val)
@@ -234,6 +237,8 @@ struct neigh_table {
 	struct neigh_statistics	__percpu *stats;
 	struct neigh_hash_table __rcu *nht;
 	struct pneigh_entry	**phash_buckets;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 enum {

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -43,6 +43,7 @@
 #include <linux/skbuff.h>
 #include <linux/notifier.h>
 #include <linux/xarray.h>
+#include <linux/deepin_kabi.h>
 
 struct user_namespace;
 struct proc_dir_entry;
@@ -190,6 +191,11 @@ struct net {
 #if IS_ENABLED(CONFIG_SMC)
 	struct netns_smc	smc;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } __randomize_layout;
 
 #include <linux/seq_file_net.h>

--- a/include/net/netfilter/nf_conntrack.h
+++ b/include/net/netfilter/nf_conntrack.h
@@ -23,6 +23,7 @@
 #include <linux/netfilter/nf_conntrack_proto_gre.h>
 
 #include <net/netfilter/nf_conntrack_tuple.h>
+#include <linux/deepin_kabi.h>
 
 struct nf_ct_udp {
 	unsigned long	stream_ts;
@@ -123,6 +124,9 @@ struct nf_conn {
 
 	/* Storage reserved for other modules, must be the last member */
 	union nf_conntrack_proto proto;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct nf_conn *

--- a/include/net/netlink.h
+++ b/include/net/netlink.h
@@ -6,6 +6,7 @@
 #include <linux/netlink.h>
 #include <linux/jiffies.h>
 #include <linux/in6.h>
+#include <linux/deepin_kabi.h>
 
 /* ========================================================================
  *         Netlink Messages and Attributes Interface (As Seen On TV)
@@ -359,6 +360,11 @@ struct nla_policy {
 		int (*validate)(const struct nlattr *attr,
 				struct netlink_ext_ack *extack);
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define NLA_POLICY_ETH_ADDR		NLA_POLICY_EXACT_LEN(ETH_ALEN)

--- a/include/net/netns/can.h
+++ b/include/net/netns/can.h
@@ -8,6 +8,7 @@
 
 #include <linux/spinlock.h>
 #include <linux/timer.h>
+#include <linux/deepin_kabi.h>
 
 struct can_dev_rcv_lists;
 struct can_pkg_stats;
@@ -36,6 +37,8 @@ struct netns_can {
 
 	/* CAN GW per-net gateway jobs */
 	struct hlist_head cgw_list;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #endif /* __NETNS_CAN_H__ */

--- a/include/net/netns/ipv4.h
+++ b/include/net/netns/ipv4.h
@@ -11,6 +11,7 @@
 #include <linux/rcupdate.h>
 #include <linux/seqlock.h>
 #include <linux/siphash.h>
+#include <linux/deepin_kabi.h>
 
 struct ctl_table_header;
 struct ipv4_devconf;
@@ -239,5 +240,12 @@ struct netns_ipv4 {
 
 	atomic_t	rt_genid;
 	siphash_key_t	ip_id_key;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 #endif

--- a/include/net/netns/ipv6.h
+++ b/include/net/netns/ipv6.h
@@ -9,6 +9,7 @@
 #define __NETNS_IPV6_H__
 #include <net/dst_ops.h>
 #include <uapi/linux/icmpv6.h>
+#include <linux/deepin_kabi.h>
 
 struct ctl_table_header;
 
@@ -119,6 +120,8 @@ struct netns_ipv6 {
 		u32		seq;
 	} ip6addrlbl_table;
 	struct ioam6_pernet_data *ioam6_data;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #if IS_ENABLED(CONFIG_NF_DEFRAG_IPV6)

--- a/include/net/netns/netfilter.h
+++ b/include/net/netns/netfilter.h
@@ -3,6 +3,7 @@
 #define __NETNS_NETFILTER_H
 
 #include <linux/netfilter_defs.h>
+#include <linux/deepin_kabi.h>
 
 struct proc_dir_entry;
 struct nf_logger;
@@ -33,5 +34,7 @@ struct netns_nf {
 #if IS_ENABLED(CONFIG_NF_DEFRAG_IPV6)
 	unsigned int defrag_ipv6_users;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
 };
 #endif

--- a/include/net/netns/nftables.h
+++ b/include/net/netns/nftables.h
@@ -2,8 +2,11 @@
 #ifndef _NETNS_NFTABLES_H_
 #define _NETNS_NFTABLES_H_
 
+#include <linux/deepin_kabi.h>
+
 struct netns_nftables {
 	u8			gencursor;
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #endif

--- a/include/net/netns/xfrm.h
+++ b/include/net/netns/xfrm.h
@@ -8,6 +8,7 @@
 #include <linux/rhashtable-types.h>
 #include <linux/xfrm.h>
 #include <net/dst_ops.h>
+#include <linux/deepin_kabi.h>
 
 struct ctl_table_header;
 
@@ -83,6 +84,8 @@ struct netns_xfrm {
 
 	spinlock_t xfrm_policy_lock;
 	struct mutex xfrm_cfg_mutex;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #endif

--- a/include/net/rtnetlink.h
+++ b/include/net/rtnetlink.h
@@ -4,6 +4,7 @@
 
 #include <linux/rtnetlink.h>
 #include <net/netlink.h>
+#include <linux/deepin_kabi.h>
 
 typedef int (*rtnl_doit_func)(struct sk_buff *, struct nlmsghdr *,
 			      struct netlink_ext_ack *);
@@ -134,6 +135,15 @@ struct rtnl_link_ops {
 	int			(*fill_linkxstats)(struct sk_buff *skb,
 						   const struct net_device *dev,
 						   int *prividx, int attr);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 int __rtnl_link_register(struct rtnl_link_ops *ops);

--- a/include/net/sch_generic.h
+++ b/include/net/sch_generic.h
@@ -19,6 +19,7 @@
 #include <net/gen_stats.h>
 #include <net/rtnetlink.h>
 #include <net/flow_offload.h>
+#include <linux/deepin_kabi.h>
 
 struct Qdisc_ops;
 struct qdisc_walker;
@@ -127,6 +128,10 @@ struct Qdisc {
 	struct rcu_head		rcu;
 	netdevice_tracker	dev_tracker;
 	struct lock_class_key	root_lock_key;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+
 	/* private data */
 	long privdata[] ____cacheline_aligned;
 };
@@ -278,6 +283,8 @@ struct Qdisc_class_ops {
 					struct sk_buff *skb, struct tcmsg*);
 	int			(*dump_stats)(struct Qdisc *, unsigned long,
 					struct gnet_dump *);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /* Qdisc_class_ops flag values */
@@ -323,6 +330,8 @@ struct Qdisc_ops {
 	u32			(*egress_block_get)(struct Qdisc *sch);
 
 	struct module		*owner;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 

--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -69,6 +69,7 @@
 #include <linux/net_tstamp.h>
 #include <net/l3mdev.h>
 #include <uapi/linux/socket.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * This structure really needs to be cleaned up.
@@ -545,6 +546,15 @@ struct sock {
 	struct rcu_head		sk_rcu;
 	netns_tracker		ns_tracker;
 	struct hlist_node	sk_bind2_node;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 enum sk_pacing {
@@ -1367,6 +1377,15 @@ struct proto {
 
 	struct list_head	node;
 	int			(*diag_destroy)(struct sock *sk, int err);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 } __randomize_layout;
 
 int proto_register(struct proto *prot, int alloc_slab);

--- a/include/net/switchdev.h
+++ b/include/net/switchdev.h
@@ -11,6 +11,7 @@
 #include <linux/notifier.h>
 #include <linux/list.h>
 #include <net/ip_fib.h>
+#include <linux/deepin_kabi.h>
 
 #define SWITCHDEV_F_NO_RECURSE		BIT(0)
 #define SWITCHDEV_F_SKIP_EOPNOTSUPP	BIT(1)
@@ -90,6 +91,11 @@ struct switchdev_obj {
 	u32 flags;
 	void *complete_priv;
 	void (*complete)(struct net_device *dev, int err, void *priv);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* SWITCHDEV_OBJ_ID_PORT_VLAN */

--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -45,6 +45,7 @@
 #include <linux/memcontrol.h>
 #include <linux/bpf-cgroup.h>
 #include <linux/siphash.h>
+#include <linux/deepin_kabi.h>
 
 extern struct inet_hashinfo tcp_hashinfo;
 
@@ -1112,6 +1113,11 @@ struct tcp_congestion_ops {
 	void (*init)(struct sock *sk);
 	/* cleanup private data  (optional) */
 	void (*release)(struct sock *sk);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } ____cacheline_aligned_in_smp;
 
 int tcp_register_congestion_control(struct tcp_congestion_ops *type);

--- a/include/net/xdp.h
+++ b/include/net/xdp.h
@@ -10,6 +10,7 @@
 #include <linux/filter.h>
 #include <linux/netdevice.h>
 #include <linux/skbuff.h> /* skb_shared_info */
+#include <linux/deepin_kabi.h>
 
 /**
  * DOC: XDP RX-queue information
@@ -64,6 +65,11 @@ struct xdp_rxq_info {
 	struct xdp_mem_info mem;
 	unsigned int napi_id;
 	u32 frag_size;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } ____cacheline_aligned; /* perf critical, avoid false-sharing */
 
 struct xdp_txq_info {

--- a/include/net/xfrm.h
+++ b/include/net/xfrm.h
@@ -27,6 +27,7 @@
 #include <net/gro_cells.h>
 
 #include <linux/interrupt.h>
+#include <linux/deepin_kabi.h>
 
 #ifdef CONFIG_XFRM_STATISTICS
 #include <net/snmp.h>
@@ -150,6 +151,11 @@ struct xfrm_dev_offload {
 	u8			dir : 2;
 	u8			type : 2;
 	u8			flags : 2;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct xfrm_mode {

--- a/include/rdma/ib_addr.h
+++ b/include/rdma/ib_addr.h
@@ -21,6 +21,7 @@
 #include <rdma/ib_verbs.h>
 #include <rdma/ib_pack.h>
 #include <net/net_namespace.h>
+#include <linux/deepin_kabi.h>
 
 /**
  * struct rdma_dev_addr - Contains resolved RDMA hardware addresses
@@ -44,6 +45,8 @@ struct rdma_dev_addr {
 	const struct ib_gid_attr *sgid_attr;
 	enum rdma_network_type network;
 	int hoplimit;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /**

--- a/include/rdma/rdma_cm.h
+++ b/include/rdma/rdma_cm.h
@@ -12,6 +12,7 @@
 #include <rdma/ib_addr.h>
 #include <rdma/ib_sa.h>
 #include <uapi/rdma/rdma_user_cm.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Upon receiving a device removal event, users must destroy the associated
@@ -77,6 +78,9 @@ struct rdma_conn_param {
 	u8 srq;
 	u32 qp_num;
 	u32 qkey;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rdma_ud_param {
@@ -95,6 +99,8 @@ struct rdma_cm_event {
 		struct rdma_ud_param	ud;
 	} param;
 	struct rdma_ucm_ece ece;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct rdma_cm_id;
@@ -119,6 +125,8 @@ struct rdma_cm_id {
 	enum ib_qp_type		 qp_type;
 	u32			 port_num;
 	struct work_struct net_work;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct rdma_cm_id *

--- a/include/rdma/rdma_counter.h
+++ b/include/rdma/rdma_counter.h
@@ -11,6 +11,7 @@
 
 #include <rdma/restrack.h>
 #include <rdma/rdma_netlink.h>
+#include <linux/deepin_kabi.h>
 
 struct ib_device;
 struct ib_qp;
@@ -41,6 +42,8 @@ struct rdma_counter {
 	struct mutex			lock;
 	struct rdma_hw_stats		*stats;
 	u32				port;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 void rdma_counter_init(struct ib_device *dev);

--- a/include/rdma/rdma_netlink.h
+++ b/include/rdma/rdma_netlink.h
@@ -5,6 +5,7 @@
 
 #include <linux/netlink.h>
 #include <uapi/rdma/rdma_netlink.h>
+#include <linux/deepin_kabi.h>
 
 enum {
 	RDMA_NLDEV_ATTR_EMPTY_STRING = 1,
@@ -114,6 +115,9 @@ struct rdma_link_ops {
 	struct list_head list;
 	const char *type;
 	int (*newlink)(const char *ibdev_name, struct net_device *ndev);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 void rdma_link_register(struct rdma_link_ops *ops);

--- a/include/rdma/rdma_vt.h
+++ b/include/rdma/rdma_vt.h
@@ -17,6 +17,7 @@
 #include <rdma/ib_verbs.h>
 #include <rdma/ib_mad.h>
 #include <rdma/rdmavt_mr.h>
+#include <linux/deepin_kabi.h>
 
 #define RVT_MAX_PKEY_VALUES 16
 
@@ -105,6 +106,8 @@ struct rvt_ibport {
 	 */
 	struct trap_list trap_lists[RVT_MAX_TRAP_LISTS];
 	struct timer_list trap_timer;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #define RVT_CQN_MAX 16 /* maximum length of cq name */
@@ -426,6 +429,9 @@ struct rvt_dev_info {
 
 	/* Memory Working Set Size */
 	struct rvt_wss *wss;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**

--- a/include/rdma/rdmavt_qp.h
+++ b/include/rdma/rdmavt_qp.h
@@ -11,6 +11,7 @@
 #include <rdma/ib_verbs.h>
 #include <rdma/rdmavt_cq.h>
 #include <rdma/rvt-abi.h>
+#include <linux/deepin_kabi.h>
 /*
  * Atomic bit definitions for r_aflags.
  */
@@ -440,6 +441,10 @@ struct rvt_qp {
 	struct hrtimer s_rnr_timer;
 
 	atomic_t local_ops_pending; /* number of fast_reg/local_inv reqs */
+
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	/*
 	 * This sge list MUST be last. Do not add anything below here.

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1930,6 +1930,13 @@ config BINDGEN_VERSION_TEXT
 config TRACEPOINTS
 	bool
 
+config DEEPIN_KABI_RESERVE
+	bool "Support for KABI RESERVE"
+	default y
+	help
+	 This option can be turned off for images that clearly do not require
+	 kabi compatibility.
+
 source "kernel/Kconfig.kexec"
 
 endmenu		# General setup


### PR DESCRIPTION
[kABI: Introduce generic kABI macros to use for kABI workarounds](https://github.com/deepin-community/kernel/commit/64ccab945882c2ce7bf5ebba4f0e65fc1925a86b)