### PR TITLE
drm/arise: Fix i386 config build error

### DIFF
--- a/drivers/gpu/drm/arise/cbios/Device/CBiosShare.h
+++ b/drivers/gpu/drm/arise/cbios/Device/CBiosShare.h
@@ -224,7 +224,7 @@ static inline CBIOS_U32 cb_swab32(CBIOS_U32 x)
 #define cbmemset(s1, v, n)     CBIOS_NULL
 #define cbmemcpy(s1, s2, n)    CBIOS_NULL
 #define cbmemcmp(s1, s2, n)    0
-#define cbdo_div(a, b) ((a)/(b))
+#define cbdo_div(a, b)         0
 #define cbvsprintf(s, f, ...)  0
 
 #else

--- a/drivers/gpu/drm/arise/core/e3k/vidsch/vidsch_engine_setup_e3k.c
+++ b/drivers/gpu/drm/arise/core/e3k/vidsch/vidsch_engine_setup_e3k.c
@@ -306,8 +306,7 @@ unsigned long long engine_update_vcp_fence_id_e3k(vidsch_mgr_t *sch_mgr)
                         unsigned long long   update_timestamp;         /* THE time update fence id */
                         unsigned long long   time_interval;
                         gf_get_nsecs(&update_timestamp);
-                        time_interval = (update_timestamp - \
-                                        sch_mgr->adapter->vcp_task_info[i].vcp_inc_timestamp)/1000000;
+                        time_interval = gf_do_div(update_timestamp - sch_mgr->adapter->vcp_task_info[i].vcp_inc_timestamp, 1000000);
                         sch_mgr->adapter->vcp_info[j].TotalDecodetime += time_interval;
                         sch_mgr->adapter->vcp_info[j].TotalDecodeFrameNum++;
                         sch_mgr->last_returned_fence_id = sch_mgr->returned_fence_id;

--- a/drivers/gpu/drm/arise/core/e3k/vidsch/vidsch_setup_e3k.c
+++ b/drivers/gpu/drm/arise/core/e3k/vidsch/vidsch_setup_e3k.c
@@ -463,13 +463,9 @@ static void vidsch_get_set_reg_e3k(adapter_t *adapter, gf_query_info_t *info)
 
             reg_offset = (CHIP_ARISE1020 <= adapter->chip_id) ? Reg_Csp_Ref_Total_Gpu_Timestamp_Offset_Arise1020 : Reg_Csp_Ms_Total_Gpu_Timestamp_Offset;
 
-#ifdef __aarch64__
             time_stamp_lo = gf_read32(adapter->mmio + MMIO_CSP_START_ADDRESS  + reg_offset * 4);
             time_stamp_hi = gf_read32(adapter->mmio + MMIO_CSP_START_ADDRESS  + reg_offset * 4 + 4);
             info->value64 = time_stamp_lo | (time_stamp_hi << 32);
-#else
-            info->value64 = gf_read64(adapter->mmio + MMIO_CSP_START_ADDRESS  + reg_offset * 4);
-#endif
         }
             break;
 

--- a/drivers/gpu/drm/arise/core/kernel_interface.c
+++ b/drivers/gpu/drm/arise/core/kernel_interface.c
@@ -1311,7 +1311,7 @@ static void krnl_task_timeout_update(void* data, unsigned long long *value, int 
     if (update)
         adapter->hw_hang_fast_timeout_ns = *value * 1000000;
     else
-        *value = adapter->hw_hang_fast_timeout_ns / 1000000;
+        *value = gf_do_div(adapter->hw_hang_fast_timeout_ns, 1000000);
 }
 
 static void krnl_reset_dvfs_power_flag(void* data)

--- a/drivers/gpu/drm/arise/linux/os_interface.c
+++ b/drivers/gpu/drm/arise/linux/os_interface.c
@@ -242,7 +242,11 @@ unsigned long gf_strlen(char *s)
 
 unsigned long long GF_API_CALL gf_read64(void* addr)
 {
+#ifdef CONFIG_64BIT
     return readq(addr);
+#else
+    return 0ull;
+#endif
 }
 
 unsigned int GF_API_CALL  gf_read32(void* addr)


### PR DESCRIPTION
When make i386_defconfig, here is follow error:

drivers/gpu/drm/arise/linux/os_interface.c: In function ‘gf_read64’: drivers/gpu/drm/arise/linux/os_interface.c:245:12: error: implicit declaration of function ‘readq’; did you mean ‘readl’? [-Werror=implicit-function-declaration]
  245 |     return readq(addr);
      |            ^~~~~
      |            readl
cc1: all warnings being treated as errors

Link: https://gitee.com/openkylin/linux/pulls/241