### PR TITLE
[linux-6.6.y] Fix built errors of Zhaoxin DMA patches for i386

### DIFF
--- a/arch/x86/kernel/Makefile
+++ b/arch/x86/kernel/Makefile
@@ -158,5 +158,5 @@ ifeq ($(CONFIG_X86_64),y)
 
 	obj-$(CONFIG_MMCONF_FAM10H)	+= mmconf-fam10h_64.o
 	obj-y				+= vsmp_64.o
-	obj-$(CONFIG_PCI)		+= zhaoxin_kh40000.o
+	obj-$(CONFIG_INTEL_IOMMU)	+= zhaoxin_kh40000.o
 endif

--- a/arch/x86/kernel/early-quirks.c
+++ b/arch/x86/kernel/early-quirks.c
@@ -696,7 +696,7 @@ static void quirk_zhaoxin_dma_patch(int num, int slot, int func)
 	revision = read_pci_config_byte(num, slot, func, PCI_REVISION_ID);
 	if (revision == 0x10) {
 		is_zhaoxin_kh40000 = true;
-		dma_ops = &kh40000_dma_direct_ops;
+		kh40000_get_direct_dma_ops();
 		pr_info("zhaoxin direct dma patch enabled\n");
 	}
 }

--- a/arch/x86/kernel/zhaoxin_kh40000.c
+++ b/arch/x86/kernel/zhaoxin_kh40000.c
@@ -175,6 +175,11 @@ const struct dma_map_ops kh40000_dma_direct_ops = {
 	.map_resource		= dma_direct_map_resource,
 };
 
+void kh40000_get_direct_dma_ops(void)
+{
+	dma_ops = &kh40000_dma_direct_ops;
+}
+
 /* zhaoxin kh-40000 iommu dma ops */
 static const struct dma_map_ops *iommu_dma_ops;
 

--- a/include/linux/dma-map-ops.h
+++ b/include/linux/dma-map-ops.h
@@ -516,20 +516,25 @@ pci_p2pdma_map_segment(struct pci_p2pdma_map_state *state, struct device *dev,
 }
 #endif /* CONFIG_PCI_P2PDMA */
 
-#if defined CONFIG_PCI && defined CONFIG_X86
+#if IS_BUILTIN(CONFIG_INTEL_IOMMU) && IS_BUILTIN(CONFIG_X86_64)
 
 extern bool is_zhaoxin_kh40000;
-extern const struct dma_map_ops kh40000_dma_direct_ops;
+void kh40000_get_direct_dma_ops(void);
 void kh40000_set_iommu_dma_ops(struct device *dev);
 
 #else
 
 bool __weak is_zhaoxin_kh40000;
-static inline void kh40000_set_iommu_dma_ops(struct device *dev)
+
+static inline void kh40000_get_direct_dma_ops(void)
 {
 
 }
 
+static inline void kh40000_set_iommu_dma_ops(struct device *dev)
+{
+
+}
 
 #endif
 


### PR DESCRIPTION
After merging d3eb024789cc ("Add kh40000_direct_dma_ops for KH-40000 platform"), builting with i386_defconfig, built errors occurred due to differences in configuration items:
ld:arch/x86/kernel/early-quirks.o: in function `quirk_zhaoxin_dma_patch': early-quirks.c:(.text+0x2b): undefined reference to kh40000_dma_direct_ops

Therefore, modified the conditionanl items related to the code and encapsulated the sturct pointer assignment into function.

Fixes: d3eb024789cc ("Add kh40000_direct_dma_ops for KH-40000 platform")