### PR TITLE
[linux-6.6.y] Fix a code logic error in Zhaoxin DMA patch

### DIFF
--- a/arch/x86/kernel/zhaoxin_kh40000.c
+++ b/arch/x86/kernel/zhaoxin_kh40000.c
@@ -42,7 +42,7 @@ static int __init zhaoxin_patch_code_setup(char *str)
 		return err;
 	}
 
-	if (ZHAOXIN_P2CW_NODE_CHECK | zhaoxin_patch_code)
+	if (ZHAOXIN_P2CW_NODE_CHECK & zhaoxin_patch_code)
 		pr_info("zhaoxin dma patch node check is enabled\n");
 
 	return 0;


### PR DESCRIPTION
Replace "ZHAOXIN_P2CW_NODE_CHECK | zhaoxin_patch_code" with "ZHAOXIN_P2CW_NODE_CHECK & zhaoxin_patch_code" in function zhaoxin_patch_code_setup()

Fixes: d3eb024789cc ("Add kh40000_direct_dma_ops for KH-40000 platform")