### PR TITLE
[6.6]Hygon: CSV3 patch series part 2 (launch and running support on both KVM and guest sides)

### DIFF
--- a/arch/x86/boot/compressed/Makefile
+++ b/arch/x86/boot/compressed/Makefile
@@ -108,6 +108,7 @@ ifdef CONFIG_X86_64
 	vmlinux-objs-$(CONFIG_AMD_MEM_ENCRYPT) += $(obj)/mem_encrypt.o
 	vmlinux-objs-y += $(obj)/pgtable_64.o
 	vmlinux-objs-$(CONFIG_AMD_MEM_ENCRYPT) += $(obj)/sev.o
+	vmlinux-objs-$(CONFIG_HYGON_CSV) += $(obj)/csv.o
 endif
 
 vmlinux-objs-$(CONFIG_ACPI) += $(obj)/acpi.o

--- a/arch/x86/boot/compressed/csv.c
+++ b/arch/x86/boot/compressed/csv.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Hygon CSV Support
+ *
+ * Copyright (C) Hygon Info Technologies Ltd.
+ */
+
+#include "misc.h"
+
+#include <asm/csv.h>
+#include <asm/cpuid.h>
+
+static unsigned int csv3_enabled __section(".data");
+
+void csv_set_status(void)
+{
+	unsigned int eax;
+	unsigned int ebx;
+	unsigned int ecx;
+	unsigned int edx;
+
+	eax = 0;
+	native_cpuid(&eax, &ebx, &ecx, &edx);
+
+	/* HygonGenuine */
+	if (ebx == CPUID_VENDOR_HygonGenuine_ebx &&
+	    ecx == CPUID_VENDOR_HygonGenuine_ecx &&
+	    edx == CPUID_VENDOR_HygonGenuine_edx &&
+	    sme_me_mask) {
+		unsigned long low, high;
+
+		asm volatile("rdmsr\n" : "=a" (low), "=d" (high) :
+			"c" (MSR_AMD64_SEV));
+
+		if (low & MSR_CSV3_ENABLED)
+			csv3_enabled = 1;
+	}
+}

--- a/arch/x86/boot/compressed/csv.c
+++ b/arch/x86/boot/compressed/csv.c
@@ -23,6 +23,22 @@
 static unsigned int csv3_enabled __section(".data");
 static unsigned int csv3_secure_call_init;
 
+void csv_update_page_attr(unsigned long address, pteval_t set, pteval_t clr)
+{
+	if (!csv3_enabled)
+		return;
+
+	if ((set | clr) & _PAGE_ENC) {
+		if (set & _PAGE_ENC)
+			csv3_early_secure_call_ident_map(__pa(address), 1,
+							 CSV3_SECURE_CMD_ENC);
+
+		if (clr & _PAGE_ENC)
+			csv3_early_secure_call_ident_map(__pa(address), 1,
+							 CSV3_SECURE_CMD_DEC);
+	}
+}
+
 /* Invoke it before jump to real kernel in case secure call pages are not mapped
  * in the identity page table.
  *

--- a/arch/x86/boot/compressed/csv.h
+++ b/arch/x86/boot/compressed/csv.h
@@ -13,10 +13,12 @@
 #ifdef CONFIG_HYGON_CSV
 
 void csv_set_status(void);
+void csv_init_secure_call_pages(void *boot_params);
 
 #else
 
 static inline void csv_set_status(void) { }
+static inline void csv_init_secure_call_pages(void *boot_params) { }
 
 #endif
 

--- a/arch/x86/boot/compressed/csv.h
+++ b/arch/x86/boot/compressed/csv.h
@@ -15,10 +15,15 @@
 void csv_set_status(void);
 void csv_init_secure_call_pages(void *boot_params);
 
+void csv_update_page_attr(unsigned long address, pteval_t set, pteval_t clr);
+
 #else
 
 static inline void csv_set_status(void) { }
 static inline void csv_init_secure_call_pages(void *boot_params) { }
+
+static inline void csv_update_page_attr(unsigned long address,
+					pteval_t set, pteval_t clr) { }
 
 #endif
 

--- a/arch/x86/boot/compressed/csv.h
+++ b/arch/x86/boot/compressed/csv.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Hygon CSV header for early boot related functions.
+ *
+ * Copyright (C) Hygon Info Technologies Ltd.
+ *
+ * Author: Liyang Han <hanliyang@hygon.cn>
+ */
+
+#ifndef BOOT_COMPRESSED_CSV_H
+#define BOOT_COMPRESSED_CSV_H
+
+#ifdef CONFIG_HYGON_CSV
+
+void csv_set_status(void);
+
+#else
+
+static inline void csv_set_status(void) { }
+
+#endif
+
+#endif	/* BOOT_COMPRESSED_CSV_H */

--- a/arch/x86/boot/compressed/head_64.S
+++ b/arch/x86/boot/compressed/head_64.S
@@ -478,6 +478,16 @@ SYM_FUNC_START_LOCAL_NOALIGN(.Lrelocated)
 	movq	%r15, %rdi
 	call	initialize_identity_maps
 
+#ifdef CONFIG_HYGON_CSV
+	/*
+	 * If running as a CSV3 guest, secure call pages must be mapped in
+	 * the identity page table before jumping to the decompressed kernel.
+	 * Scan secure call pages here in safe.
+	 */
+	movq	%r15, %rdi
+	call	csv_init_secure_call_pages
+#endif
+
 /*
  * Do the extraction, and jump to the new kernel..
  */

--- a/arch/x86/boot/compressed/head_64.S
+++ b/arch/x86/boot/compressed/head_64.S
@@ -397,6 +397,16 @@ SYM_CODE_START(startup_64)
 	movq	%r15, %rdi
 	call	sev_enable
 #endif
+#ifdef CONFIG_HYGON_CSV
+	/*
+	 * Check CSV active status. The CSV and CSV2 guest are indicated by
+	 * MSR_AMD64_SEV_ENABLED_BIT and MSR_AMD64_SEV_ES_ENABLED_BIT in MSR
+	 * register 0xc0010131, respectively.
+	 * The CSV3 guest is indicated by MSR_CSV3_ENABLED in MSR register
+	 * 0xc0010131.
+	 */
+	call	csv_set_status
+#endif
 
 	/* Preserve only the CR4 bits that must be preserved, and clear the rest */
 	movq	%cr4, %rax

--- a/arch/x86/boot/compressed/ident_map_64.c
+++ b/arch/x86/boot/compressed/ident_map_64.c
@@ -298,6 +298,9 @@ static int set_clr_page_flags(struct x86_mapping_info *info,
 	if ((set | clr) & _PAGE_ENC) {
 		clflush_page(address);
 
+		/* On CSV3, notify secure processor to manage page attr changes */
+		csv_update_page_attr(address, set, clr);
+
 		/*
 		 * If the encryption attribute is being cleared, change the page state
 		 * to shared in the RMP table.

--- a/arch/x86/boot/compressed/misc.h
+++ b/arch/x86/boot/compressed/misc.h
@@ -37,6 +37,7 @@
 #include <asm/desc_defs.h>
 
 #include "tdx.h"
+#include "csv.h"
 
 #define BOOT_CTYPE_H
 #include <linux/acpi.h>

--- a/arch/x86/include/asm/csv.h
+++ b/arch/x86/include/asm/csv.h
@@ -63,6 +63,8 @@ void __init csv_early_reset_memory(struct boot_params *bp);
 void __init csv_early_update_memory_enc(u64 vaddr, u64 pages);
 void __init csv_early_update_memory_dec(u64 vaddr, u64 pages);
 
+void __init csv_early_memory_enc_dec(u64 vaddr, u64 size, bool enc);
+
 #else	/* !CONFIG_HYGON_CSV */
 
 static inline bool csv3_active(void) { return false; }
@@ -70,6 +72,9 @@ static inline bool csv3_active(void) { return false; }
 static inline void __init csv_early_reset_memory(struct boot_params *bp) { }
 static inline void __init csv_early_update_memory_enc(u64 vaddr, u64 pages) { }
 static inline void __init csv_early_update_memory_dec(u64 vaddr, u64 pages) { }
+
+static inline void __init csv_early_memory_enc_dec(u64 vaddr, u64 size,
+						   bool enc) { }
 
 #endif	/* CONFIG_HYGON_CSV */
 

--- a/arch/x86/include/asm/csv.h
+++ b/arch/x86/include/asm/csv.h
@@ -55,6 +55,24 @@ static inline uint32_t csv_get_smr_entry_shift(void) { return 0; }
 #define MSR_CSV3_ENABLED_BIT		30
 #define MSR_CSV3_ENABLED		BIT_ULL(MSR_CSV3_ENABLED_BIT)
 
+#ifdef CONFIG_HYGON_CSV
+
+bool csv3_active(void);
+
+void __init csv_early_reset_memory(struct boot_params *bp);
+void __init csv_early_update_memory_enc(u64 vaddr, u64 pages);
+void __init csv_early_update_memory_dec(u64 vaddr, u64 pages);
+
+#else	/* !CONFIG_HYGON_CSV */
+
+static inline bool csv3_active(void) { return false; }
+
+static inline void __init csv_early_reset_memory(struct boot_params *bp) { }
+static inline void __init csv_early_update_memory_enc(u64 vaddr, u64 pages) { }
+static inline void __init csv_early_update_memory_dec(u64 vaddr, u64 pages) { }
+
+#endif	/* CONFIG_HYGON_CSV */
+
 #endif	/* __ASSEMBLY__ */
 
 #endif	/* __ASM_X86_CSV_H__ */

--- a/arch/x86/include/asm/csv.h
+++ b/arch/x86/include/asm/csv.h
@@ -65,6 +65,8 @@ void __init csv_early_update_memory_dec(u64 vaddr, u64 pages);
 
 void __init csv_early_memory_enc_dec(u64 vaddr, u64 size, bool enc);
 
+void csv_memory_enc_dec(u64 vaddr, u64 pages, bool enc);
+
 #else	/* !CONFIG_HYGON_CSV */
 
 static inline bool csv3_active(void) { return false; }
@@ -75,6 +77,8 @@ static inline void __init csv_early_update_memory_dec(u64 vaddr, u64 pages) { }
 
 static inline void __init csv_early_memory_enc_dec(u64 vaddr, u64 size,
 						   bool enc) { }
+
+static inline void csv_memory_enc_dec(u64 vaddr, u64 pages, bool enc) { }
 
 #endif	/* CONFIG_HYGON_CSV */
 

--- a/arch/x86/include/asm/csv.h
+++ b/arch/x86/include/asm/csv.h
@@ -48,6 +48,13 @@ static inline uint32_t csv_get_smr_entry_shift(void) { return 0; }
 
 #endif	/* CONFIG_HYGON_CSV */
 
+#define CPUID_VENDOR_HygonGenuine_ebx	0x6f677948
+#define CPUID_VENDOR_HygonGenuine_ecx	0x656e6975
+#define CPUID_VENDOR_HygonGenuine_edx	0x6e65476e
+
+#define MSR_CSV3_ENABLED_BIT		30
+#define MSR_CSV3_ENABLED		BIT_ULL(MSR_CSV3_ENABLED_BIT)
+
 #endif	/* __ASSEMBLY__ */
 
 #endif	/* __ASM_X86_CSV_H__ */

--- a/arch/x86/kernel/Makefile
+++ b/arch/x86/kernel/Makefile
@@ -160,3 +160,5 @@ ifeq ($(CONFIG_X86_64),y)
 	obj-y				+= vsmp_64.o
 	obj-$(CONFIG_INTEL_IOMMU)	+= zhaoxin_kh40000.o
 endif
+
+obj-$(CONFIG_HYGON_CSV)			+= csv.o

--- a/arch/x86/kernel/csv-shared.c
+++ b/arch/x86/kernel/csv-shared.c
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Hygon CSV support
+ *
+ * This file is shared between decompression boot code and running
+ * linux kernel.
+ *
+ * Copyright (C) Hygon Info Technologies Ltd.
+ */
+
+#include <asm/e820/types.h>
+
+/*
+ ****************************** CSV3 secure call *******************************
+ *
+ * CSV3 guest is based on hygon secure isolated virualization feature. An secure
+ * processor which resides in hygon SOC manages guest's private memory. The
+ * secure processor allocates or frees private memory for CSV3 guest and manages
+ * CSV3 guest's nested page table.
+ *
+ * As the secure processor is considered as a PCI device in host, CSV3 guest can
+ * not communicate with it directly. Howerver, CSV3 guest must request the secure
+ * processor to change its physical memory between private memory and shared
+ * memory. CSV3 secure call command is a method used to communicate with secure
+ * processor that host cannot tamper with the data in CSV3 guest. Host can only
+ * perform an external command to notify the secure processor to handle the
+ * pending guest's command.
+ *
+ * CSV3 secure call pages:
+ * Secure call pages are two dedicated pages that reserved by BIOS. We define
+ * secure call pages as page A and page B. During guest launch stage, the secure
+ * processor will parse the address of secure call pages. The secure processor
+ * maps the two pages with same private memory page in NPT. The secure processor
+ * always set one page as present and another page as non-present in NPT.
+
+ * CSV3 secure call main work flow:
+ * If we write the guest's commands in one page then read them from another page,
+ * nested page fault happens and the guest exits to host. Then host will perform
+ * an external command with the gpa(page A or page B) to the secure processor.
+ * The secure processor checks that the gpa in NPF belongs to secure call pages,
+ * read the guest's command to handle, then switch the present bit between the
+ * two pages.
+ *
+ *			guest page A    guest page B
+ *			      |              |
+ *			  ____|______________|____
+ *			  |                      |
+ *			  |  nested page table   |
+ *			  |______________________|
+ *			      \              /
+ *			       \            /
+ *			        \          /
+ *			         \        /
+ *			          \      /
+ *			       secure memory page
+ *
+ * CSV3_SECURE_CMD_ENC:
+ *	CSV3 guest declares a specifid memory range as secure. By default, all of
+ *	CSV3 guest's memory mapped as secure.
+ *	The secure processor allocate a block of secure memory and map the memory
+ *	in CSV3 guest's NPT with the specified guest physical memory range in CSV3
+ *	secure call.
+ *
+ * CSV3_SECURE_CMD_DEC:
+ *	CSV3 guest declares a specified memory range as shared.
+ *	The secure processor save the guest physical memory range in its own ram
+ *	and free the range in CSV3 guest's NPT. When CSV3 guest access the memory,
+ *	a new nested page fault happens.
+ *
+ * CSV3_SECURE_CMD_RESET:
+ *	CSV3 guest switches all of the shared memory to secure.
+ *	The secure processor resets all the shared memory in CSV3 guest's NPT and
+ *	clears the saved shared memory range. Then the secure process allocates
+ *	secure memory to map in CSV3 guest's NPT.
+ *
+ * CSV3_SECURE_CMD_UPDATE_SECURE_CALL_TABLE:
+ *	CSV3 guest wants to change the secure call pages.
+ *	The secure processor re-init the secure call context.
+ */
+enum csv3_secure_command_type {
+	CSV3_SECURE_CMD_ENC	= 1,
+	CSV3_SECURE_CMD_DEC,
+	CSV3_SECURE_CMD_RESET,
+	CSV3_SECURE_CMD_UPDATE_SECURE_CALL_TABLE,
+};
+
+/*
+ * Secure call page fields.
+ * Secure call page size is 4KB always. We define CSV3 secure call page structure
+ * as below.
+ * guid:	Must be in the first 128 bytes of the page. Its value should be
+ *		(0xceba2fa59a5d926ful, 0xa556555d276b21abul) always.
+ * cmd_type:	Command to be issued to the secure processor.
+ * nums:	number of entries in the command.
+ * base_address:Start address of the memory range.
+ * size:	Size of the memory range.
+ */
+#define SECURE_CALL_ENTRY_MAX	(254)
+
+/* size of secure call cmd is 4KB. */
+struct csv3_secure_call_cmd {
+	union {
+		u8	guid[16];
+		u64	guid_64[2];
+	};
+	u32	cmd_type;
+	u32	nums;
+	u64	unused;
+	struct {
+		u64	base_address;
+		u64	size;
+	} entry[SECURE_CALL_ENTRY_MAX];
+};
+
+/* csv3 secure call guid, do not change the value. */
+#define CSV3_SECURE_CALL_GUID_LOW	0xceba2fa59a5d926ful
+#define CSV3_SECURE_CALL_GUID_HIGH	0xa556555d276b21abul
+
+static u64 csv3_boot_sc_page_a __initdata = -1ul;
+static u64 csv3_boot_sc_page_b __initdata = -1ul;
+static u32 early_page_idx __initdata;
+
+/**
+ * csv3_scan_secure_call_pages - try to find the secure call pages.
+ * @boot_params:	boot parameters where e820_table resides.
+ *
+ * The secure call pages are reserved by BIOS. We scan all the reserved pages
+ * to check the CSV3 secure call guid bytes.
+ */
+void __init csv3_scan_secure_call_pages(struct boot_params *boot_params)
+{
+	struct boot_e820_entry *entry;
+	struct csv3_secure_call_cmd *sc_page;
+	u64 offset;
+	u64 addr;
+	u8 i;
+	u8 table_num;
+	int count = 0;
+
+	if (!boot_params)
+		return;
+
+	if (csv3_boot_sc_page_a != -1ul && csv3_boot_sc_page_b != -1ul)
+		return;
+
+	table_num = min_t(u8, boot_params->e820_entries,
+			  E820_MAX_ENTRIES_ZEROPAGE);
+	entry = &boot_params->e820_table[0];
+	for (i = 0; i < table_num; i++) {
+		if (entry[i].type != E820_TYPE_RESERVED)
+			continue;
+
+		addr = entry[i].addr & PAGE_MASK;
+		for (offset = 0; offset < entry[i].size; offset += PAGE_SIZE) {
+			sc_page = (void *)(addr + offset);
+			if (sc_page->guid_64[0] == CSV3_SECURE_CALL_GUID_LOW &&
+			    sc_page->guid_64[1] == CSV3_SECURE_CALL_GUID_HIGH) {
+				if (count == 0)
+					csv3_boot_sc_page_a = addr + offset;
+				else if (count == 1)
+					csv3_boot_sc_page_b = addr + offset;
+				count++;
+			}
+			if (count >= 2)
+				return;
+		}
+	}
+}
+
+/**
+ * csv3_early_secure_call_ident_map - issue early secure call command at the
+ *			stage where identity page table is created.
+ * @base_address:	Start address of the specified memory range.
+ * @num_pages:		number of the specific pages.
+ * @cmd_type:		Secure call cmd type.
+ */
+void __init csv3_early_secure_call_ident_map(u64 base_address, u64 num_pages,
+					     enum csv3_secure_command_type cmd_type)
+{
+	struct csv3_secure_call_cmd *page_rd;
+	struct csv3_secure_call_cmd *page_wr;
+	u32 cmd_ack;
+
+	if (csv3_boot_sc_page_a == -1ul || csv3_boot_sc_page_b == -1ul)
+		return;
+
+	/* identity mapping at the stage. */
+	page_rd = (void *)(early_page_idx ? csv3_boot_sc_page_a : csv3_boot_sc_page_b);
+	page_wr = (void *)(early_page_idx ? csv3_boot_sc_page_b : csv3_boot_sc_page_a);
+
+	while (1) {
+		page_wr->cmd_type = (u32)cmd_type;
+		page_wr->nums = 1;
+		page_wr->entry[0].base_address = base_address;
+		page_wr->entry[0].size = num_pages << PAGE_SHIFT;
+
+		/*
+		 * Write command in page_wr must be done before retrieve cmd
+		 * ack from page_rd, and it is ensured by the mb below.
+		 */
+		mb();
+
+		cmd_ack = page_rd->cmd_type;
+		if (cmd_ack != cmd_type)
+			break;
+	}
+	early_page_idx ^= 1;
+}

--- a/arch/x86/kernel/csv.c
+++ b/arch/x86/kernel/csv.c
@@ -19,6 +19,15 @@ struct secure_call_pages {
 	struct csv3_secure_call_cmd page_b;
 };
 
+static u32 csv3_percpu_secure_call_init __initdata;
+static u32 early_secure_call_page_idx __initdata;
+
+static DEFINE_PER_CPU(struct secure_call_pages*, secure_call_data);
+static DEFINE_PER_CPU(int, secure_call_page_idx);
+
+typedef void (*csv3_secure_call_func)(u64 base_address, u64 num_pages,
+				      enum csv3_secure_command_type cmd_type);
+
 void __init csv_early_reset_memory(struct boot_params *bp)
 {
 	if (!csv3_active())
@@ -46,4 +55,181 @@ void __init csv_early_update_memory_enc(u64 vaddr, u64 pages)
 	if (pages)
 		csv3_early_secure_call_ident_map(__pa(vaddr), pages,
 						 CSV3_SECURE_CMD_ENC);
+}
+
+static void __init csv3_alloc_secure_call_data(int cpu)
+{
+	struct secure_call_pages *data;
+
+	data = memblock_alloc(sizeof(*data), PAGE_SIZE);
+	if (!data)
+		panic("Can't allocate CSV3 secure all data");
+
+	per_cpu(secure_call_data, cpu) = data;
+}
+
+static void __init csv3_secure_call_update_table(void)
+{
+	int cpu;
+	struct secure_call_pages *data;
+	struct csv3_secure_call_cmd *page_rd;
+	struct csv3_secure_call_cmd *page_wr;
+	u32 cmd_ack;
+
+	if (!csv3_active())
+		return;
+
+	page_rd = (void *)early_memremap_encrypted(csv3_boot_sc_page_a, PAGE_SIZE);
+	page_wr = (void *)early_memremap_encrypted(csv3_boot_sc_page_b, PAGE_SIZE);
+
+	while (1) {
+		page_wr->cmd_type = CSV3_SECURE_CMD_UPDATE_SECURE_CALL_TABLE;
+		page_wr->nums = 0;
+
+		/* initialize per-cpu secure call pages */
+		for_each_possible_cpu(cpu) {
+			if (cpu >= SECURE_CALL_ENTRY_MAX)
+				panic("csv does not support cpus > %d\n",
+				      SECURE_CALL_ENTRY_MAX);
+			csv3_alloc_secure_call_data(cpu);
+			data = per_cpu(secure_call_data, cpu);
+			per_cpu(secure_call_page_idx, cpu) = 0;
+			page_wr->entry[cpu].base_address = __pa(data);
+			page_wr->entry[cpu].size = PAGE_SIZE * 2;
+			page_wr->nums++;
+		}
+
+		/*
+		 * Write command in page_wr must be done before retrieve cmd
+		 * ack from page_rd, and it is ensured by the mb below.
+		 */
+		mb();
+
+		cmd_ack = page_rd->cmd_type;
+		if (cmd_ack != CSV3_SECURE_CMD_UPDATE_SECURE_CALL_TABLE)
+			break;
+	}
+
+	early_memunmap(page_rd, PAGE_SIZE);
+	early_memunmap(page_wr, PAGE_SIZE);
+}
+
+/**
+ * __csv3_early_secure_call - issue secure call command at the stage where new
+ *			kernel page table is created and early identity page
+ *			table is deprecated .
+ * @base_address:	Start address of the specified memory range.
+ * @num_pages:		number of the specific pages.
+ * @cmd_type:		Secure call cmd type.
+ */
+static void __init __csv3_early_secure_call(u64 base_address, u64 num_pages,
+					    enum csv3_secure_command_type cmd_type)
+{
+	struct csv3_secure_call_cmd *page_rd;
+	struct csv3_secure_call_cmd *page_wr;
+	u32 cmd_ack;
+
+	if (csv3_boot_sc_page_a == -1ul || csv3_boot_sc_page_b == -1ul)
+		return;
+
+	if (!csv3_percpu_secure_call_init) {
+		csv3_secure_call_update_table();
+		csv3_percpu_secure_call_init = 1;
+	}
+
+	if (early_secure_call_page_idx == 0) {
+		page_rd = (void *)early_memremap_encrypted(csv3_boot_sc_page_a,
+							   PAGE_SIZE);
+		page_wr = (void *)early_memremap_encrypted(csv3_boot_sc_page_b,
+							   PAGE_SIZE);
+	} else {
+		page_wr = (void *)early_memremap_encrypted(csv3_boot_sc_page_a,
+							   PAGE_SIZE);
+		page_rd = (void *)early_memremap_encrypted(csv3_boot_sc_page_b,
+							   PAGE_SIZE);
+	}
+
+	while (1) {
+		page_wr->cmd_type = (u32)cmd_type;
+		page_wr->nums = 1;
+		page_wr->entry[0].base_address = base_address;
+		page_wr->entry[0].size = num_pages << PAGE_SHIFT;
+
+		/*
+		 * Write command in page_wr must be done before retrieve cmd
+		 * ack from page_rd, and it is ensured by the mb below.
+		 */
+		mb();
+
+		cmd_ack = page_rd->cmd_type;
+		if (cmd_ack != cmd_type)
+			break;
+	}
+
+	early_memunmap(page_rd, PAGE_SIZE);
+	early_memunmap(page_wr, PAGE_SIZE);
+
+	early_secure_call_page_idx ^= 1;
+}
+
+
+static void __csv3_memory_enc_dec(csv3_secure_call_func secure_call, u64 vaddr,
+				  u64 pages, bool enc)
+{
+	u64 vaddr_end, vaddr_next;
+	u64 psize, pmask;
+	u64 last_paddr, paddr;
+	u64 last_psize = 0;
+	pte_t *kpte;
+	int level;
+	enum csv3_secure_command_type cmd_type;
+
+	cmd_type = enc ? CSV3_SECURE_CMD_ENC : CSV3_SECURE_CMD_DEC;
+	vaddr_next = vaddr;
+	vaddr_end = vaddr + (pages << PAGE_SHIFT);
+	for (; vaddr < vaddr_end; vaddr = vaddr_next) {
+		kpte = lookup_address(vaddr, &level);
+		if (!kpte || pte_none(*kpte)) {
+			panic("invalid pte, vaddr 0x%llx\n", vaddr);
+			goto out;
+		}
+
+		psize = page_level_size(level);
+		pmask = page_level_mask(level);
+
+		vaddr_next = (vaddr & pmask) + psize;
+		paddr = ((pte_pfn(*kpte) << PAGE_SHIFT) & pmask) +
+			(vaddr & ~pmask);
+		psize -= (vaddr & ~pmask);
+
+		if (vaddr_end - vaddr < psize)
+			psize = vaddr_end - vaddr;
+		if (last_psize == 0 || (last_paddr + last_psize) == paddr) {
+			last_paddr = (last_psize == 0 ? paddr : last_paddr);
+			last_psize += psize;
+		} else {
+			secure_call(last_paddr, last_psize >> PAGE_SHIFT,
+				    cmd_type);
+			last_paddr = paddr;
+			last_psize = psize;
+		}
+	}
+
+	if (last_psize)
+		secure_call(last_paddr, last_psize >> PAGE_SHIFT, cmd_type);
+
+out:
+	return;
+}
+
+void __init csv_early_memory_enc_dec(u64 vaddr, u64 size, bool enc)
+{
+	u64 npages;
+
+	if (!csv3_active())
+		return;
+
+	npages = (size + (vaddr & ~PAGE_MASK) + PAGE_SIZE - 1) >> PAGE_SHIFT;
+	__csv3_memory_enc_dec(__csv3_early_secure_call, vaddr & PAGE_MASK,
+			      npages, enc);
 }

--- a/arch/x86/kernel/csv.c
+++ b/arch/x86/kernel/csv.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * HYGON CSV support
+ *
+ * Copyright (C) Hygon Info Technologies Ltd.
+ */
+
+#include <linux/preempt.h>
+#include <linux/smp.h>
+#include <linux/memblock.h>
+#include <asm/mem_encrypt.h>
+#include <asm/csv.h>
+
+#include "../mm/mm_internal.h"
+#include "csv-shared.c"
+
+struct secure_call_pages {
+	struct csv3_secure_call_cmd page_a;
+	struct csv3_secure_call_cmd page_b;
+};
+
+void __init csv_early_reset_memory(struct boot_params *bp)
+{
+	if (!csv3_active())
+		return;
+
+	csv3_scan_secure_call_pages(bp);
+	csv3_early_secure_call_ident_map(0, 0, CSV3_SECURE_CMD_RESET);
+}
+
+void __init csv_early_update_memory_dec(u64 vaddr, u64 pages)
+{
+	if (!csv3_active())
+		return;
+
+	if (pages)
+		csv3_early_secure_call_ident_map(__pa(vaddr), pages,
+						 CSV3_SECURE_CMD_DEC);
+}
+
+void __init csv_early_update_memory_enc(u64 vaddr, u64 pages)
+{
+	if (!csv3_active())
+		return;
+
+	if (pages)
+		csv3_early_secure_call_ident_map(__pa(vaddr), pages,
+						 CSV3_SECURE_CMD_ENC);
+}

--- a/arch/x86/kernel/head64.c
+++ b/arch/x86/kernel/head64.c
@@ -42,6 +42,7 @@
 #include <asm/sev.h>
 #include <asm/tdx.h>
 #include <asm/init.h>
+#include <asm/csv.h>
 
 /*
  * Manage page tables very early on.
@@ -159,6 +160,14 @@ static unsigned long __head sme_postprocess_startup(struct boot_params *bp, pmdv
 
 			i = pmd_index(vaddr);
 			pmd[i] -= sme_get_me_mask();
+		}
+
+		/* On CSV3, move the shared pages out of isolated memory region. */
+		if (csv3_active()) {
+			vaddr = (unsigned long)__start_bss_decrypted;
+			csv_early_reset_memory(bp);
+			csv_early_update_memory_dec((unsigned long)vaddr,
+						    (vaddr_end - vaddr) >> PAGE_SHIFT);
 		}
 	}
 

--- a/arch/x86/kvm/svm/csv.c
+++ b/arch/x86/kvm/svm/csv.c
@@ -14,6 +14,7 @@
 #include <linux/memory.h>
 #include <linux/kvm_types.h>
 #include <asm/cacheflush.h>
+#include <asm/csv.h>
 #include "kvm_cache_regs.h"
 #include "svm.h"
 #include "csv.h"
@@ -808,10 +809,19 @@ e_free_hdr:
 	return ret;
 }
 
+struct encrypt_data_block {
+	struct {
+		u64 npages:	12;
+		u64 pfn:	52;
+	} entry[512];
+};
+
 struct kvm_csv_info {
 	struct kvm_sev_info *sev;
 
 	bool csv3_active;	/* CSV3 enabled guest */
+
+	struct list_head smr_list; /* List of guest secure memory regions */
 	unsigned long nodemask; /* Nodemask where CSV3 guest's memory resides */
 };
 
@@ -820,9 +830,22 @@ struct kvm_svm_csv {
 	struct kvm_csv_info csv_info;
 };
 
+struct secure_memory_region {
+	struct list_head list;
+	u64 npages;
+	u64 hpa;
+};
+
 static inline struct kvm_svm_csv *to_kvm_svm_csv(struct kvm *kvm)
 {
 	return (struct kvm_svm_csv *)container_of(kvm, struct kvm_svm, kvm);
+}
+
+static bool csv3_guest(struct kvm *kvm)
+{
+	struct kvm_csv_info *csv = &to_kvm_svm_csv(kvm)->csv_info;
+
+	return sev_es_guest(kvm) && csv->csv3_active;
 }
 
 static int csv3_guest_init(struct kvm *kvm, struct kvm_sev_cmd *argp)
@@ -846,6 +869,248 @@ static int csv3_guest_init(struct kvm *kvm, struct kvm_sev_cmd *argp)
 	csv->nodemask = (unsigned long)params.nodemask;
 
 	return 0;
+}
+
+static int csv3_set_guest_private_memory(struct kvm *kvm)
+{
+	struct kvm_memslots *slots = kvm_memslots(kvm);
+	struct kvm_memory_slot *memslot;
+	struct secure_memory_region *smr;
+	struct kvm_sev_info *sev = &to_kvm_svm(kvm)->sev_info;
+	struct kvm_csv_info *csv = &to_kvm_svm_csv(kvm)->csv_info;
+	struct csv3_data_set_guest_private_memory *set_guest_private_memory;
+	struct csv3_data_memory_region *regions;
+	nodemask_t nodemask;
+	nodemask_t *nodemask_ptr;
+
+	LIST_HEAD(tmp_list);
+	struct list_head *pos, *q;
+	u32 i = 0, count = 0, remainder;
+	int ret = 0, error;
+	u64 size = 0, nr_smr = 0, nr_pages = 0;
+	u32 smr_entry_shift;
+	int bkt;
+
+	unsigned int flags = FOLL_HWPOISON;
+	int npages;
+	struct page *page;
+
+	if (!csv3_guest(kvm))
+		return -ENOTTY;
+
+	nodes_clear(nodemask);
+	for_each_set_bit(i, &csv->nodemask, BITS_PER_LONG)
+		if (i < MAX_NUMNODES)
+			node_set(i, nodemask);
+
+	nodemask_ptr = csv->nodemask ? &nodemask : &node_online_map;
+
+	set_guest_private_memory = kzalloc(sizeof(*set_guest_private_memory),
+					GFP_KERNEL_ACCOUNT);
+	if (!set_guest_private_memory)
+		return -ENOMEM;
+
+	regions = kzalloc(PAGE_SIZE, GFP_KERNEL_ACCOUNT);
+	if (!regions) {
+		kfree(set_guest_private_memory);
+		return -ENOMEM;
+	}
+
+	/* Get guest secure memory size */
+	kvm_for_each_memslot(memslot, bkt, slots) {
+		npages = get_user_pages_unlocked(memslot->userspace_addr, 1,
+						&page, flags);
+		if (npages != 1)
+			continue;
+
+		nr_pages += memslot->npages;
+
+		put_page(page);
+	}
+
+	/*
+	 * NPT secure memory size
+	 *
+	 * PTEs_entries = nr_pages
+	 * PDEs_entries = nr_pages / 512
+	 * PDPEs_entries = nr_pages / (512 * 512)
+	 * PML4Es_entries = nr_pages / (512 * 512 * 512)
+	 *
+	 * Totals_entries = nr_pages + nr_pages / 512 + nr_pages / (512 * 512) +
+	 *		nr_pages / (512 * 512 * 512) <= nr_pages + nr_pages / 256
+	 *
+	 * Total_NPT_size = (Totals_entries / 512) * PAGE_SIZE = ((nr_pages +
+	 *      nr_pages / 256) / 512) * PAGE_SIZE = nr_pages * 8 + nr_pages / 32
+	 *      <= nr_pages * 9
+	 *
+	 */
+	smr_entry_shift = csv_get_smr_entry_shift();
+	size = ALIGN((nr_pages << PAGE_SHIFT), 1UL << smr_entry_shift) +
+		ALIGN(nr_pages * 9, 1UL << smr_entry_shift);
+	nr_smr = size >> smr_entry_shift;
+	remainder = nr_smr;
+	for (i = 0; i < nr_smr; i++) {
+		smr = kzalloc(sizeof(*smr), GFP_KERNEL_ACCOUNT);
+		if (!smr) {
+			ret = -ENOMEM;
+			goto e_free_smr;
+		}
+
+		smr->hpa = csv_alloc_from_contiguous((1UL << smr_entry_shift),
+						nodemask_ptr,
+						get_order(1 << smr_entry_shift));
+		if (!smr->hpa) {
+			kfree(smr);
+			ret = -ENOMEM;
+			goto e_free_smr;
+		}
+
+		smr->npages = ((1UL << smr_entry_shift) >> PAGE_SHIFT);
+		list_add_tail(&smr->list, &tmp_list);
+
+		regions[count].size = (1UL << smr_entry_shift);
+		regions[count].base_address = smr->hpa;
+		count++;
+
+		if (count >= (PAGE_SIZE / sizeof(regions[0])) || (remainder == count)) {
+			set_guest_private_memory->nregions = count;
+			set_guest_private_memory->handle = sev->handle;
+			set_guest_private_memory->regions_paddr = __sme_pa(regions);
+
+			/* set secury memory region for launch enrypt data */
+			ret = hygon_kvm_hooks.sev_issue_cmd(kvm,
+						CSV3_CMD_SET_GUEST_PRIVATE_MEMORY,
+						set_guest_private_memory, &error);
+			if (ret)
+				goto e_free_smr;
+
+			memset(regions, 0, PAGE_SIZE);
+			remainder -= count;
+			count = 0;
+		}
+	}
+
+	list_splice(&tmp_list, &csv->smr_list);
+
+	goto done;
+
+e_free_smr:
+	if (!list_empty(&tmp_list)) {
+		list_for_each_safe(pos, q, &tmp_list) {
+			smr = list_entry(pos, struct secure_memory_region, list);
+			if (smr) {
+				csv_release_to_contiguous(smr->hpa,
+							smr->npages << PAGE_SHIFT);
+				list_del(&smr->list);
+				kfree(smr);
+			}
+		}
+	}
+done:
+	kfree(set_guest_private_memory);
+	kfree(regions);
+	return ret;
+}
+
+static int csv3_launch_encrypt_data(struct kvm *kvm, struct kvm_sev_cmd *argp)
+{
+	struct kvm_csv_info *csv = &to_kvm_svm_csv(kvm)->csv_info;
+	struct kvm_csv3_launch_encrypt_data params;
+	struct csv3_data_launch_encrypt_data *encrypt_data = NULL;
+	struct encrypt_data_block *blocks = NULL;
+	u8 *data = NULL;
+	u32 offset;
+	u32 num_entries, num_entries_in_block;
+	u32 num_blocks, num_blocks_max;
+	u32 i, n;
+	unsigned long pfn, pfn_sme_mask;
+	int ret = 0;
+
+	if (!csv3_guest(kvm))
+		return -ENOTTY;
+
+	if (copy_from_user(&params, (void __user *)(uintptr_t)argp->data,
+			   sizeof(params))) {
+		ret = -EFAULT;
+		goto exit;
+	}
+
+	if ((params.len & ~PAGE_MASK) || !params.len || !params.uaddr) {
+		ret = -EINVAL;
+		goto exit;
+	}
+
+	/* Allocate all the guest memory from CMA */
+	ret = csv3_set_guest_private_memory(kvm);
+	if (ret)
+		goto exit;
+
+	num_entries = params.len / PAGE_SIZE;
+	num_entries_in_block = ARRAY_SIZE(blocks->entry);
+	num_blocks = (num_entries + num_entries_in_block - 1) / num_entries_in_block;
+	num_blocks_max = ARRAY_SIZE(encrypt_data->data_blocks);
+
+	if (num_blocks >= num_blocks_max) {
+		ret = -EINVAL;
+		goto exit;
+	}
+
+	data = vzalloc(params.len);
+	if (!data) {
+		ret = -ENOMEM;
+		goto exit;
+	}
+	if (copy_from_user(data, (void __user *)params.uaddr, params.len)) {
+		ret = -EFAULT;
+		goto data_free;
+	}
+
+	blocks = vzalloc(num_blocks * sizeof(*blocks));
+	if (!blocks) {
+		ret = -ENOMEM;
+		goto data_free;
+	}
+
+	for (offset = 0, i = 0, n = 0; offset < params.len; offset += PAGE_SIZE) {
+		pfn = vmalloc_to_pfn(offset + data);
+		pfn_sme_mask = __sme_set(pfn << PAGE_SHIFT) >> PAGE_SHIFT;
+		if (offset && ((blocks[n].entry[i].pfn + 1) == pfn_sme_mask))
+			blocks[n].entry[i].npages += 1;
+		else {
+			if (offset) {
+				i = (i + 1) % num_entries_in_block;
+				n = (i == 0) ? (n + 1) : n;
+			}
+			blocks[n].entry[i].pfn = pfn_sme_mask;
+			blocks[n].entry[i].npages = 1;
+		}
+	}
+
+	encrypt_data = kzalloc(sizeof(*encrypt_data), GFP_KERNEL);
+	if (!encrypt_data) {
+		ret = -ENOMEM;
+		goto block_free;
+	}
+
+	encrypt_data->handle = csv->sev->handle;
+	encrypt_data->length = params.len;
+	encrypt_data->gpa = params.gpa;
+	for (i = 0; i <= n; i++) {
+		encrypt_data->data_blocks[i] =
+		__sme_set(vmalloc_to_pfn((void *)blocks + i * sizeof(*blocks)) << PAGE_SHIFT);
+	}
+
+	clflush_cache_range(data, params.len);
+	ret = hygon_kvm_hooks.sev_issue_cmd(kvm, CSV3_CMD_LAUNCH_ENCRYPT_DATA,
+					    encrypt_data, &argp->error);
+
+	kfree(encrypt_data);
+block_free:
+	vfree(blocks);
+data_free:
+	vfree(data);
+exit:
+	return ret;
 }
 
 static int csv_mem_enc_ioctl(struct kvm *kvm, void __user *argp)
@@ -895,6 +1160,9 @@ static int csv_mem_enc_ioctl(struct kvm *kvm, void __user *argp)
 			goto out;
 		}
 		r = csv3_guest_init(kvm, &sev_cmd);
+		break;
+	case KVM_CSV3_LAUNCH_ENCRYPT_DATA:
+		r = csv3_launch_encrypt_data(kvm, &sev_cmd);
 		break;
 	default:
 		/*

--- a/arch/x86/kvm/svm/csv.c
+++ b/arch/x86/kvm/svm/csv.c
@@ -14,6 +14,7 @@
 #include <linux/memory.h>
 #include <linux/kvm_types.h>
 #include <asm/cacheflush.h>
+#include <asm/e820/api.h>
 #include <asm/csv.h>
 #include "kvm_cache_regs.h"
 #include "svm.h"
@@ -816,10 +817,40 @@ struct encrypt_data_block {
 	} entry[512];
 };
 
+union csv3_page_attr {
+	struct {
+		u64 reserved:	1;
+		u64 rw:		1;
+		u64 reserved1:	49;
+		u64 mmio:	1;
+		u64 reserved2:	12;
+	};
+	u64 val;
+};
+
+enum csv3_pg_level {
+	CSV3_PG_LEVEL_NONE,
+	CSV3_PG_LEVEL_4K,
+	CSV3_PG_LEVEL_2M,
+	CSV3_PG_LEVEL_NUM
+};
+
+struct shared_page_block {
+	struct list_head list;
+	struct page **pages;
+	u64 count;
+};
+
 struct kvm_csv_info {
 	struct kvm_sev_info *sev;
 
 	bool csv3_active;	/* CSV3 enabled guest */
+
+	/* List of shared pages */
+	u64 total_shared_page_count;
+	struct list_head shared_pages_list;
+	void *cached_shared_page_block;
+	struct mutex shared_page_block_lock;
 
 	struct list_head smr_list; /* List of guest secure memory regions */
 	unsigned long nodemask; /* Nodemask where CSV3 guest's memory resides */
@@ -841,11 +872,39 @@ static inline struct kvm_svm_csv *to_kvm_svm_csv(struct kvm *kvm)
 	return (struct kvm_svm_csv *)container_of(kvm, struct kvm_svm, kvm);
 }
 
+static int to_csv3_pg_level(int level)
+{
+	int ret;
+
+	switch (level) {
+	case PG_LEVEL_4K:
+		ret = CSV3_PG_LEVEL_4K;
+		break;
+	case PG_LEVEL_2M:
+		ret = CSV3_PG_LEVEL_2M;
+		break;
+	default:
+		ret = CSV3_PG_LEVEL_NONE;
+	}
+
+	return ret;
+}
+
 static bool csv3_guest(struct kvm *kvm)
 {
 	struct kvm_csv_info *csv = &to_kvm_svm_csv(kvm)->csv_info;
 
 	return sev_es_guest(kvm) && csv->csv3_active;
+}
+
+static inline void csv3_init_update_npt(struct csv3_data_update_npt *update_npt,
+					gpa_t gpa, u32 error, u32 handle)
+{
+	memset(update_npt, 0x00, sizeof(*update_npt));
+
+	update_npt->gpa = gpa & PAGE_MASK;
+	update_npt->error_code = error;
+	update_npt->handle = handle;
 }
 
 static int csv3_guest_init(struct kvm *kvm, struct kvm_sev_cmd *argp)
@@ -868,7 +927,18 @@ static int csv3_guest_init(struct kvm *kvm, struct kvm_sev_cmd *argp)
 	csv->sev = sev;
 	csv->nodemask = (unsigned long)params.nodemask;
 
+	INIT_LIST_HEAD(&csv->shared_pages_list);
+	INIT_LIST_HEAD(&csv->smr_list);
+	mutex_init(&csv->shared_page_block_lock);
+
 	return 0;
+}
+
+static bool csv3_is_mmio_pfn(kvm_pfn_t pfn)
+{
+	return !e820__mapped_raw_any(pfn_to_hpa(pfn),
+				     pfn_to_hpa(pfn + 1) - 1,
+				     E820_TYPE_RAM);
 }
 
 static int csv3_set_guest_private_memory(struct kvm *kvm)
@@ -1178,6 +1248,424 @@ e_free:
 	kfree(encrypt_vmcb);
 exit:
 	return ret;
+}
+
+static void csv3_mark_page_dirty(struct kvm_vcpu *vcpu, gva_t gpa,
+				 unsigned long npages)
+{
+	gfn_t gfn;
+	gfn_t gfn_end;
+
+	gfn = gpa >> PAGE_SHIFT;
+	gfn_end = gfn + npages;
+#ifdef KVM_HAVE_MMU_RWLOCK
+	write_lock(&vcpu->kvm->mmu_lock);
+#else
+	spin_lock(&vcpu->kvm->mmu_lock);
+#endif
+	for (; gfn < gfn_end; gfn++)
+		kvm_vcpu_mark_page_dirty(vcpu, gfn);
+#ifdef KVM_HAVE_MMU_RWLOCK
+	write_unlock(&vcpu->kvm->mmu_lock);
+#else
+	spin_unlock(&vcpu->kvm->mmu_lock);
+#endif
+}
+
+static int csv3_mmio_page_fault(struct kvm_vcpu *vcpu, gva_t gpa, u32 error_code)
+{
+	int r = 0;
+	struct kvm_svm *kvm_svm = to_kvm_svm(vcpu->kvm);
+	union csv3_page_attr page_attr = {.mmio = 1};
+	union csv3_page_attr page_attr_mask = {.mmio = 1};
+	struct csv3_data_update_npt *update_npt;
+	int psp_ret;
+
+	if (!hygon_kvm_hooks.sev_hooks_installed)
+		return -EFAULT;
+
+	update_npt = kzalloc(sizeof(*update_npt), GFP_KERNEL);
+	if (!update_npt) {
+		r = -ENOMEM;
+		goto exit;
+	}
+
+	csv3_init_update_npt(update_npt, gpa, error_code,
+			     kvm_svm->sev_info.handle);
+	update_npt->page_attr = page_attr.val;
+	update_npt->page_attr_mask = page_attr_mask.val;
+	update_npt->level = CSV3_PG_LEVEL_4K;
+
+	r = hygon_kvm_hooks.sev_issue_cmd(vcpu->kvm, CSV3_CMD_UPDATE_NPT,
+					  update_npt, &psp_ret);
+
+	if (psp_ret != SEV_RET_SUCCESS)
+		r = -EFAULT;
+
+	kfree(update_npt);
+exit:
+	return r;
+}
+
+static int __csv3_page_fault(struct kvm_vcpu *vcpu, gva_t gpa,
+			     u32 error_code, struct kvm_memory_slot *slot,
+			     int *psp_ret_ptr, kvm_pfn_t pfn, u32 level)
+{
+	int r = 0;
+	struct csv3_data_update_npt *update_npt;
+	struct kvm_svm *kvm_svm = to_kvm_svm(vcpu->kvm);
+	int psp_ret = 0;
+
+	if (!hygon_kvm_hooks.sev_hooks_installed)
+		return -EFAULT;
+
+	update_npt = kzalloc(sizeof(*update_npt), GFP_KERNEL);
+	if (!update_npt) {
+		r = -ENOMEM;
+		goto exit;
+	}
+
+	csv3_init_update_npt(update_npt, gpa, error_code,
+			     kvm_svm->sev_info.handle);
+
+	update_npt->spa = pfn << PAGE_SHIFT;
+	update_npt->level = level;
+
+	if (!csv3_is_mmio_pfn(pfn))
+		update_npt->spa |= sme_me_mask;
+
+	r = hygon_kvm_hooks.sev_issue_cmd(vcpu->kvm, CSV3_CMD_UPDATE_NPT,
+					  update_npt, &psp_ret);
+
+	kvm_make_request(KVM_REQ_TLB_FLUSH, vcpu);
+	kvm_flush_remote_tlbs(vcpu->kvm);
+
+	csv3_mark_page_dirty(vcpu, update_npt->gpa, update_npt->npages);
+
+	if (psp_ret_ptr)
+		*psp_ret_ptr = psp_ret;
+
+	kfree(update_npt);
+exit:
+	return r;
+}
+
+static int csv3_pin_shared_memory(struct kvm_vcpu *vcpu,
+				  struct kvm_memory_slot *slot, gfn_t gfn,
+				  kvm_pfn_t *pfn)
+{
+	struct page **pages, *page;
+	u64 hva;
+	int npinned;
+	kvm_pfn_t tmp_pfn;
+	struct kvm *kvm = vcpu->kvm;
+	struct kvm_csv_info *csv = &to_kvm_svm_csv(kvm)->csv_info;
+	struct shared_page_block *shared_page_block = NULL;
+	u64 npages = PAGE_SIZE / sizeof(struct page *);
+	bool write = !(slot->flags & KVM_MEM_READONLY);
+
+	tmp_pfn = __gfn_to_pfn_memslot(slot, gfn, false, false, NULL, write,
+				       NULL, NULL);
+	if (unlikely(is_error_pfn(tmp_pfn)))
+		return -ENOMEM;
+
+	if (csv3_is_mmio_pfn(tmp_pfn)) {
+		*pfn = tmp_pfn;
+		return 0;
+	}
+
+	if (!page_maybe_dma_pinned(pfn_to_page(tmp_pfn))) {
+		kvm_release_pfn_clean(tmp_pfn);
+		if (csv->total_shared_page_count % npages == 0) {
+			shared_page_block = kzalloc(sizeof(*shared_page_block),
+						    GFP_KERNEL_ACCOUNT);
+			if (!shared_page_block)
+				return -ENOMEM;
+
+			pages = kzalloc(PAGE_SIZE, GFP_KERNEL_ACCOUNT);
+			if (!pages) {
+				kfree(shared_page_block);
+				return -ENOMEM;
+			}
+
+			shared_page_block->pages = pages;
+			list_add_tail(&shared_page_block->list,
+				      &csv->shared_pages_list);
+			csv->cached_shared_page_block = shared_page_block;
+		} else {
+			shared_page_block = csv->cached_shared_page_block;
+			pages = shared_page_block->pages;
+		}
+
+		hva = __gfn_to_hva_memslot(slot, gfn);
+		npinned = pin_user_pages_fast(hva, 1, FOLL_WRITE | FOLL_LONGTERM,
+					      &page);
+		if (npinned != 1) {
+			if (shared_page_block->count == 0) {
+				list_del(&shared_page_block->list);
+				kfree(pages);
+				kfree(shared_page_block);
+			}
+			return -ENOMEM;
+		}
+
+		pages[csv->total_shared_page_count % npages] = page;
+		shared_page_block->count++;
+		csv->total_shared_page_count++;
+		*pfn = page_to_pfn(page);
+	} else {
+		kvm_release_pfn_clean(tmp_pfn);
+		*pfn = tmp_pfn;
+	}
+
+	return 0;
+}
+
+static int __pfn_mapping_level(struct kvm *kvm, gfn_t gfn,
+			       const struct kvm_memory_slot *slot)
+{
+	int level = PG_LEVEL_4K;
+	unsigned long hva;
+	unsigned long flags;
+	pgd_t pgd;
+	p4d_t p4d;
+	pud_t pud;
+	pmd_t pmd;
+
+	/*
+	 * Note, using the already-retrieved memslot and __gfn_to_hva_memslot()
+	 * is not solely for performance, it's also necessary to avoid the
+	 * "writable" check in __gfn_to_hva_many(), which will always fail on
+	 * read-only memslots due to gfn_to_hva() assuming writes.  Earlier
+	 * page fault steps have already verified the guest isn't writing a
+	 * read-only memslot.
+	 */
+	hva = __gfn_to_hva_memslot(slot, gfn);
+
+	/*
+	 * Disable IRQs to prevent concurrent tear down of host page tables,
+	 * e.g. if the primary MMU promotes a P*D to a huge page and then frees
+	 * the original page table.
+	 */
+	local_irq_save(flags);
+
+	/*
+	 * Read each entry once.  As above, a non-leaf entry can be promoted to
+	 * a huge page _during_ this walk.  Re-reading the entry could send the
+	 * walk into the weeks, e.g. p*d_large() returns false (sees the old
+	 * value) and then p*d_offset() walks into the target huge page instead
+	 * of the old page table (sees the new value).
+	 */
+	pgd = READ_ONCE(*pgd_offset(kvm->mm, hva));
+	if (pgd_none(pgd))
+		goto out;
+
+	p4d = READ_ONCE(*p4d_offset(&pgd, hva));
+	if (p4d_none(p4d) || !p4d_present(p4d))
+		goto out;
+
+	pud = READ_ONCE(*pud_offset(&p4d, hva));
+	if (pud_none(pud) || !pud_present(pud))
+		goto out;
+
+	if (pud_large(pud)) {
+		level = PG_LEVEL_1G;
+		goto out;
+	}
+
+	pmd = READ_ONCE(*pmd_offset(&pud, hva));
+	if (pmd_none(pmd) || !pmd_present(pmd))
+		goto out;
+
+	if (pmd_large(pmd))
+		level = PG_LEVEL_2M;
+
+out:
+	local_irq_restore(flags);
+	return level;
+}
+
+static int csv3_mapping_level(struct kvm_vcpu *vcpu, gfn_t gfn, kvm_pfn_t pfn,
+			      struct kvm_memory_slot *slot)
+{
+	int level;
+	int page_num;
+	gfn_t gfn_base;
+
+	if (csv3_is_mmio_pfn(pfn)) {
+		level = PG_LEVEL_4K;
+		goto end;
+	}
+
+	if (!PageCompound(pfn_to_page(pfn))) {
+		level = PG_LEVEL_4K;
+		goto end;
+	}
+
+	level = PG_LEVEL_2M;
+	page_num = KVM_PAGES_PER_HPAGE(level);
+	gfn_base = gfn & ~(page_num - 1);
+
+	/*
+	 * 2M aligned guest address in memslot.
+	 */
+	if ((gfn_base < slot->base_gfn) ||
+	    (gfn_base + page_num > slot->base_gfn + slot->npages)) {
+		level = PG_LEVEL_4K;
+		goto end;
+	}
+
+	/*
+	 * hva in memslot is 2M aligned.
+	 */
+	if (__gfn_to_hva_memslot(slot, gfn_base) & ~PMD_MASK) {
+		level = PG_LEVEL_4K;
+		goto end;
+	}
+
+	level = __pfn_mapping_level(vcpu->kvm, gfn, slot);
+
+	/*
+	 * Firmware supports 2M/4K level.
+	 */
+	level = level > PG_LEVEL_2M ? PG_LEVEL_2M : level;
+
+end:
+	return to_csv3_pg_level(level);
+}
+
+static int csv3_page_fault(struct kvm_vcpu *vcpu, struct kvm_memory_slot *slot,
+			   gfn_t gfn, u32 error_code)
+{
+	int ret = 0;
+	int psp_ret = 0;
+	int level;
+	kvm_pfn_t pfn = KVM_PFN_NOSLOT;
+	struct kvm_csv_info *csv = &to_kvm_svm_csv(vcpu->kvm)->csv_info;
+
+	if (error_code & PFERR_PRESENT_MASK)
+		level = CSV3_PG_LEVEL_4K;
+	else {
+		mutex_lock(&csv->shared_page_block_lock);
+		ret = csv3_pin_shared_memory(vcpu, slot, gfn, &pfn);
+		mutex_unlock(&csv->shared_page_block_lock);
+		if (ret)
+			goto exit;
+
+		level = csv3_mapping_level(vcpu, gfn, pfn, slot);
+	}
+
+	ret = __csv3_page_fault(vcpu, gfn << PAGE_SHIFT, error_code, slot,
+				&psp_ret, pfn, level);
+
+	if (psp_ret != SEV_RET_SUCCESS)
+		ret = -EFAULT;
+exit:
+	return ret;
+}
+
+static void csv_vm_destroy(struct kvm *kvm)
+{
+	struct kvm_csv_info *csv = &to_kvm_svm_csv(kvm)->csv_info;
+	struct list_head *head = &csv->shared_pages_list;
+	struct list_head *pos, *q;
+	struct shared_page_block *shared_page_block;
+	struct kvm_vcpu *vcpu;
+	unsigned long i = 0;
+
+	struct list_head *smr_head = &csv->smr_list;
+	struct secure_memory_region *smr;
+
+	if (csv3_guest(kvm)) {
+		mutex_lock(&csv->shared_page_block_lock);
+		if (!list_empty(head)) {
+			list_for_each_safe(pos, q, head) {
+				shared_page_block = list_entry(pos,
+						struct shared_page_block, list);
+				unpin_user_pages(shared_page_block->pages,
+						shared_page_block->count);
+				kfree(shared_page_block->pages);
+				csv->total_shared_page_count -=
+					shared_page_block->count;
+				list_del(&shared_page_block->list);
+				kfree(shared_page_block);
+			}
+		}
+		mutex_unlock(&csv->shared_page_block_lock);
+
+		kvm_for_each_vcpu(i, vcpu, kvm) {
+			struct vcpu_svm *svm = to_svm(vcpu);
+
+			svm->current_vmcb->pa = __sme_pa(svm->vmcb);
+		}
+	}
+
+	if (likely(csv_x86_ops.vm_destroy))
+		csv_x86_ops.vm_destroy(kvm);
+
+	if (!csv3_guest(kvm))
+		return;
+
+	/* free secure memory region */
+	if (!list_empty(smr_head)) {
+		list_for_each_safe(pos, q, smr_head) {
+			smr = list_entry(pos, struct secure_memory_region, list);
+			if (smr) {
+				csv_release_to_contiguous(smr->hpa, smr->npages << PAGE_SHIFT);
+				list_del(&smr->list);
+				kfree(smr);
+			}
+		}
+	}
+}
+
+static int csv3_handle_page_fault(struct kvm_vcpu *vcpu, gpa_t gpa,
+				  u32 error_code)
+{
+	gfn_t gfn = gpa_to_gfn(gpa);
+	struct kvm_memory_slot *slot = gfn_to_memslot(vcpu->kvm, gfn);
+	int ret;
+	int r = -EIO;
+
+	if (kvm_is_visible_memslot(slot))
+		ret = csv3_page_fault(vcpu, slot, gfn, error_code);
+	else
+		ret = csv3_mmio_page_fault(vcpu, gpa, error_code);
+
+	if (!ret)
+		r = 1;
+
+	return r;
+}
+
+static int csv_handle_exit(struct kvm_vcpu *vcpu, fastpath_t exit_fastpath)
+{
+	struct vcpu_svm *svm = to_svm(vcpu);
+	u32 exit_code = svm->vmcb->control.exit_code;
+	int ret = -EIO;
+
+	/*
+	 * NPF for csv3 is dedicated.
+	 */
+	if (csv3_guest(vcpu->kvm) && exit_code == SVM_EXIT_NPF) {
+		gpa_t gpa = __sme_clr(svm->vmcb->control.exit_info_2);
+		u64 error_code = svm->vmcb->control.exit_info_1;
+
+		ret = csv3_handle_page_fault(vcpu, gpa, error_code);
+	} else {
+		if (likely(csv_x86_ops.handle_exit))
+			ret = csv_x86_ops.handle_exit(vcpu, exit_fastpath);
+	}
+
+	return ret;
+}
+
+static void csv_guest_memory_reclaimed(struct kvm *kvm)
+{
+	if (!csv3_guest(kvm)) {
+		if (likely(csv_x86_ops.guest_memory_reclaimed))
+			csv_x86_ops.guest_memory_reclaimed(kvm);
+	}
 }
 
 static int csv_mem_enc_ioctl(struct kvm *kvm, void __user *argp)
@@ -1549,6 +2037,11 @@ void __init csv_init(struct kvm_x86_ops *ops)
 	ops->control_pre_system_reset = csv_control_pre_system_reset;
 	ops->control_post_system_reset = csv_control_post_system_reset;
 
-	if (boot_cpu_has(X86_FEATURE_SEV_ES) && boot_cpu_has(X86_FEATURE_CSV3))
+	if (boot_cpu_has(X86_FEATURE_SEV_ES) && boot_cpu_has(X86_FEATURE_CSV3)) {
 		ops->vm_size = sizeof(struct kvm_svm_csv);
+
+		ops->vm_destroy = csv_vm_destroy;
+		ops->handle_exit = csv_handle_exit;
+		ops->guest_memory_reclaimed = csv_guest_memory_reclaimed;
+	}
 }

--- a/arch/x86/kvm/svm/csv.c
+++ b/arch/x86/kvm/svm/csv.c
@@ -1242,6 +1242,15 @@ static int csv3_launch_encrypt_vmcb(struct kvm *kvm, struct kvm_sev_cmd *argp)
 
 		svm->current_vmcb->pa = encrypt_vmcb->secure_vmcb_addr;
 		svm->vcpu.arch.guest_state_protected = true;
+
+		/*
+		 * CSV3 guest mandates LBR Virtualization to be _always_ ON.
+		 * Enable it only after setting guest_state_protected because
+		 * KVM_SET_MSRS allows dynamic toggling of LBRV (for performance
+		 * reason) on write access to MSR_IA32_DEBUGCTLMSR when
+		 * guest_state_protected is not set.
+		 */
+		svm_enable_lbrv(vcpu);
 	}
 
 e_free:

--- a/arch/x86/kvm/svm/csv.h
+++ b/arch/x86/kvm/svm/csv.h
@@ -41,16 +41,7 @@ struct csv_asid_userid {
 	u32 userid_len;
 	char userid[ASID_USERID_LENGTH];
 };
-
 extern struct csv_asid_userid *csv_asid_userid_array;
-
-int csv_alloc_asid_userid_array(unsigned int nr_asids);
-void csv_free_asid_userid_array(void);
-
-#else
-
-static inline int csv_alloc_asid_userid_array(unsigned int nr_asids) { return -ENOMEM; }
-static inline void csv_free_asid_userid_array(void) { }
 
 #endif	/* CONFIG_KVM_SUPPORTS_CSV_REUSE_ASID */
 
@@ -79,8 +70,9 @@ extern struct hygon_kvm_hooks_table {
 void __init csv_init(struct kvm_x86_ops *ops);
 void csv_exit(void);
 
-int csv_alloc_trans_mempool(void);
-void csv_free_trans_mempool(void);
+void __init csv_hardware_setup(unsigned int max_csv_asid);
+void csv_hardware_unsetup(void);
+
 int csv_get_msr(struct kvm_vcpu *vcpu, struct msr_data *msr_info);
 int csv_set_msr(struct kvm_vcpu *vcpu, struct msr_data *msr_info);
 bool csv_has_emulated_ghcb_msr(struct kvm *kvm);
@@ -98,8 +90,9 @@ static inline bool csv2_state_unstable(struct vcpu_svm *svm)
 static inline void __init csv_init(struct kvm_x86_ops *ops) { }
 static inline void csv_exit(void) { }
 
-static inline int csv_alloc_trans_mempool(void) { return 0; }
-static inline void csv_free_trans_mempool(void) { }
+static inline void __init csv_hardware_setup(unsigned int max_csv_asid) { }
+static inline void csv_hardware_unsetup(void) { }
+
 static inline
 int csv_get_msr(struct kvm_vcpu *vcpu, struct msr_data *msr_info) { return 1; }
 static inline

--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -2463,19 +2463,8 @@ out:
 		 */
 		sev_install_hooks();
 
-		if (sev_enabled) {
-			/*
-			 * Allocate a memory pool to speed up live migration of
-			 * the CSV/CSV2 guests. If the allocation fails, no
-			 * acceleration is performed at live migration.
-			 */
-			csv_alloc_trans_mempool();
-			/*
-			 * Allocate a buffer to support reuse ASID, reuse ASID
-			 * will not work if the allocation fails.
-			 */
-			csv_alloc_asid_userid_array(nr_asids);
-		}
+		if (sev_enabled)
+			csv_hardware_setup(max_sev_asid);
 	}
 #endif
 
@@ -2487,11 +2476,8 @@ void sev_hardware_unsetup(void)
 	if (!sev_enabled)
 		return;
 
-	/* Free the memory that allocated in sev_hardware_setup(). */
-	if (is_x86_vendor_hygon()) {
-		csv_free_trans_mempool();
-		csv_free_asid_userid_array();
-	}
+	if (is_x86_vendor_hygon())
+		csv_hardware_unsetup();
 
 	/* No need to take sev_bitmap_lock, all VMs have been destroyed. */
 	sev_flush_asids(1, max_sev_asid);

--- a/arch/x86/mm/mem_encrypt_amd.c
+++ b/arch/x86/mm/mem_encrypt_amd.c
@@ -345,6 +345,14 @@ static bool amd_enc_status_change_finish(unsigned long vaddr, int npages, bool e
 	if (!cc_platform_has(CC_ATTR_HOST_MEM_ENCRYPT))
 		enc_dec_hypercall(vaddr, npages << PAGE_SHIFT, enc);
 
+	/*
+	 * On CSV3, the shared and private page attr changes should be managed
+	 * by secure processor. Private pages live in isolated memory region,
+	 * while shared pages live out of isolated memory region.
+	 */
+	if (csv3_active())
+		csv_memory_enc_dec(vaddr, npages, enc);
+
 	return true;
 }
 

--- a/arch/x86/mm/mem_encrypt_hygon.c
+++ b/arch/x86/mm/mem_encrypt_hygon.c
@@ -49,6 +49,9 @@ void print_hygon_cc_feature_info(void)
 	/* Encrypted Register State */
 	if (cc_platform_has(CC_ATTR_GUEST_STATE_ENCRYPT))
 		pr_info(" HYGON CSV2");
+
+	if (csv3_active())
+		pr_info(" HYGON CSV3");
 }
 
 /*

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -2310,4 +2310,25 @@ struct kvm_csv_init {
 #define KVM_CONTROL_PRE_SYSTEM_RESET	 _IO(KVMIO, 0xe8)
 #define KVM_CONTROL_POST_SYSTEM_RESET	 _IO(KVMIO, 0xe9)
 
+/* CSV3 command */
+enum csv3_cmd_id {
+	KVM_CSV3_NR_MIN = 0xc0,
+
+	KVM_CSV3_INIT = KVM_CSV3_NR_MIN,
+	KVM_CSV3_LAUNCH_ENCRYPT_DATA,
+	KVM_CSV3_LAUNCH_ENCRYPT_VMCB,
+
+	KVM_CSV3_NR_MAX,
+};
+
+struct kvm_csv3_init_data {
+	__u64 nodemask;
+};
+
+struct kvm_csv3_launch_encrypt_data {
+	__u64 gpa;
+	__u64 uaddr;
+	__u32 len;
+};
+
 #endif /* __LINUX_KVM_H */


### PR DESCRIPTION
Host side support:
Implement APIs and KVM ioctl interfaces to support boot and handling VMExit in the lifecycle of the CSV3 guest.
KVM: Define CSV3 key management command id
KVM: SVM: CSV: Add KVM_CSV3_INIT command
KVM: SVM: CSV: Add KVM_CSV3_LAUNCH_ENCRYPT_DATA command
KVM: SVM: CSV: Add KVM_CSV3_LAUNCH_ENCRYPT_VMCB command
KVM: SVM: CSV: Manage CSV3 guest's nested page table

Guest side support:
Detect whether the CSV3 is active in the guest, and use secure call to maintain the private and shared pages.
x86/boot/compressed/64: Add CSV3 guest detection
x86/boot/compressed/64: Init CSV3 secure call pages
x86/boot/compressed/64: Add CSV3 update page attr(private/shared)
x86/kernel: Add CSV3 early update(enc/dec)/reset memory helpers
x86/kernel: Set bss decrypted memory as shared in CSV3 guest
x86: Update memory shared/private attribute in early boot for CSV3 guest
x86: Add support for changing the memory attribute for CSV3 guest
x86/mm: Print CSV3 info into kernel log

Host side fix:
LBRV is necessary when running CSV3 guest, the code to enable LBRV is changed since b7e4be0a224f ("KVM: SEV-ES: Delegate LBR virtualization to the processor"), we need enable LBRV explicitly.
KVM: SVM: CSV: Explicitly enable LBR Virtualization after succeed to LAUNCH_ENCRYPT_VMCB