### PR TITLE
[6.6]Hygon: CSV3 patch series part 3 (Support live migration for Hygon CSV3 guest, and manage shared page by rbtree)

### DIFF
--- a/arch/x86/kvm/svm/csv.c
+++ b/arch/x86/kvm/svm/csv.c
@@ -828,6 +828,18 @@ union csv3_page_attr {
 	u64 val;
 };
 
+struct guest_paddr_block {
+	struct {
+		u64 share:	1;
+		u64 reserved:	11;
+		u64 gfn:	52;
+	} entry[512];
+};
+
+struct trans_paddr_block {
+	u64	trans_paddr[512];
+};
+
 enum csv3_pg_level {
 	CSV3_PG_LEVEL_NONE,
 	CSV3_PG_LEVEL_4K,
@@ -1255,6 +1267,164 @@ static int csv3_launch_encrypt_vmcb(struct kvm *kvm, struct kvm_sev_cmd *argp)
 
 e_free:
 	kfree(encrypt_vmcb);
+exit:
+	return ret;
+}
+
+/* Userspace wants to query either header or trans length. */
+static int
+csv3_send_encrypt_data_query_lengths(struct kvm *kvm, struct kvm_sev_cmd *argp,
+				     struct kvm_csv3_send_encrypt_data *params)
+{
+	struct kvm_sev_info *sev = &to_kvm_svm(kvm)->sev_info;
+	struct csv3_data_send_encrypt_data data;
+	int ret;
+
+	memset(&data, 0, sizeof(data));
+	data.handle = sev->handle;
+	ret = hygon_kvm_hooks.sev_issue_cmd(kvm, CSV3_CMD_SEND_ENCRYPT_DATA,
+					    &data, &argp->error);
+
+	params->hdr_len = data.hdr_len;
+	params->trans_len = data.trans_len;
+
+	if (copy_to_user((void __user *)(uintptr_t)argp->data, params, sizeof(*params)))
+		ret = -EFAULT;
+
+	return ret;
+}
+
+#define CSV3_SEND_ENCRYPT_DATA_MIGRATE_PAGE  0x00000000
+#define CSV3_SEND_ENCRYPT_DATA_SET_READONLY  0x00000001
+static int csv3_send_encrypt_data(struct kvm *kvm, struct kvm_sev_cmd *argp)
+{
+	struct kvm_sev_info *sev = &to_kvm_svm(kvm)->sev_info;
+	struct csv3_data_send_encrypt_data data;
+	struct kvm_csv3_send_encrypt_data params;
+	void *hdr;
+	void *trans_data;
+	struct trans_paddr_block *trans_block;
+	struct guest_paddr_block *guest_block;
+	unsigned long pfn;
+	u32 offset;
+	int ret = 0;
+	int i;
+
+	if (!csv3_guest(kvm))
+		return -ENOTTY;
+
+	if (copy_from_user(&params, (void __user *)(uintptr_t)argp->data,
+			   sizeof(params)))
+		return -EFAULT;
+
+	/* userspace wants to query either header or trans length */
+	if (!params.trans_len || !params.hdr_len)
+		return csv3_send_encrypt_data_query_lengths(kvm, argp, &params);
+
+	if (!params.trans_uaddr || !params.guest_addr_data ||
+	    !params.guest_addr_len || !params.hdr_uaddr)
+		return -EINVAL;
+
+	if (params.guest_addr_len > sizeof(*guest_block))
+		return -EINVAL;
+
+	if (params.trans_len > ARRAY_SIZE(trans_block->trans_paddr) * PAGE_SIZE)
+		return -EINVAL;
+
+	if ((params.trans_len & PAGE_MASK) == 0 ||
+	    (params.trans_len & ~PAGE_MASK) != 0)
+		return -EINVAL;
+
+	/* allocate memory for header and transport buffer */
+	hdr = kzalloc(params.hdr_len, GFP_KERNEL_ACCOUNT);
+	if (!hdr) {
+		ret = -ENOMEM;
+		goto exit;
+	}
+
+	guest_block = kzalloc(sizeof(*guest_block), GFP_KERNEL_ACCOUNT);
+	if (!guest_block) {
+		ret = -ENOMEM;
+		goto e_free_hdr;
+	}
+
+	if (copy_from_user(guest_block,
+			   (void __user *)(uintptr_t)params.guest_addr_data,
+			   params.guest_addr_len)) {
+		ret = -EFAULT;
+		goto e_free_guest_block;
+	}
+
+	trans_block = kzalloc(sizeof(*trans_block), GFP_KERNEL_ACCOUNT);
+	if (!trans_block) {
+		ret = -ENOMEM;
+		goto e_free_guest_block;
+	}
+	trans_data = vzalloc(params.trans_len);
+	if (!trans_data) {
+		ret = -ENOMEM;
+		goto e_free_trans_block;
+	}
+
+	for (offset = 0, i = 0; offset < params.trans_len; offset += PAGE_SIZE) {
+		pfn = vmalloc_to_pfn(offset + trans_data);
+		trans_block->trans_paddr[i] = __sme_set(pfn_to_hpa(pfn));
+		i++;
+	}
+	memset(&data, 0, sizeof(data));
+	data.hdr_address = __psp_pa(hdr);
+	data.hdr_len = params.hdr_len;
+	data.trans_block = __psp_pa(trans_block);
+	data.trans_len = params.trans_len;
+
+	data.guest_block = __psp_pa(guest_block);
+	data.guest_len = params.guest_addr_len;
+	data.handle = sev->handle;
+
+	clflush_cache_range(hdr, params.hdr_len);
+	clflush_cache_range(trans_data, params.trans_len);
+	clflush_cache_range(trans_block, PAGE_SIZE);
+	clflush_cache_range(guest_block, PAGE_SIZE);
+
+	data.flag = CSV3_SEND_ENCRYPT_DATA_SET_READONLY;
+	ret = hygon_kvm_hooks.sev_issue_cmd(kvm, CSV3_CMD_SEND_ENCRYPT_DATA,
+					    &data, &argp->error);
+	if (ret)
+		goto e_free_trans_data;
+
+	kvm_flush_remote_tlbs(kvm);
+
+	data.flag = CSV3_SEND_ENCRYPT_DATA_MIGRATE_PAGE;
+	ret = hygon_kvm_hooks.sev_issue_cmd(kvm, CSV3_CMD_SEND_ENCRYPT_DATA,
+					    &data, &argp->error);
+	if (ret)
+		goto e_free_trans_data;
+
+	ret = -EFAULT;
+	/* copy transport buffer to user space */
+	if (copy_to_user((void __user *)(uintptr_t)params.trans_uaddr,
+			 trans_data, params.trans_len))
+		goto e_free_trans_data;
+
+	/* copy guest address block to user space */
+	if (copy_to_user((void __user *)(uintptr_t)params.guest_addr_data,
+			 guest_block, params.guest_addr_len))
+		goto e_free_trans_data;
+
+	/* copy packet header to userspace. */
+	if (copy_to_user((void __user *)(uintptr_t)params.hdr_uaddr, hdr,
+			 params.hdr_len))
+		goto e_free_trans_data;
+
+	ret = 0;
+e_free_trans_data:
+	vfree(trans_data);
+e_free_trans_block:
+	kfree(trans_block);
+e_free_guest_block:
+	kfree(guest_block);
+e_free_hdr:
+	kfree(hdr);
 exit:
 	return ret;
 }
@@ -1730,6 +1900,9 @@ static int csv_mem_enc_ioctl(struct kvm *kvm, void __user *argp)
 		break;
 	case KVM_CSV3_LAUNCH_ENCRYPT_VMCB:
 		r = csv3_launch_encrypt_vmcb(kvm, &sev_cmd);
+		break;
+	case KVM_CSV3_SEND_ENCRYPT_DATA:
+		r = csv3_send_encrypt_data(kvm, &sev_cmd);
 		break;
 	default:
 		/*

--- a/arch/x86/kvm/svm/csv.c
+++ b/arch/x86/kvm/svm/csv.c
@@ -1881,6 +1881,15 @@ static int csv3_receive_encrypt_context(struct kvm *kvm, struct kvm_sev_cmd *arg
 
 		svm->current_vmcb->pa = secure_vmcb_block->vmcb_paddr[i];
 		svm->vcpu.arch.guest_state_protected = true;
+
+		/*
+		 * CSV3 guest mandates LBR Virtualization to be _always_ ON.
+		 * Enable it only after setting guest_state_protected because
+		 * KVM_SET_MSRS allows dynamic toggling of LBRV (for performance
+		 * reason) on write access to MSR_IA32_DEBUGCTLMSR when
+		 * guest_state_protected is not set.
+		 */
+		svm_enable_lbrv(vcpu);
 	}
 
 e_free_shadow_vmcb_block:

--- a/drivers/crypto/ccp/hygon/csv-dev.c
+++ b/drivers/crypto/ccp/hygon/csv-dev.c
@@ -71,6 +71,13 @@ int csv_cmd_buffer_len(int cmd)
 					return sizeof(struct csv3_data_set_guest_private_memory);
 	case CSV3_CMD_DBG_READ_VMSA:		return sizeof(struct csv3_data_dbg_read_vmsa);
 	case CSV3_CMD_DBG_READ_MEM:		return sizeof(struct csv3_data_dbg_read_mem);
+	case CSV3_CMD_SEND_ENCRYPT_DATA:	return sizeof(struct csv3_data_send_encrypt_data);
+	case CSV3_CMD_SEND_ENCRYPT_CONTEXT:
+					return sizeof(struct csv3_data_send_encrypt_context);
+	case CSV3_CMD_RECEIVE_ENCRYPT_DATA:
+					return sizeof(struct csv3_data_receive_encrypt_data);
+	case CSV3_CMD_RECEIVE_ENCRYPT_CONTEXT:
+					return sizeof(struct csv3_data_receive_encrypt_context);
 	default:				return 0;
 	}
 }

--- a/include/linux/psp-hygon.h
+++ b/include/linux/psp-hygon.h
@@ -306,6 +306,103 @@ struct csv3_data_dbg_read_mem {
 	u32 size;			/* In */
 } __packed;
 
+/**
+ * struct csv3_data_send_encrypt_data - SEND_ENCRYPT_DATA command parameters
+ *
+ * @handle: handle of the VM to process
+ * @hdr_address: physical address containing packet header
+ * @hdr_len: len of packet header
+ * @guest_block: physical address containing multiple guest address
+ * @guest_len: len of guest block
+ * @flag: flag of send encrypt data
+ *        0x00000000: migrate pages in guest block
+ *        0x00000001: set readonly of pages in guest block
+ *            others: invalid
+ * @trans_block: physical address of a page containing multiple host memory pages
+ * @trans_len: len of host memory region
+ */
+struct csv3_data_send_encrypt_data {
+	u32 handle;			/* In */
+	u32 reserved;			/* In */
+	u64 hdr_address;		/* In */
+	u32 hdr_len;			/* In/Out */
+	u32 reserved1;			/* In */
+	u64 guest_block;		/* In */
+	u32 guest_len;			/* In */
+	u32 flag;			/* In */
+	u64 trans_block;		/* In */
+	u32 trans_len;			/* In/Out */
+} __packed;
+
+/**
+ * struct csv3_data_send_encrypt_context - SEND_ENCRYPT_CONTEXT command parameters
+ *
+ * @handle: handle of the VM to process
+ * @hdr_address: physical address containing packet header
+ * @hdr_len: len of packet header
+ * @trans_block: physical address of a page containing multiple host memory pages
+ * @trans_len: len of host memory region
+ */
+struct csv3_data_send_encrypt_context {
+	u32 handle;			/* In */
+	u32 reserved;			/* In */
+	u64 hdr_address;		/* In */
+	u32 hdr_len;			/* In/Out */
+	u32 reserved1;			/* In */
+	u64 trans_block;		/* In */
+	u32 trans_len;			/* In/Out */
+} __packed;
+
+/**
+ * struct csv3_data_receive_encrypt_data - RECEIVE_ENCRYPT_DATA command parameters
+ *
+ * @handle: handle of the VM to process
+ * @hdr_address: physical address containing packet header blob
+ * @hdr_len: len of packet header
+ * @guest_block: system physical address containing multiple guest address
+ * @guest_len: len of guest block memory region
+ * @trans_block: physical address of a page containing multiple host memory pages
+ * @trans_len: len of host memory region
+ */
+struct csv3_data_receive_encrypt_data {
+	u32 handle;			/* In */
+	u32 reserved;			/* In */
+	u64 hdr_address;		/* In */
+	u32 hdr_len;			/* In */
+	u32 reserved1;			/* In */
+	u64 guest_block;		/* In */
+	u32 guest_len;			/* In */
+	u32 reserved2;			/* In */
+	u64 trans_block;		/* In */
+	u32 trans_len;			/* In */
+} __packed;
+
+/**
+ * struct csv3_data_receive_encrypt_context - RECEIVE_ENCRYPT_CONTEXT command parameters
+ *
+ * @handle: handle of the VM to process
+ * @hdr_address: physical address containing packet header
+ * @hdr_len: len of packet header
+ * @trans_block: physical address of a page containing multiple host memory pages
+ * @trans_len: len of host memory region
+ * @shadow_vmcb_block: physical address of a page containing multiple shadow vmcb address
+ * @secure_vmcb_block: physical address of a page containing multiple secure vmcb address
+ * @vmcb_block_len: len of shadow/secure vmcb block
+ */
+struct csv3_data_receive_encrypt_context {
+	u32 handle;			/* In */
+	u32 reserved;			/* In */
+	u64 hdr_address;		/* In */
+	u32 hdr_len;			/* In */
+	u32 reserved1;			/* In */
+	u64 trans_block;		/* In */
+	u32 trans_len;			/* In */
+	u32 reserved2;			/* In */
+	u64 shadow_vmcb_block;		/* In */
+	u64 secure_vmcb_block;		/* In */
+	u32 vmcb_block_len;		/* In */
+} __packed;
+
 /*
  * enum VPSP_CMD_STATUS - virtual psp command status
  *

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -2318,6 +2318,7 @@ enum csv3_cmd_id {
 	KVM_CSV3_LAUNCH_ENCRYPT_DATA,
 	KVM_CSV3_LAUNCH_ENCRYPT_VMCB,
 	KVM_CSV3_SEND_ENCRYPT_DATA,
+	KVM_CSV3_SEND_ENCRYPT_CONTEXT,
 
 	KVM_CSV3_NR_MAX,
 };
@@ -2337,6 +2338,13 @@ struct kvm_csv3_send_encrypt_data {
 	__u32 hdr_len;
 	__u64 guest_addr_data;
 	__u32 guest_addr_len;
+	__u64 trans_uaddr;
+	__u32 trans_len;
+};
+
+struct kvm_csv3_send_encrypt_context {
+	__u64 hdr_uaddr;
+	__u32 hdr_len;
 	__u64 trans_uaddr;
 	__u32 trans_len;
 };

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -2319,6 +2319,7 @@ enum csv3_cmd_id {
 	KVM_CSV3_LAUNCH_ENCRYPT_VMCB,
 	KVM_CSV3_SEND_ENCRYPT_DATA,
 	KVM_CSV3_SEND_ENCRYPT_CONTEXT,
+	KVM_CSV3_RECEIVE_ENCRYPT_DATA,
 
 	KVM_CSV3_NR_MAX,
 };
@@ -2345,6 +2346,15 @@ struct kvm_csv3_send_encrypt_data {
 struct kvm_csv3_send_encrypt_context {
 	__u64 hdr_uaddr;
 	__u32 hdr_len;
+	__u64 trans_uaddr;
+	__u32 trans_len;
+};
+
+struct kvm_csv3_receive_encrypt_data {
+	__u64 hdr_uaddr;
+	__u32 hdr_len;
+	__u64 guest_addr_data;
+	__u32 guest_addr_len;
 	__u64 trans_uaddr;
 	__u32 trans_len;
 };

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -2317,6 +2317,7 @@ enum csv3_cmd_id {
 	KVM_CSV3_INIT = KVM_CSV3_NR_MIN,
 	KVM_CSV3_LAUNCH_ENCRYPT_DATA,
 	KVM_CSV3_LAUNCH_ENCRYPT_VMCB,
+	KVM_CSV3_SEND_ENCRYPT_DATA,
 
 	KVM_CSV3_NR_MAX,
 };
@@ -2329,6 +2330,15 @@ struct kvm_csv3_launch_encrypt_data {
 	__u64 gpa;
 	__u64 uaddr;
 	__u32 len;
+};
+
+struct kvm_csv3_send_encrypt_data {
+	__u64 hdr_uaddr;
+	__u32 hdr_len;
+	__u64 guest_addr_data;
+	__u32 guest_addr_len;
+	__u64 trans_uaddr;
+	__u32 trans_len;
 };
 
 #endif /* __LINUX_KVM_H */

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -2321,6 +2321,7 @@ enum csv3_cmd_id {
 	KVM_CSV3_SEND_ENCRYPT_CONTEXT,
 	KVM_CSV3_RECEIVE_ENCRYPT_DATA,
 	KVM_CSV3_RECEIVE_ENCRYPT_CONTEXT,
+	KVM_CSV3_HANDLE_MEMORY,
 
 	KVM_CSV3_NR_MAX,
 };
@@ -2365,6 +2366,14 @@ struct kvm_csv3_receive_encrypt_context {
 	__u32 hdr_len;
 	__u64 trans_uaddr;
 	__u32 trans_len;
+};
+
+#define KVM_CSV3_RELEASE_SHARED_MEMORY (0x0001)
+
+struct kvm_csv3_handle_memory {
+	__u64 gpa;
+	__u32 num_pages;
+	__u32 opcode;
 };
 
 #endif /* __LINUX_KVM_H */

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -2320,6 +2320,7 @@ enum csv3_cmd_id {
 	KVM_CSV3_SEND_ENCRYPT_DATA,
 	KVM_CSV3_SEND_ENCRYPT_CONTEXT,
 	KVM_CSV3_RECEIVE_ENCRYPT_DATA,
+	KVM_CSV3_RECEIVE_ENCRYPT_CONTEXT,
 
 	KVM_CSV3_NR_MAX,
 };
@@ -2355,6 +2356,13 @@ struct kvm_csv3_receive_encrypt_data {
 	__u32 hdr_len;
 	__u64 guest_addr_data;
 	__u32 guest_addr_len;
+	__u64 trans_uaddr;
+	__u32 trans_len;
+};
+
+struct kvm_csv3_receive_encrypt_context {
+	__u64 hdr_uaddr;
+	__u32 hdr_len;
 	__u64 trans_uaddr;
 	__u32 trans_len;
 };


### PR DESCRIPTION
Add firmware API and host ioctl interface to support migrate CSV3 guest:
```
crypto: ccp: Define CSV3 migration command id
be2eec84e527 KVM: SVM: CSV: Add KVM_CSV3_SEND_ENCRYPT_DATA command
67f9642a4b5d KVM: SVM: CSV: Add KVM_CSV3_SEND_ENCRYPT_CONTEXT command
378add72843f KVM: SVM: CSV: Add KVM_CSV3_RECEIVE_ENCRYPT_DATA command
70d320515147 KVM: SVM: CSV: Add KVM_CSV3_RECEIVE_ENCRYPT_CONTEXT command
```
Add ioctl interface to manage shared pages and optimize the shared page management:
```
25e3de37d5e6 KVM: SVM: CSV: Add ioctl API to unpin shared pages of CSV3 guest
a6c78812aa2d KVM: SVM: CSV: Manage CSV3 guest's shared pages by rbtree
```
Optimize the notification of guest's page enc status:
```
f465bdc842ff x86/mm: Merge contiguous pages into a large range when notifying pages enc status changes
```
Explicit enable LBRV when the target machine accept source context successfully:
```
102928eb9da4 KVM: SVM: CSV: Explicitly enable LBR Virtualization after succeed to RECEIVE_ENCRYPT_CONTEXT
```