### PR TITLE
[6.6]Hygon: CSV3 patch series part 4 (Enable the concurrent memory allocation of CMA for Hygon CSV3)

### DIFF
--- a/arch/x86/mm/mem_encrypt_hygon.c
+++ b/arch/x86/mm/mem_encrypt_hygon.c
@@ -282,6 +282,7 @@ static void __init csv_cma_reserve_mem(void)
 					1 << CSV_CMA_SHIFT, node);
 				break;
 			}
+			cma_enable_concurrency(csv_cma->cma);
 
 			if (start > cma_get_base(csv_cma->cma) || !start)
 				start = cma_get_base(csv_cma->cma);

--- a/include/linux/cma.h
+++ b/include/linux/cma.h
@@ -58,4 +58,5 @@ extern int cma_for_each_area(int (*it)(struct cma *cma, void *data), void *data)
 extern void cma_reserve_pages_on_error(struct cma *cma);
 
 extern int __init cma_alloc_areas(unsigned int max_cma_size);
+extern void cma_enable_concurrency(struct cma *cma);
 #endif

--- a/mm/cma.h
+++ b/mm/cma.h
@@ -16,6 +16,7 @@ struct cma {
 	unsigned long   *bitmap;
 	unsigned int order_per_bit; /* Order of pages represented by one bit */
 	spinlock_t	lock;
+	bool no_mutex;
 #ifdef CONFIG_CMA_DEBUGFS
 	struct hlist_head mem_head;
 	spinlock_t mem_head_lock;


### PR DESCRIPTION
Add member to control CMA's concurrent allocation:
```
mm/cma: add API to enable concurrent allocation from the CMA
```
Enable CMA's concurrent allocation when allocate CSV3 guest's mem from CMA:
```
x86/mm: CSV allows CMA allocation concurrently
```