### PR TITLE
net: Fix Makefile to compile linkdata card driver successfully

### DIFF
--- a/drivers/net/ethernet/Makefile
+++ b/drivers/net/ethernet/Makefile
@@ -109,4 +109,4 @@ obj-$(CONFIG_NET_VENDOR_PENSANDO) += pensando/
 obj-$(CONFIG_NET_VENDOR_PHYTIUM) += phytium/
 obj-$(CONFIG_NET_VENDOR_GRT) += guangruntong/
 obj-$(CONFIG_NET_VENDOR_BZWX) += bzwx/
-obj-$(NET_VENDOR_LINKDATA) += linkdata/
+obj-$(CONFIG_NET_VENDOR_LINKDATA) += linkdata/


### PR DESCRIPTION
Change 'obj-$(NET_VENDOR_LINKDATA) += linkdata/' to 'obj-$(CONFIG_NET_VENDOR_LINKDATA) += linkdata/'.