### PR TITLE
[Deepin-Kernel-SIG] [linux-6.6.y] [deepin] hwmon: (k10temp) Check return value of hygon_read_temp()

### DIFF
--- a/drivers/acpi/cppc_acpi.c
+++ b/drivers/acpi/cppc_acpi.c
@@ -681,7 +681,11 @@ int acpi_cppc_processor_probe(struct acpi_processor *pr)
 	acpi_status status;
 	int ret = -ENODATA;
 
+#ifdef CONFIG_ARM64
+	if (read_cpuid_implementor() != ARM_CPU_IMP_HISI && !osc_sb_cppc2_support_acked) {
+#else
 	if (!osc_sb_cppc2_support_acked) {
+#endif
 		pr_debug("CPPC v2 _OSC not acked\n");
 		if (!cpc_supported_by_cpu())
 			return -ENODEV;


### PR DESCRIPTION
Check the return value of amd_smn_read() before saving a value. This ensures invalid values aren't saved or used.

There are three cases here with slightly different behavior.

1) read_tempreg_nb_zen():
	This is a function pointer which does not include a return code.
	In this case, set the register value to 0 on failure. This
	enforces Read-as-Zero behavior.

2) k10temp_read_temp():
	This function does have return codes, so return the error code
	from the failed register read. Continued operation is not
	necessary, since there is no valid data from the register.
	Furthermore, if the register value was set to 0, then the
	following operation would underflow.

3) k10temp_get_ccd_support():
	This function reads the same register from multiple CCD
	instances in a loop. And a bitmask is formed if a specific bit
	is set in each register instance. The loop should continue on a
	failed register read, skipping the bit check.

WangYuli:
  When check amd_smn_read(), don't forget Hygon.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.11-rc6&id=c2d79cc5455c891de6c93e1e0c73d806e299c54f
Link: https://github.com/deepin-community/kernel/pull/410/commits/d693d4a25ea3a925fe992aa0414dbbebc46f0d40