### PR TITLE
deepin: Use BFQ as the elevator for SQ rotate devices

### DIFF
--- a/block/elevator.c
+++ b/block/elevator.c
@@ -576,7 +576,9 @@ static struct elevator_type *elevator_get_default(struct request_queue *q)
 	    !blk_mq_is_shared_tags(q->tag_set->flags))
 		return NULL;
 #if defined(CONFIG_IOSCHED_BFQ)
-	return elevator_find_get(q, "bfq");
+	if (!blk_queue_nonrot(q))
+		return elevator_find_get(q, "bfq");
+	return elevator_find_get(q, "mq-deadline");
 #else
 	return elevator_find_get(q, "mq-deadline");
 #endif

--- a/block/elevator.c
+++ b/block/elevator.c
@@ -575,8 +575,11 @@ static struct elevator_type *elevator_get_default(struct request_queue *q)
 	if (q->nr_hw_queues != 1 &&
 	    !blk_mq_is_shared_tags(q->tag_set->flags))
 		return NULL;
-
+#if defined(CONFIG_IOSCHED_BFQ)
+	return elevator_find_get(q, "bfq");
+#else
 	return elevator_find_get(q, "mq-deadline");
+#endif
 }
 
 /*


### PR DESCRIPTION
For hdd optimize.
Question: 
1.How to test QUEUE_FLAG_NONROT?
2.It is correct time to get the flag?？
3.If we can get the flag,so we can only use BFQ elevator for hdd.

Link:https://github.com/zen-kernel/zen-kernel/commit/c614dbbfd3480cf18c90fd51bb52abd53339b790