### PR TITLE
crypto: ccp: fix the sev_do_cmd panic on non-Hygon platforms

### DIFF
--- a/drivers/crypto/ccp/hygon/csv-dev.c
+++ b/drivers/crypto/ccp/hygon/csv-dev.c
@@ -217,7 +217,7 @@ static long csv_ioctl(struct file *file, unsigned int ioctl, unsigned long arg)
 	if (input.cmd > CSV_MAX)
 		return -EINVAL;
 
-	if (is_vendor_hygon() && mutex_enabled) {
+	if (mutex_enabled) {
 		if (psp_mutex_lock_timeout(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex,
 					   PSP_MUTEX_TIMEOUT) != 1)
 			return -EBUSY;
@@ -245,7 +245,7 @@ static long csv_ioctl(struct file *file, unsigned int ioctl, unsigned long arg)
 		 * Release the mutex before calling the native ioctl function
 		 * because it will acquires the mutex.
 		 */
-		if (is_vendor_hygon() && mutex_enabled)
+		if (mutex_enabled)
 			psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 		else
 			mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
@@ -255,7 +255,7 @@ static long csv_ioctl(struct file *file, unsigned int ioctl, unsigned long arg)
 	if (copy_to_user(argp, &input, sizeof(struct sev_issue_cmd)))
 		ret = -EFAULT;
 
-	if (is_vendor_hygon() && mutex_enabled)
+	if (mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
 		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
@@ -418,7 +418,7 @@ static int csv_do_ringbuf_cmds(int *psp_ret)
 	if (!hygon_psp_hooks.sev_dev_hooks_installed)
 		return -ENODEV;
 
-	if (is_vendor_hygon() && mutex_enabled) {
+	if (mutex_enabled) {
 		if (psp_mutex_lock_timeout(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex,
 					   PSP_MUTEX_TIMEOUT) != 1)
 			return -EBUSY;
@@ -437,7 +437,7 @@ static int csv_do_ringbuf_cmds(int *psp_ret)
 	csv_comm_mode = CSV_COMM_MAILBOX_ON;
 
 cmd_unlock:
-	if (is_vendor_hygon() && mutex_enabled)
+	if (mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
 		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
@@ -727,7 +727,10 @@ static int vpsp_psp_mutex_trylock(void)
 {
 	int mutex_enabled = READ_ONCE(hygon_psp_hooks.psp_mutex_enabled);
 
-	if (is_vendor_hygon() && mutex_enabled)
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
+
+	if (mutex_enabled)
 		return psp_mutex_trylock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
 		return mutex_trylock(hygon_psp_hooks.sev_cmd_mutex);
@@ -737,7 +740,10 @@ static int vpsp_psp_mutex_unlock(void)
 {
 	int mutex_enabled = READ_ONCE(hygon_psp_hooks.psp_mutex_enabled);
 
-	if (is_vendor_hygon() && mutex_enabled)
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
+
+	if (mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
 		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
@@ -752,6 +758,9 @@ static int __vpsp_ring_buffer_enter_locked(int *error)
 	struct csv_ringbuffer_queue *low_queue;
 	struct csv_ringbuffer_queue *hi_queue;
 	struct sev_device *sev = psp_master->sev_data;
+
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
 
 	if (csv_comm_mode == CSV_COMM_RINGBUFFER_ON)
 		return -EEXIST;
@@ -789,7 +798,7 @@ static int __vpsp_do_ringbuf_cmds_locked(int *psp_ret, uint8_t prio, int index)
 	unsigned int rb_ctl;
 	struct sev_device *sev;
 
-	if (!psp)
+	if (!psp || !hygon_psp_hooks.sev_dev_hooks_installed)
 		return -ENODEV;
 
 	if (*hygon_psp_hooks.psp_dead)
@@ -851,6 +860,9 @@ static int vpsp_do_ringbuf_cmds_locked(int *psp_ret, uint8_t prio, int index)
 {
 	struct sev_user_data_status data;
 	int rc;
+
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
 
 	rc = __vpsp_ring_buffer_enter_locked(psp_ret);
 	if (rc)
@@ -967,6 +979,9 @@ int vpsp_try_get_result(uint32_t vid, uint8_t prio, uint32_t index, void *data,
 	int ret = 0;
 	struct csv_cmdptr_entry cmd = {0};
 
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
+
 	/* Get the retult directly if the command has been executed */
 	if (index >= 0 && vpsp_get_cmd_status(prio, index) !=
 			VPSP_CMD_STATUS_RUNNING) {
@@ -1031,6 +1046,9 @@ int vpsp_try_do_cmd(uint32_t vid, int cmd, void *data, struct vpsp_ret *psp_ret)
 	int rb_supported;
 	int index = -1;
 	uint8_t prio = CSV_COMMAND_PRIORITY_LOW;
+
+	if (!hygon_psp_hooks.sev_dev_hooks_installed)
+		return -ENODEV;
 
 	/* ringbuffer mode check and parse command prio*/
 	rb_supported = vpsp_rb_check_and_cmd_prio_parse(&prio,

--- a/drivers/crypto/ccp/sev-dev.c
+++ b/drivers/crypto/ccp/sev-dev.c
@@ -415,13 +415,13 @@ static int sev_do_cmd(int cmd, void *data, int *psp_ret)
 					   PSP_MUTEX_TIMEOUT) != 1)
 			return -EBUSY;
 	} else {
-		mutex_lock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_lock(&sev_cmd_mutex);
 	}
 	rc = __sev_do_cmd_locked(cmd, data, psp_ret);
 	if (is_vendor_hygon() && mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
-		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_unlock(&sev_cmd_mutex);
 
 	return rc;
 }
@@ -546,13 +546,13 @@ int sev_platform_init(int *error)
 					   PSP_MUTEX_TIMEOUT) != 1)
 			return -EBUSY;
 	} else {
-		mutex_lock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_lock(&sev_cmd_mutex);
 	}
 	rc = __sev_platform_init_locked(error);
 	if (is_vendor_hygon() && mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
-		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_unlock(&sev_cmd_mutex);
 
 	return rc;
 }
@@ -596,13 +596,13 @@ static int sev_platform_shutdown(int *error)
 					   PSP_MUTEX_TIMEOUT) != 1)
 			return -EBUSY;
 	} else {
-		mutex_lock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_lock(&sev_cmd_mutex);
 	}
 	rc = __sev_platform_shutdown_locked(NULL);
 	if (is_vendor_hygon() && mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
-		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_unlock(&sev_cmd_mutex);
 
 	return rc;
 }
@@ -1168,7 +1168,7 @@ static long sev_ioctl(struct file *file, unsigned int ioctl, unsigned long arg)
 					   PSP_MUTEX_TIMEOUT) != 1)
 			return -EBUSY;
 	} else {
-		mutex_lock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_lock(&sev_cmd_mutex);
 	}
 
 	switch (input.cmd) {
@@ -1212,7 +1212,7 @@ out:
 	if (is_vendor_hygon() && mutex_enabled)
 		psp_mutex_unlock(&hygon_psp_hooks.psp_misc->data_pg_aligned->mb_mutex);
 	else
-		mutex_unlock(hygon_psp_hooks.sev_cmd_mutex);
+		mutex_unlock(&sev_cmd_mutex);
 
 	return ret;
 }


### PR DESCRIPTION

The Hygon platform indirectly accesses the `sev_cmd_mutex` variable through `hygon_psp_hooks`.

However, on non-Hygon platforms (such as AMD), `hygon_psp_hooks` is not initialized, so `sev_cmd_mutex` should be accessed directly.