### PR TITLE
HID: multitouch: Add quirk for HONOR MagicBook Art 14 touchpad

### DIFF
--- a/drivers/hid/hid-multitouch.c
+++ b/drivers/hid/hid-multitouch.c
@@ -2085,6 +2085,11 @@ static const struct hid_device_id mt_devices[] = {
 		HID_DEVICE(BUS_I2C, HID_GROUP_MULTITOUCH_WIN_8,
 			0x347d, 0x7853) },
 
+	/* HONOR MagicBook Art 14 touchpad */
+	{ .driver_data = MT_CLS_VTL,
+		HID_DEVICE(BUS_I2C, HID_GROUP_MULTITOUCH_WIN_8,
+			0x35cc, 0x0104) },
+
 	/* Ilitek dual touch panel */
 	{  .driver_data = MT_CLS_NSMU,
 		MT_USB_DEVICE(USB_VENDOR_ID_ILITEK,


### PR DESCRIPTION
[Problem]
It sometimes after reboot change output from Touchpad to Mouse, evtest show it output from "TOPS0102:00 35CC:0104 Touchpad"  to "TOPS0102:00 35CC:0104 Mouse",and it works as A mouse.

[Solution]
Like GLO-GXXX,As a workaround, it is possible to call MT_QUIRK_FORCE_GET_FEATURE to force set feature in mt_set_input_mode for such special touchpad device.

Link:https://gitlab.freedesktop.org/libinput/libinput/-/issues/1040 Link:https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9ffccb691adb854e7b7f3ee57fbbda12ff70533f Link:https://www.cnblogs.com/szdytom/p/fix-honormagic-touchpad.html