### PR TITLE
[UPSTREAM] drm/i915/bios: bump expected child device size

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_bios.c
+++ b/drivers/gpu/drm/i915/display/intel_bios.c
@@ -2727,11 +2727,13 @@ parse_general_definitions(struct drm_i915_private *i915)
 		expected_size = 37;
 	} else if (i915->display.vbt.version <= 215) {
 		expected_size = 38;
-	} else if (i915->display.vbt.version <= 250) {
+	} else if (i915->display.vbt.version <= 255) {
 		expected_size = 39;
+	} else if (i915->display.vbt.version <= 256) {
+		expected_size = 40;
 	} else {
 		expected_size = sizeof(*child);
-		BUILD_BUG_ON(sizeof(*child) < 39);
+		BUILD_BUG_ON(sizeof(*child) < 40);
 		drm_dbg(&i915->drm,
 			"Expected child device config size for VBT version %u not known; assuming %u\n",
 			i915->display.vbt.version, expected_size);

--- a/drivers/gpu/drm/i915/display/intel_vbt_defs.h
+++ b/drivers/gpu/drm/i915/display/intel_vbt_defs.h
@@ -485,6 +485,7 @@ struct child_device_config {
 	u8 hdmi_iboost_level:4;					/* 196+ */
 	u8 dp_max_link_rate:3;					/* 216+ */
 	u8 dp_max_link_rate_reserved:5;				/* 216+ */
+	u8 efp_index;						/* 256+ */
 } __packed;
 
 struct bdb_general_definitions {


### PR DESCRIPTION
VBT versions since 256 have an extra byte for EFP index.

v2: Update BUILD_BUG_ON() (Matt)

Reviewed-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
Link: https://patchwork.freedesktop.org/patch/msgid/20240226175854.287871-1-jani.nikula@intel.com