### PR TITLE
[Deepin-Kernel-SIG] [Upstream] Reapply "usb: xHCI: add XHCI_RESET_ON_RESUME quirk for Phytium xHCI host"

### DIFF
--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -63,6 +63,8 @@
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI		0x51ed
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_N_PCH_XHCI	0x54ed
 
+#define PCI_DEVICE_ID_PHYTIUM_XHCI			0xdc27
+
 #define PCI_DEVICE_ID_AMD_RENOIR_XHCI			0x1639
 #define PCI_DEVICE_ID_AMD_PROMONTORYA_4			0x43b9
 #define PCI_DEVICE_ID_AMD_PROMONTORYA_3			0x43ba
@@ -482,6 +484,10 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 		xhci->quirks |= XHCI_ZERO_64B_REGS;
 	}
 	if (pdev->vendor == PCI_VENDOR_ID_VIA)
+		xhci->quirks |= XHCI_RESET_ON_RESUME;
+
+	if (pdev->vendor == PCI_VENDOR_ID_PHYTIUM &&
+	    pdev->device == PCI_DEVICE_ID_PHYTIUM_XHCI)
 		xhci->quirks |= XHCI_RESET_ON_RESUME;
 
 	/* See https://bugzilla.kernel.org/show_bug.cgi?id=79511 */

--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -62,7 +62,6 @@
 #define PCI_DEVICE_ID_INTEL_MAPLE_RIDGE_XHCI		0x1138
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI		0x51ed
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_N_PCH_XHCI	0x54ed
-#define PCI_DEVICE_ID_PHYTIUM_XHCI			0xdc27
 
 #define PCI_DEVICE_ID_AMD_RENOIR_XHCI			0x1639
 #define PCI_DEVICE_ID_AMD_PROMONTORYA_4			0x43b9
@@ -483,10 +482,6 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 		xhci->quirks |= XHCI_ZERO_64B_REGS;
 	}
 	if (pdev->vendor == PCI_VENDOR_ID_VIA)
-		xhci->quirks |= XHCI_RESET_ON_RESUME;
-
-	if (pdev->vendor == PCI_VENDOR_ID_PHYTIUM ||
-	    pdev->device == PCI_DEVICE_ID_PHYTIUM_XHCI)
 		xhci->quirks |= XHCI_RESET_ON_RESUME;
 
 	/* See https://bugzilla.kernel.org/show_bug.cgi?id=79511 */


### PR DESCRIPTION
1. Revert "xHCI: add XHCI_RESET_ON_RESUME quirk for Phytium xHCI host"
2. usb: xHCI: add XHCI_RESET_ON_RESUME quirk for Phytium xHCI host