### PR TITLE
[Deepin Kernel SIG] deepin: KABI: KABI reservation for dentry

### DIFF
--- a/include/linux/dcache.h
+++ b/include/linux/dcache.h
@@ -14,6 +14,7 @@
 #include <linux/lockref.h>
 #include <linux/stringhash.h>
 #include <linux/wait.h>
+#include <linux/deepin_kabi.h>
 
 struct path;
 struct file;
@@ -111,6 +112,9 @@ struct dentry {
 		struct hlist_bl_node d_in_lookup_hash;	/* only for in-lookup ones */
 	 	struct rcu_head d_rcu;
 	} d_u;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } __randomize_layout;
 
 /*
@@ -140,6 +144,10 @@ struct dentry_operations {
 	struct vfsmount *(*d_automount)(struct path *);
 	int (*d_manage)(const struct path *, bool);
 	struct dentry *(*d_real)(struct dentry *, const struct inode *);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 } ____cacheline_aligned;
 
 /*


### PR DESCRIPTION
    structure                size reserves reserved

    dentry                   200     2      216
    dentry_operations        104     3      128

Link: https://gitee.com/openeuler/kernel/issues/I91CF6