### PR TITLE
[Deepin-Kernel-SIG] crypto: mips/crc32 - fix the CRC32C implementation

### DIFF
--- a/arch/mips/crypto/crc32-mips.c
+++ b/arch/mips/crypto/crc32-mips.c
@@ -123,20 +123,20 @@ static u32 crc32c_mips_le_hw(u32 crc_, const u8 *p, unsigned int len)
 		for (; len >= sizeof(u64); p += sizeof(u64), len -= sizeof(u64)) {
 			u64 value = get_unaligned_le64(p);
 
-			CRC32(crc, value, d);
+			CRC32C(crc, value, d);
 		}
 
 		if (len & sizeof(u32)) {
 			u32 value = get_unaligned_le32(p);
 
-			CRC32(crc, value, w);
+			CRC32C(crc, value, w);
 			p += sizeof(u32);
 		}
 	} else {
 		for (; len >= sizeof(u32); len -= sizeof(u32)) {
 			u32 value = get_unaligned_le32(p);
 
-			CRC32(crc, value, w);
+			CRC32C(crc, value, w);
 			p += sizeof(u32);
 		}
 	}


### PR DESCRIPTION
Commit ca459e5f826f ("crypto: mips/crc32 - Clean up useless assignment operations") changed crc32c_mips_le_hw() to use the instructions that use the "regular" CRC32 polynomial instead of the Castagnoli polynomial. Therefore it can't be computing CRC32C values correctly anymore.

I haven't been successful in running a MIPS kernel in QEMU, but based on code review this is the fix that is needed.

Fixes: ca459e5f826f ("crypto: mips/crc32 - Clean up useless assignment operations")
Cc: Guan Wentao <guanwentao@uniontech.com>
Cc: WangYuli <wangyuli@uniontech.com>

Acked-by: Wentao Guan <guanwentao@uniontech.com>
Acked-by: WangYuli <wangyuli@uniontech.com>