### PR TITLE
net: mucse: sync rnpgbe driver updates:

### DIFF
--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe.h
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe.h
@@ -504,8 +504,8 @@ struct hwmon_attr {
 struct hwmon_buff {
 	struct attribute_group group;
 	const struct attribute_group *groups[2];
-	struct attribute *attrs[RNP_MAX_SENSORS * 4 + 1];
-	struct hwmon_attr hwmon_list[RNP_MAX_SENSORS * 4];
+	struct attribute *attrs[RNPGBE_MAX_SENSORS * 4 + 1];
+	struct hwmon_attr hwmon_list[RNPGBE_MAX_SENSORS * 4];
 	unsigned int n_hwmon;
 };
 #endif /* RNPGBE_HWMON */
@@ -1173,7 +1173,7 @@ int rnp500_fw_update(struct rnpgbe_hw *hw, int partition, const u8 *fw_bin,
 int rnpgbe_fw_update(struct rnpgbe_hw *hw, int partition, const u8 *fw_bin,
 		     int bytes);
 #define RNPM_FW_VERSION_NEW_ETHTOOL 0x00050010
-
+void rnpgbe_service_event_schedule(struct rnpgbe_adapter *adapter);
 static inline bool rnpgbe_fw_is_old_ethtool(struct rnpgbe_hw *hw)
 {
 	return hw->fw_version >= RNPM_FW_VERSION_NEW_ETHTOOL ? false : true;

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_main.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_main.c
@@ -45,8 +45,8 @@
 char rnpgbe_driver_name[] = "rnpgbe";
 static const char rnpgbe_driver_string[] =
 	"mucse 1 Gigabit PCI Express Network Driver";
-#define DRV_VERSION "0.2.3-rc3"
-static u32 driver_version = 0x00020303;
+#define DRV_VERSION "0.2.3-rc10"
+static u32 driver_version = 0x0002030a;
 #include "version.h"
 
 const char rnpgbe_driver_version[] = DRV_VERSION;
@@ -118,7 +118,7 @@ static int enable_hi_dma;
 static void rnpgbe_service_timer(struct timer_list *t);
 static void rnpgbe_setup_eee_mode(struct rnpgbe_adapter *adapter, bool status);
 
-static void rnpgbe_service_event_schedule(struct rnpgbe_adapter *adapter)
+void rnpgbe_service_event_schedule(struct rnpgbe_adapter *adapter)
 {
 	if (!test_bit(__RNP_DOWN, &adapter->state) &&
 	    !test_and_set_bit(__RNP_SERVICE_SCHED, &adapter->state))
@@ -3134,9 +3134,6 @@ static int rnpgbe_vlan_rx_kill_vid(struct net_device *netdev,
 				}
 				/* if no other tags use this vid */
 				if (true_remove) {
-					if ((adapter->flags2 &
-					     RNP_FLAG2_VLAN_STAGS_ENABLED) &&
-					    (vid != adapter->stags_vid))
 						hw->ops.set_vlan_filter(
 							hw, vid, false,
 							veb_setup);
@@ -7228,10 +7225,6 @@ static int rnpgbe_add_adpater(struct pci_dev *pdev, struct rnpgbe_info *ii,
 
 	netdev->hw_features |= netdev->features;
 
-	if (hw->feature_flags & RNP_NET_FEATURE_VLAN_FILTER)
-		netdev->hw_features |= NETIF_F_HW_VLAN_CTAG_FILTER;
-	if (hw->feature_flags & RNP_NET_FEATURE_STAG_FILTER)
-		netdev->hw_features |= NETIF_F_HW_VLAN_STAG_FILTER;
 	if (hw->feature_flags & RNP_NET_FEATURE_VLAN_OFFLOAD) {
 		if (!hw->ncsi_en) {
 			netdev->hw_features |= NETIF_F_HW_VLAN_CTAG_RX;

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_mbx.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_mbx.c
@@ -631,7 +631,7 @@ s32 rnpgbe_init_mbx_params_pf(struct rnpgbe_hw *hw)
 	return 0;
 }
 
-struct rnpgbe_mbx_operations mbx_ops_generic = {
+struct rnpgbe_mbx_operations rnpgbe_mbx_ops_generic = {
 	.init_params = rnpgbe_init_mbx_params_pf,
 	.read = rnpgbe_read_mbx_pf,
 	.write = rnpgbe_write_mbx_pf,

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_mbx.h
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_mbx.h
@@ -175,7 +175,7 @@ s32 rnpgbe_check_for_msg(struct rnpgbe_hw *hw, enum MBX_ID);
 s32 rnpgbe_check_for_ack(struct rnpgbe_hw *hw, enum MBX_ID);
 s32 rnpgbe_check_for_rst(struct rnpgbe_hw *hw, enum MBX_ID);
 s32 rnpgbe_init_mbx_params_pf(struct rnpgbe_hw *hw);
-extern struct rnpgbe_mbx_operations mbx_ops_generic;
+extern struct rnpgbe_mbx_operations rnpgbe_mbx_ops_generic;
 int rnpgbe_fw_get_macaddr(struct rnpgbe_hw *hw, int pfvfnum, u8 *mac_addr,
 			  int lane);
 int rnpgbe_mbx_fw_reset_phy(struct rnpgbe_hw *hw);

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_mbx_fw.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_mbx_fw.c
@@ -1426,6 +1426,7 @@ static inline int rnpgbe_mbx_fw_req_handler(struct rnpgbe_adapter *adapter,
 		adapter->flags |= RNP_FLAG_NEED_LINK_UPDATE;
 		break;
 	}
+	rnpgbe_service_event_schedule(adapter);
 
 	return 0;
 }

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_sysfs.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_sysfs.c
@@ -74,7 +74,7 @@ static ssize_t rnpgbe_hwmon_show_location(struct device __always_unused *dev,
 static ssize_t rnpgbe_hwmon_show_name(struct device __always_unused *dev,
 				      struct device_attribute *attr, char *buf)
 {
-	return snprintf(buf, PAGE_SIZE, "rnp\n");
+	return snprintf(buf, PAGE_SIZE, "rnpgbe\n");
 }
 
 static ssize_t rnpgbe_hwmon_show_temp(struct device __always_unused *dev,
@@ -1202,7 +1202,7 @@ int rnpgbe_sysfs_init(struct rnpgbe_adapter *adapter)
 
 	adapter->rnpgbe_hwmon_buff = rnpgbe_hwmon;
 
-	for (i = 0; i < RNP_MAX_SENSORS; i++) {
+	for (i = 0; i < RNPGBE_MAX_SENSORS; i++) {
 		/*
 		 * Only create hwmon sysfs entries for sensors that have
 		 * meaningful data for.
@@ -1230,7 +1230,7 @@ int rnpgbe_sysfs_init(struct rnpgbe_adapter *adapter)
 	rnpgbe_hwmon->group.attrs = rnpgbe_hwmon->attrs;
 
 	hwmon_dev = devm_hwmon_device_register_with_groups(
-		&adapter->pdev->dev, "rnp", rnpgbe_hwmon, rnpgbe_hwmon->groups);
+		&adapter->pdev->dev, "rnpgbe", rnpgbe_hwmon, rnpgbe_hwmon->groups);
 
 	if (IS_ERR(hwmon_dev)) {
 		rc = PTR_ERR(hwmon_dev);

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_type.h
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_type.h
@@ -107,16 +107,16 @@ static inline struct device *pci_dev_to_dev(struct pci_dev *pdev)
 #define ADVERTISE_2500_HALF 0x0040 /* NOT used, just FYI */
 #define ADVERTISE_2500_FULL 0x0080
 
-#define RNP_MAX_SENSORS 1
+#define RNPGBE_MAX_SENSORS 1
 struct rnpgbe_thermal_diode_data {
-	u8 location;
-	u8 temp;
-	u8 caution_thresh;
-	u8 max_op_thresh;
+	unsigned int location;
+	unsigned int temp;
+	unsigned int caution_thresh;
+	unsigned int max_op_thresh;
 };
 
 struct rnpgbe_thermal_sensor_data {
-	struct rnpgbe_thermal_diode_data sensor[RNP_MAX_SENSORS];
+	struct rnpgbe_thermal_diode_data sensor[RNPGBE_MAX_SENSORS];
 };
 
 /* Proxy Status */


### PR DESCRIPTION
update fixes:
1. optimz link status time
2. fix 'ethtool -C  rx-frame N' errors
3. set vlan-filter-on[fixed]
4. fix remove vlan error in sriov mode
5. rx-pause reg define error
6. rename mbx_ops_generic to rnpgbe_mbx_ops_generic
7. fix register hwmon error
8. fix mdix show if in autoneg off 1000M