### PR TITLE
[Deepin-Kernel-SIG] [linux-6.6.y] wifi: rtw89: get release driver version via more convenient method

### DIFF
--- a/drivers/net/wireless/realtek/rtw89/drv_ver.c
+++ b/drivers/net/wireless/realtek/rtw89/drv_ver.c
@@ -1,3 +1,22 @@
-static char drv_ver[] = "v6.8-backport-6.6-1-g809f4dd07";
+#define VERSTR  "v6.8-backport-6.6-1-g809f4dd07"
+
+static char *drv_ver = VERSTR;
 #include <linux/module.h>
 module_param_string(drv_ver, drv_ver, sizeof(drv_ver), 0444);
+
+MODULE_PARM_DESC(drv_ver, VERSTR);
+
+static int __init rtw89_drv_init(void)
+{
+	printk("rtw89 drv init version: %s\n", VERSTR);
+
+	return 0;
+}
+
+static void __exit rtw89_drv_exit(void)
+{
+	printk("rtw89 drv exit\n");
+}
+
+module_init(rtw89_drv_init);
+module_exit(rtw89_drv_exit);


### PR DESCRIPTION
We add below methods to show release driver version.
1. Use modinfo command
2. Print version in kernel log when loading modules

Change-Id: I524c0537bc76643231ae411436ab19583aeb32b4