### PR TITLE
[Deepin-Kernel-SIG] [linux-6.6.y] wifi: rtw89: Fix initializer element is not constant build err

### DIFF
--- a/drivers/net/wireless/realtek/rtw89/drv_ver.c
+++ b/drivers/net/wireless/realtek/rtw89/drv_ver.c
@@ -1,6 +1,6 @@
 #define VERSTR  "v6.8-backport-6.6-1-g809f4dd07"
 
-static char *drv_ver = VERSTR;
+static char drv_ver[] = VERSTR;
 #include <linux/module.h>
 module_param_string(drv_ver, drv_ver, sizeof(drv_ver), 0444);
 


### PR DESCRIPTION
Log:
 In file included from ./include/linux/module.h:22,
        from drivers/net/wireless/realtek/rtw89/drv_ver.c:4:
 drivers/net/wireless/realtek/rtw89/drv_ver.c:5:30: error: initializer element is not constant
     5 | module_param_string(drv_ver, drv_ver, sizeof(drv_ver), 0444);
       |                              ^~~~~~~
 ./include/linux/moduleparam.h:358:26: note: in definition of macro ‘module_param_string’
   358 |                 = { len, string };                                      \
       |                          ^~~~~~
 drivers/net/wireless/realtek/rtw89/drv_ver.c:5:30: note: (near initialization for ‘__param_string_drv_ver.string’)
     5 | module_param_string(drv_ver, drv_ver, sizeof(drv_ver), 0444);
       |                              ^~~~~~~
 ./include/linux/moduleparam.h:358:26: note: in definition of macro ‘module_param_string’
   358 |                 = { len, string };                                      \
       |                          ^~~~~~