### PR TITLE
[Jemoic] [DeepinKernel SIG] drm/mwv207: add parentheses to evaluate the bitwise operator first

### DIFF
--- a/drivers/gpu/drm/mwv207/mwv207_bo.c
+++ b/drivers/gpu/drm/mwv207/mwv207_bo.c
@@ -162,7 +162,7 @@ int mwv207_bo_kmap_reserved(struct mwv207_bo *jbo, void **ptr)
 	bool is_iomem;
 	int ret;
 
-	if (!jbo->flags & (1<<0))
+	if ((!jbo->flags) & (1<<0))
 		return -EPERM;
 
 	if (jbo->kptr) {


### PR DESCRIPTION
Fix a comlipe error with clang-19:

drivers/gpu/drm/mwv207/mwv207_bo.c:165:6: error: logical not is only applied to the left hand side of this bitwise operator [-Werror,-Wlogical-not-parentheses]
  165 |         if (!jbo->flags & (1<<0))
      |             ^           ~
drivers/gpu/drm/mwv207/mwv207_bo.c:165:6: note: add parentheses after the '!' to evaluate the bitwise operator first
  165 |         if (!jbo->flags & (1<<0))
      |             ^
      |              (                  )
drivers/gpu/drm/mwv207/mwv207_bo.c:165:6: note: add parentheses around left hand side expression to silence this warning
  165 |         if (!jbo->flags & (1<<0))
      |             ^
      |             (          )
1 error generated.