### PR TITLE
[BeiZhongWangXin] [Deepin Kernel SIG] eth: bzwx: ne6x_vf: break when ETH_SS_TEST

### DIFF
--- a/drivers/net/ethernet/bzwx/nce/ne6x_vf/ne6xvf_ethtool.c
+++ b/drivers/net/ethernet/bzwx/nce/ne6x_vf/ne6xvf_ethtool.c
@@ -208,6 +208,7 @@ static void ne6xvf_get_strings(struct net_device *netdev, u32 stringset, u8 *dat
 		break;
 	case ETH_SS_TEST:
 		memcpy(data, ne6xvf_gstrings_test, NE6XVF_TEST_LEN * ETH_GSTRING_LEN);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Fix follow error with clang-19:

drivers/net/ethernet/bzwx/nce/ne6x_vf/ne6xvf_ethtool.c:211:2: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  211 |         default:
      |         ^
drivers/net/ethernet/bzwx/nce/ne6x_vf/ne6xvf_ethtool.c:211:2: note: insert 'break;' to avoid fall-through
  211 |         default:
      |         ^
      |         break;
1 error generated.