### PR TITLE
[Phytium [Deepin Kernel SIG] ]net: macb: phytium-gem: donot convert the enum constant to a boolean

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -722,7 +722,7 @@ static void macb_mac_config(struct phylink_config *config, unsigned int mode,
 	 * otherwise writes will not take effect.
 	 */
 	if (macb_is_gem(bp) && (state->interface == PHY_INTERFACE_MODE_SGMII ||
-				PHY_INTERFACE_MODE_2500BASEX)) {
+				state->interface == PHY_INTERFACE_MODE_2500BASEX)) {
 		u32 pcsctrl, old_pcsctrl;
 
 		old_pcsctrl = gem_readl(bp, PCSCNTRL);


### PR DESCRIPTION
Fix follow error with clang-19:

drivers/net/ethernet/cadence/macb_main.c:724:71: error: converting the enum constant to a boolean [-Werror,-Wint-in-bool-context]
  724 |         if (macb_is_gem(bp) && (state->interface == PHY_INTERFACE_MODE_SGMII ||
      |                                                                              ^
1 error generated.