### PR TITLE
[6.6][Hygon]crypto: ccp: Fix some compile errors on Hygon interfaces

### DIFF
--- a/drivers/crypto/ccp/Makefile
+++ b/drivers/crypto/ccp/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 obj-$(CONFIG_CRYPTO_DEV_CCP_DD) += ccp.o
-ccp-objs  := sp-dev.o sp-platform.o
+ccp-objs  := sp-dev.o sp-platform.o \
+	    hygon/sp-dev.o
 ccp-$(CONFIG_CRYPTO_DEV_SP_CCP) += ccp-dev.o \
 	    ccp-ops.o \
 	    ccp-dev-v3.o \
@@ -18,8 +19,7 @@ ccp-$(CONFIG_CRYPTO_DEV_SP_PSP) += psp-dev.o \
                                    hygon/psp-dev.o \
                                    hygon/csv-dev.o \
                                    hygon/ring-buffer.o \
-                                   hygon/vpsp.o \
-                                   hygon/sp-dev.o
+                                   hygon/vpsp.o
 
 ccp-$(CONFIG_TDM_DEV_HYGON) += hygon/tdm-dev.o
 

--- a/drivers/crypto/ccp/hygon/psp-dev.h
+++ b/drivers/crypto/ccp/hygon/psp-dev.h
@@ -13,7 +13,6 @@
 #include <linux/mutex.h>
 #include <linux/bits.h>
 #include <linux/miscdevice.h>
-#include <linux/pci.h>
 
 #include "sp-dev.h"
 
@@ -71,11 +70,5 @@ int psp_mutex_unlock(struct psp_mutex *mutex);
 int fixup_hygon_psp_caps(struct psp_device *psp);
 int sp_request_hygon_psp_irq(struct sp_device *sp, irq_handler_t handler,
 			     const char *name, void *data);
-
-#ifdef CONFIG_PM_SLEEP
-void hygon_psp_dev_freeze(struct sp_device *sp);
-void hygon_psp_dev_thaw(struct sp_device *sp);
-void hygon_psp_dev_restore(struct sp_device *sp);
-#endif
 
 #endif	/* __CCP_HYGON_PSP_DEV_H__ */

--- a/drivers/crypto/ccp/hygon/sp-dev.c
+++ b/drivers/crypto/ccp/hygon/sp-dev.c
@@ -36,8 +36,10 @@ int hygon_sp_freeze(struct sp_device *sp)
 	if (sp->dev_vdata->ccp_vdata)
 		ccp_dev_suspend(sp);
 
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
 	if (sp->dev_vdata->psp_vdata)
 		hygon_psp_dev_freeze(sp);
+#endif
 
 	return 0;
 }
@@ -47,8 +49,10 @@ int hygon_sp_thaw(struct sp_device *sp)
 	if (sp->dev_vdata->ccp_vdata)
 		ccp_dev_resume(sp);
 
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
 	if (sp->dev_vdata->psp_vdata)
 		hygon_psp_dev_thaw(sp);
+#endif
 
 	return 0;
 }
@@ -66,8 +70,10 @@ int hygon_sp_restore(struct sp_device *sp)
 	if (sp->dev_vdata->ccp_vdata)
 		ccp_dev_resume(sp);
 
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
 	if (sp->dev_vdata->psp_vdata)
 		hygon_psp_dev_restore(sp);
+#endif
 
 	return 0;
 }

--- a/drivers/crypto/ccp/hygon/sp-dev.h
+++ b/drivers/crypto/ccp/hygon/sp-dev.h
@@ -12,10 +12,10 @@
 
 #include <linux/processor.h>
 #include <linux/ccp.h>
+#include <linux/pci.h>
 
 #include "../ccp-dev.h"
 #include "../sp-dev.h"
-#include "psp-dev.h"
 
 #ifdef CONFIG_X86_64
 static inline bool is_vendor_hygon(void)
@@ -39,6 +39,12 @@ int hygon_sp_restore(struct sp_device *sp);
 
 void hygon_set_pm_cb(struct pci_driver *drv);
 
-#endif
+#ifdef CONFIG_CRYPTO_DEV_SP_PSP
+void hygon_psp_dev_freeze(struct sp_device *sp);
+void hygon_psp_dev_thaw(struct sp_device *sp);
+void hygon_psp_dev_restore(struct sp_device *sp);
+#endif	/* CONFIG_CRYPTO_DEV_SP_PSP */
+
+#endif	/* CONFIG_PM_SLEEP */
 
 #endif	/* __CCP_HYGON_SP_DEV_H__ */

--- a/include/linux/psp-hygon.h
+++ b/include/linux/psp-hygon.h
@@ -511,6 +511,19 @@ struct vpsp_context {
 
 int psp_do_cmd(int cmd, void *data, int *psp_ret);
 
+typedef int (*p2c_notifier_t)(uint32_t id, uint64_t data);
+
+#ifdef CONFIG_HYGON_PSP2CPU_CMD
+int psp_register_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier);
+int psp_unregister_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier);
+#else	/* !CONFIG_HYGON_PSP2CPU_CMD */
+static int __maybe_unused
+psp_register_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier) { return -ENODEV; }
+
+static int __maybe_unused
+psp_unregister_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier) { return -ENODEV; }
+#endif	/* CONFIG_HYGON_PSP2CPU_CMD */
+
 int csv_ring_buffer_queue_init(void);
 int csv_ring_buffer_queue_free(void);
 int csv_fill_cmd_queue(int prio, int cmd, void *data, uint16_t flags);
@@ -586,19 +599,5 @@ kvm_pv_psp_forward_op(struct kvm_vpsp *vpsp, uint32_t cmd,
 static inline int csv_get_extension_info(void *buf, size_t *size) { return -ENODEV; }
 
 #endif	/* CONFIG_CRYPTO_DEV_SP_PSP */
-
-typedef int (*p2c_notifier_t)(uint32_t id, uint64_t data);
-
-#ifdef CONFIG_HYGON_PSP2CPU_CMD
-
-int psp_register_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier);
-int psp_unregister_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier);
-
-#else	/* !CONFIG_HYGON_PSP2CPU_CMD */
-
-int psp_register_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier) { return -ENODEV; }
-int psp_unregister_cmd_notifier(uint32_t cmd_id, p2c_notifier_t notifier) { return -ENODEV; }
-
-#endif	/* CONFIG_HYGON_PSP2CPU_CMD */
 
 #endif	/* __PSP_HYGON_H__ */


### PR DESCRIPTION
hygon inclusion
category: bugfix
CVE: NA

---------------------------

The commit 973eb41361b6 ("crypto: ccp: Fix S4 kernel panic issue on HYGON psp") introduced a HYGON-specific PM interface to resolve S4 issues. This commit assumed that the file .../hygon/sp-dev.c depended on CONFIG_CRYPTO_DEV_SP_PSP, which was incorrect because sp-dev.c serves as an abstraction for all secure processors. Consequently, we encountered compile errors on the aarch64 platform. To address these issues, we removed the dependency of .../hygon/sp-dev.c on CONFIG_CRYPTO_DEV_SP_PSP.

Additionally, HYGON_PSP2CPU_CMD is depends on CONFIG_CRYPTO_DEV_SP_PSP, so we moved the related function declarations to resolve some compilation issues.

Fixes: 973eb41361b6 ("crypto: ccp: Fix S4 kernel panic issue on HYGON psp")
Fixes: a4a33c4bf37a ("crypto: ccp: Add another mailbox interrupt support for PSP sending command to X86")