### PR TITLE
[Deepin-Kernel-SIG] [Upstream] [linux 6.6-y] net: save some cycles when doing skb_attempt_defer_free()

### DIFF
--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -6834,9 +6834,9 @@ void skb_attempt_defer_free(struct sk_buff *skb)
 	unsigned int defer_max;
 	bool kick;
 
-	if (WARN_ON_ONCE(cpu >= nr_cpu_ids) ||
-	    !cpu_online(cpu) ||
-	    cpu == raw_smp_processor_id()) {
+	if (cpu == raw_smp_processor_id() ||
+	    WARN_ON_ONCE(cpu >= nr_cpu_ids) ||
+	    !cpu_online(cpu)) {
 nodefer:	__kfree_skb(skb);
 		return;
 	}


### PR DESCRIPTION
mainline inclusion
from mainline-v6.10-rc1
category: performance

Normally, we don't face these two exceptions very often meanwhile we have some chance to meet the condition where the current cpu id is the same as skb->alloc_cpu.

One simple test that can help us see the frequency of this statement 'cpu == raw_smp_processor_id()':
1. running iperf -s and iperf -c [ip] -P [MAX CPU]
2. using BPF to capture skb_attempt_defer_free()

I can see around 4% chance that happens to satisfy the statement. So moving this statement at the beginning can save some cycles in most cases.


Reviewed-by: Alexander Lobakin <aleksander.lobakin@intel.com>