### PR TITLE
[Deepin Kernel SIG] [SIG] Arch features from Debian

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -6379,6 +6379,10 @@
 			later by a loaded module cannot be set this way.
 			Example: sysctl.vm.swappiness=40
 
+	syscall.x32=	[KNL,x86_64] Enable/disable use of x32 syscalls on
+			an x86_64 kernel where CONFIG_X86_X32 is enabled.
+			Default depends on CONFIG_X86_X32_DISABLED.
+
 	sysrq_always_enabled
 			[KNL]
 			Ignore sysrq setting - this boot parameter will

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -3013,6 +3013,14 @@ config COMPAT_32
 	select HAVE_UID16
 	select OLD_SIGSUSPEND3
 
+config X86_X32_DISABLED
+	bool "x32 ABI disabled by default"
+	depends on X86_X32_ABI
+	default n
+	help
+	  Disable the x32 ABI unless explicitly enabled using the
+	  kernel paramter "syscall.x32=y".
+
 config COMPAT
 	def_bool y
 	depends on IA32_EMULATION || X86_X32_ABI

--- a/arch/x86/entry/common.c
+++ b/arch/x86/entry/common.c
@@ -63,7 +63,7 @@ static __always_inline bool do_syscall_x32(struct pt_regs *regs, int nr)
 	 */
 	unsigned int xnr = nr - __X32_SYSCALL_BIT;
 
-	if (IS_ENABLED(CONFIG_X86_X32_ABI) && likely(xnr < X32_NR_syscalls)) {
+	if (IS_ENABLED(CONFIG_X86_X32_ABI) && unlikely(x32_enabled) && likely(xnr < X32_NR_syscalls)) {
 		xnr = array_index_nospec(xnr, X32_NR_syscalls);
 		regs->ax = x32_sys_call(regs, xnr);
 		return true;

--- a/arch/x86/entry/syscall_x32.c
+++ b/arch/x86/entry/syscall_x32.c
@@ -4,6 +4,9 @@
 #include <linux/linkage.h>
 #include <linux/sys.h>
 #include <linux/cache.h>
+#include <linux/moduleparam.h>
+#undef MODULE_PARAM_PREFIX
+#define MODULE_PARAM_PREFIX "syscall."
 #include <linux/syscalls.h>
 #include <asm/syscall.h>
 
@@ -20,3 +23,46 @@ long x32_sys_call(const struct pt_regs *regs, unsigned int nr)
 	default: return __x64_sys_ni_syscall(regs);
 	}
 };
+
+/* Maybe enable x32 syscalls */
+
+#if defined(CONFIG_X86_X32_DISABLED)
+DEFINE_STATIC_KEY_FALSE(x32_enabled_skey);
+#else
+DEFINE_STATIC_KEY_TRUE(x32_enabled_skey);
+#endif
+
+static int __init x32_param_set(const char *val, const struct kernel_param *p)
+{
+	bool enabled;
+	int ret;
+
+	ret = kstrtobool(val, &enabled);
+	if (ret)
+		return ret;
+	if (IS_ENABLED(CONFIG_X86_X32_DISABLED)) {
+		if (enabled) {
+			static_key_enable(&x32_enabled_skey.key);
+			pr_info("Enabled x32 syscalls\n");
+		}
+	} else {
+		if (!enabled) {
+			static_key_disable(&x32_enabled_skey.key);
+			pr_info("Disabled x32 syscalls\n");
+		}
+	}
+	return 0;
+}
+
+static int x32_param_get(char *buffer, const struct kernel_param *p)
+{
+	return sprintf(buffer, "%c\n",
+		       static_key_enabled(&x32_enabled_skey) ? 'Y' : 'N');
+}
+
+static const struct kernel_param_ops x32_param_ops = {
+	.set = x32_param_set,
+	.get = x32_param_get,
+};
+
+arch_param_cb(x32, &x32_param_ops, NULL, 0444);

--- a/arch/x86/include/asm/elf.h
+++ b/arch/x86/include/asm/elf.h
@@ -11,6 +11,9 @@
 #include <asm/user.h>
 #include <asm/auxvec.h>
 #include <asm/fsgsbase.h>
+#ifndef COMPILE_OFFSETS /* avoid a circular dependency on asm-offsets.h */
+#include <asm/syscall.h>
+#endif
 
 typedef unsigned long elf_greg_t;
 
@@ -150,7 +153,8 @@ do {						\
 
 #define compat_elf_check_arch(x)					\
 	(elf_check_arch_ia32(x) ||					\
-	 (IS_ENABLED(CONFIG_X86_X32_ABI) && (x)->e_machine == EM_X86_64))
+		 (IS_ENABLED(CONFIG_X86_X32_ABI) && x32_enabled &&		\
+		  (x)->e_machine == EM_X86_64))
 
 static inline void elf_common_init(struct thread_struct *t,
 				   struct pt_regs *regs, const u16 ds)

--- a/mm/memtest.c
+++ b/mm/memtest.c
@@ -31,6 +31,10 @@ static u64 patterns[] __initdata = {
 
 static void __init reserve_bad_mem(u64 pattern, phys_addr_t start_bad, phys_addr_t end_bad)
 {
+#ifdef CONFIG_X86
+	WARN_ONCE(1, "Bad RAM detected. Use memtest86+ to perform a thorough test\n"
+		  "and the memmap= parameter to reserve the bad areas.");
+#endif
 	pr_info("  %016llx bad mem addr %pa - %pa reserved\n",
 		cpu_to_be64(pattern), &start_bad, &end_bad);
 	memblock_reserve(start_bad, end_bad - start_bad);


### PR DESCRIPTION
Apply follow patches from Debian:
```
# Arch features
features/x86/x86-memtest-WARN-if-bad-RAM-found.patch
features/x86/x86-make-x32-syscall-support-conditional.patch
```
Link: https://salsa.debian.org/kernel-team/linux/-/tree/debian/latest/debian/patches?ref_type=heads