### PR TITLE
[Deepin Kernel SIG] [Debian] Apply some changes to better support package build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1194,7 +1194,8 @@ PHONY += prepare archprepare
 
 archprepare: outputmakefile archheaders archscripts scripts include/config/kernel.release \
 	asm-generic $(version_h) include/generated/utsrelease.h \
-	include/generated/compile.h include/generated/autoconf.h remove-stale-files
+	include/generated/compile.h include/generated/autoconf.h \
+	include/generated/package.h remove-stale-files
 
 prepare0: archprepare
 	$(Q)$(MAKE) $(build)=scripts/mod
@@ -1252,6 +1253,10 @@ define filechk_version.h
 	echo \#define LINUX_VERSION_SUBLEVEL $(SUBLEVEL)
 endef
 
+define filechk_package.h
+	echo \#define LINUX_PACKAGE_ID \" $(DISTRIBUTOR) $(DISTRIBUTION_VERSION)\"
+endef
+
 $(version_h): PATCHLEVEL := $(or $(PATCHLEVEL), 0)
 $(version_h): SUBLEVEL := $(or $(SUBLEVEL), 0)
 $(version_h): FORCE
@@ -1265,6 +1270,9 @@ filechk_compile.h = $(srctree)/scripts/mkcompile_h \
 
 include/generated/compile.h: FORCE
 	$(call filechk,compile.h)
+
+include/generated/package.h: $(srctree)/Makefile FORCE
+	$(call filechk,package.h)
 
 PHONY += headerdep
 headerdep:

--- a/arch/mips/kernel/fpu-probe.c
+++ b/arch/mips/kernel/fpu-probe.c
@@ -144,7 +144,12 @@ static void cpu_set_fpu_2008(struct cpuinfo_mips *c)
  * IEEE 754 conformance mode to use.  Affects the NaN encoding and the
  * ABS.fmt/NEG.fmt execution mode.
  */
-static enum { STRICT, EMULATED, LEGACY, STD2008, RELAXED } ieee754 = STRICT;
+enum ieee754_mode { STRICT, EMULATED, LEGACY, STD2008, RELAXED };
+#ifdef CONFIG_CPU_LOONGSON64
+static enum ieee754_mode ieee754 = RELAXED;
+#else
+static enum ieee754_mode ieee754 = STRICT;
+#endif
 
 /*
  * Set the IEEE 754 NaN encodings and the ABS.fmt/NEG.fmt execution modes

--- a/arch/powerpc/kernel/process.c
+++ b/arch/powerpc/kernel/process.c
@@ -38,6 +38,7 @@
 #include <linux/uaccess.h>
 #include <linux/pkeys.h>
 #include <linux/seq_buf.h>
+#include <generated/package.h>
 
 #include <asm/interrupt.h>
 #include <asm/io.h>
@@ -1555,8 +1556,9 @@ static void __show_regs(struct pt_regs *regs)
 
 	printk("NIP:  "REG" LR: "REG" CTR: "REG"\n",
 	       regs->nip, regs->link, regs->ctr);
-	printk("REGS: %px TRAP: %04lx   %s  (%s)\n",
-	       regs, regs->trap, print_tainted(), init_utsname()->release);
+	printk("REGS: %px TRAP: %04lx   %s  (%s%s)\n",
+	       regs, regs->trap, print_tainted(), init_utsname()->release,
+	       LINUX_PACKAGE_ID);
 	printk("MSR:  "REG" ", regs->msr);
 	print_msr_bits(regs->msr);
 	pr_cont("  CR: %08lx  XER: %08lx\n", regs->ccr, regs->xer);

--- a/arch/x86/um/sysrq_64.c
+++ b/arch/x86/um/sysrq_64.c
@@ -9,6 +9,7 @@
 #include <linux/sched.h>
 #include <linux/sched/debug.h>
 #include <linux/utsname.h>
+#include <generated/package.h>
 #include <asm/current.h>
 #include <asm/ptrace.h>
 #include <asm/sysrq.h>
@@ -17,8 +18,9 @@ void show_regs(struct pt_regs *regs)
 {
 	printk("\n");
 	print_modules();
-	printk(KERN_INFO "Pid: %d, comm: %.20s %s %s\n", task_pid_nr(current),
-		current->comm, print_tainted(), init_utsname()->release);
+	printk(KERN_INFO "Pid: %d, comm: %.20s %s %s%s\n", task_pid_nr(current),
+		current->comm, print_tainted(), init_utsname()->release,
+		LINUX_PACKAGE_ID);
 	printk(KERN_INFO "RIP: %04lx:%pS\n", PT_REGS_CS(regs) & 0xffff,
 	       (void *)PT_REGS_IP(regs));
 	printk(KERN_INFO "RSP: %016lx  EFLAGS: %08lx\n", PT_REGS_SP(regs),

--- a/drivers/android/Kconfig
+++ b/drivers/android/Kconfig
@@ -2,7 +2,7 @@
 menu "Android"
 
 config ANDROID_BINDER_IPC
-	bool "Android Binder IPC Driver"
+	tristate "Android Binder IPC Driver"
 	depends on MMU
 	default n
 	help

--- a/drivers/android/Makefile
+++ b/drivers/android/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 ccflags-y += -I$(src)			# needed for trace events
 
-obj-$(CONFIG_ANDROID_BINDERFS)		+= binderfs.o
-obj-$(CONFIG_ANDROID_BINDER_IPC)	+= binder.o binder_alloc.o
-obj-$(CONFIG_ANDROID_BINDER_IPC_SELFTEST) += binder_alloc_selftest.o
+obj-$(CONFIG_ANDROID_BINDER_IPC)	+= binder_linux.o
+binder_linux-y := binder.o binder_alloc.o
+binder_linux-$(CONFIG_ANDROID_BINDERFS)	+= binderfs.o
+binder_linux-$(CONFIG_ANDROID_BINDER_IPC_SELFTEST) += binder_alloc_selftest.o

--- a/drivers/android/binder_alloc.c
+++ b/drivers/android/binder_alloc.c
@@ -38,7 +38,7 @@ enum {
 };
 static uint32_t binder_alloc_debug_mask = BINDER_DEBUG_USER_ERROR;
 
-module_param_named(debug_mask, binder_alloc_debug_mask,
+module_param_named(alloc_debug_mask, binder_alloc_debug_mask,
 		   uint, 0644);
 
 #define binder_alloc_debug(mask, x...) \

--- a/init/Makefile
+++ b/init/Makefile
@@ -29,7 +29,7 @@ preempt-flag-$(CONFIG_PREEMPT_DYNAMIC)	:= PREEMPT_DYNAMIC
 preempt-flag-$(CONFIG_PREEMPT_RT)	:= PREEMPT_RT
 
 build-version = $(or $(KBUILD_BUILD_VERSION), $(build-version-auto))
-build-timestamp = $(or $(KBUILD_BUILD_TIMESTAMP), $(build-timestamp-auto))
+build-timestamp = $(or $(KBUILD_BUILD_VERSION_TIMESTAMP), $(KBUILD_BUILD_TIMESTAMP), $(build-timestamp-auto))
 
 # Maximum length of UTS_VERSION is 64 chars
 filechk_uts_version = \

--- a/ipc/msgutil.c
+++ b/ipc/msgutil.c
@@ -33,6 +33,7 @@ struct ipc_namespace init_ipc_ns = {
 	.ns.ops = &ipcns_operations,
 #endif
 };
+EXPORT_SYMBOL_GPL(init_ipc_ns);
 
 struct msg_msgseg {
 	struct msg_msgseg *next;

--- a/ipc/namespace.c
+++ b/ipc/namespace.c
@@ -207,6 +207,7 @@ void put_ipc_ns(struct ipc_namespace *ns)
 			schedule_work(&free_ipc_work);
 	}
 }
+EXPORT_SYMBOL_GPL(put_ipc_ns);
 
 static inline struct ipc_namespace *to_ipc_ns(struct ns_common *ns)
 {

--- a/kernel/hung_task.c
+++ b/kernel/hung_task.c
@@ -24,6 +24,7 @@
 #include <linux/sched/sysctl.h>
 
 #include <trace/events/sched.h>
+#include <generated/package.h>
 
 /*
  * The number of tasks checked:
@@ -131,10 +132,11 @@ static void check_hung_task(struct task_struct *t, unsigned long timeout)
 			sysctl_hung_task_warnings--;
 		pr_err("INFO: task %s:%d blocked for more than %ld seconds.\n",
 		       t->comm, t->pid, (jiffies - t->last_switch_time) / HZ);
-		pr_err("      %s %s %.*s\n",
+		pr_err("      %s %s %.*s%s\n",
 			print_tainted(), init_utsname()->release,
 			(int)strcspn(init_utsname()->version, " "),
-			init_utsname()->version);
+			init_utsname()->version,
+			LINUX_PACKAGE_ID);
 		pr_err("\"echo 0 > /proc/sys/kernel/hung_task_timeout_secs\""
 			" disables this message.\n");
 		sched_show_task(t);

--- a/kernel/sched/wait.c
+++ b/kernel/sched/wait.c
@@ -252,6 +252,7 @@ void __wake_up_pollfree(struct wait_queue_head *wq_head)
 	/* POLLFREE must have cleared the queue. */
 	WARN_ON_ONCE(waitqueue_active(wq_head));
 }
+EXPORT_SYMBOL_GPL(__wake_up_pollfree);
 
 /*
  * Note: we use "set_current_state()" _after_ the wait-queue add,

--- a/kernel/task_work.c
+++ b/kernel/task_work.c
@@ -108,6 +108,7 @@ int task_work_add(struct task_struct *task, struct callback_head *work,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(task_work_add);
 
 /**
  * task_work_cancel_match - cancel a pending work added by task_work_add()

--- a/lib/dump_stack.c
+++ b/lib/dump_stack.c
@@ -14,6 +14,7 @@
 #include <linux/kexec.h>
 #include <linux/utsname.h>
 #include <linux/stop_machine.h>
+#include <generated/package.h>
 
 static char dump_stack_arch_desc_str[128];
 
@@ -54,13 +55,15 @@ void __init dump_stack_set_arch_desc(const char *fmt, ...)
  */
 void dump_stack_print_info(const char *log_lvl)
 {
-	printk("%sCPU: %d PID: %d Comm: %.20s %s%s %s %.*s" BUILD_ID_FMT "\n",
+	printk("%sCPU: %d PID: %d Comm: %.20s %s%s %s %.*s %s" BUILD_ID_FMT "\n",
 	       log_lvl, raw_smp_processor_id(), current->pid, current->comm,
 	       kexec_crash_loaded() ? "Kdump: loaded " : "",
 	       print_tainted(),
 	       init_utsname()->release,
 	       (int)strcspn(init_utsname()->version, " "),
-	       init_utsname()->version, BUILD_ID_VAL);
+	       init_utsname()->version,
+	       LINUX_PACKAGE_ID,
+	       BUILD_ID_VAL);
 
 	if (dump_stack_arch_desc_str[0] != '\0')
 		printk("%sHardware name: %s\n",

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -1770,6 +1770,7 @@ void zap_page_range_single(struct vm_area_struct *vma, unsigned long address,
 	tlb_finish_mmu(&tlb);
 	hugetlb_zap_end(vma, details);
 }
+EXPORT_SYMBOL_GPL(zap_page_range_single);
 
 /**
  * zap_vma_ptes - remove ptes mapping the vma

--- a/security/security.c
+++ b/security/security.c
@@ -799,6 +799,7 @@ int security_binder_set_context_mgr(const struct cred *mgr)
 {
 	return call_int_hook(binder_set_context_mgr, 0, mgr);
 }
+EXPORT_SYMBOL_GPL(security_binder_set_context_mgr);
 
 /**
  * security_binder_transaction() - Check if a binder transaction is allowed
@@ -814,6 +815,7 @@ int security_binder_transaction(const struct cred *from,
 {
 	return call_int_hook(binder_transaction, 0, from, to);
 }
+EXPORT_SYMBOL_GPL(security_binder_transaction);
 
 /**
  * security_binder_transfer_binder() - Check if a binder transfer is allowed
@@ -829,6 +831,7 @@ int security_binder_transfer_binder(const struct cred *from,
 {
 	return call_int_hook(binder_transfer_binder, 0, from, to);
 }
+EXPORT_SYMBOL_GPL(security_binder_transfer_binder);
 
 /**
  * security_binder_transfer_file() - Check if a binder file xfer is allowed
@@ -845,6 +848,7 @@ int security_binder_transfer_file(const struct cred *from,
 {
 	return call_int_hook(binder_transfer_file, 0, from, to, file);
 }
+EXPORT_SYMBOL_GPL(security_binder_transfer_file);
 
 /**
  * security_ptrace_access_check() - Check if tracing is allowed

--- a/tools/lib/perf/Documentation/Makefile
+++ b/tools/lib/perf/Documentation/Makefile
@@ -35,7 +35,7 @@ htmldir  = $(docdir)/html
 exdir    = $(docdir)/examples
 
 ASCIIDOC        = asciidoc
-ASCIIDOC_EXTRA  = --unsafe -f asciidoc.conf
+ASCIIDOC_EXTRA  =
 ASCIIDOC_HTML   = xhtml11
 MANPAGE_XSL     = manpage-normal.xsl
 XMLTO_EXTRA     =

--- a/tools/perf/Documentation/Makefile
+++ b/tools/perf/Documentation/Makefile
@@ -45,7 +45,7 @@ man5dir=$(mandir)/man5
 man7dir=$(mandir)/man7
 
 ASCIIDOC=asciidoc
-ASCIIDOC_EXTRA += --unsafe -f asciidoc.conf
+ASCIIDOC_EXTRA +=
 ASCIIDOC_HTML = xhtml11
 MANPAGE_XSL = manpage-normal.xsl
 XMLTO_EXTRA =

--- a/tools/perf/Makefile.perf
+++ b/tools/perf/Makefile.perf
@@ -1018,7 +1018,7 @@ install-bin: install-tools install-tests
 install: install-bin try-install-man
 
 install-python_ext:
-	$(PYTHON_WORD) util/setup.py --quiet install --root='/$(DESTDIR_SQ)'
+	$(PYTHON_WORD) util/setup.py --quiet install --root='/$(DESTDIR_SQ)' --install-layout=deb
 
 # 'make install-doc' should call 'make -C Documentation install'
 $(INSTALL_DOC_TARGETS):


### PR DESCRIPTION
Those each patch needs to be evaluated before merging, some may require trimming or modification. 

The decision to merge a patch should be based on its merits.

Origin patches list:
```

# Changes to support package build system
debian/version.patch
debian/uname-version-timestamp.patch
debian/kernelvariables.patch
debian/mips-boston-disable-its.patch
debian/mips-ieee754-relaxed.patch
debian/mips-enable-r2-to-r6-emu-by-default.patch
debian/arch-sh4-fix-uimage-build.patch
debian/tools-perf-perf-read-vdso-in-libexec.patch
debian/tools-perf-install-python-bindings.patch
debian/wireless-add-debian-wireless-regdb-certificates.patch
debian/export-symbols-needed-by-android-drivers.patch
debian/android-enable-building-ashmem-and-binder-as-modules.patch
debian/documentation-drop-sphinx-version-check.patch
debian/perf-traceevent-support-asciidoctor-for-documentatio.patch
debian/kbuild-look-for-module.lds-under-arch-directory-too.patch
debian/kbuild-abort-build-if-subdirs-used.patch
debian/makefile-make-compiler-version-comparison-optional.patch
bugfix/all/revert-tools-build-clean-cflags-and-ldflags-for-fixdep.patch
debian/fixdep-allow-overriding-hostcc-and-hostld.patch
debian/linux-perf-remove-remaining-source-filenames-from-executable.patch
```

Link: https://salsa.debian.org/kernel-team/linux/-/tree/debian/latest/debian/patches?ref_type=heads