### PR TITLE
[Deepin Kernel SIG] [Debian] binder: Export close_fd_get_file and can_nice

### DIFF
--- a/fs/file.c
+++ b/fs/file.c
@@ -785,6 +785,7 @@ struct file *close_fd_get_file(unsigned int fd)
 
 	return file;
 }
+EXPORT_SYMBOL_GPL(close_fd_get_file);
 
 void do_close_on_exec(struct files_struct *files)
 {

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -7271,6 +7271,7 @@ int can_nice(const struct task_struct *p, const int nice)
 {
 	return is_nice_reduction(p, nice) || capable(CAP_SYS_NICE);
 }
+EXPORT_SYMBOL_GPL(can_nice);
 
 #ifdef __ARCH_WANT_SYS_NICE
 


### PR DESCRIPTION
Fix follow compile errors:
ERROR: modpost: "close_fd_get_file" [drivers/android/binder_linux.ko] undefined! ERROR: modpost: "can_nice" [drivers/android/binder_linux.ko] undefined!