### PR TITLE
[linux-6.6.y] cpufreq: export sched_set_itmt_support and sched_set_itmt_core_prio

### DIFF
--- a/arch/x86/kernel/itmt.c
+++ b/arch/x86/kernel/itmt.c
@@ -122,6 +122,7 @@ int sched_set_itmt_support(void)
 
 	return 0;
 }
+EXPORT_SYMBOL(sched_set_itmt_support);
 
 /**
  * sched_clear_itmt_support() - Revoke platform's support of ITMT
@@ -181,3 +182,4 @@ void sched_set_itmt_core_prio(int prio, int cpu)
 {
 	per_cpu(sched_core_priority, cpu) = prio;
 }
+EXPORT_SYMBOL(sched_set_itmt_core_prio);


### PR DESCRIPTION
When "CONFIG_X86_ACPI_CPUFREQ" in the config is modified to "m", there will be compilation errors:
ERROR: modpost: "sched_set_itmt_core_prio" [drivers/cpufreq/acpi-cpufreq.ko] undefined! ERROR: modpost: "sched_set_itmt_support" [drivers/cpufreq/acpi-cpufreq.ko] undefined! Therefore, it is necessary to export sched_set_itmt_support and sched_set_itmt_core_prio.