### PR TITLE
Bluetooth: btintel: Fix the sfi name for BlazarU

### DIFF
--- a/drivers/bluetooth/btintel.c
+++ b/drivers/bluetooth/btintel.c
@@ -2206,7 +2206,7 @@ static void btintel_get_fw_name_tlv(const struct intel_version_tlv *ver,
 	/* Only Blazar  product supports downloading of intermediate loader
 	 * image
 	 */
-	if ((ver->cnvi_top & 0xfff) >= BTINTEL_CNVI_BLAZARI) {
+	if (INTEL_HW_VARIANT(ver->cnvi_bt) >= 0x1e) {
 		u8 zero[BTINTEL_FWID_MAXLEN];
 
 		if (ver->img_type == BTINTEL_IMG_BOOTLOADER) {
@@ -2298,7 +2298,7 @@ static int btintel_prepare_fw_download_tlv(struct hci_dev *hdev,
 		 * firmware image which doesn't exist. Lets compare the version
 		 * of IML image
 		 */
-		if ((ver->cnvi_top & 0xfff) >= BTINTEL_CNVI_BLAZARI)
+		if (INTEL_HW_VARIANT(ver->cnvi_bt) >= 0x1e)
 			btintel_get_iml_tlv(ver, fwname, sizeof(fwname), "sfi");
 		else
 			btintel_get_fw_name_tlv(ver, fwname, sizeof(fwname), "sfi");

--- a/fs/file.c
+++ b/fs/file.c
@@ -785,6 +785,7 @@ struct file *close_fd_get_file(unsigned int fd)
 
 	return file;
 }
+EXPORT_SYMBOL_GPL(close_fd_get_file);
 
 void do_close_on_exec(struct files_struct *files)
 {

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -7271,6 +7271,7 @@ int can_nice(const struct task_struct *p, const int nice)
 {
 	return is_nice_reduction(p, nice) || capable(CAP_SYS_NICE);
 }
+EXPORT_SYMBOL_GPL(can_nice);
 
 #ifdef __ARCH_WANT_SYS_NICE
 


### PR DESCRIPTION
Bluetooth: btintel: Fix the sfi name for BlazarU
Use INTEL_HW_VARIANT() instead of CNVi Id to decide to load Intermediate
Loader (IML) image. Fix the driver loading incorrect firmware for
BlazarU product.

dmesg:
.....
[146.111834] Bluetooth: hci0: Minimum firmware build 1 week 10 2014
[146.111839] Bluetooth: hci0: Bootloader timestamp 2022.18 buildtype 1 build 16362
[146.111848] Bluetooth: hci0: No support for _PRR ACPI method
[146.112204] Bluetooth: hci0: Failed to load Intel firmware file intel/ibt-0291-0291-iml.sfi (-2)

Fixes: 164c62f958f8 ("Bluetooth: btintel: Add firmware ID to firmware name")
Reported-by: Tsigan, Vladislav <vladislav.tsigan@intel.com>
Signed-off-by: Kiran K <kiran.k@intel.com>
Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>