### PR TITLE
deepin: KABI: KABI reservation for fuse structures

### DIFF
--- a/fs/fuse/fuse_i.h
+++ b/fs/fuse/fuse_i.h
@@ -31,6 +31,7 @@
 #include <linux/pid_namespace.h>
 #include <linux/refcount.h>
 #include <linux/user_namespace.h>
+#include <linux/deepin_kabi.h>
 
 /** Default max number of pages that can be used in a single read request */
 #define FUSE_DEFAULT_MAX_PAGES_PER_REQ 32
@@ -173,6 +174,7 @@ struct fuse_inode {
 #endif
 	/** Submount specific lookup tracking */
 	struct fuse_submount_lookup *submount_lookup;
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /** FUSE inode state bits */
@@ -501,6 +503,7 @@ struct fuse_dev {
 
 	/** list entry on fc->devices */
 	struct list_head entry;
+	DEEPIN_KABI_RESERVE(1)
 };
 
 enum fuse_dax_mode {
@@ -867,6 +870,11 @@ struct fuse_conn {
 
 	/* New writepages go into this bucket */
 	struct fuse_sync_bucket __rcu *curr_bucket;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*


### PR DESCRIPTION
Reserve space for future fuse kabi expansion

Link:https://gitee.com/openeuler/kernel/issues/I8PFAL

Reviewed-by: Wu Bo <wubo40@huawei.com>
Reviewed-by: Zhang Yi <yi.zhang@huawei.com>