### PR TITLE
deepin: KABI: KABI reservation for mm structures

### DIFF
--- a/include/linux/mempolicy.h
+++ b/include/linux/mempolicy.h
@@ -52,6 +52,9 @@ struct mempolicy {
 		nodemask_t cpuset_mems_allowed;	/* relative to these nodes */
 		nodemask_t user_nodemask;	/* nodemask passed by user */
 	} w;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 /*

--- a/include/linux/mempool.h
+++ b/include/linux/mempool.h
@@ -7,6 +7,7 @@
 
 #include <linux/wait.h>
 #include <linux/compiler.h>
+#include <linux/deepin_kabi.h>
 
 struct kmem_cache;
 
@@ -23,6 +24,9 @@ typedef struct mempool_s {
 	mempool_alloc_t *alloc;
 	mempool_free_t *free;
 	wait_queue_head_t wait;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 } mempool_t;
 
 static inline bool mempool_initialized(mempool_t *pool)

--- a/include/linux/memremap.h
+++ b/include/linux/memremap.h
@@ -25,6 +25,8 @@ struct vmem_altmap {
 	unsigned long free;
 	unsigned long align;
 	unsigned long alloc;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*
@@ -99,6 +101,8 @@ struct dev_pagemap_ops {
 	 */
 	int (*memory_failure)(struct dev_pagemap *pgmap, unsigned long pfn,
 			      unsigned long nr_pages, int mf_flags);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define PGMAP_ALTMAP_VALID	(1 << 0)
@@ -133,6 +137,11 @@ struct dev_pagemap {
 	const struct dev_pagemap_ops *ops;
 	void *owner;
 	int nr_range;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 	union {
 		struct range range;
 		DECLARE_FLEX_ARRAY(struct range, ranges);

--- a/include/linux/mm_types.h
+++ b/include/linux/mm_types.h
@@ -23,6 +23,8 @@
 
 #include <asm/mmu.h>
 
+#include <linux/deepin_kabi.h>
+
 #ifndef AT_VECTOR_SIZE_ARCH
 #define AT_VECTOR_SIZE_ARCH 0
 #endif
@@ -1232,6 +1234,11 @@ enum vm_fault_reason {
 struct vm_special_mapping {
 	const char *name;	/* The name, e.g. "[vdso]". */
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 	/*
 	 * If .fault is not provided, this points to a
 	 * NULL-terminated array of pages that back the special mapping.

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -644,6 +644,10 @@ struct lruvec {
 #ifdef CONFIG_MEMCG
 	struct pglist_data *pgdat;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* Isolate unmapped pages */

--- a/include/linux/pagemap.h
+++ b/include/linux/pagemap.h
@@ -15,6 +15,7 @@
 #include <linux/bitops.h>
 #include <linux/hardirq.h> /* for in_interrupt() */
 #include <linux/hugetlb_inline.h>
+#include <linux/deepin_kabi.h>
 
 struct folio_batch;
 
@@ -1277,6 +1278,9 @@ struct readahead_control {
 	struct file *file;
 	struct address_space *mapping;
 	struct file_ra_state *ra;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 /* private: use the readahead_* accessors instead */
 	pgoff_t _index;
 	unsigned int _nr_pages;

--- a/include/linux/shrinker.h
+++ b/include/linux/shrinker.h
@@ -4,6 +4,7 @@
 
 #include <linux/atomic.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * This struct is used to pass information from page reclaim to the shrinkers.
@@ -34,6 +35,9 @@ struct shrink_control {
 
 	/* current memcg being shrunk (for memcg aware shrinkers) */
 	struct mem_cgroup *memcg;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define SHRINK_STOP (~0UL)
@@ -83,6 +87,9 @@ struct shrinker {
 #endif
 	/* objs pending delete, per node */
 	atomic_long_t *nr_deferred;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #define DEFAULT_SEEKS 2 /* A good number if you don't know better. */
 


### PR DESCRIPTION
Reserve space for the structure in mm subsystem.

Link:https://gitee.com/openeuler/kernel/issues/I8UU53