### PR TITLE
deepin: KABI: KABI reservation for audit structures

### DIFF
--- a/kernel/audit.h
+++ b/kernel/audit.h
@@ -15,6 +15,7 @@
 #include <uapi/linux/mqueue.h>
 #include <linux/tty.h>
 #include <uapi/linux/openat2.h> // struct open_how
+#include <linux/deepin_kabi.h>
 
 /* AUDIT_NAMES is the number of slots we reserve in the audit_context
  * for saving names from getname().  If we get more names we will allocate
@@ -208,6 +209,8 @@ struct audit_context {
 	};
 	int fds[2];
 	struct audit_proctitle proctitle;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 extern bool audit_ever_enabled;


### PR DESCRIPTION
Reserve space for audit module in advance to prepare for merging new feature in the future.

Link: https://gitee.com/openeuler/kernel/issues/I8WCAR