### PR TITLE
[Deepin-Kernel-SIG] [Backport] [linux 6.6-y] Sync Uniontech patches from v6.14-rc1

### DIFF
--- a/drivers/usb/host/xhci-plat.c
+++ b/drivers/usb/host/xhci-plat.c
@@ -324,6 +324,8 @@ int xhci_plat_probe(struct platform_device *pdev, struct device *sysdev, const s
 		usb3_hcd->can_do_streams = 1;
 
 	if (xhci->shared_hcd) {
+		xhci->shared_hcd->rsrc_start = hcd->rsrc_start;
+		xhci->shared_hcd->rsrc_len = hcd->rsrc_len;
 		ret = usb_add_hcd(xhci->shared_hcd, irq, IRQF_SHARED);
 		if (ret)
 			goto put_usb3_hcd;

--- a/tools/testing/ktest/examples/include/defaults.conf
+++ b/tools/testing/ktest/examples/include/defaults.conf
@@ -46,7 +46,7 @@ CLEAR_LOG = 1
 
 SSH_USER = root
 
-# For accesing the machine, we will ssh to root@machine.
+# For accessing the machine, we will ssh to root@machine.
 SSH := ssh ${SSH_USER}@${MACHINE}
 
 # Update this. The default here is ktest will ssh to the target box


### PR DESCRIPTION
## Summary by Sourcery

Synchronize Uniontech patches from v6.14-rc1 to Deepin Linux Kernel.

Bug Fixes:
- Fix a typo in a comment.

Enhancements:
- Share resources between XHCI host controllers.

Tests:
- Update default SSH configuration.