### PR TITLE
deepin: KABI: KABI reservation for iommu structures

### DIFF
--- a/include/linux/seq_file.h
+++ b/include/linux/seq_file.h
@@ -27,6 +27,8 @@ struct seq_file {
 	int poll_event;
 	const struct file *file;
 	void *private;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct seq_operations {
@@ -34,6 +36,8 @@ struct seq_operations {
 	void (*stop) (struct seq_file *m, void *v);
 	void * (*next) (struct seq_file *m, void *v, loff_t *pos);
 	int (*show) (struct seq_file *m, void *v);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #define SEQ_SKIP 1


### PR DESCRIPTION
Reserve kabi space for seq_file and seq_operations

    structure                size reserves reserved
    seq_file                 120     1       128
    seq_operations           32      1       40

Link: https://gitee.com/openeuler/kernel/issues/IBC34X

## Summary by Sourcery

Enhancements:
- Reserve KABI space for `seq_file` and `seq_operations` structures.