### PR TITLE
deepin: KABI: KABI reservation for some structures

### DIFF
--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -1011,6 +1011,14 @@ struct perf_cpu_pmu_context {
 	struct hrtimer			hrtimer;
 	ktime_t				hrtimer_interval;
 	unsigned int			hrtimer_active;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /**
@@ -1032,6 +1040,14 @@ struct perf_cpu_context {
 	int				heap_size;
 	struct perf_event		**heap;
 	struct perf_event		*heap_default[2];
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 struct perf_output_handle {

--- a/include/linux/uprobes.h
+++ b/include/linux/uprobes.h
@@ -47,6 +47,7 @@ struct uprobe_consumer {
 
 #ifdef CONFIG_UPROBES
 #include <asm/uprobes.h>
+#include <linux/deepin_kabi.h>
 
 enum uprobe_task_state {
 	UTASK_RUNNING,
@@ -80,6 +81,14 @@ struct uprobe_task {
 
 	struct return_instance		*return_instances;
 	unsigned int			depth;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 struct return_instance {

--- a/kernel/events/internal.h
+++ b/kernel/events/internal.h
@@ -5,6 +5,7 @@
 #include <linux/hardirq.h>
 #include <linux/uaccess.h>
 #include <linux/refcount.h>
+#include <linux/deepin_kabi.h>
 
 /* Buffer handling */
 
@@ -54,6 +55,15 @@ struct perf_buffer {
 	int				aux_in_sampling;
 	void				**aux_pages;
 	void				*aux_priv;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 
 	struct perf_event_mmap_page	*user_page;
 	void				*data_pages[];


### PR DESCRIPTION
Commit:
deepin: KABI: KABI reservation for uprobe.h
deepin: KABI: KABI reservation for internel.h
deepin: KABI: KABI reservation for perf_event structures

## Summary by Sourcery

Enhancements:
- Added `DEEPIN_KABI_RESERVE` fields to several kernel structures to maintain ABI compatibility across kernel versions.