### PR TITLE
deepin: KABI: KABI reservation for tracing structures

### DIFF
--- a/include/linux/ftrace.h
+++ b/include/linux/ftrace.h
@@ -21,6 +21,7 @@
 #include <linux/fs.h>
 
 #include <asm/ftrace.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * If the arch supports passing the variable contents of
@@ -340,6 +341,8 @@ struct ftrace_ops {
 	unsigned long			direct_call;
 #endif
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern struct ftrace_ops __rcu *ftrace_ops_list;

--- a/include/linux/trace_events.h
+++ b/include/linux/trace_events.h
@@ -9,6 +9,7 @@
 #include <linux/hardirq.h>
 #include <linux/perf_event.h>
 #include <linux/tracepoint.h>
+#include <linux/deepin_kabi.h>
 
 struct trace_array;
 struct array_buffer;
@@ -681,6 +682,8 @@ struct trace_event_file {
 	atomic_t		ref;	/* ref count for opened files */
 	atomic_t		sm_ref;	/* soft-mode reference counter */
 	atomic_t		tm_ref;	/* trigger-mode reference counter */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define __TRACE_EVENT_FLAGS(name, value)				\

--- a/include/linux/tracepoint-defs.h
+++ b/include/linux/tracepoint-defs.h
@@ -10,6 +10,7 @@
 
 #include <linux/atomic.h>
 #include <linux/static_key.h>
+#include <linux/deepin_kabi.h>
 
 struct static_call_key;
 
@@ -39,6 +40,8 @@ struct tracepoint {
 	int (*regfunc)(void);
 	void (*unregfunc)(void);
 	struct tracepoint_func __rcu *funcs;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #ifdef CONFIG_HAVE_ARCH_PREL32_RELOCATIONS

--- a/kernel/trace/ring_buffer.c
+++ b/kernel/trace/ring_buffer.c
@@ -28,6 +28,7 @@
 #include <linux/oom.h>
 
 #include <asm/local.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * The "absolute" timestamp in the buffer is only 59 bits.
@@ -536,6 +537,9 @@ struct ring_buffer_per_cpu {
 	struct completion		update_done;
 
 	struct rb_irq_work		irq_work;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 struct trace_buffer {
@@ -570,6 +574,9 @@ struct ring_buffer_iter {
 	u64				page_stamp;
 	struct ring_buffer_event	*event;
 	int				missed_events;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 #ifdef RB_TIME_32

--- a/kernel/trace/trace.h
+++ b/kernel/trace/trace.h
@@ -21,6 +21,7 @@
 #include <linux/workqueue.h>
 #include <linux/ctype.h>
 #include <linux/once_lite.h>
+#include <linux/deepin_kabi.h>
 
 #include "pid_list.h"
 
@@ -410,6 +411,9 @@ struct trace_array {
 	struct cond_snapshot	*cond_snapshot;
 #endif
 	struct trace_func_repeats	__percpu *last_func_repeats;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 enum {
@@ -1325,6 +1329,8 @@ struct ftrace_event_field {
 	unsigned int		is_signed:1;
 	unsigned int		needs_test:1;
 	int			len;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct prog_entry;


### PR DESCRIPTION
Reserve fields in tracing related structs for possible kabi compatibility processing in future.

Link: https://gitee.com/openeuler/kernel/issues/I8YPFE

## Summary by Sourcery

Enhancements:
- Added `DEEPIN_KABI_RESERVE` fields to `ring_buffer_per_cpu`, `ring_buffer_iter`, `trace_array`, `ftrace_event_field`, `ftrace_ops`, `trace_event_file`, and `tracepoint` structures.