### PR TITLE
deepin: KABI: KABI reservation for vfs

### DIFF
--- a/include/linux/filelock.h
+++ b/include/linux/filelock.h
@@ -31,6 +31,9 @@ struct file_lock;
 struct file_lock_operations {
 	void (*fl_copy_lock)(struct file_lock *, struct file_lock *);
 	void (*fl_release_private)(struct file_lock *);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct lock_manager_operations {
@@ -45,6 +48,9 @@ struct lock_manager_operations {
 	bool (*lm_breaker_owns_lease)(struct file_lock *);
 	bool (*lm_lock_expirable)(struct file_lock *cfl);
 	void (*lm_expire_lock)(void);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct lock_manager {

--- a/include/linux/fs.h
+++ b/include/linux/fs.h
@@ -443,6 +443,11 @@ struct address_space_operations {
 				sector_t *span);
 	void (*swap_deactivate)(struct file *file);
 	int (*swap_rw)(struct kiocb *iocb, struct iov_iter *iter);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 extern const struct address_space_operations empty_aops;
@@ -489,6 +494,14 @@ struct address_space {
 	struct list_head	private_list;
 	struct rw_semaphore	i_mmap_rwsem;
 	void			*private_data;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
 } __attribute__((aligned(sizeof(long)))) __randomize_layout;
 	/*
 	 * On most architectures that alignment is already the case; but
@@ -748,6 +761,11 @@ struct inode {
 #endif
 
 	void			*i_private; /* fs or device private pointer */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } __randomize_layout;
 
 struct timespec64 timestamp_truncate(struct timespec64 t, struct inode *inode);
@@ -1319,6 +1337,9 @@ struct super_block {
 
 	spinlock_t		s_inode_wblist_lock;
 	struct list_head	s_inodes_wb;	/* writeback inodes */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } __randomize_layout;
 
 static inline struct user_namespace *i_user_ns(const struct inode *inode)


### PR DESCRIPTION
struture			size	reserves

address_space_operations	160	4
address_space			200	7
inode				624	4
file_lock_operations		16	2
lock_manager_operations		88	2
super_block			1392	2

Link: https://gitee.com/openeuler/kernel/issues/I900QB

## Summary by Sourcery

Enhancements:
- Added DEEPIN_KABI_RESERVE macros to several kernel structures to ensure future compatibility.