### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] Update kernel base to 6.6.77

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 6
-SUBLEVEL = 76
+SUBLEVEL = 77
 EXTRAVERSION =
 NAME = Pinguïn Aangedreven
 

--- a/fs/hostfs/hostfs_kern.c
+++ b/fs/hostfs/hostfs_kern.c
@@ -16,15 +16,10 @@
 #include <linux/seq_file.h>
 #include <linux/writeback.h>
 #include <linux/mount.h>
-#include <linux/fs_context.h>
 #include <linux/namei.h>
 #include "hostfs.h"
 #include <init.h>
 #include <kern.h>
-
-struct hostfs_fs_info {
-	char *host_root_path;
-};
 
 struct hostfs_inode_info {
 	int fd;
@@ -95,10 +90,8 @@ static char *__dentry_name(struct dentry *dentry, char *name)
 	char *p = dentry_path_raw(dentry, name, PATH_MAX);
 	char *root;
 	size_t len;
-	struct hostfs_fs_info *fsi;
 
-	fsi = dentry->d_sb->s_fs_info;
-	root = fsi->host_root_path;
+	root = dentry->d_sb->s_fs_info;
 	len = strlen(root);
 	if (IS_ERR(p)) {
 		__putname(name);
@@ -203,10 +196,8 @@ static int hostfs_statfs(struct dentry *dentry, struct kstatfs *sf)
 	long long f_bavail;
 	long long f_files;
 	long long f_ffree;
-	struct hostfs_fs_info *fsi;
 
-	fsi = dentry->d_sb->s_fs_info;
-	err = do_statfs(fsi->host_root_path,
+	err = do_statfs(dentry->d_sb->s_fs_info,
 			&sf->f_bsize, &f_blocks, &f_bfree, &f_bavail, &f_files,
 			&f_ffree, &sf->f_fsid, sizeof(sf->f_fsid),
 			&sf->f_namelen);
@@ -254,11 +245,7 @@ static void hostfs_free_inode(struct inode *inode)
 
 static int hostfs_show_options(struct seq_file *seq, struct dentry *root)
 {
-	struct hostfs_fs_info *fsi;
-	const char *root_path;
-
-	fsi = root->d_sb->s_fs_info;
-	root_path = fsi->host_root_path;
+	const char *root_path = root->d_sb->s_fs_info;
 	size_t offset = strlen(root_ino) + 1;
 
 	if (strlen(root_path) > offset)
@@ -937,11 +924,10 @@ static const struct inode_operations hostfs_link_iops = {
 	.get_link	= hostfs_get_link,
 };
 
-static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
+static int hostfs_fill_sb_common(struct super_block *sb, void *d, int silent)
 {
-	struct hostfs_fs_info *fsi = sb->s_fs_info;
 	struct inode *root_inode;
-	char *host_root = fc->source;
+	char *host_root_path, *req_root = d;
 	int err;
 
 	sb->s_blocksize = 1024;
@@ -955,15 +941,15 @@ static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		return err;
 
 	/* NULL is printed as '(null)' by printf(): avoid that. */
-	if (fc->source == NULL)
-		host_root = "";
+	if (req_root == NULL)
+		req_root = "";
 
-	fsi->host_root_path =
-		kasprintf(GFP_KERNEL, "%s/%s", root_ino, host_root);
-	if (fsi->host_root_path == NULL)
+	sb->s_fs_info = host_root_path =
+		kasprintf(GFP_KERNEL, "%s/%s", root_ino, req_root);
+	if (host_root_path == NULL)
 		return -ENOMEM;
 
-	root_inode = hostfs_iget(sb, fsi->host_root_path);
+	root_inode = hostfs_iget(sb, host_root_path);
 	if (IS_ERR(root_inode))
 		return PTR_ERR(root_inode);
 
@@ -971,7 +957,7 @@ static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		char *name;
 
 		iput(root_inode);
-		name = follow_link(fsi->host_root_path);
+		name = follow_link(host_root_path);
 		if (IS_ERR(name))
 			return PTR_ERR(name);
 
@@ -988,38 +974,11 @@ static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	return 0;
 }
 
-static int hostfs_fc_get_tree(struct fs_context *fc)
+static struct dentry *hostfs_read_sb(struct file_system_type *type,
+			  int flags, const char *dev_name,
+			  void *data)
 {
-	return get_tree_nodev(fc, hostfs_fill_super);
-}
-
-static void hostfs_fc_free(struct fs_context *fc)
-{
-	struct hostfs_fs_info *fsi = fc->s_fs_info;
-
-	if (!fsi)
-		return;
-
-	kfree(fsi->host_root_path);
-	kfree(fsi);
-}
-
-static const struct fs_context_operations hostfs_context_ops = {
-	.get_tree	= hostfs_fc_get_tree,
-	.free		= hostfs_fc_free,
-};
-
-static int hostfs_init_fs_context(struct fs_context *fc)
-{
-	struct hostfs_fs_info *fsi;
-
-	fsi = kzalloc(sizeof(*fsi), GFP_KERNEL);
-	if (!fsi)
-		return -ENOMEM;
-
-	fc->s_fs_info = fsi;
-	fc->ops = &hostfs_context_ops;
-	return 0;
+	return mount_nodev(type, flags, data, hostfs_fill_sb_common);
 }
 
 static void hostfs_kill_sb(struct super_block *s)
@@ -1029,11 +988,11 @@ static void hostfs_kill_sb(struct super_block *s)
 }
 
 static struct file_system_type hostfs_type = {
-	.owner			= THIS_MODULE,
-	.name			= "hostfs",
-	.init_fs_context	= hostfs_init_fs_context,
-	.kill_sb		= hostfs_kill_sb,
-	.fs_flags		= 0,
+	.owner 		= THIS_MODULE,
+	.name 		= "hostfs",
+	.mount	 	= hostfs_read_sb,
+	.kill_sb	= hostfs_kill_sb,
+	.fs_flags 	= 0,
 };
 MODULE_ALIAS_FS("hostfs");
 

--- a/fs/hostfs/hostfs_kern.c
+++ b/fs/hostfs/hostfs_kern.c
@@ -93,17 +93,32 @@ __uml_setup("hostfs=", hostfs_args,
 static char *__dentry_name(struct dentry *dentry, char *name)
 {
 	char *p = dentry_path_raw(dentry, name, PATH_MAX);
-	struct hostfs_fs_info *fsi = dentry->d_sb->s_fs_info;
-	char *root = fsi->host_root_path;
-	size_t len = strlen(root);
+	char *root;
+	size_t len;
+	struct hostfs_fs_info *fsi;
 
-	if (IS_ERR(p) || len > p - name) {
+	fsi = dentry->d_sb->s_fs_info;
+	root = fsi->host_root_path;
+	len = strlen(root);
+	if (IS_ERR(p)) {
 		__putname(name);
 		return NULL;
 	}
 
-	memcpy(name, root, len);
-	memmove(name + len, p, name + PATH_MAX - p);
+	/*
+	 * This function relies on the fact that dentry_path_raw() will place
+	 * the path name at the end of the provided buffer.
+	 */
+	BUG_ON(p + strlen(p) + 1 != name + PATH_MAX);
+
+	strscpy(name, root, PATH_MAX);
+	if (len > p - name) {
+		__putname(name);
+		return NULL;
+	}
+
+	if (p > name + len)
+		strcpy(name + len, p);
 
 	return name;
 }

--- a/fs/hostfs/hostfs_kern.c
+++ b/fs/hostfs/hostfs_kern.c
@@ -17,7 +17,6 @@
 #include <linux/writeback.h>
 #include <linux/mount.h>
 #include <linux/fs_context.h>
-#include <linux/fs_parser.h>
 #include <linux/namei.h>
 #include "hostfs.h"
 #include <init.h>
@@ -926,6 +925,7 @@ static const struct inode_operations hostfs_link_iops = {
 static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 {
 	struct hostfs_fs_info *fsi = sb->s_fs_info;
+	const char *host_root = fc->source;
 	struct inode *root_inode;
 	int err;
 
@@ -938,6 +938,15 @@ static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	err = super_setup_bdi(sb);
 	if (err)
 		return err;
+
+	/* NULL is printed as '(null)' by printf(): avoid that. */
+	if (fc->source == NULL)
+		host_root = "";
+
+	fsi->host_root_path =
+		kasprintf(GFP_KERNEL, "%s/%s", root_ino, host_root);
+	if (fsi->host_root_path == NULL)
+		return -ENOMEM;
 
 	root_inode = hostfs_iget(sb, fsi->host_root_path);
 	if (IS_ERR(root_inode))
@@ -964,58 +973,6 @@ static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	return 0;
 }
 
-enum hostfs_parma {
-	Opt_hostfs,
-};
-
-static const struct fs_parameter_spec hostfs_param_specs[] = {
-	fsparam_string_empty("hostfs",		Opt_hostfs),
-	{}
-};
-
-static int hostfs_parse_param(struct fs_context *fc, struct fs_parameter *param)
-{
-	struct hostfs_fs_info *fsi = fc->s_fs_info;
-	struct fs_parse_result result;
-	char *host_root;
-	int opt;
-
-	opt = fs_parse(fc, hostfs_param_specs, param, &result);
-	if (opt < 0)
-		return opt;
-
-	switch (opt) {
-	case Opt_hostfs:
-		host_root = param->string;
-		if (!*host_root)
-			host_root = "";
-		fsi->host_root_path =
-			kasprintf(GFP_KERNEL, "%s/%s", root_ino, host_root);
-		if (fsi->host_root_path == NULL)
-			return -ENOMEM;
-		break;
-	}
-
-	return 0;
-}
-
-static int hostfs_parse_monolithic(struct fs_context *fc, void *data)
-{
-	struct hostfs_fs_info *fsi = fc->s_fs_info;
-	char *host_root = (char *)data;
-
-	/* NULL is printed as '(null)' by printf(): avoid that. */
-	if (host_root == NULL)
-		host_root = "";
-
-	fsi->host_root_path =
-		kasprintf(GFP_KERNEL, "%s/%s", root_ino, host_root);
-	if (fsi->host_root_path == NULL)
-		return -ENOMEM;
-
-	return 0;
-}
-
 static int hostfs_fc_get_tree(struct fs_context *fc)
 {
 	return get_tree_nodev(fc, hostfs_fill_super);
@@ -1033,8 +990,6 @@ static void hostfs_fc_free(struct fs_context *fc)
 }
 
 static const struct fs_context_operations hostfs_context_ops = {
-	.parse_monolithic = hostfs_parse_monolithic,
-	.parse_param	= hostfs_parse_param,
 	.get_tree	= hostfs_fc_get_tree,
 	.free		= hostfs_fc_free,
 };

--- a/fs/hostfs/hostfs_kern.c
+++ b/fs/hostfs/hostfs_kern.c
@@ -925,8 +925,8 @@ static const struct inode_operations hostfs_link_iops = {
 static int hostfs_fill_super(struct super_block *sb, struct fs_context *fc)
 {
 	struct hostfs_fs_info *fsi = sb->s_fs_info;
-	const char *host_root = fc->source;
 	struct inode *root_inode;
+	char *host_root = fc->source;
 	int err;
 
 	sb->s_blocksize = 1024;


### PR DESCRIPTION
Update kernel base to 6.6.77.

## Summary by Sourcery

Chores:
- Simplify the hostfs filesystem by removing the hostfs_fs_info struct and directly using the superblock's s_fs_info field.