### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] [Intel] Intel: backport KVM Fix for Clearing SGX EDECCSSA to 6.6

### DIFF
--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -7987,6 +7987,7 @@ static __init void vmx_set_cpu_caps(void)
 		kvm_cpu_cap_clear(X86_FEATURE_SGX_LC);
 		kvm_cpu_cap_clear(X86_FEATURE_SGX1);
 		kvm_cpu_cap_clear(X86_FEATURE_SGX2);
+		kvm_cpu_cap_clear(X86_FEATURE_SGX_EDECCSSA);
 	}
 
 	if (vmx_umip_emulated())


### PR DESCRIPTION
Description
When SGX EDECCSSA support was added to KVM in commit 16a7fe3728a8 ("KVM/VMX: Allow exposing EDECCSSA user leaf function to KVM guest"), it forgot to clear the X86_FEATURE_SGX_EDECCSSA bit in KVM CPU caps when KVM SGX is disabled. Fix it.

Fixes: 16a7fe3728a8 ("KVM/VMX: Allow exposing EDECCSSA user leaf function to KVM guest")

About the patches
The total patch number is 1:

7efb4d8a392a KVM: VMX: Also clear SGX EDECCSSA in KVM CPU caps when SGX is disabled
Tests

Build successfully for each commit
Kernel selftest - SGX: PASSED
cd tools/testing/selftests/sgx/
make
./test_sgx
Kernel selftest - SGX in VM: PASSED
Function test
Step 1. Original SGX EDECCSSA status in guest
[root@guest ~]# cpuid -1 -l 0x12
CPU:
   Software Guard Extensions (SGX) capability (0x12/0):
      SGX1 supported                           = true
      SGX2 supported                           = true
      SGX ENCLV E*VIRTCHILD, ESETCONTEXT       = false
      SGX ENCLS ETRACKC, ERDINFO, ELDBC, ELDUC = false
      SGX ENCLU EVERIFYREPORT2                 = false
      SGX ENCLS EUPDATESVN                     = false
      SGX ENCLU EDECCSSA                       = true
      MISCSELECT.EXINFO supported: #PF & #GP   = true
      MISCSELECT.CPINFO supported: #CP         = false
      MaxEnclaveSize_Not64 (log2)              = 0x1f (31)
      MaxEnclaveSize_64 (log2)                 = 0x38 (56)
Step 2. Disable SGX in guest

root@KVM-host:~# rmmod kvm_intel
root@KVM-host:~# modprobe kvm_intel sgx=0 
Step 3. The SGX EDECCSSA capability is cleared in KVM, then its status becomes false

[root@guest ~]# cpuid -1 -l 0x12
CPU:
   Software Guard Extensions (SGX) capability (0x12/0):
      SGX1 supported                           = false
      SGX2 supported                           = false
      SGX ENCLV E*VIRTCHILD, ESETCONTEXT       = false
      SGX ENCLS ETRACKC, ERDINFO, ELDBC, ELDUC = false
      SGX ENCLU EVERIFYREPORT2                 = false
      SGX ENCLS EUPDATESVN                     = false
      SGX ENCLU EDECCSSA                       = false
      MISCSELECT.EXINFO supported: #PF & #GP   = false
      MISCSELECT.CPINFO supported: #CP         = false
      MaxEnclaveSize_Not64 (log2)              = 0x0 (0)
      MaxEnclaveSize_64 (log2)                 = 0x0 (0)
[root@TDX-guest ~]# 
Known issue:
None

Default config change:
None


Link: https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel/pulls/307


Upstream commit 7efb4d8a392a18e37fcdb5e77c111af6e9a9e2f2 Conflict: none

When SGX EDECCSSA support was added to KVM in commit 16a7fe3728a8 ("KVM/VMX: Allow exposing EDECCSSA user leaf function to KVM guest"), it forgot to clear the X86_FEATURE_SGX_EDECCSSA bit in KVM CPU caps when KVM SGX is disabled.  Fix it.

Intel-SIG: commit 7efb4d8a392a KVM: VMX: Also clear SGX EDECCSSA in KVM CPU caps when SGX is disabled
Backport a SGX bug fix from upstream.

Fixes: 16a7fe3728a8 ("KVM/VMX: Allow exposing EDECCSSA user leaf function to KVM guest")

Link: https://lore.kernel.org/r/20240905120837.579102-1-kai.huang@intel.com

[ Zhiquan Li: amend commit log ]

## Summary by Sourcery

Bug Fixes:
- Clear the X86_FEATURE_SGX_EDECCSSA bit in KVM CPU capabilities when KVM SGX is disabled to resolve an issue where the bit remained set even when SGX was disabled in the guest VM. This fixes a bug introduced when EDECCSSA support was added to KVM, ensuring that the guest CPU capabilities accurately reflect the SGX configuration.