### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Hygon] Hygon: Update drivers' support for Hygon model 4h, 6h~8h and 10h processors 

### DIFF
--- a/arch/x86/events/amd/core.c
+++ b/arch/x86/events/amd/core.c
@@ -296,6 +296,9 @@ static u64 amd_pmu_event_map(int hw_event)
 	if (cpu_feature_enabled(X86_FEATURE_ZEN1))
 		return amd_zen1_perfmon_event_map[hw_event];
 
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
+		return amd_zen1_perfmon_event_map[hw_event];
+
 	return amd_perfmon_event_map[hw_event];
 }
 

--- a/arch/x86/include/asm/amd_nb.h
+++ b/arch/x86/include/asm/amd_nb.h
@@ -83,6 +83,7 @@ bool amd_nb_has_feature(unsigned int feature);
 struct amd_northbridge *node_to_amd_nb(int node);
 
 bool hygon_f18h_m4h(void);
+bool hygon_f18h_m10h(void);
 u16 hygon_nb_num(void);
 int get_df_id(struct pci_dev *misc, u8 *id);
 
@@ -127,6 +128,7 @@ static inline struct amd_northbridge *node_to_amd_nb(int node)
 #define amd_gart_present(x)	false
 
 #define hygon_f18h_m4h		false
+#define hygon_f18h_m10h		false
 #define hygon_nb_num(x)	0
 #define get_df_id(x, y)	NULL
 

--- a/arch/x86/kernel/amd_nb.c
+++ b/arch/x86/kernel/amd_nb.c
@@ -299,8 +299,7 @@ static int get_df_register(struct pci_dev *misc, u8 func, int offset, u32 *value
 			else
 				device = PCI_DEVICE_ID_HYGON_18H_M04H_DF_F1;
 			break;
-		case 0x6:
-		case 0x7:
+		case 0x6 ... 0x8:
 			device = PCI_DEVICE_ID_HYGON_18H_M05H_DF_F1;
 			break;
 		default:
@@ -308,8 +307,7 @@ static int get_df_register(struct pci_dev *misc, u8 func, int offset, u32 *value
 		}
 	} else if (func == 5) {
 		switch (boot_cpu_data.x86_model) {
-		case 0x6:
-		case 0x7:
+		case 0x6 ... 0x8:
 			device = PCI_DEVICE_ID_HYGON_18H_M06H_DF_F5;
 			break;
 		default:
@@ -343,7 +341,7 @@ int get_df_id(struct pci_dev *misc, u8 *id)
 	int ret;
 
 	if (boot_cpu_data.x86_model >= 0x6 &&
-	    boot_cpu_data.x86_model <= 0x7) {
+	    boot_cpu_data.x86_model <= 0xf) {
 		/* F5x180[19:16]: DF ID */
 		ret = get_df_register(misc, 5, 0x180, &value);
 		*id = (value >> 16) & 0xf;

--- a/arch/x86/kernel/amd_nb.c
+++ b/arch/x86/kernel/amd_nb.c
@@ -262,6 +262,20 @@ bool hygon_f18h_m4h(void)
 }
 EXPORT_SYMBOL_GPL(hygon_f18h_m4h);
 
+bool hygon_f18h_m10h(void)
+{
+	if (boot_cpu_data.x86_vendor != X86_VENDOR_HYGON)
+		return false;
+
+	if (boot_cpu_data.x86 == 0x18 &&
+	    boot_cpu_data.x86_model >= 0x10 &&
+	    boot_cpu_data.x86_model <= 0x1f)
+		return true;
+
+	return false;
+}
+EXPORT_SYMBOL_GPL(hygon_f18h_m10h);
+
 u16 hygon_nb_num(void)
 {
 	return nb_num;

--- a/arch/x86/kernel/amd_nb.c
+++ b/arch/x86/kernel/amd_nb.c
@@ -328,7 +328,8 @@ int get_df_id(struct pci_dev *misc, u8 *id)
 	u32 value;
 	int ret;
 
-	if (boot_cpu_data.x86_model == 0x6) {
+	if (boot_cpu_data.x86_model >= 0x6 &&
+	    boot_cpu_data.x86_model <= 0x7) {
 		/* F5x180[19:16]: DF ID */
 		ret = get_df_register(misc, 5, 0x180, &value);
 		*id = (value >> 16) & 0xf;

--- a/arch/x86/kernel/amd_nb.c
+++ b/arch/x86/kernel/amd_nb.c
@@ -466,8 +466,9 @@ err:
 	amd_northbridges.nb = NULL;
 
 ret:
-	pr_err("Hygon Fam%xh Model%xh northbridge init failed(%d)!\n",
-		boot_cpu_data.x86, boot_cpu_data.x86_model, err);
+	if (!boot_cpu_has(X86_FEATURE_HYPERVISOR))
+		pr_err("Hygon Fam%xh Model%xh northbridge init failed(%d)!\n",
+			boot_cpu_data.x86, boot_cpu_data.x86_model, err);
 	return err;
 }
 

--- a/arch/x86/kvm/svm/svm.h
+++ b/arch/x86/kvm/svm/svm.h
@@ -30,6 +30,8 @@
 #define	IOPM_SIZE PAGE_SIZE * 3
 #define	MSRPM_SIZE PAGE_SIZE * 2
 
+#define GUEST_PAT_WB_ATTR	0x0606060606060606
+
 #define MAX_DIRECT_ACCESS_MSRS	48
 #define MSRPM_OFFSETS	32
 extern u32 msrpm_offsets[MSRPM_OFFSETS] __read_mostly;

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -1130,7 +1130,12 @@ static int umc_normaddr_to_sysaddr(u64 norm_addr, u16 nid, u8 umc, u64 *sys_addr
 {
 	u64 dram_base_addr, dram_limit_addr, dram_hole_base;
 
-	u8 die_id_shift, die_id_mask, socket_id_shift, socket_id_mask;
+	u8 die_id_shift, socket_id_shift;
+#ifdef CONFIG_CPU_SUP_HYGON
+	u16 die_id_mask, socket_id_mask;
+#else
+	u8 die_id_mask, socket_id_mask;
+#endif
 	u8 intlv_num_dies, intlv_num_chan, intlv_num_sockets;
 	u8 intlv_addr_sel, intlv_addr_bit;
 	u8 num_intlv_bits, hashed_bit;
@@ -1245,7 +1250,12 @@ static int umc_normaddr_to_sysaddr(u64 norm_addr, u16 nid, u8 umc, u64 *sys_addr
 
 	if (num_intlv_bits > 0) {
 		u64 temp_addr_x, temp_addr_i, temp_addr_y;
-		u8 die_id_bit, sock_id_bit, cs_fabric_id;
+		u8 die_id_bit, sock_id_bit;
+#ifdef CONFIG_CPU_SUP_HYGON
+		u16 cs_fabric_id;
+#else
+		u8 cs_fabric_id;
+#endif
 
 		/*
 		 * Read FabricBlockInstanceInformation3_CS[BlockFabricID].

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -3160,8 +3160,8 @@ static void decode_umc_error(int node_id, struct mce *m)
 
 	pvt->ops->get_err_info(m, &err);
 
-	if (hygon_f18h_m4h() && boot_cpu_data.x86_model == 0x6)
-		umc = err.channel << 1;
+	if (hygon_f18h_m4h() && boot_cpu_data.x86_model >= 0x6)
+		umc = (err.channel << 1) + ((m->ipid & BIT(13)) >> 13);
 	else
 		umc = err.channel;
 

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -4209,6 +4209,9 @@ static int per_family_init(struct amd64_pvt *pvt)
 		} else if (pvt->model == 0x7) {
 			pvt->ctl_name			= "F18h_M07h";
 			break;
+		} else if (pvt->model == 0x8) {
+			pvt->ctl_name			= "F18h_M08h";
+			break;
 		} else if (pvt->model == 0x10) {
 			pvt->ctl_name			= "F18h_M10h";
 			break;

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -1906,7 +1906,9 @@ static void umc_determine_memory_type(struct amd64_pvt *pvt)
 		 * Check if the system supports the "DDR Type" field in UMC Config
 		 * and has DDR5 DIMMs in use.
 		 */
-		if ((pvt->flags.zn_regs_v2 || hygon_f18h_m4h()) &&
+		if ((pvt->flags.zn_regs_v2 ||
+		     hygon_f18h_m4h() ||
+		     hygon_f18h_m10h()) &&
 		    ((umc->umc_cfg & GENMASK(2, 0)) == 0x1)) {
 			if (umc->dimm_cfg & BIT(5))
 				umc->dram_type = MEM_LRDDR5;

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -3189,7 +3189,8 @@ static void decode_umc_error(int node_id, struct mce *m)
 
 	pvt->ops->get_err_info(m, &err);
 
-	if (hygon_f18h_m4h() && boot_cpu_data.x86_model >= 0x6)
+	if ((hygon_f18h_m4h() && boot_cpu_data.x86_model >= 0x6) ||
+	    hygon_f18h_m10h())
 		umc = (err.channel << 1) + ((m->ipid & BIT(13)) >> 13);
 	else
 		umc = err.channel;

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -1207,6 +1207,12 @@ static int umc_normaddr_to_sysaddr(u64 norm_addr, u16 nid, u8 umc, u64 *sys_addr
 
 	intlv_addr_bit = intlv_addr_sel + 8;
 
+	if (hygon_f18h_m4h() && boot_cpu_data.x86_model >= 0x6) {
+		if (df_indirect_read_instance(nid, 0, 0x60, umc, &ctx.tmp))
+			goto out_err;
+		intlv_num_dies = ctx.tmp & 0x3;
+	}
+
 	/* Re-use intlv_num_chan by setting it equal to log2(#channels) */
 	switch (intlv_num_chan) {
 	case 0:	intlv_num_chan = 0; break;

--- a/drivers/edac/amd64_edac.c
+++ b/drivers/edac/amd64_edac.c
@@ -1282,12 +1282,14 @@ static int umc_normaddr_to_sysaddr(u64 norm_addr, u16 nid, u8 umc, u64 *sys_addr
 			if (hygon_f18h_m4h()) {
 				die_id_shift = (ctx.tmp >> 12) & 0xF;
 				die_id_mask  = ctx.tmp & 0x7FF;
+				cs_id |= (((cs_fabric_id & die_id_mask) >> die_id_shift) - 4) <<
+						die_id_bit;
 			} else {
 				die_id_shift = (ctx.tmp >> 24) & 0xF;
 				die_id_mask  = (ctx.tmp >> 8) & 0xFF;
+				cs_id |= ((cs_fabric_id & die_id_mask) >> die_id_shift) <<
+						die_id_bit;
 			}
-
-			cs_id |= ((cs_fabric_id & die_id_mask) >> die_id_shift) << die_id_bit;
 		}
 
 		/* If interleaved over more than 1 socket. */

--- a/drivers/edac/mce_amd.c
+++ b/drivers/edac/mce_amd.c
@@ -168,6 +168,33 @@ static const char * const smca_ls_mce_desc[] = {
 	"L2 Fill Data error",
 };
 
+/* Hygon Model7h Scalable MCA LS error strings */
+static const char * const smca_ls_mce_hygon_desc[] = {
+	"Load queue parity error",
+	"Store queue parity error",
+	"Miss address buffer payload parity error",
+	"Level 1 TLB parity error",
+	"DC Tag error type 5",
+	"DC Tag error type 6",
+	"DC Tag error type 1",
+	"Internal error type 1",
+	"Internal error type 2",
+	"System Read Data Error 0",
+	"System Read Data Error 1",
+	"System Read Data Error 2",
+	"System Read Data Error 3",
+	"DC Tag error type 2",
+	"DC Data error type 1 and poison consumption",
+	"DC Data error type 2",
+	"DC Data error type 3",
+	"DC Tag error type 4",
+	"Level 2 TLB parity error",
+	"PDC parity error",
+	"DC Tag error type 3",
+	"DC Tag error type 5",
+	"L2 Fill Data error",
+};
+
 static const char * const smca_ls2_mce_desc[] = {
 	"An ECC error was detected on a data cache read by a probe or victimization",
 	"An ECC error or L2 poison was detected on a data cache read by a load",
@@ -206,6 +233,31 @@ static const char * const smca_if_mce_desc[] = {
 	"L2 ITLB Parity Error",
 	"BPQ Thread 0 Snoop Parity Error",
 	"BPQ Thread 1 Snoop Parity Error",
+	"L1 BTB Multi-Match Error",
+	"L2 BTB Multi-Match Error",
+	"L2 Cache Response Poison Error",
+	"System Read Data Error",
+	"Hardware Assertion Error",
+	"L1-TLB Multi-Hit",
+	"L2-TLB Multi-Hit",
+	"BSR Parity Error",
+	"CT MCE",
+};
+
+/* Hygon Model7h Scalable MCA IF error strings */
+static const char * const smca_if_mce_hygon_desc[] = {
+	"Op Cache Microtag Probe Port Parity Error",
+	"IC Microtag or Full Tag Multi-hit Error",
+	"IC Full Tag Parity Error",
+	"IC Data Array Parity Error",
+	"Decoupling Queue PhysAddr Parity Error",
+	"L0 ITLB Parity Error",
+	"L1 ITLB Parity Error",
+	"L2 ITLB Parity Error",
+	"BPQ 0 Snoop Parity Error",
+	"BPQ 1 Snoop Parity Error",
+	"BPQ 2 Snoop Parity Error",
+	"BPQ 3 Snoop Parity Error",
 	"L1 BTB Multi-Match Error",
 	"L2 BTB Multi-Match Error",
 	"L2 Cache Response Poison Error",
@@ -1432,6 +1484,16 @@ static int __init mce_amd_init(void)
 
 out:
 	pr_info("MCE: In-kernel MCE decoding enabled.\n");
+
+	if (c->x86_vendor == X86_VENDOR_HYGON &&
+	    c->x86_model >= 0x7 && c->x86_model <= 0xf) {
+		smca_mce_descs[SMCA_LS].descs = smca_ls_mce_hygon_desc;
+		smca_mce_descs[SMCA_LS].num_descs = ARRAY_SIZE(smca_ls_mce_hygon_desc);
+		smca_mce_descs[SMCA_IF].descs = smca_if_mce_hygon_desc;
+		smca_mce_descs[SMCA_IF].num_descs = ARRAY_SIZE(smca_if_mce_hygon_desc);
+		pr_info("MCE: Hygon Fam%xh Model%xh smca mce descs setup.\n",
+				c->x86, c->x86_model);
+	}
 
 	mce_register_decode_chain(&amd_mce_dec_nb);
 

--- a/drivers/iommu/amd/init.c
+++ b/drivers/iommu/amd/init.c
@@ -3045,7 +3045,7 @@ static bool __init check_ioapic_information(void)
 			   (boot_cpu_data.x86_vendor == X86_VENDOR_HYGON &&
 			    boot_cpu_data.x86 == 0x18 &&
 			    boot_cpu_data.x86_model >= 0x4 &&
-			    boot_cpu_data.x86_model <= 0xf &&
+			    boot_cpu_data.x86_model <= 0x10 &&
 			    devid == IOAPIC_SB_DEVID_FAM18H_M4H)) {
 			has_sb_ioapic = true;
 			ret           = true;

--- a/drivers/pinctrl/pinctrl-amd.c
+++ b/drivers/pinctrl/pinctrl-amd.c
@@ -1207,6 +1207,7 @@ static const struct acpi_device_id amd_gpio_acpi_match[] = {
 	{ "AMD0030", 0 },
 	{ "AMDI0030", 0},
 	{ "AMDI0031", 0},
+	{ "HYGO0030", 0},
 	{ },
 };
 MODULE_DEVICE_TABLE(acpi, amd_gpio_acpi_match);


### PR DESCRIPTION
[liaoxuan](https://gitcode.com/liaoxuan):
Update EDAC, NB, IOMMU, GPIO and KVM drivers for Hygon family 18h model 4h, 6h~8h and 10h processors.

Reference:
https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel/pulls/54
https://gitee.com/anolis/cloud-kernel/pulls/3366

Link: https://gitcode.com/deepin-community/kernel/pull/1

## Summary by Sourcery

Update drivers for Hygon family 18h model 4h, 6h-8h, and 10h processors.  This includes updates to EDAC, northbridge, IOMMU, GPIO, KVM, and performance monitoring drivers.  Additionally, update MCE error descriptions for Hygon Model 7h processors and add support for setting guest PAT to WB to improve performance in non-passthrough scenarios.

Enhancements:
- Update EDAC, NB, IOMMU, GPIO and KVM drivers to support Hygon family 18h model 4h, 6h, 7h, 8h, and 10h processors.
- Add support for setting guest PAT to WB in certain non-passthrough scenarios to improve performance.
- Update MCE error descriptions for Hygon Model 7h processors.