### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Backport] [Aspeed] [wxiat] drm/ast: Fix io access error when resuming from sleep

### DIFF
--- a/drivers/gpu/drm/ast/ast_drv.c
+++ b/drivers/gpu/drm/ast/ast_drv.c
@@ -138,6 +138,11 @@ static int ast_drm_freeze(struct drm_device *dev)
 
 static int ast_drm_thaw(struct drm_device *dev)
 {
+	struct ast_device *ast = to_ast_device(dev);
+
+	ast_enable_vga(dev);
+	ast_open_key(ast);
+	ast_enable_mmio(ast);
 	ast_post_gpu(dev);
 
 	return drm_mode_config_helper_resume(dev);

--- a/drivers/gpu/drm/ast/ast_drv.h
+++ b/drivers/gpu/drm/ast/ast_drv.h
@@ -340,6 +340,11 @@ static inline void ast_set_index_reg_mask(struct ast_device *ast, u32 base, u8 i
 	ast_set_index_reg(ast, base, index, tmp);
 }
 
+static inline void ast_open_key(struct ast_device *ast)
+{
+	ast_set_index_reg(ast, AST_IO_CRTC_PORT, 0x80, 0xA8);
+}
+
 #define AST_VIDMEM_SIZE_8M    0x00800000
 #define AST_VIDMEM_SIZE_16M   0x01000000
 #define AST_VIDMEM_SIZE_32M   0x02000000
@@ -518,6 +523,8 @@ int ast_mode_config_init(struct ast_device *ast);
 int ast_mm_init(struct ast_device *ast);
 
 /* ast post */
+void ast_enable_vga(struct drm_device *dev);
+int ast_enable_mmio(struct ast_device *ast);
 void ast_post_gpu(struct drm_device *dev);
 u32 ast_mindwm(struct ast_device *ast, u32 r);
 void ast_moutdwm(struct ast_device *ast, u32 r, u32 v);

--- a/drivers/gpu/drm/ast/ast_main.c
+++ b/drivers/gpu/drm/ast/ast_main.c
@@ -45,7 +45,7 @@ static bool ast_is_vga_enabled(struct drm_device *dev)
 	return !!(ch & 0x01);
 }
 
-static void ast_enable_vga(struct drm_device *dev)
+void ast_enable_vga(struct drm_device *dev)
 {
 	struct ast_device *ast = to_ast_device(dev);
 
@@ -65,7 +65,7 @@ static void ast_enable_mmio_release(void *data)
 	ast_set_index_reg(ast, AST_IO_CRTC_PORT, 0xa1, 0x04);
 }
 
-static int ast_enable_mmio(struct ast_device *ast)
+int ast_enable_mmio(struct ast_device *ast)
 {
 	struct drm_device *dev = &ast->base;
 
@@ -74,10 +74,6 @@ static int ast_enable_mmio(struct ast_device *ast)
 	return devm_add_action_or_reset(dev->dev, ast_enable_mmio_release, ast);
 }
 
-static void ast_open_key(struct ast_device *ast)
-{
-	ast_set_index_reg(ast, AST_IO_CRTC_PORT, 0x80, 0xA8);
-}
 
 static int ast_device_config_init(struct ast_device *ast)
 {


### PR DESCRIPTION
commit 12c35c5582acb0fd8f7713ffa75f450766022ff1 upstream.

Suspend will disable pcie device. Thus, resume should do full hw initialization again.
Add some APIs to ast_drm_thaw() before ast_post_gpu() to fix the issue.

v2:
- fix function-call arguments

Fixes: 5b71707dd13c ("drm/ast: Enable and unlock device access early during init")
Reported-by: Cary Garrett <cogarre@gmail.com>
Closes: https://lore.kernel.org/dri-devel/8ce1e1cc351153a890b65e62fed93b54ccd43f6a.camel@gmail.com/
Cc: Thomas Zimmermann <tzimmermann@suse.de>
Cc: Jocelyn Falempe <jfalempe@redhat.com>
Cc: Dave Airlie <airlied@redhat.com>
Cc: dri-devel@lists.freedesktop.org
Cc: <stable@vger.kernel.org> # v6.6+

Reviewed-by: Thomas Zimmermann <tzimmermann@suse.de>

Link: https://patchwork.freedesktop.org/patch/msgid/20240718030352.654155-1-jammy_huang@aspeedtech.com
[ wxiat: Redefine some APIs to fix compile error. ]

[ deepin: Backport - keep out-of-tree, unlikely to merge 6.6.y. ]

## Summary by Sourcery

Re-initialize the AST hardware after resuming from sleep. This fix addresses an IO access error that occurs when the PCIe device is disabled during suspend and not properly re-initialized upon resume.

Bug Fixes:
- Fix io access error when resuming from sleep by re-initializing the hardware after resuming from suspend and disabling the PCIe device.
- Fix compile error by redefining some APIs