### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Bugfix] [Glenfly] drm/arise: Conditional compile for specified archs.

### DIFF
--- a/drivers/gpu/drm/arise/Kconfig
+++ b/drivers/gpu/drm/arise/Kconfig
@@ -1,6 +1,7 @@
 config DRM_ARISE
 	tristate "Arise DRM"
 	default m
+	depends on ARM || LOONGARCH || MIPS || X86 || COMPILE_TEST
 	depends on DRM
 	select DRM_KMS_HELPER
 	help


### PR DESCRIPTION
The current driver is only compatible with ARM, LoongArch, MIPS and x86 architectures.

Non-conformant code style prevents compilation on other architectures.

Even if code changes are made to allow compilation, the resulting executable may not run as anticipated.

## Summary by Sourcery

Bug Fixes:
- Add conditional compilation to the DRM Arise driver to ensure compatibility with ARM, LoongArch, MIPS, and x86 architectures.