### PR TITLE
deepin: wifi: mt76: mt7921: add pci aspm probe log

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7921/pci.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/pci.c
@@ -339,6 +339,9 @@ static int mt7921_pci_probe(struct pci_dev *pdev,
 	if (!mt7921_disable_aspm && mt76_pci_aspm_supported(pdev))
 		dev->aspm_supported = true;
 
+	pr_info("mt7921_pci_probe: disable_aspm:%d,aspm_supported:%d\n",
+		mt7921_disable_aspm, dev->aspm_supported);
+
 	ret = mt792xe_mcu_fw_pmctrl(dev);
 	if (ret)
 		goto err_free_dev;


### PR DESCRIPTION
We met many platform relate issue, add the log to help tracking aspm bug.

## Summary by Sourcery

Enhancements:
- Added logging to the mt7921 PCI probe function to aid in debugging ASPM-related issues.