### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] pci/quirks: LS7A2000: Fix quirks runs on every platform

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -396,6 +396,8 @@ static void quirk_tigerpoint_bm_sts(struct pci_dev *dev)
 DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_TGP_LPC, quirk_tigerpoint_bm_sts);
 #endif
 
+#if defined(CONFIG_MACH_LOONGSON64)
+
 #define DEV_PCIE_PORT_4	0x7a39
 #define DEV_PCIE_PORT_5	0x7a49
 #define DEV_PCIE_PORT_6	0x7a59
@@ -425,6 +427,7 @@ static void loongson_d3_and_link_quirk(struct pci_dev *dev)
 	}
 }
 DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, loongson_d3_and_link_quirk);
+#endif
 
 /* Chipsets where PCI->PCI transfers vanish or hang */
 static void quirk_nopcipci(struct pci_dev *dev)


### PR DESCRIPTION
The quirk function be complied and run everywhere machine. 
I saw it that in my daliy test kernel initcall_debug log. 
As Kconfig MACH_LOONGSON64 say, limit quirks it by this config.

Fixes: 8f6b9680af3e ("pci/quirks: LS7A2000: Fix pm transition of devices under pcie port")

Log:
[    0.000000] microcode: updated early: 0x4111 -> 0x4123, date = 2024-05-29
[    0.000000] Linux version 6.6.78-g9460afe3d9ac (deepin@deepin-PC) (gcc (Deepin 12.3.0-17deepin8) 12.3.0, GNU ld (GNU Binutils for Deepin) 2.41) (9460afe3d) #4 SMP PREEMPT_DYNAMIC Sat Feb 22 17:18:35 CST 2025
........
[    1.147608] pci 0000:00:0d.0: calling  loongson_d3_and_link_quirk+0x0/0x80 @ 1
........
[    1.164242] pcieport 0000:00:06.0: calling  loongson_d3_and_link_quirk+0x0/0x80 @ 1
........
[    1.341470] nvme 0000:02:00.0: calling  loongson_d3_and_link_quirk+0x0/0x80 @ 160
........
[   21.330986] xhci_hcd 0000:00:0d.0: loongson_d3_and_link_quirk+0x0/0x80 took 0 usecs
## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the LS7A2000 PCIe port quirks were being applied on non-Loongson64 architectures, by limiting the quirks to the Loongson64 architecture.