### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] x86/cpufeatures: Make AVX-VNNI depend on AVX

### DIFF
--- a/arch/x86/kernel/cpu/cpuid-deps.c
+++ b/arch/x86/kernel/cpu/cpuid-deps.c
@@ -45,6 +45,7 @@ static const struct cpuid_dep cpuid_deps[] = {
 	{ X86_FEATURE_AES,			X86_FEATURE_XMM2      },
 	{ X86_FEATURE_SHA_NI,			X86_FEATURE_XMM2      },
 	{ X86_FEATURE_GFNI,			X86_FEATURE_XMM2      },
+	{ X86_FEATURE_AVX_VNNI,			X86_FEATURE_AVX       },
 	{ X86_FEATURE_FMA,			X86_FEATURE_AVX       },
 	{ X86_FEATURE_VAES,			X86_FEATURE_AVX       },
 	{ X86_FEATURE_VPCLMULQDQ,		X86_FEATURE_AVX       },


### PR DESCRIPTION
mainline inclusion
from mainline-v6.14-rc4
category: bugfix

The 'noxsave' boot option disables support for AVX, but support for the AVX-VNNI feature was still declared on CPUs that support it.  Fix this.



Cc: Dave Hansen <dave.hansen@linux.intel.com>
Link: https://lore.kernel.org/r/20250220060124.89622-1-ebiggers@kernel.org (cherry picked from commit 517120728484df1ab8b71cba8d2cad19f52f18a1)

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where AVX-VNNI was incorrectly enabled when AVX was disabled via the 'noxsave' boot option.