### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] CI: clang build kernel test in x86 and arm64

### DIFF
--- a/.github/workflows/build-kernel-arm64.yml
+++ b/.github/workflows/build-kernel-arm64.yml
@@ -33,3 +33,9 @@ jobs:
         with:
           name: Kernel-ABI-arm64
           path: "Module.symvers"
+
+      - name: 'Clang build kernel'
+        run: |
+          # .config
+          make LLVM=18 deepin_arm64_desktop_defconfig
+          make LLVM=18 -j$(nproc)

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -33,3 +33,9 @@ jobs:
         with:
           name: Kernel-ABI-x86-64
           path: "Module.symvers"
+
+      - name: "Clang build kernel"
+        run: |
+          # .config
+          make LLVM=18 deepin_x86_desktop_defconfig
+          make LLVM=18 -j$(nproc)


### PR DESCRIPTION
chore for github CI pipeline

## Summary by Sourcery

CI:
- Add a new CI job to build the kernel with clang for both x86-64 and arm64 architectures.