### PR TITLE
[Deepin-Kernel-SIG] [Upstream] [linux 6.6-y] Fixes: sched/fair: Simplify Util_est 

### DIFF
--- a/drivers/base/arch_topology.c
+++ b/drivers/base/arch_topology.c
@@ -344,6 +344,10 @@ bool __init topology_parse_cpu_capacity(struct device_node *cpu_node, int cpu)
 	return !ret;
 }
 
+void __weak freq_inv_set_max_ratio(int cpu, u64 max_rate)
+{
+}
+
 #ifdef CONFIG_ACPI_CPPC_LIB
 #include <acpi/cppc_acpi.h>
 
@@ -381,6 +385,9 @@ void topology_init_cpu_capacity_cppc(void)
 	}
 
 	for_each_possible_cpu(cpu) {
+		freq_inv_set_max_ratio(cpu,
+				       per_cpu(capacity_freq_ref, cpu) * HZ_PER_KHZ);
+
 		capacity = raw_capacity[cpu];
 		capacity = div64_u64(capacity << SCHED_CAPACITY_SHIFT,
 				     capacity_scale);
@@ -419,8 +426,11 @@ init_cpu_capacity_callback(struct notifier_block *nb,
 
 	cpumask_andnot(cpus_to_visit, cpus_to_visit, policy->related_cpus);
 
-	for_each_cpu(cpu, policy->related_cpus)
+	for_each_cpu(cpu, policy->related_cpus) {
 		per_cpu(capacity_freq_ref, cpu) = policy->cpuinfo.max_freq;
+		freq_inv_set_max_ratio(cpu,
+				       per_cpu(capacity_freq_ref, cpu) * HZ_PER_KHZ);
+	}
 
 	if (cpumask_empty(cpus_to_visit)) {
 		if (raw_capacity) {

--- a/include/linux/arch_topology.h
+++ b/include/linux/arch_topology.h
@@ -99,6 +99,7 @@ void update_siblings_masks(unsigned int cpu);
 void remove_cpu_topology(unsigned int cpuid);
 void reset_cpu_topology(void);
 int parse_acpi_topology(void);
+void freq_inv_set_max_ratio(int cpu, u64 max_rate);
 #endif
 
 #endif /* _LINUX_ARCH_TOPOLOGY_H_ */


### PR DESCRIPTION
#572 (merged after merge v6.6.75 )cherry-pick the patches from a patchset and stopped at 
cpufreq/cppc: Move and rename cppc_cpufreq_{perf_to_khz|khz_to_perf}()
it is not a break, it merged at 33e89c16cea0882bb05c585fa13236b730dd0efa in v6.6.59.
and cause capacity_freq_ref always init with 1.
https://github.com/deepin-community/kernel/pull/572/files#diff-33c1494c40c04818625c02eab2e170d8a37345e5703e60def7335b2623ff35feR30

merged the next two patches to fix the sched problem :
Ensure that amu_scale_freq_tick() will return SCHED_CAPACITY_SCALE until
the CPU capacity and its associated frequency have been correctly
initialized.
static DEFINE_PER_CPU_READ_MOSTLY(unsigned long, arch_max_freq_scale) =  1UL << (2 * SCHED_CAPACITY_SHIFT);

## Summary by Sourcery

Fixes CPU capacity initialization and scaling, ensuring correct frequency scaling by initializing CPU capacity and its associated frequency. It also ensures `amu_scale_freq_tick()` returns `SCHED_CAPACITY_SCALE` until the CPU capacity and its associated frequency have been correctly initialized.