### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] block: fix 'kmem_cache of name 'bio-108' already exists'

### DIFF
--- a/block/bio.c
+++ b/block/bio.c
@@ -78,7 +78,7 @@ struct bio_slab {
 	struct kmem_cache *slab;
 	unsigned int slab_ref;
 	unsigned int slab_size;
-	char name[8];
+	char name[12];
 };
 static DEFINE_MUTEX(bio_slab_lock);
 static DEFINE_XARRAY(bio_slabs);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.14-rc5
category: bugfix

Device mapper bioset often has big bio_slab size, which can be more than 1000, then 8byte can't hold the slab name any more, cause the kmem_cache allocation warning of 'kmem_cache of name 'bio-108' already exists'.

Fix the warning by extending bio_slab->name to 12 bytes, but fix output of /proc/slabinfo

Reported-by: Guangwu Zhang <guazhang@redhat.com>

Link: https://lore.kernel.org/r/20250228132656.2838008-1-ming.lei@redhat.com

(cherry picked from commit b654f7a51ffb386131de42aa98ed831f8c126546)

## Summary by Sourcery

Bug Fixes:
- Fixes kmem_cache allocation warning of 'kmem_cache of name 'bio-108' already exists' by extending bio_slab->name to 12 bytes.