### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Bugfix] [Glenfly] drm/arise: Recover ARM64 support

### DIFF
--- a/drivers/gpu/drm/arise/Kconfig
+++ b/drivers/gpu/drm/arise/Kconfig
@@ -1,7 +1,7 @@
 config DRM_ARISE
 	tristate "Arise DRM"
 	default m
-	depends on ARM || LOONGARCH || MIPS || X86 || COMPILE_TEST
+	depends on ARM64 || LOONGARCH || MIPS || X86 || COMPILE_TEST
 	depends on DRM
 	select DRM_KMS_HELPER
 	help


### PR DESCRIPTION
Commit 6add9b13fe6d ("drm/arise: Conditional compile for specified archs.") brokes Arise cards' ARM64 support.

Now recover it.

## Summary by Sourcery

Bug Fixes:
- Restores ARM64 support for Arise cards.