### PR TITLE
[6.6][bugfix]Hygon: Rename Hygon SM{3,4} feature macro to X86_FEATURE_HYGON_SM{3,4}

### DIFF
--- a/arch/x86/include/asm/cpufeatures.h
+++ b/arch/x86/include/asm/cpufeatures.h
@@ -495,8 +495,8 @@
 #define X86_FEATURE_ZXPAUSE            (22*32+ 0) /* ZHAOXIN ZXPAUSE */
 
 /* HYGON-defined CPU features, CPUID level 0x8c860000:0 (EDX), word 23 */
-#define X86_FEATURE_SM3			(23*32 + 1) /* SM3 instructions */
-#define X86_FEATURE_SM4			(23*32 + 2) /* SM4 instructions */
+#define X86_FEATURE_HYGON_SM3		(23*32 + 1) /* "sm3" SM3 instructions */
+#define X86_FEATURE_HYGON_SM4		(23*32 + 2) /* "sm4" SM4 instructions */
 
 /*
  * BUG word(s)


### PR DESCRIPTION
The upstream commit a0423af92cb3 ("x86: KVM: Advertise CPUIDs for new instructions in Clearwater Forest") has introduced the macros X86_FEATURE_SM3 and X86_FEATURE_SM4, which conflict with the non-upstreamed commit 4a0be8dc9e1f ("x86/cpufeatures: Add CPUID_8C86_0000_EDX CPUID leaf").

## Summary by Sourcery

Enhancements:
- Rename X86_FEATURE_SM3 and X86_FEATURE_SM4 to X86_FEATURE_HYGON_SM3 and X86_FEATURE_HYGON_SM4 respectively.