### PR TITLE
deepin: config: check-config.yml: make check for arm64

### DIFF
--- a/.github/workflows/check-config-arm64.yml
+++ b/.github/workflows/check-config-arm64.yml
@@ -1,0 +1,34 @@
+name: Check defconfig Consistency ARM64
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-defconfig:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bc build-essential zstd flex bison libssl-dev make libelf-dev git debhelper pahole libncurses-dev
+
+    - name: Backup original defconfig (ARM64)
+      run: |
+        cp arch/arm64/configs/deepin_arm64_desktop_defconfig defconfig.orig
+
+    - name: Generate new defconfig (ARM64)
+      run: |
+        make ARCH=arm64 deepin_arm64_desktop_defconfig
+        make ARCH=arm64 savedefconfig
+
+    - name: Compare defconfig files (ARM64)
+      run: |
+        if ! diff -u defconfig defconfig.orig; then
+          echo "::error:: deepin_arm64_desktop_defconfig 文件不一致，请执行 'make savedefconfig' 并提交更新"
+          exit 1
+        fi


### PR DESCRIPTION
chore: Check Config Consistency CI for arm64

## Summary by Sourcery

CI:
- Add a new CI workflow to check the consistency of the deepin_arm64_desktop_defconfig file for the ARM64 architecture.