### PR TITLE
AOSCOS: platform: x86: ideapad-laptop: add fixes for ThinkBook 14+ (2024 G6+)

### DIFF
--- a/drivers/platform/x86/ideapad-laptop.c
+++ b/drivers/platform/x86/ideapad-laptop.c
@@ -152,6 +152,7 @@ struct ideapad_private {
 		struct led_classdev led;
 		unsigned int last_brightness;
 	} kbd_bl;
+	bool suspended;
 };
 
 static bool no_bt_rfkill;
@@ -1101,6 +1102,8 @@ static const struct key_entry ideapad_keymap[] = {
 	{ KE_KEY,	0x27 | IDEAPAD_WMI_KEY, { KEY_HELP } },
 	/* Refresh Rate Toggle */
 	{ KE_KEY,	0x0a | IDEAPAD_WMI_KEY, { KEY_DISPLAYTOGGLE } },
+	/* Touchpad Toggle */
+	{ KE_KEY,  0x29 | IDEAPAD_WMI_KEY, { KEY_TOUCHPAD_TOGGLE } },
 
 	{ KE_END },
 };
@@ -1503,6 +1506,14 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
 	struct ideapad_private *priv = data;
 	unsigned long vpc1, vpc2, bit;
 
+	if (!data) {
+		acpi_handle_info(handle, "no data");
+		return;
+	}
+
+	if (priv->suspended)
+		return;
+
 	if (read_ec_data(handle, VPCCMD_R_VPC1, &vpc1))
 		return;
 
@@ -1548,6 +1559,7 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
 			ideapad_backlight_notify_power(priv);
 			break;
 		case KBD_BL_KBLC_CHANGED_EVENT:
+		case 0:
 		case 1:
 			/*
 			 * Some IdeaPads report event 1 every ~20
@@ -1557,8 +1569,6 @@ static void ideapad_acpi_notify(acpi_handle handle, u32 event, void *data)
 			 * backlight has changed.
 			 */
 			ideapad_kbd_bl_notify(priv);
-			break;
-		case 0:
 			ideapad_check_special_buttons(priv);
 			break;
 		default:
@@ -1757,6 +1767,8 @@ static const struct wmi_device_id ideapad_wmi_ids[] = {
 	{ "26CAB2E5-5CF1-46AE-AAC3-4A12B6BA50E6", &ideapad_wmi_context_esc }, /* Yoga 3 */
 	{ "56322276-8493-4CE8-A783-98C991274F5E", &ideapad_wmi_context_esc }, /* Yoga 700 */
 	{ "8FC0DE0C-B4E4-43FD-B0F3-8871711C1294", &ideapad_wmi_context_fn_keys }, /* Legion 5 */
+	{ "46f16367-fb9d-11ee-a4f6-40c2ba4a5625", &ideapad_wmi_context_esc }, /* ThinkBook 16+ 2024 IMH */
+	{ "077c4a1f-e344-11ee-a4f6-40c2ba413e67", &ideapad_wmi_context_esc }, /* ThinkBook 2024 AMD */
 	{},
 };
 MODULE_DEVICE_TABLE(wmi, ideapad_wmi_ids);
@@ -1929,10 +1941,19 @@ static int ideapad_acpi_resume(struct device *dev)
 	if (priv->dytc)
 		dytc_profile_refresh(priv);
 
+	priv->suspended = false;
+
+	return 0;
+}
+
+static int ideapad_acpi_suspended(struct device *dev)
+{
+	struct ideapad_private *priv = dev_get_drvdata(dev);
+	priv->suspended = true;
 	return 0;
 }
 #endif
-static SIMPLE_DEV_PM_OPS(ideapad_pm, NULL, ideapad_acpi_resume);
+static SIMPLE_DEV_PM_OPS(ideapad_pm, ideapad_acpi_suspended, ideapad_acpi_resume);
 
 static const struct acpi_device_id ideapad_device_ids[] = {
 	{"VPC2004", 0},


### PR DESCRIPTION
This is a patch taken from ideapad-laptop-tb2024g6plus in an attempt to incorporate these changes in the mainline kernel. This patch fixes the following issues:

- Laptop shuts down unexpectedly after closing the lid.
- The Fn-F5 combination shuts down or resets AMD models.
- Keyboard backlight status resets after waking up from S3 suspend.


Link: https://github.com/ty2/ideapad-laptop-tb2024g6plus/blob/6d934407981294d05a6a4e4ed0e59d3c6c964990/ideapad-laptop.patch


[Mingcong Bai: Resolved minor conflicts in
drivers/platform/x86/ideapad-laptop.c and reverted a scoped_guard() refactor. Also include a fix for bad if branch syntax.]

## Summary by Sourcery

Adds support for ThinkBook 14+ (2024 G6+) laptops, including fixes for unexpected shutdowns after closing the lid, Fn-F5 key combination issues, and keyboard backlight reset after S3 suspend.

New Features:
- Adds support for the touchpad toggle key.

Bug Fixes:
- Fixes an issue where the laptop shuts down unexpectedly after closing the lid.
- Fixes an issue where the Fn-F5 combination shuts down or resets AMD models.
- Fixes an issue where the keyboard backlight status resets after waking up from S3 suspend.
- Fixes a potential null pointer dereference in the ACPI notify handler.
- Avoids processing ACPI events while suspended.
- Fixes bad if branch syntax.