### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] wifi: rtw89: pci: treat first receiving part as first segment for 8922AE

### DIFF
--- a/drivers/net/wireless/realtek/rtw89/pci.h
+++ b/drivers/net/wireless/realtek/rtw89/pci.h
@@ -1039,7 +1039,8 @@
 #define RTW89_PCI_TXWD_NUM_MAX		512
 #define RTW89_PCI_TXWD_PAGE_SIZE	128
 #define RTW89_PCI_ADDRINFO_MAX		4
-#define RTW89_PCI_RX_BUF_SIZE		(11454 + 40) /* +40 for rtw89_rxdesc_long_v2 */
+/* +40 for rtw89_rxdesc_long_v2; +4 for rtw89_pci_rxbd_info */
+#define RTW89_PCI_RX_BUF_SIZE		(11454 + 40 + 4)
 
 #define RTW89_PCI_POLL_BDRAM_RST_CNT	100
 #define RTW89_PCI_MULTITAG		8
@@ -1297,6 +1298,7 @@ struct rtw89_pci_info {
 	enum mac_ax_io_rcy_tmr io_rcy_tmr;
 	bool rx_ring_eq_is_full;
 	bool check_rx_tag;
+	bool no_rxbd_fs;
 
 	u32 init_cfg_reg;
 	u32 txhci_en_bit;

--- a/drivers/net/wireless/realtek/rtw89/rtw8851be.c
+++ b/drivers/net/wireless/realtek/rtw89/rtw8851be.c
@@ -27,6 +27,7 @@ static const struct rtw89_pci_info rtw8851b_pci_info = {
 	.io_rcy_tmr		= MAC_AX_IO_RCY_ANA_TMR_6MS,
 	.rx_ring_eq_is_full	= false,
 	.check_rx_tag		= false,
+	.no_rxbd_fs		= false,
 
 	.init_cfg_reg		= R_AX_PCIE_INIT_CFG1,
 	.txhci_en_bit		= B_AX_TXHCI_EN,

--- a/drivers/net/wireless/realtek/rtw89/rtw8852ae.c
+++ b/drivers/net/wireless/realtek/rtw89/rtw8852ae.c
@@ -27,6 +27,7 @@ static const struct rtw89_pci_info rtw8852a_pci_info = {
 	.io_rcy_tmr		= MAC_AX_IO_RCY_ANA_TMR_6MS,
 	.rx_ring_eq_is_full	= false,
 	.check_rx_tag		= false,
+	.no_rxbd_fs		= false,
 
 	.init_cfg_reg		= R_AX_PCIE_INIT_CFG1,
 	.txhci_en_bit		= B_AX_TXHCI_EN,

--- a/drivers/net/wireless/realtek/rtw89/rtw8852bte.c
+++ b/drivers/net/wireless/realtek/rtw89/rtw8852bte.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
-/* Copyright(c) 2020-2022  Realtek Corporation
+/* Copyright(c) 2024  Realtek Corporation
  */
 
 #include <linux/module.h>
@@ -7,9 +7,15 @@
 
 #include "pci.h"
 #include "reg.h"
-#include "rtw8852b.h"
+#include "rtw8852bt.h"
 
-static const struct rtw89_pci_info rtw8852b_pci_info = {
+static const struct rtw89_pci_ssid_quirk rtw8852bt_pci_ssid_quirks[] = {
+	{RTW89_PCI_SSID(PCI_VENDOR_ID_REALTEK, 0xB520, 0x103C, 0x88E9, HP),
+	 .bitmap = BIT(RTW89_QUIRK_THERMAL_PROT_110C)},
+	{},
+};
+
+static const struct rtw89_pci_info rtw8852bt_pci_info = {
 	.gen_def		= &rtw89_pci_gen_ax,
 	.txbd_trunc_mode	= MAC_AX_BD_TRUNC,
 	.rxbd_trunc_mode	= MAC_AX_BD_TRUNC,
@@ -61,38 +67,36 @@ static const struct rtw89_pci_info rtw8852b_pci_info = {
 	.enable_intr		= rtw89_pci_enable_intr,
 	.disable_intr		= rtw89_pci_disable_intr,
 	.recognize_intrs	= rtw89_pci_recognize_intrs,
+
+	.ssid_quirks		= rtw8852bt_pci_ssid_quirks,
 };
 
-static const struct rtw89_driver_info rtw89_8852be_info = {
-	.chip = &rtw8852b_chip_info,
+static const struct rtw89_driver_info rtw89_8852bte_info = {
+	.chip = &rtw8852bt_chip_info,
 	.quirks = NULL,
 	.bus = {
-		.pci = &rtw8852b_pci_info,
+		.pci = &rtw8852bt_pci_info,
 	},
 };
 
-static const struct pci_device_id rtw89_8852be_id_table[] = {
+static const struct pci_device_id rtw89_8852bte_id_table[] = {
 	{
-		PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0xb852),
-		.driver_data = (kernel_ulong_t)&rtw89_8852be_info,
-	},
-	{
-		PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0xb85b),
-		.driver_data = (kernel_ulong_t)&rtw89_8852be_info,
+		PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0xb520),
+		.driver_data = (kernel_ulong_t)&rtw89_8852bte_info,
 	},
 	{},
 };
-MODULE_DEVICE_TABLE(pci, rtw89_8852be_id_table);
+MODULE_DEVICE_TABLE(pci, rtw89_8852bte_id_table);
 
-static struct pci_driver rtw89_8852be_driver = {
-	.name		= "rtw89_8852be",
-	.id_table	= rtw89_8852be_id_table,
+static struct pci_driver rtw89_8852bte_driver = {
+	.name		= "rtw89_8852bte",
+	.id_table	= rtw89_8852bte_id_table,
 	.probe		= rtw89_pci_probe,
 	.remove		= rtw89_pci_remove,
 	.driver.pm	= &rtw89_pm_ops,
 };
-module_pci_driver(rtw89_8852be_driver);
+module_pci_driver(rtw89_8852bte_driver);
 
 MODULE_AUTHOR("Realtek Corporation");
-MODULE_DESCRIPTION("Realtek 802.11ax wireless 8852BE driver");
+MODULE_DESCRIPTION("Realtek 802.11ax wireless 8852BE-VT driver");
 MODULE_LICENSE("Dual BSD/GPL");

--- a/drivers/net/wireless/realtek/rtw89/rtw8852ce.c
+++ b/drivers/net/wireless/realtek/rtw89/rtw8852ce.c
@@ -36,6 +36,7 @@ static const struct rtw89_pci_info rtw8852c_pci_info = {
 	.io_rcy_tmr		= MAC_AX_IO_RCY_ANA_TMR_6MS,
 	.rx_ring_eq_is_full	= false,
 	.check_rx_tag		= false,
+	.no_rxbd_fs		= false,
 
 	.init_cfg_reg		= R_AX_HAXI_INIT_CFG1,
 	.txhci_en_bit		= B_AX_TXHCI_EN_V1,

--- a/drivers/net/wireless/realtek/rtw89/rtw8922ae.c
+++ b/drivers/net/wireless/realtek/rtw89/rtw8922ae.c
@@ -27,6 +27,7 @@ static const struct rtw89_pci_info rtw8922a_pci_info = {
 	.io_rcy_tmr		= MAC_AX_IO_RCY_ANA_TMR_DEF,
 	.rx_ring_eq_is_full	= true,
 	.check_rx_tag		= true,
+	.no_rxbd_fs		= true,
 
 	.init_cfg_reg		= R_BE_HAXI_INIT_CFG1,
 	.txhci_en_bit		= B_BE_TXDMA_EN,


### PR DESCRIPTION
mainline inclusion
from mainline-v6.14-rc1
category: bugfix

For early chips, the RX BD info contains FS/LS bits for first/last segments of a receiving packet. For 8922AE, the FS bit should be ignored, or it may throw warning:

  rtw89_8922ae 0000:1a:00.0: skb should not be ready before first segment start

To have compatible logic, FS determined by what pending skb is existing (!new) or not.

Since we expect every single receiving packet in single one segment, enlarge 4 bytes for RX BD info, and add a debug message to note if RX buffer is possibly smaller than expected size.

Signed-off-by: Ping-Ke Shih <pkshih@realtek.com>
Link: https://patch.msgid.link/20250103025126.15378-1-pkshih@realtek.com (cherry picked from commit 6ab452d458fd060644ce62c604baa2fe444a6822)
Signed-off-by: Hao Li <lihao1@uniontech.com>
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

Conflicts:
	drivers/net/wireless/realtek/rtw89/rtw8852bte.c

## Summary by Sourcery

Fixes an issue with Realtek 8922AE chips where the FS bit in the RX BD info could cause warnings. The fix ignores the FS bit for these chips and adjusts the RX buffer size. Also adds a new driver for Realtek 8852BTE devices.

New Features:
- Adds a new driver for Realtek 8852BTE devices.

Bug Fixes:
- Fixes a warning caused by the FS bit in the RX BD info for Realtek 8922AE chips by ignoring the FS bit.
- Increase RX buffer size to accommodate RX BD info for single segment packets.
- Add a debug message to indicate when the RX buffer is smaller than expected