### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] Bluetooth: mediatek: use module param to disable isopkt by default

### DIFF
--- a/drivers/bluetooth/btmtk.c
+++ b/drivers/bluetooth/btmtk.c
@@ -24,6 +24,7 @@
 
 /* It is for mt79xx iso data transmission setting */
 #define MTK_ISO_THRESHOLD	264
+static bool enable_isopkt = 0;
 
 struct btmtk_patch_header {
 	u8 datetime[16];
@@ -1375,7 +1376,7 @@ int btmtk_usb_setup(struct hci_dev *hdev)
 		hci_set_aosp_capable(hdev);
 
 		/* Set up ISO interface after protocol enabled */
-		if (test_bit(BTMTK_ISOPKT_OVER_INTR, &btmtk_data->flags)) {
+		if (enable_isopkt && test_bit(BTMTK_ISOPKT_OVER_INTR, &btmtk_data->flags)) {
 			if (!btmtk_usb_isointf_init(hdev))
 				set_bit(BTMTK_ISOPKT_RUNNING, &btmtk_data->flags);
 		}
@@ -1501,6 +1502,8 @@ int btmtk_usb_shutdown(struct hci_dev *hdev)
 EXPORT_SYMBOL_GPL(btmtk_usb_shutdown);
 #endif
 
+module_param(enable_isopkt, bool, 0644);
+MODULE_PARM_DESC(enable_isopkt, "Enable isopkt by default");
 MODULE_AUTHOR("Sean Wang <sean.wang@mediatek.com>");
 MODULE_AUTHOR("Mark Chen <mark-yw.chen@mediatek.com>");
 MODULE_DESCRIPTION("Bluetooth support for MediaTek devices ver " VERSION);


### PR DESCRIPTION
close the feature by default for it break mt7921u init flow.

Test in kernel 6.12.y
Log:
3月 15 17:00:19 uos-PC kernel: Bluetooth: hci0: Failed to read MSFT supported features (-110) 3月 15 17:00:20 uos-PC kernel: xe 0000:00:02.0: [drm] *ERROR* Atomic update failure on pipe A (start=57761 end=57762) time 139 us, min 1778, max 1799, scanline start 1769, end 1791 3月 15 17:00:21 uos-PC kernel: Bluetooth: hci0: AOSP get vendor capabilities (-110) 3月 15 17:00:21 uos-PC kernel: usb 4-1: reset SuperSpeed USB device number 8 using xhci_hcd 3月 15 17:00:21 uos-PC kernel: mt7921u 4-1:1.3: HW/SW Version: 0x8a108a10, Build Time: 20241106151007a 3月 15 17:00:21 uos-PC kernel: mt7921u 4-1:1.3: WM Firmware Version: ____010000, Build Time: 20241106151045 3月 15 17:00:21 uos-PC kernel: Bluetooth: hci0: HW/SW Version: 0x008a008a, Build Time: 20241106151414 3月 15 17:00:23 uos-PC kernel: mt7921u 4-1:1.3 wlxe0e1a935c9c9: renamed from wlan0 3月 15 17:00:26 uos-PC kernel: Bluetooth: hci0: command 0xfd98 tx timeout 3月 15 17:00:26 uos-PC kernel: Bluetooth: hci0: Failed to apply iso setting (-110) 3月 15 17:00:26 uos-PC kernel: Bluetooth: hci0: Device setup in 4145932 usecs 3月 15 17:00:26 uos-PC kernel: Bluetooth: hci0: HCI Enhanced Setup Synchronous Connection command is advertised, but not supported. 3月 15 17:00:28 uos-PC kernel: Bluetooth: hci0: Opcode 0x0c03 failed: -110 3月 15 17:00:30 uos-PC kernel: Bluetooth: hci0: Failed to read MSFT supported features (-110) 3月 15 17:00:32 uos-PC kernel: Bluetooth: hci0: AOSP get vendor capabilities (-110) 3月 15 17:00:32 uos-PC kernel: usb 4-1: reset SuperSpeed USB device number 8 using xhci_hcd 3月 15 17:00:32 uos-PC kernel: mt7921u 4-1:1.3: HW/SW Version: 0x8a108a10, Build Time: 20241106151007a 3月 15 17:00:32 uos-PC kernel: mt7921u 4-1:1.3: WM Firmware Version: ____010000, Build Time: 20241106151045 3月 15 17:00:32 uos-PC kernel: Bluetooth: hci0: HW/SW Version: 0x008a008a, Build Time: 20241106151414 3月 15 17:00:34 uos-PC kernel: mt7921u 4-1:1.3 wlxe0e1a935c9c9: renamed from wlan0 3月 15 17:00:36 uos-PC kernel: Bluetooth: hci0: command 0xfd98 tx timeout 3月 15 17:00:36 uos-PC kernel: Bluetooth: hci0: Failed to apply iso setting (-110) 3月 15 17:00:36 uos-PC kernel: Bluetooth: hci0: Device setup in 4143932 usecs 3月 15 17:00:36 uos-PC kernel: Bluetooth: hci0: HCI Enhanced Setup Synchronous Connection command is advertised, but not supported. 3月 15 17:00:38 uos-PC kernel: Bluetooth: hci0: Opcode 0x0c03 failed: -110 3月 15 17:00:40 uos-PC kernel: Bluetooth: hci0: Failed to read MSFT supported features (-110) 3月 15 17:00:42 uos-PC kernel: Bluetooth: hci0: AOSP get vendor capabilities (-110) 3月 15 17:00:43 uos-PC kernel: usb 4-1: reset SuperSpeed USB device number 8 using xhci_hcd 3月 15 17:00:43 uos-PC kernel: mt7921u 4-1:1.3: HW/SW Version: 0x8a108a10, Build Time: 20241106151007a 3月 15 17:00:43 uos-PC kernel: mt7921u 4-1:1.3: WM Firmware Version: ____010000, Build Time: 20241106151045 3月 15 17:00:43 uos-PC kernel: Bluetooth: hci0: HW/SW Version: 0x008a008a, Build Time: 20241106151414 3月 15 17:00:44 uos-PC kernel: mt7921u 4-1:1.3 wlxe0e1a935c9c9: renamed from wlan0 3月 15 17:00:47 uos-PC kernel: Bluetooth: hci0: command 0xfd98 tx timeout 3月 15 17:00:47 uos-PC kernel: Bluetooth: hci0: Failed to apply iso setting (-110) 3月 15 17:00:47 uos-PC kernel: Bluetooth: hci0: Device setup in 4104912 usecs 3月 15 17:00:47 uos-PC kernel: Bluetooth: hci0: HCI Enhanced Setup Synchronous Connection command is advertised, but not supported. 3月 15 17:00:49 uos-PC kernel: Bluetooth: hci0: Opcode 0x0c03 failed: -110 3月 15 17:00:51 uos-PC kernel: Bluetooth: hci0: Failed to read MSFT supported features (-110) 3月 15 17:00:53 uos-PC kernel: Bluetooth: hci0: AOSP get vendor capabilities (-110) 3月 15 17:00:54 uos-PC kernel: usb 4-1: reset SuperSpeed USB device number 8 using xhci_hcd 3月 15 17:00:54 uos-PC kernel: mt7921u 4-1:1.3: HW/SW Version: 0x8a108a10, Build Time: 20241106151007a 3月 15 17:00:54 uos-PC kernel: mt7921u 4-1:1.3: WM Firmware Version: ____010000, Build Time: 20241106151045 3月 15 17:00:54 uos-PC kernel: Bluetooth: hci0: HW/SW Version: 0x008a008a, Build Time: 20241106151414 3月 15 17:00:55 uos-PC kernel: mt7921u 4-1:1.3 wlxe0e1a935c9c9: renamed from wlan0 3月 15 17:00:58 uos-PC kernel: Bluetooth: hci0: command 0xfd98 tx timeout 3月 15 17:00:58 uos-PC kernel: Bluetooth: hci0: Failed to apply iso setting (-110) 3月 15 17:00:58 uos-PC kernel: Bluetooth: hci0: Device setup in 4188859 usecs 3月 15 17:00:58 uos-PC kernel: Bluetooth: hci0: HCI Enhanced Setup Synchronous Connection command is advertised, but not supported. 3月 15 17:01:00 uos-PC kernel: Bluetooth: hci0: Opcode 0x0c03 failed: -110 3月 15 17:01:02 uos-PC kernel: Bluetooth: hci0: Failed to read MSFT supported features (-110)

## Summary by Sourcery

Disable the Bluetooth isopkt feature by default for MediaTek devices to prevent issues during device initialization. A module parameter is added to allow enabling the feature.