### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] smb: client: fix regression with guest option

### DIFF
--- a/fs/smb/client/fs_context.c
+++ b/fs/smb/client/fs_context.c
@@ -162,6 +162,7 @@ const struct fs_parameter_spec smb3_fs_parameters[] = {
 	fsparam_string("username", Opt_user),
 	fsparam_string("pass", Opt_pass),
 	fsparam_string("password", Opt_pass),
+	fsparam_string("pass2", Opt_pass2),
 	fsparam_string("password2", Opt_pass2),
 	fsparam_string("ip", Opt_ip),
 	fsparam_string("addr", Opt_ip),
@@ -1041,6 +1042,9 @@ static int smb3_fs_context_parse_param(struct fs_context *fc,
 		} else if (!strcmp("user", param->key) || !strcmp("username", param->key)) {
 			skip_parsing = true;
 			opt = Opt_user;
+		} else if (!strcmp("pass2", param->key) || !strcmp("password2", param->key)) {
+			skip_parsing = true;
+			opt = Opt_pass2;
 		}
 	}
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.14-rc7
category: bugfix

When mounting a CIFS share with 'guest' mount option, mount.cifs(8) will set empty password= and password2= options.  Currently we only handle empty strings from user= and password= options, so the mount will fail with

	cifs: Bad value for 'password2'

Fix this by handling empty string from password2= option as well.

Link: https://bbs.archlinux.org/viewtopic.php?id=303927
Reported-by: Adam Williamson <awilliam@redhat.com>
Closes: https://lore.kernel.org/r/83c00b5fea81c07f6897a5dd3ef50fd3b290f56c.camel@redhat.com
Fixes: 35f834265e0d ("smb3: fix broken reconnect when password changing on the server by allowing password rotation")
Cc: stable@vger.kernel.org


(cherry picked from commit fc99045effa81fdf509c2a97cbb7e6e8f2fd4443)

## Summary by Sourcery

Bug Fixes:
- Fixes a regression when mounting a CIFS share with the 'guest' option that caused mount failures due to an unhandled empty password2= option.