### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] sched: idle: Optimize the generic idle loop by removing needless memo…

### DIFF
--- a/kernel/sched/idle.c
+++ b/kernel/sched/idle.c
@@ -256,7 +256,6 @@ static void do_idle(void)
 	tick_nohz_idle_enter();
 
 	while (!need_resched()) {
-		rmb();
 
 		local_irq_disable();
 


### PR DESCRIPTION
…ry barrier

mainline inclusion
from mainline-v6.13-rc1
category: performance

The memory barrier rmb() in generic idle loop do_idle() function is not needed, it doesn't order any load instruction, just remove it as needless rmb() can cause performance impact.

The rmb() was introduced by the tglx/history.git commit f2f1b44c75c4 ("[PATCH] Remove RCU abuse in cpu_idle()") to order the loads between cpu_idle_map and pm_idle. It pairs with wmb() in function cpu_idle_wait().

And then with the removal of cpu_idle_state in function cpu_idle() and wmb() in function cpu_idle_wait() in commit 783e391b7b5b ("x86: Simplify cpu_idle_wait"), rmb() no longer has a reason to exist.

After that, commit d16699123434 ("idle: Implement generic idle function") implemented a generic idle function cpu_idle_loop() which resembles the functionality found in arch/. And it retained the rmb() in generic idle loop in file kernel/cpu/idle.c.

And at last, commit cf37b6b48428 ("sched/idle: Move cpu/idle.c to sched/idle.c") moved cpu/idle.c to sched/idle.c. And commit c1de45ca831a ("sched/idle: Add support for tasks that inject idle") renamed function cpu_idle_loop() to do_idle().

History Tree: https://git.kernel.org/pub/scm/linux/kernel/git/tglx/history.git
Signed-off-by: Zhongqiu Han <quic_zhonhan@quicinc.com>
Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Link: https://lkml.kernel.org/r/20241009093745.9504-1-quic_zhonhan@quicinc.com (cherry picked from commit 8e113df990c9df70fc6d83ebd53ee1b2867c23c4)
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

## Summary by Sourcery

Enhancements:
- Remove the memory barrier rmb() in the generic idle loop function do_idle() as it is no longer needed and can negatively impact performance.