### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] objtool: Ignore dangling jump table entries

### DIFF
--- a/tools/objtool/check.c
+++ b/tools/objtool/check.c
@@ -2079,14 +2079,6 @@ static int add_jump_table(struct objtool_file *file, struct instruction *insn,
 		if (reloc->sym->sec == pfunc->sec && offset == pfunc->offset)
 			break;
 
-		/*
-		 * Clang sometimes leaves dangling unused jump table entries
-		 * which point to the end of the function.  Ignore them.
-		 */
-		if (reloc->sym->sec == pfunc->sec &&
-		    reloc_addend(reloc) == pfunc->offset + pfunc->len)
-			goto next;
-
 		dest_insn = find_insn(file, reloc->sym->sec, offset);
 		if (!dest_insn)
 			break;
@@ -2111,7 +2103,6 @@ static int add_jump_table(struct objtool_file *file, struct instruction *insn,
 		alt->insn = dest_insn;
 		alt->next = insn->alts;
 		insn->alts = alt;
-next:
 		prev_offset = reloc_offset(reloc);
 	}
 

--- a/tools/objtool/check.c
+++ b/tools/objtool/check.c
@@ -2079,6 +2079,14 @@ static int add_jump_table(struct objtool_file *file, struct instruction *insn,
 		if (reloc->sym->sec == pfunc->sec && offset == pfunc->offset)
 			break;
 
+		/*
+		 * Clang sometimes leaves dangling unused jump table entries
+		 * which point to the end of the function.  Ignore them.
+		 */
+		if (reloc->sym->sec == pfunc->sec &&
+		    offset == pfunc->offset + pfunc->len)
+			goto next;
+
 		dest_insn = find_insn(file, reloc->sym->sec, offset);
 		if (!dest_insn)
 			break;
@@ -2103,6 +2111,7 @@ static int add_jump_table(struct objtool_file *file, struct instruction *insn,
 		alt->insn = dest_insn;
 		alt->next = insn->alts;
 		insn->alts = alt;
+next:
 		prev_offset = reloc_offset(reloc);
 	}
 


### PR DESCRIPTION
Revert "objtool: Ignore dangling jump table entries"

This reverts commit 8a69697eb9d9d194ea90b1bb89fb97f6661f6f5a.
It has a small context change need to be handle.

Reapply: objtool: Ignore dangling jump table entries

[ Upstream commit 3724062ca2b1364f02cf44dbea1a552227844ad1 ]

Clang sometimes leaves dangling unused jump table entries which point to
the end of the function.  Ignore them.

Closes: https://lore.kernel.org/20250113235835.vqgvb7cdspksy5dn@jpoimboe
Reported-by: Klaus Kusche <klaus.kusche@computerix.info>
Signed-off-by: Josh Poimboeuf <jpoimboe@kernel.org>
Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Link: https://lkml.kernel.org/r/ee25c0b7e80113e950bd1d4c208b671d35774ff4.1736891751.git.jpoimboe@kernel.org
Signed-off-by: Sasha Levin <sashal@kernel.org>
(cherry picked from commit 5b1c48532f71630a9e462dc7d3624bd70bb7446f)
Conflicts:
            tools/objtool/check.c
[Handle 765ecc2:("objtool: Handle various symbol types of rodata")]
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where clang sometimes leaves dangling unused jump table entries.