### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [CIX] Kconfig: add arm64 depends for CIX

### DIFF
--- a/drivers/clk/cix/Kconfig
+++ b/drivers/clk/cix/Kconfig
@@ -8,6 +8,7 @@ config COMMON_CLK_CIX
 	tristate "Support for Cix's clock controllers"
 	select REGMAP_MMIO
 	select RESET_CONTROLLER
+	depends on ARM64 || COMPILE_TEST
 	help
 	  Say y here to enable common clock controller for Cix platforms.
 

--- a/drivers/gpu/drm/cix/Kconfig
+++ b/drivers/gpu/drm/cix/Kconfig
@@ -4,6 +4,7 @@ config DRM_CIX
 	select DRM_KMS_HELPER
 	select VIDEOMODE_HELPERS
 	select DRM_GEM_DMA_HELPER
+	depends on ARM64 || COMPILE_TEST
 	depends on DRM
 	help
 	  enable CiX DRM display support

--- a/drivers/phy/cix/Kconfig
+++ b/drivers/phy/cix/Kconfig
@@ -6,6 +6,7 @@
 config PHY_CIX_USBDP
 	tristate "Cix USBDP PHY Driver"
 	depends on OF && HAS_IOMEM
+	depends on ARM64 || COMPILE_TEST
 	select GENERIC_PHY
 	help
 	  Enable this to support the CIX USBDP PHY for TYPEC Connection
@@ -13,6 +14,7 @@ config PHY_CIX_USBDP
 config PHY_CIX_USB2
 	tristate "Cix USB2 PHY Driver"
 	depends on OF
+	depends on ARM64 || COMPILE_TEST
 	select GENERIC_PHY
 	help
 	  Enable this to support the CIX USB2 PHY
@@ -20,6 +22,7 @@ config PHY_CIX_USB2
 config PHY_CIX_USB3
 	tristate "Cix USB3 PHY Driver"
 	depends on OF && HAS_IOMEM
+	depends on ARM64 || COMPILE_TEST
 	select GENERIC_PHY
 	help
 	  Enable this to support the CIX USB3 PHY for TYPEA Connection

--- a/drivers/remoteproc/Kconfig
+++ b/drivers/remoteproc/Kconfig
@@ -368,6 +368,7 @@ config XLNX_R5_REMOTEPROC
 config CIX_DSP_REMOTEPROC
 	tristate "CIX DSP remoteproc support"
 	depends on MAILBOX
+	depends on ARM64 || COMPILE_TEST
 	help
 	  Say y here to support CIX DSP remote processor framework.
 

--- a/drivers/soc/cix/Kconfig
+++ b/drivers/soc/cix/Kconfig
@@ -3,6 +3,7 @@ menu "Cix Dst drivers"
 
 config SOC_CIX
 	bool "Cix Sky SoC family support"
+	depends on ARM64 || COMPILE_TEST
 	default n
 	help
 	  If you say yes here you get support for the Cix sky family
@@ -11,6 +12,7 @@ config SOC_CIX
 
 config CIX_SKY1_SOCINFO
 	bool "Cix Sky1 SoC Information driver"
+	depends on ARM64 || COMPILE_TEST
 	select SOC_BUS
 	help
 	  Say yes to support decoding of CIX Sky1 SoC family information
@@ -18,6 +20,7 @@ config CIX_SKY1_SOCINFO
 
 config CIX_SOC_ACPI
 	bool "Cix SoC ACPI drivers"
+	depends on ARM64 || COMPILE_TEST
 	depends on ACPI
 	select SOC_BUS
 	help

--- a/drivers/usb/cdns3/Kconfig
+++ b/drivers/usb/cdns3/Kconfig
@@ -26,6 +26,7 @@ config USB_CDNS3
 config USB_CDNSP_CIX
        bool "Cadence USBSSP Dual-Role Controller for Cix platform"
        depends on USB_CDNS_SUPPORT
+	   depends on ARM64 || COMPILE_TEST
        help
          Say Y here if your system has a Cadence USBSSP dual-role controller.
          It supports: dual-role switch, Host-only, and Peripheral-only.

--- a/sound/soc/cix/Kconfig
+++ b/sound/soc/cix/Kconfig
@@ -6,6 +6,7 @@ comment "ASoC options for Cixtech CPUs:"
 config SND_SOC_CIX
 	tristate "CIX ASoC"
 	imply SND_SOC_RT5682S
+	depends on ARM64 || COMPILE_TEST
 	default n
 	help
 	  Select Y or M to add support for CIX sound card
@@ -14,6 +15,7 @@ config SND_SOC_CIX
 config SND_SOC_CDNS_I2S_SC_CIX
 	tristate "Cadence I2S-SC Controller Driver"
 	select SND_SOC_GENERIC_DMAENGINE_PCM
+	depends on ARM64 || COMPILE_TEST
 	help
 	  Say Y or M if you want to add driver support for Cadence
 	  I2S-SC (SingleChannel) controller.
@@ -21,6 +23,7 @@ config SND_SOC_CDNS_I2S_SC_CIX
 config SND_SOC_CDNS_I2S_MC_CIX
 	tristate "Cadence I2S-MC Controller Driver"
 	select SND_SOC_GENERIC_DMAENGINE_PCM
+	depends on ARM64 || COMPILE_TEST
 	help
 	  Say Y or M if you want to add driver support for Cadence
 	  I2S-MC (MultiChannel) controller.
@@ -30,12 +33,14 @@ config SND_SOC_IPBLOQ_HDA_CIX
 	select SND_HDA_CORE
 	select SND_HDA_EXT_CORE
 	select SND_HDA_ALIGNED_MMIO
+	depends on ARM64 || COMPILE_TEST
 	help
 	  Say Y or M if you want add support for ipbloq hda
 
 config SND_HDACODEC_REALTEK_CIX
-        tristate "Build Realtek HD-audio codec support"
+	tristate "Build Realtek HD-audio codec support"
 	depends on SND_SOC_IPBLOQ_HDA_CIX
+	depends on ARM64 || COMPILE_TEST
         help
           Say Y or M here to include Realtek HD-audio codec support in
           snd-soc-hda driver, such as ALC256.


### PR DESCRIPTION
## Summary by Sourcery

Add arm64 dependencies for CIX.