### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] wifi: iwlwifi: mvm: fix a battery life regression

### DIFF
--- a/drivers/net/wireless/intel/iwlwifi/fw/api/debug.h
+++ b/drivers/net/wireless/intel/iwlwifi/fw/api/debug.h
@@ -531,7 +531,7 @@ enum iwl_fw_dbg_config_cmd_type {
 }; /* LDBG_CFG_CMD_TYPE_API_E_VER_1 */
 
 /* this token disables debug asserts in the firmware */
-#define IWL_FW_DBG_CONFIG_TOKEN 0x00011301
+#define IWL_FW_DBG_CONFIG_TOKEN 0x00010001
 
 /**
  * struct iwl_fw_dbg_config_cmd - configure FW debug


### PR DESCRIPTION
mainline inclusion
from mainline-v6.8-rc4
category: bugfix

Fix the DBG_CONFIG_TOKEN to not enable debug components that would prevent the device to save power.

Fixes: fc2fe0a5e856 ("wifi: iwlwifi: fw: disable firmware debug asserts")
Cc: stable@vger.kernel.org

Reviewed-by: Eilon Rinat <eilon.rinat@intel.com>
Reviewed-by: Gregory Greenman <gregory.greenman@intel.com>

Link: https://msgid.link/20240128084842.90d2600edc27.Id657ea2f0ddb131f5f9d0ac39aeb8c88754fe54b@changeid

(cherry picked from commit 1fa942f31665ea5dc5d4d95893dd13723eaa97cc)

## Summary by Sourcery

Bug Fixes:
- Corrects the IWL_FW_DBG_CONFIG_TOKEN value to prevent unintended enabling of debug components that negatively impact power saving.