### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [CIX] [Phytium] [AOSC] Fix compiler errors when "make allyesconfig" on x86

### DIFF
--- a/drivers/clk/cix/clk-sky1-audss.c
+++ b/drivers/clk/cix/clk-sky1-audss.c
@@ -2,6 +2,7 @@
 // Copyright 2024 Cix Technology Group Co., Ltd.
 
 #include <linux/acpi.h>
+#include <linux/bitfield.h>
 #include <linux/clk.h>
 #include <linux/clk-provider.h>
 #include <linux/delay.h>
@@ -19,6 +20,7 @@
 #include <linux/clk-provider.h>
 
 #include <dt-bindings/clock/sky1-audss.h>
+
 #include "acpi_clk.h"
 
 #define INFO_HIFI0		0x00

--- a/drivers/clk/cix/clk.c
+++ b/drivers/clk/cix/clk.c
@@ -8,6 +8,8 @@
 #include <linux/err.h>
 #include <linux/module.h>
 #include <linux/of.h>
+#include <linux/slab.h>
+
 #include "clk.h"
 
 #ifndef MODULE

--- a/drivers/gpu/drm/cix/dptx/trilin_dptx.c
+++ b/drivers/gpu/drm/cix/dptx/trilin_dptx.c
@@ -32,6 +32,7 @@
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/device.h>
+#include <linux/irq.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/pm_runtime.h>

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_crtc.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_crtc.c
@@ -124,7 +124,6 @@ static int linlondp_crtc_prepare(struct linlondp_crtc *kcrtc)
 	struct linlondp_dev *mdev = kcrtc->base.dev->dev_private;
 	struct linlondp_pipeline *master = kcrtc->master;
 	struct linlondp_crtc_state *kcrtc_st = to_kcrtc_st(kcrtc->base.state);
-	struct drm_display_mode *mode = &kcrtc_st->base.adjusted_mode;
 	u32 new_mode;
 	int err;
 
@@ -161,6 +160,8 @@ static int linlondp_crtc_prepare(struct linlondp_crtc *kcrtc)
 #endif
 	}
 #if !IS_ENABLED(CONFIG_DRM_LINLONDP_CLOCK_FIXED)
+	struct drm_display_mode *mode = &kcrtc_st->base.adjusted_mode;
+
 	err = clk_set_rate(master->pxlclk, mode->crtc_clock * 1000);
 	if (err)
 		DRM_ERROR("failed to set pxlclk for pipe%d\n", master->id);
@@ -544,7 +545,6 @@ static bool linlondp_crtc_mode_fixup(struct drm_crtc *crtc,
 				     struct drm_display_mode *adjusted_mode)
 {
 	struct linlondp_crtc *kcrtc = to_kcrtc(crtc);
-	unsigned long clk_rate;
 	u16 hor_divisor = 1;
 
 	drm_mode_set_crtcinfo(adjusted_mode, 0);
@@ -561,6 +561,8 @@ static bool linlondp_crtc_mode_fixup(struct drm_crtc *crtc,
 		adjusted_mode->crtc_htotal /= hor_divisor;
 	}
 #if !IS_ENABLED(CONFIG_DRM_LINLONDP_CLOCK_FIXED)
+	unsigned long clk_rate;
+
 	clk_rate = adjusted_mode->crtc_clock * 1000;
 	/* crtc_clock will be used as the linlondp output pixel clock */
 	adjusted_mode->crtc_clock = clk_round_rate(kcrtc->master->pxlclk,

--- a/drivers/perf/phytium/phytium_ddr_pmu.c
+++ b/drivers/perf/phytium/phytium_ddr_pmu.c
@@ -24,7 +24,9 @@
 #include <linux/smp.h>
 #include <linux/types.h>
 
+#if IS_ENABLED(CONFIG_ARM || CONFIG_ARM64)
 #include <asm/cputype.h>
+#endif /* CONFIG_ARM || CONFIG_ARM64 */
 #include <asm/local64.h>
 
 #undef pr_fmt

--- a/drivers/perf/phytium/phytium_pcie_pmu.c
+++ b/drivers/perf/phytium/phytium_pcie_pmu.c
@@ -24,7 +24,9 @@
 #include <linux/smp.h>
 #include <linux/types.h>
 
+#if IS_ENABLED(CONFIG_ARM || CONFIG_ARM64)
 #include <asm/cputype.h>
+#endif /* CONFIG_ARM || CONFIG_ARM64 */
 #include <asm/local64.h>
 
 #undef pr_fmt

--- a/drivers/soc/cix/acpi/acpi_resource_lookup.c
+++ b/drivers/soc/cix/acpi/acpi_resource_lookup.c
@@ -7,6 +7,7 @@
 #include <linux/cma.h>
 #include <linux/device.h>
 #include <linux/kernel.h>
+#include <linux/memblock.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/reset-controller.h>

--- a/drivers/soc/cix/acpi/reserved_memory.c
+++ b/drivers/soc/cix/acpi/reserved_memory.c
@@ -9,6 +9,7 @@
 #include <linux/cma.h>
 #include <linux/device.h>
 #include <linux/kernel.h>
+#include <linux/memblock.h>
 #include <linux/module.h>
 
 enum {

--- a/drivers/staging/sb105x/sb_pci_mp.c
+++ b/drivers/staging/sb105x/sb_pci_mp.c
@@ -43,7 +43,7 @@ static ssize_t mp_write(struct tty_struct *tty, const unsigned char *buf, long u
 static unsigned int mp_write_room(struct tty_struct *tty);
 static unsigned int mp_chars_in_buffer(struct tty_struct *tty);
 static void mp_flush_buffer(struct tty_struct *tty);
-static void mp_send_xchar(struct tty_struct *tty, u8 ch);
+static void mp_send_xchar(struct tty_struct *tty, char ch);
 static void mp_throttle(struct tty_struct *tty);
 static void mp_unthrottle(struct tty_struct *tty);
 static int mp_get_info(struct sb_uart_state *state, struct serial_struct *retinfo);
@@ -703,7 +703,7 @@ static void mp_flush_buffer(struct tty_struct *tty)
 	tty_wakeup(tty);
 }
 
-static void mp_send_xchar(struct tty_struct *tty, u8 ch)
+static void mp_send_xchar(struct tty_struct *tty, char ch)
 {
 	struct sb_uart_state *state = tty->driver_data;
 	struct sb_uart_port *port = state->port;

--- a/sound/soc/cix/cdns_i2s_mc.c
+++ b/sound/soc/cix/cdns_i2s_mc.c
@@ -2,6 +2,7 @@
 // Copyright 2024 Cix Technology Group Co., Ltd.
 
 #include <linux/acpi.h>
+#include <linux/bitfield.h>
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/module.h>

--- a/sound/soc/cix/cdns_i2s_sc.c
+++ b/sound/soc/cix/cdns_i2s_sc.c
@@ -2,6 +2,7 @@
 // Copyright 2024 Cix Technology Group Co., Ltd.
 
 #include <linux/acpi.h>
+#include <linux/bitfield.h>
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/module.h>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes compiler errors when building with allyesconfig on x86.