### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [CIX] [Intel] [Glenfly] [Linkdata] [Mucse] [Zhaoxin] Fix link errors when "make allyesconfig" on x86

### DIFF
--- a/drivers/crypto/zhaoxin-aes.c
+++ b/drivers/crypto/zhaoxin-aes.c
@@ -62,7 +62,7 @@ struct aes_ctx {
 	u32 *D;
 };
 
-static DEFINE_PER_CPU(struct cword *, paes_last_cword);
+static DEFINE_PER_CPU(struct cword *, paes_last_cword_zx);
 
 /* Tells whether the ACE is capable to generate the extended key for a given key_len. */
 static inline int aes_hw_extkey_available(uint8_t key_len)
@@ -142,9 +142,9 @@ static int aes_set_key(struct crypto_tfm *tfm, const u8 *in_key, unsigned int ke
 
 ok:
 	for_each_online_cpu(cpu)
-		if (&ctx->cword.encrypt == per_cpu(paes_last_cword, cpu) ||
-			&ctx->cword.decrypt == per_cpu(paes_last_cword, cpu))
-			per_cpu(paes_last_cword, cpu) = NULL;
+		if (&ctx->cword.encrypt == per_cpu(paes_last_cword_zx, cpu) ||
+			&ctx->cword.decrypt == per_cpu(paes_last_cword_zx, cpu))
+			per_cpu(paes_last_cword_zx, cpu) = NULL;
 
 	return 0;
 }
@@ -162,7 +162,7 @@ static inline void padlock_reset_key(struct cword *cword)
 {
 	int cpu = raw_smp_processor_id();
 
-	if (cword != per_cpu(paes_last_cword, cpu))
+	if (cword != per_cpu(paes_last_cword_zx, cpu))
 #ifndef CONFIG_X86_64
 		asm volatile ("pushfl; popfl");
 #else
@@ -172,7 +172,7 @@ static inline void padlock_reset_key(struct cword *cword)
 
 static inline void padlock_store_cword(struct cword *cword)
 {
-	per_cpu(paes_last_cword, raw_smp_processor_id()) = cword;
+	per_cpu(paes_last_cword_zx, raw_smp_processor_id()) = cword;
 }
 
 /*

--- a/drivers/gpu/drm/arise/core/kernel_interface.c
+++ b/drivers/gpu/drm/arise/core/kernel_interface.c
@@ -124,7 +124,7 @@ static  void krnl_init_adapter(void* adp, int reserved_vmem, void *disp_info)
 
     gf_register_trace_events();
 
-    perf_event_init(adapter);
+    arise_perf_event_init(adapter);
 
     gf_hwq_event_init(adapter);
 

--- a/drivers/gpu/drm/arise/core/perfevent/perfevent.c
+++ b/drivers/gpu/drm/arise/core/perfevent/perfevent.c
@@ -38,7 +38,7 @@
 
 
 
-int perf_event_init(adapter_t *adapter)
+int arise_perf_event_init(adapter_t *adapter)
 {
     perf_event_mgr_t *perf_event_mgr;
     int ret = 0;

--- a/drivers/gpu/drm/arise/core/perfevent/perfevent.h
+++ b/drivers/gpu/drm/arise/core/perfevent/perfevent.h
@@ -26,7 +26,7 @@
 
 #include "gf_def.h"
 
-extern int perf_event_init(adapter_t *adapter);
+extern int arise_perf_event_init(adapter_t *adapter);
 extern int perf_event_deinit(adapter_t *adapter);
 extern int perf_event_begin(adapter_t *adapter, gf_begin_perf_event_t *begin);
 extern int perf_event_end(adapter_t *adapter, gf_end_perf_event_t *end);

--- a/drivers/gpu/drm/cix/linlon-dp/hw/dp_component.c
+++ b/drivers/gpu/drm/cix/linlon-dp/hw/dp_component.c
@@ -233,7 +233,7 @@ static u32 dp_layer_update_color(struct drm_plane_state *st,
 	if (kplane_st->ctm) {
 		u32 ctm_coeffs[LINLONDP_N_CTM_COEFFS];
 
-		drm_ctm_to_coeffs(kplane_st->ctm, ctm_coeffs);
+		cix_drm_ctm_to_coeffs(kplane_st->ctm, ctm_coeffs);
 		linlondp_write_group(reg, LAYER_RGB_RGB_COEFF0,
 				     ARRAY_SIZE(ctm_coeffs), ctm_coeffs);
 		ctrl |= L_R2R;	/* enable RGB2RGB conversion */

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_color_mgmt.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_color_mgmt.c
@@ -194,12 +194,12 @@ void drm_lut_to_coeffs(struct drm_property_blob *lut_blob,
 	coeffs[num] = BIT(LINLONDP_COLOR_PRECISION);
 }
 
-void drm_lut_to_fgamma_coeffs(struct drm_property_blob *lut_blob, u32 *coeffs)
+void cix_drm_lut_to_fgamma_coeffs(struct drm_property_blob *lut_blob, u32 *coeffs)
 {
 	drm_lut_to_coeffs(lut_blob, coeffs, false);
 }
 
-void drm_ctm_to_coeffs(struct drm_property_blob *ctm_blob, u32 *coeffs)
+void cix_drm_ctm_to_coeffs(struct drm_property_blob *ctm_blob, u32 *coeffs)
 {
 	struct drm_color_ctm *ctm;
 	u32 i;

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_color_mgmt.h
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_color_mgmt.h
@@ -39,8 +39,8 @@ int linlondp_color_validate(struct linlondp_color_manager *mgr,
 
 void drm_lut_to_coeffs(struct drm_property_blob *lut_blob,
 		u32 *coeffs, bool igamma);
-void drm_lut_to_fgamma_coeffs(struct drm_property_blob *lut_blob, u32 *coeffs);
-void drm_ctm_to_coeffs(struct drm_property_blob *ctm_blob, u32 *coeffs);
+void cix_drm_lut_to_fgamma_coeffs(struct drm_property_blob *lut_blob, u32 *coeffs);
+void cix_drm_ctm_to_coeffs(struct drm_property_blob *ctm_blob, u32 *coeffs);
 
 const s32 *linlondp_select_yuv2rgb_coeffs(u32 color_encoding, u32 color_range);
 const s32 *linlondp_select_rgb2yuv_coeffs(u32 color_encoding, u32 color_range);

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_dev.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_dev.c
@@ -91,7 +91,7 @@ static void linlondp_debugfs_init(struct linlondp_dev *mdev)
 static ssize_t
 core_id_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 
 	return sysfs_emit(buf, "0x%08x\n", mdev->chip.core_id);
 }
@@ -101,7 +101,7 @@ static DEVICE_ATTR_RO(core_id);
 static ssize_t
 config_id_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe = mdev->pipelines[0];
 	union linlondp_config_id config_id;
 	int i;
@@ -126,7 +126,7 @@ static DEVICE_ATTR_RO(config_id);
 static ssize_t
 aclk_hz_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 
 	return sysfs_emit(buf, "%lu\n", mdev->aclk_freq);
 }
@@ -137,7 +137,7 @@ static ssize_t
 aclk_freq_fixed_store(struct device *dev, struct device_attribute *attr,
 			const char *buf, size_t count)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	long val;
 	int err;
 
@@ -159,7 +159,7 @@ aclk_freq_fixed_store(struct device *dev, struct device_attribute *attr,
 static ssize_t
 aclk_freq_fixed_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 
 	return sysfs_emit(buf, "%lu\n", mdev->aclk_freq_fixed);
 }
@@ -170,7 +170,7 @@ static ssize_t
 smart_aclk_freq_store(struct device *dev, struct device_attribute *attr,
 		      const char *buf, size_t count)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	long val;
 	int err;
 
@@ -189,7 +189,7 @@ static ssize_t
 smart_aclk_freq_show(struct device *dev, struct device_attribute *attr,
 		     char *buf)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 
 	return sysfs_emit(buf, "%d\n", mdev->smart_aclk_freq ? 1 : 0);
 }
@@ -200,7 +200,7 @@ static ssize_t
 test_pattern_store(struct device *dev, struct device_attribute *attr,
 		   const char *buf, size_t count)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe0 = mdev->pipelines[0];
 	struct linlondp_pipeline *pipe1 = mdev->pipelines[1];
 	long val;
@@ -222,7 +222,7 @@ static ssize_t
 test_pattern_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	long val;
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe0 = mdev->pipelines[0];
 	struct linlondp_pipeline *pipe1 = mdev->pipelines[1];
 
@@ -245,7 +245,7 @@ static ssize_t
 crc_enable_store(struct device *dev, struct device_attribute *attr,
 		 const char *buf, size_t count)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe0 = mdev->pipelines[0];
 	struct linlondp_pipeline *pipe1 = mdev->pipelines[1];
 	long val;
@@ -267,7 +267,7 @@ static ssize_t
 crc_enable_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	long val;
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe0 = mdev->pipelines[0];
 	struct linlondp_pipeline *pipe1 = mdev->pipelines[1];
 
@@ -290,7 +290,7 @@ static ssize_t
 dither_enable_store(struct device *dev, struct device_attribute *attr,
 		    const char *buf, size_t count)
 {
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe0 = mdev->pipelines[0];
 	struct linlondp_pipeline *pipe1 = mdev->pipelines[1];
 	long val;
@@ -312,7 +312,7 @@ static ssize_t
 dither_enable_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	long val;
-	struct linlondp_dev *mdev = dev_to_mdev(dev);
+	struct linlondp_dev *mdev = cix_dev_to_mdev(dev);
 	struct linlondp_pipeline *pipe0 = mdev->pipelines[0];
 	struct linlondp_pipeline *pipe1 = mdev->pipelines[1];
 

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_dev.h
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_dev.h
@@ -272,7 +272,7 @@ dp_identify(u32 __iomem *reg, struct linlondp_chip_info *chip);
 struct linlondp_dev *linlondp_dev_create(struct device *dev);
 void linlondp_dev_destroy(struct linlondp_dev *mdev);
 
-struct linlondp_dev *dev_to_mdev(struct device *dev);
+struct linlondp_dev *cix_dev_to_mdev(struct device *dev);
 
 void linlondp_print_events(struct linlondp_events *evts, struct drm_device *dev);
 

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_drv.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_drv.c
@@ -21,7 +21,7 @@ struct linlondp_drv {
 	struct linlondp_kms_dev *kms;
 };
 
-struct linlondp_dev *dev_to_mdev(struct device *dev)
+struct linlondp_dev *cix_dev_to_mdev(struct device *dev)
 {
 	struct linlondp_drv *mdrv = dev_get_drvdata(dev);
 

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_pipeline.h
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_pipeline.h
@@ -553,7 +553,7 @@ struct linlondp_plane_state;
 struct linlondp_crtc_state;
 struct linlondp_crtc;
 
-void pipeline_composition_size(struct linlondp_crtc_state *kcrtc_st,
+void cix_pipeline_composition_size(struct linlondp_crtc_state *kcrtc_st,
 			       bool side_by_side,
 			       u16 *hsize, u16 *vsize, bool is_overlap);
 

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_pipeline_state.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_pipeline_state.c
@@ -681,7 +681,7 @@ linlondp_merger_validate(struct linlondp_merger *merger,
 	return err;
 }
 
-void pipeline_composition_size(struct linlondp_crtc_state *kcrtc_st,
+void cix_pipeline_composition_size(struct linlondp_crtc_state *kcrtc_st,
 	bool side_by_side, u16 *hsize, u16 *vsize, bool is_overlap)
 {
 	struct linlondp_crtc *kcrtc = to_kcrtc(kcrtc_st->base.crtc);
@@ -707,7 +707,7 @@ linlondp_compiz_set_input(struct linlondp_compiz *compiz,
 	u16 compiz_w, compiz_h;
 	int idx = dflow->blending_zorder;
 
-	pipeline_composition_size(kcrtc_st, to_kcrtc(crtc)->side_by_side,
+	cix_pipeline_composition_size(kcrtc_st, to_kcrtc(crtc)->side_by_side,
 				  &compiz_w, &compiz_h, true);
 	/* check display rect */
 	//FIXME
@@ -776,7 +776,7 @@ linlondp_compiz_validate(struct linlondp_compiz *compiz,
 
 	st = to_compiz_st(c_st);
 
-	pipeline_composition_size(state, to_kcrtc(crtc)->side_by_side,
+	cix_pipeline_composition_size(state, to_kcrtc(crtc)->side_by_side,
 				  &st->hsize, &st->vsize, true);
 
 	linlondp_component_set_output(&dflow->input, &compiz->base, 0);
@@ -858,9 +858,9 @@ linlondp_improc_validate(struct linlondp_improc *improc,
 	}
 
 	if (kcrtc_st->base.color_mgmt_changed) {
-		drm_lut_to_fgamma_coeffs(kcrtc_st->base.gamma_lut,
+		cix_drm_lut_to_fgamma_coeffs(kcrtc_st->base.gamma_lut,
 					 st->fgamma_coeffs);
-		drm_ctm_to_coeffs(kcrtc_st->base.ctm, st->ctm_coeffs);
+		cix_drm_ctm_to_coeffs(kcrtc_st->base.ctm, st->ctm_coeffs);
 	}
 
 	linlondp_component_add_input(&st->base, &m_dflow->input, 0);
@@ -1223,7 +1223,7 @@ linlondp_split_sbs_master_data_flow(struct linlondp_crtc_state *kcrtc_st,
 	u32 disp_end = master->out_x + master->out_w;
 	u16 boundary;
 
-	pipeline_composition_size(kcrtc_st, true, &boundary, NULL, false);
+	cix_pipeline_composition_size(kcrtc_st, true, &boundary, NULL, false);
 
 	if (disp_end <= boundary) {
 		/* the master viewport only located in master side, no need
@@ -1333,7 +1333,7 @@ linlondp_split_sbs_slave_data_flow(struct linlondp_crtc_state *kcrtc_st,
 {
 	u16 boundary;
 
-	pipeline_composition_size(kcrtc_st, true, &boundary, NULL, false);
+	cix_pipeline_composition_size(kcrtc_st, true, &boundary, NULL, false);
 
 	if (slave->out_x < boundary) {
 		DRM_DEBUG_ATOMIC

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_wb_connector.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_wb_connector.c
@@ -23,7 +23,7 @@ linlondp_wb_init_data_flow(struct linlondp_layer *wb_layer,
 	dflow->out_h = fb->height;
 
 	/* the write back data comes from the compiz */
-	pipeline_composition_size(kcrtc_st, false, &dflow->in_w, &dflow->in_h,
+	cix_pipeline_composition_size(kcrtc_st, false, &dflow->in_w, &dflow->in_h,
 				  false);
 	dflow->input.component = &wb_layer->base.pipeline->compiz->base;
 	/* compiz doesn't output alpha */

--- a/drivers/net/ethernet/mucse/rnp/rnp_main.c
+++ b/drivers/net/ethernet/mucse/rnp/rnp_main.c
@@ -63,8 +63,8 @@ static struct rnp_info *rnp_info_tbl[] = {
 	[board_n400] = &rnp_n400_info,
 };
 
-static int register_mbx_irq(struct rnp_adapter *adapter);
-static void remove_mbx_irq(struct rnp_adapter *adapter);
+static int rnp_register_mbx_irq(struct rnp_adapter *adapter);
+static void rnp_remove_mbx_irq(struct rnp_adapter *adapter);
 
 static void rnp_pull_tail(struct sk_buff *skb);
 #ifdef OPTM_WITH_LPAGE
@@ -2485,7 +2485,7 @@ static irqreturn_t rnp_msix_clean_rings(int irq, void *data)
 	return IRQ_HANDLED;
 }
 
-static void update_rx_count(int cleaned, struct rnp_q_vector *q_vector)
+static void rnp_update_rx_count(int cleaned, struct rnp_q_vector *q_vector)
 {
 	struct rnp_adapter *adapter = q_vector->adapter;
 	u32 link_speed = adapter->link_speed;
@@ -2636,7 +2636,7 @@ int rnp_poll(struct napi_struct *napi, int budget)
 	}
 	/* all work done, exit the polling mode */
 	if (!(q_vector->vector_flags & RNP_QVECTOR_FLAG_ITR_FEATURE))
-		update_rx_count(cleaned_total, q_vector);
+		rnp_update_rx_count(cleaned_total, q_vector);
 
 	if (!clean_complete) {
 		int cpu_id = smp_processor_id();
@@ -4908,7 +4908,7 @@ static int rnp_resume(struct pci_dev *pdev)
 
 	err = rnp_init_interrupt_scheme(adapter);
 	if (!err)
-		err = register_mbx_irq(adapter);
+		err = rnp_register_mbx_irq(adapter);
 
 	if (hw->ops.driver_status)
 		hw->ops.driver_status(hw, false, rnp_driver_suspuse);
@@ -4954,7 +4954,7 @@ static int __rnp_shutdown(struct pci_dev *pdev, bool *enable_wake)
 	if (hw->ops.driver_status)
 		hw->ops.driver_status(hw, true, rnp_driver_suspuse);
 
-	remove_mbx_irq(adapter);
+	rnp_remove_mbx_irq(adapter);
 	rnp_clear_interrupt_scheme(adapter);
 
 #ifdef CONFIG_PM
@@ -5447,13 +5447,13 @@ static void rnp_reset_pf_subtask(struct rnp_adapter *adapter)
 	usleep_range(500, 1000);
 
 	rnp_reset(adapter);
-	remove_mbx_irq(adapter);
+	rnp_remove_mbx_irq(adapter);
 	rnp_clear_interrupt_scheme(adapter);
 
 	rtnl_lock();
 	err = rnp_init_interrupt_scheme(adapter);
 
-	register_mbx_irq(adapter);
+	rnp_register_mbx_irq(adapter);
 
 	if (!err && netif_running(netdev))
 		err = rnp_open(netdev);
@@ -6514,7 +6514,7 @@ int rnp_setup_tc(struct net_device *dev, u8 tc)
 
 	rnp_fdir_filter_exit(adapter);
 	adapter->priv_flags &= (~RNP_PRIV_FLAG_TCP_SYNC);
-	remove_mbx_irq(adapter);
+	rnp_remove_mbx_irq(adapter);
 	rnp_clear_interrupt_scheme(adapter);
 	adapter->num_tc = tc;
 
@@ -6528,7 +6528,7 @@ int rnp_setup_tc(struct net_device *dev, u8 tc)
 
 	rnp_init_interrupt_scheme(adapter);
 
-	register_mbx_irq(adapter);
+	rnp_register_mbx_irq(adapter);
 	/* rss table must reset */
 	adapter->rss_tbl_setup_flag = 0;
 
@@ -7202,7 +7202,7 @@ static inline unsigned long rnp_tso_features(struct rnp_hw *hw)
 	return features;
 }
 
-static void remove_mbx_irq(struct rnp_adapter *adapter)
+static void rnp_remove_mbx_irq(struct rnp_adapter *adapter)
 {
 	/* mbx */
 	if (adapter->num_other_vectors) {
@@ -7218,7 +7218,7 @@ static void remove_mbx_irq(struct rnp_adapter *adapter)
 	}
 }
 
-static int register_mbx_irq(struct rnp_adapter *adapter)
+static int rnp_register_mbx_irq(struct rnp_adapter *adapter)
 {
 	struct rnp_hw *hw = &adapter->hw;
 	struct net_device *netdev = adapter->netdev;
@@ -7287,7 +7287,7 @@ static int rnp_rm_adpater(struct rnp_adapter *adapter)
 	if (hw->ops.driver_status)
 		hw->ops.driver_status(hw, false, rnp_driver_insmod);
 
-	remove_mbx_irq(adapter);
+	rnp_remove_mbx_irq(adapter);
 
 	rnp_clear_interrupt_scheme(adapter);
 
@@ -7723,7 +7723,7 @@ static int rnp_add_adpater(struct pci_dev *pdev, struct rnp_info *ii,
 	if (err)
 		goto err_sw_init;
 
-	err = register_mbx_irq(adapter);
+	err = rnp_register_mbx_irq(adapter);
 	if (err)
 		goto err_register;
 
@@ -7785,7 +7785,7 @@ static int rnp_add_adpater(struct pci_dev *pdev, struct rnp_info *ii,
 
 	return 0;
 err_register:
-	remove_mbx_irq(adapter);
+	rnp_remove_mbx_irq(adapter);
 	rnp_clear_interrupt_scheme(adapter);
 err_sw_init:
 	rnp_disable_sriov(adapter);

--- a/drivers/net/ethernet/mucse/rnp/rnp_mbx.c
+++ b/drivers/net/ethernet/mucse/rnp/rnp_mbx.c
@@ -638,7 +638,7 @@ s32 rnp_init_mbx_params_pf(struct rnp_hw *hw)
 	return 0;
 }
 
-struct rnp_mbx_operations mbx_ops_generic = {
+struct rnp_mbx_operations rnp_mbx_ops_generic = {
 	.init_params = rnp_init_mbx_params_pf,
 	.read = rnp_read_mbx_pf,
 	.write = rnp_write_mbx_pf,

--- a/drivers/net/ethernet/mucse/rnp/rnp_mbx.h
+++ b/drivers/net/ethernet/mucse/rnp/rnp_mbx.h
@@ -183,7 +183,7 @@ s32 rnp_check_for_msg(struct rnp_hw *, enum MBX_ID);
 s32 rnp_check_for_ack(struct rnp_hw *, enum MBX_ID);
 s32 rnp_check_for_rst(struct rnp_hw *, enum MBX_ID);
 s32 rnp_init_mbx_params_pf(struct rnp_hw *);
-extern struct rnp_mbx_operations mbx_ops_generic;
+extern struct rnp_mbx_operations rnp_mbx_ops_generic;
 #define MBX_IFDOWN (0)
 #define MBX_IFUP (1)
 #define MBX_PROBE (2)

--- a/drivers/net/ethernet/mucse/rnp/rnp_n10.c
+++ b/drivers/net/ethernet/mucse/rnp/rnp_n10.c
@@ -4662,7 +4662,7 @@ struct rnp_info rnp_n10_info = {
 	.get_invariants = &rnp_get_invariants_n10,
 	.mac_ops = &mac_ops_n10,
 	.eeprom_ops = NULL,
-	.mbx_ops = &mbx_ops_generic,
+	.mbx_ops = &rnp_mbx_ops_generic,
 	.pcs_ops = &pcs_ops_generic,
 };
 
@@ -4807,6 +4807,6 @@ struct rnp_info rnp_n400_info = {
 	.get_invariants = &rnp_get_invariants_n400,
 	.mac_ops = &mac_ops_n10,
 	.eeprom_ops = NULL,
-	.mbx_ops = &mbx_ops_generic,
+	.mbx_ops = &rnp_mbx_ops_generic,
 	.pcs_ops = &pcs_ops_generic,
 };

--- a/drivers/net/ethernet/mucse/rnp/rnp_ptp.c
+++ b/drivers/net/ethernet/mucse/rnp/rnp_ptp.c
@@ -163,7 +163,7 @@ static int adjust_systime(void __iomem *ioaddr, u32 sec, u32 nsec, int add_sub,
 	return 0;
 }
 
-const struct rnp_hwtimestamp mac_ptp = {
+const struct rnp_hwtimestamp rnp_mac_ptp = {
 	.config_hw_tstamping = config_hw_tstamping,
 	.config_mac_irq_enable = config_mac_interrupt_enable,
 	.init_systime = init_systime,
@@ -533,7 +533,7 @@ static struct ptp_clock_info rnp_ptp_clock_ops = {
 
 int rnp_ptp_register(struct rnp_adapter *pf)
 {
-	pf->hwts_ops = &mac_ptp;
+	pf->hwts_ops = &rnp_mac_ptp;
 
 	pf->ptp_tx_en = 0;
 	pf->ptp_rx_en = 0;

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_main.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_main.c
@@ -58,8 +58,8 @@ static struct rnpgbe_info *rnpgbe_info_tbl[] = {
 	[board_n210] = &rnpgbe_n210_info,
 };
 
-static int register_mbx_irq(struct rnpgbe_adapter *adapter);
-static void remove_mbx_irq(struct rnpgbe_adapter *adapter);
+static int rnpgbe_register_mbx_irq(struct rnpgbe_adapter *adapter);
+static void rnpgbe_remove_mbx_irq(struct rnpgbe_adapter *adapter);
 
 static void rnpgbe_pull_tail(struct sk_buff *skb);
 #ifdef OPTM_WITH_LPAGE
@@ -4631,7 +4631,7 @@ static int rnpgbe_resume(struct device *dev)
 
 	err = rnpgbe_init_interrupt_scheme(adapter);
 	if (!err)
-		err = register_mbx_irq(adapter);
+		err = rnpgbe_register_mbx_irq(adapter);
 
 	if (hw->ops.driver_status)
 		hw->ops.driver_status(hw, false, rnpgbe_driver_suspuse);
@@ -4684,7 +4684,7 @@ static int rnpgbe_freeze(struct device *dev)
 		rnpgbe_free_all_rx_resources(adapter);
 	}
 
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 	rnpgbe_clear_interrupt_scheme(adapter);
 	rtnl_unlock();
 
@@ -4741,7 +4741,7 @@ static int __rnpgbe_shutdown_suspuse(struct pci_dev *pdev, bool *enable_wake)
 	if ((hw->ncsi_en || adapter->wol) && hw->ops.driver_status)
 		hw->ops.driver_status(hw, true, rnpgbe_driver_suspuse);
 
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 	rnpgbe_clear_interrupt_scheme(adapter);
 
 	retval = pci_save_state(pdev);
@@ -4795,7 +4795,7 @@ static int __rnpgbe_shutdown(struct pci_dev *pdev, bool *enable_wake)
 	if ((hw->ncsi_en || adapter->wol) && hw->ops.driver_status)
 		hw->ops.driver_status(hw, false, rnpgbe_driver_insmod);
 
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 	rnpgbe_clear_interrupt_scheme(adapter);
 
 	retval = pci_save_state(pdev);
@@ -5253,11 +5253,11 @@ static void rnpgbe_reset_pf_subtask(struct rnpgbe_adapter *adapter)
 	/* wait all vf get this status */
 	usleep_range(500, 1000);
 	rnpgbe_reset(adapter);
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 	rnpgbe_clear_interrupt_scheme(adapter);
 	rtnl_lock();
 	err = rnpgbe_init_interrupt_scheme(adapter);
-	register_mbx_irq(adapter);
+	rnpgbe_register_mbx_irq(adapter);
 
 	if (!err && netif_running(netdev))
 		err = rnpgbe_open(netdev);
@@ -6323,7 +6323,7 @@ int rnpgbe_setup_tc(struct net_device *dev, u8 tc)
 
 	rnpgbe_fdir_filter_exit(adapter);
 	adapter->priv_flags &= (~RNP_PRIV_FLAG_TCP_SYNC);
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 	rnpgbe_clear_interrupt_scheme(adapter);
 	adapter->num_tc = tc;
 
@@ -6339,7 +6339,7 @@ int rnpgbe_setup_tc(struct net_device *dev, u8 tc)
 
 	rnpgbe_init_interrupt_scheme(adapter);
 
-	register_mbx_irq(adapter);
+	rnpgbe_register_mbx_irq(adapter);
 	/* rss table must reset */
 	adapter->rss_tbl_setup_flag = 0;
 
@@ -6708,7 +6708,7 @@ static inline unsigned long rnpgbe_tso_features(struct rnpgbe_hw *hw)
 	return features;
 }
 
-static void remove_mbx_irq(struct rnpgbe_adapter *adapter)
+static void rnpgbe_remove_mbx_irq(struct rnpgbe_adapter *adapter)
 {
 	/* mbx */
 	if (adapter->num_other_vectors) {
@@ -6725,7 +6725,7 @@ static void remove_mbx_irq(struct rnpgbe_adapter *adapter)
 	}
 }
 
-static int register_mbx_irq(struct rnpgbe_adapter *adapter)
+static int rnpgbe_register_mbx_irq(struct rnpgbe_adapter *adapter)
 {
 	struct rnpgbe_hw *hw = &adapter->hw;
 	struct net_device *netdev = adapter->netdev;
@@ -6792,7 +6792,7 @@ static int rnpgbe_rm_adpater(struct rnpgbe_adapter *adapter)
 	if (hw->ops.driver_status)
 		hw->ops.driver_status(hw, false, rnpgbe_driver_insmod);
 
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 
 	rnpgbe_clear_interrupt_scheme(adapter);
 
@@ -7324,7 +7324,7 @@ static int rnpgbe_add_adpater(struct pci_dev *pdev, struct rnpgbe_info *ii,
 	if (err)
 		goto err_sw_init;
 
-	err = register_mbx_irq(adapter);
+	err = rnpgbe_register_mbx_irq(adapter);
 	if (err)
 		goto err_register;
 
@@ -7377,7 +7377,7 @@ static int rnpgbe_add_adpater(struct pci_dev *pdev, struct rnpgbe_info *ii,
 
 	return 0;
 err_register:
-	remove_mbx_irq(adapter);
+	rnpgbe_remove_mbx_irq(adapter);
 	rnpgbe_clear_interrupt_scheme(adapter);
 err_sw_init:
 	rnpgbe_disable_sriov(adapter);

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_ptp.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_ptp.c
@@ -170,7 +170,7 @@ static int adjust_systime(void __iomem *ioaddr, u32 sec, u32 nsec, int add_sub,
 	return 0;
 }
 
-const struct rnpgbe_hwtimestamp mac_ptp = {
+const struct rnpgbe_hwtimestamp rnpgbe_mac_ptp = {
 	.config_hw_tstamping = config_hw_tstamping,
 	.config_mac_irq_enable = config_mac_interrupt_enable,
 	.init_systime = init_systime,
@@ -534,7 +534,7 @@ static struct ptp_clock_info rnpgbe_ptp_clock_ops = {
 
 int rnpgbe_ptp_register(struct rnpgbe_adapter *pf)
 {
-	pf->hwts_ops = &mac_ptp;
+	pf->hwts_ops = &rnpgbe_mac_ptp;
 
 	pf->ptp_tx_en = 0;
 	pf->ptp_rx_en = 0;

--- a/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf.h
+++ b/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf.h
@@ -654,9 +654,9 @@ extern void rnpgbevf_free_tx_resources(struct rnpgbevf_adapter *adapter,
 				       struct rnpgbevf_ring *ring);
 extern void rnpgbevf_update_stats(struct rnpgbevf_adapter *adapter);
 extern int ethtool_ioctl(struct ifreq *ifr);
-extern void remove_mbx_irq(struct rnpgbevf_adapter *adapter);
+extern void rnpgbevf_remove_mbx_irq(struct rnpgbevf_adapter *adapter);
 extern void rnpgbevf_clear_interrupt_scheme(struct rnpgbevf_adapter *adapter);
-extern int register_mbx_irq(struct rnpgbevf_adapter *adapter);
+extern int rnpgbevf_register_mbx_irq(struct rnpgbevf_adapter *adapter);
 extern int rnpgbevf_init_interrupt_scheme(struct rnpgbevf_adapter *adapter);
 extern int rnpgbevf_close(struct net_device *netdev);
 extern int rnpgbevf_open(struct net_device *netdev);

--- a/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf_ethtool.c
+++ b/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf_ethtool.c
@@ -666,10 +666,10 @@ static int rnpgbevf_set_coalesce(struct net_device *netdev,
 	if (reset) {
 		if (netif_running(netdev))
 			rnpgbevf_close(netdev);
-		remove_mbx_irq(adapter);
+		rnpgbevf_remove_mbx_irq(adapter);
 		rnpgbevf_clear_interrupt_scheme(adapter);
 		rnpgbevf_init_interrupt_scheme(adapter);
-		register_mbx_irq(adapter);
+		rnpgbevf_register_mbx_irq(adapter);
 		if (netif_running(netdev))
 			return rnpgbevf_open(netdev);
 	}

--- a/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf_main.c
+++ b/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf_main.c
@@ -2036,7 +2036,7 @@ static irqreturn_t rnpgbevf_msix_clean_rings(int irq, void *data)
 	return IRQ_HANDLED;
 }
 
-void update_rx_count(int cleaned, struct rnpgbevf_q_vector *q_vector)
+void rnpgbevf_update_rx_count(int cleaned, struct rnpgbevf_q_vector *q_vector)
 {
 	struct rnpgbevf_adapter *adapter = q_vector->adapter;
 
@@ -2227,7 +2227,7 @@ static int rnpgbevf_poll(struct napi_struct *napi, int budget)
 		clean_complete = true;
 
 	if (!(q_vector->vector_flags & RNPVF_QVECTOR_FLAG_ITR_FEATURE))
-		update_rx_count(cleaned_total, q_vector);
+		rnpgbevf_update_rx_count(cleaned_total, q_vector);
 
 	/* If all work not completed, return budget and keep polling */
 	if (!clean_complete)
@@ -5400,7 +5400,7 @@ static int rnpgbevf_set_mac(struct net_device *netdev, void *p)
 	return 0;
 }
 
-void remove_mbx_irq(struct rnpgbevf_adapter *adapter)
+void rnpgbevf_remove_mbx_irq(struct rnpgbevf_adapter *adapter)
 {
 	u32 msgbuf[2];
 	struct rnpgbevf_hw *hw = &adapter->hw;
@@ -5450,7 +5450,7 @@ static void rnp_get_link_status(struct rnpgbevf_adapter *adapter)
 	spin_unlock_bh(&adapter->mbx_lock);
 }
 
-int register_mbx_irq(struct rnpgbevf_adapter *adapter)
+int rnpgbevf_register_mbx_irq(struct rnpgbevf_adapter *adapter)
 {
 	struct rnpgbevf_hw *hw = &adapter->hw;
 	struct net_device *netdev = adapter->netdev;
@@ -5493,7 +5493,7 @@ static int rnpgbevf_suspend(struct pci_dev *pdev, pm_message_t state)
 		rtnl_unlock();
 	}
 
-	remove_mbx_irq(adapter);
+	rnpgbevf_remove_mbx_irq(adapter);
 	rnpgbevf_clear_interrupt_scheme(adapter);
 
 #ifdef CONFIG_PM
@@ -5532,7 +5532,7 @@ static int rnpgbevf_resume(struct pci_dev *pdev)
 	rtnl_lock();
 	err = rnpgbevf_init_interrupt_scheme(adapter);
 	rtnl_unlock();
-	register_mbx_irq(adapter);
+	rnpgbevf_register_mbx_irq(adapter);
 
 	if (err) {
 		dev_err(&pdev->dev, "Cannot initialize interrupts\n");
@@ -5976,7 +5976,7 @@ static int rnpgbevf_add_adpater(struct pci_dev *pdev,
 	if (err)
 		goto err_sw_init;
 
-	err = register_mbx_irq(adapter);
+	err = rnpgbevf_register_mbx_irq(adapter);
 	if (err)
 		goto err_register;
 
@@ -6019,7 +6019,7 @@ static int rnpgbevf_add_adpater(struct pci_dev *pdev,
 
 	return 0;
 err_register:
-	remove_mbx_irq(adapter);
+	rnpgbevf_remove_mbx_irq(adapter);
 	rnpgbevf_clear_interrupt_scheme(adapter);
 err_sw_init:
 err_ioremap:
@@ -6066,7 +6066,7 @@ static int rnpgbevf_rm_adpater(struct rnpgbevf_adapter *adapter)
 			unregister_netdev(netdev);
 	}
 
-	remove_mbx_irq(adapter);
+	rnpgbevf_remove_mbx_irq(adapter);
 	rnpgbevf_clear_interrupt_scheme(adapter);
 	rnpgbevf_reset_interrupt_capability(adapter);
 

--- a/drivers/net/ethernet/mucse/rnpvf/ethtool.c
+++ b/drivers/net/ethernet/mucse/rnpvf/ethtool.c
@@ -536,10 +536,10 @@ static int rnpvf_set_coalesce(struct net_device *netdev,
 	if (reset) {
 		if (netif_running(netdev))
 			rnpvf_close(netdev);
-		remove_mbx_irq(adapter);
+		rnpvf_remove_mbx_irq(adapter);
 		rnpvf_clear_interrupt_scheme(adapter);
 		rnpvf_init_interrupt_scheme(adapter);
-		register_mbx_irq(adapter);
+		rnpvf_register_mbx_irq(adapter);
 		if (netif_running(netdev))
 			return rnpvf_open(netdev);
 	}

--- a/drivers/net/ethernet/mucse/rnpvf/rnpvf.h
+++ b/drivers/net/ethernet/mucse/rnpvf/rnpvf.h
@@ -672,9 +672,9 @@ extern void rnpvf_free_tx_resources(struct rnpvf_adapter *,
 				    struct rnpvf_ring *);
 extern void rnpvf_update_stats(struct rnpvf_adapter *adapter);
 extern int ethtool_ioctl(struct ifreq *ifr);
-extern void remove_mbx_irq(struct rnpvf_adapter *adapter);
+extern void rnpvf_remove_mbx_irq(struct rnpvf_adapter *adapter);
 extern void rnpvf_clear_interrupt_scheme(struct rnpvf_adapter *adapter);
-extern int register_mbx_irq(struct rnpvf_adapter *adapter);
+extern int rnpvf_register_mbx_irq(struct rnpvf_adapter *adapter);
 extern int rnpvf_init_interrupt_scheme(struct rnpvf_adapter *adapter);
 extern int rnpvf_close(struct net_device *netdev);
 extern int rnpvf_open(struct net_device *netdev);

--- a/drivers/net/ethernet/mucse/rnpvf/rnpvf_main.c
+++ b/drivers/net/ethernet/mucse/rnpvf/rnpvf_main.c
@@ -2077,7 +2077,7 @@ static irqreturn_t rnpvf_msix_clean_rings(int irq, void *data)
 	return IRQ_HANDLED;
 }
 
-void update_rx_count(int cleaned, struct rnpvf_q_vector *q_vector)
+void rnpvf_update_rx_count(int cleaned, struct rnpvf_q_vector *q_vector)
 {
 	struct rnpvf_adapter *adapter = q_vector->adapter;
 
@@ -2209,7 +2209,7 @@ static int rnpvf_poll(struct napi_struct *napi, int budget)
 		clean_complete = true;
 
 	if (!(q_vector->vector_flags & RNPVF_QVECTOR_FLAG_ITR_FEATURE))
-		update_rx_count(cleaned_total, q_vector);
+		rnpvf_update_rx_count(cleaned_total, q_vector);
 
 	/* If all work not completed, return budget and keep polling */
 	if (!clean_complete)
@@ -5601,7 +5601,7 @@ static int rnpvf_set_mac(struct net_device *netdev, void *p)
 	return 0;
 }
 
-void remove_mbx_irq(struct rnpvf_adapter *adapter)
+void rnpvf_remove_mbx_irq(struct rnpvf_adapter *adapter)
 {
 	u32 msgbuf[2];
 	struct rnpvf_hw *hw = &adapter->hw;
@@ -5651,7 +5651,7 @@ static void rnp_get_link_status(struct rnpvf_adapter *adapter)
 	spin_unlock_bh(&adapter->mbx_lock);
 }
 
-int register_mbx_irq(struct rnpvf_adapter *adapter)
+int rnpvf_register_mbx_irq(struct rnpvf_adapter *adapter)
 {
 	struct rnpvf_hw *hw = &adapter->hw;
 	struct net_device *netdev = adapter->netdev;
@@ -5696,7 +5696,7 @@ static int rnpvf_suspend(struct pci_dev *pdev, pm_message_t state)
 		rtnl_unlock();
 	}
 
-	remove_mbx_irq(adapter);
+	rnpvf_remove_mbx_irq(adapter);
 	rnpvf_clear_interrupt_scheme(adapter);
 
 #ifdef CONFIG_PM
@@ -5736,7 +5736,7 @@ static int rnpvf_resume(struct pci_dev *pdev)
 	rtnl_lock();
 	err = rnpvf_init_interrupt_scheme(adapter);
 	rtnl_unlock();
-	register_mbx_irq(adapter);
+	rnpvf_register_mbx_irq(adapter);
 
 	if (err) {
 		dev_err(&pdev->dev, "Cannot initialize interrupts\n");
@@ -6148,7 +6148,7 @@ static int rnpvf_add_adpater(struct pci_dev *pdev,
 	if (err)
 		goto err_sw_init;
 
-	err = register_mbx_irq(adapter);
+	err = rnpvf_register_mbx_irq(adapter);
 	if (err)
 		goto err_register;
 
@@ -6180,7 +6180,7 @@ static int rnpvf_add_adpater(struct pci_dev *pdev,
 
 	return 0;
 err_register:
-	remove_mbx_irq(adapter);
+	rnpvf_remove_mbx_irq(adapter);
 	rnpvf_clear_interrupt_scheme(adapter);
 err_sw_init:
 err_ioremap:
@@ -6214,7 +6214,7 @@ static int rnpvf_rm_adpater(struct rnpvf_adapter *adapter)
 			unregister_netdev(netdev);
 	}
 
-	remove_mbx_irq(adapter);
+	rnpvf_remove_mbx_irq(adapter);
 	rnpvf_clear_interrupt_scheme(adapter);
 	rnpvf_reset_interrupt_capability(adapter);
 

--- a/drivers/scsi/linkdata/ps3_ioc_manager.c
+++ b/drivers/scsi/linkdata/ps3_ioc_manager.c
@@ -450,6 +450,7 @@ static inline bool ps3_pgdat_is_empty(pg_data_t *pgdat)
 	return !pgdat->node_start_pfn && !pgdat->node_spanned_pages;
 }
 
+#ifdef MODULE
 struct pglist_data *first_online_pgdat(void)
 {
 	return NODE_DATA(first_online_node);
@@ -463,6 +464,7 @@ struct pglist_data *next_online_pgdat(struct pglist_data *pgdat)
 	}
 	return NODE_DATA(nid);
 }
+#endif /* MODULE */
 
 static Bool ps3_get_numa_mem_addr(struct ps3_instance *instance)
 {

--- a/sound/soc/cix/hda_pcm.c
+++ b/sound/soc/cix/hda_pcm.c
@@ -333,7 +333,7 @@ int hda_pcm_trigger(struct snd_soc_component *component,
 }
 EXPORT_SYMBOL_GPL(hda_pcm_trigger);
 
-unsigned int azx_get_pos_posbuf(struct hdac *hdac, struct hdac_stream *hstr)
+unsigned int cix_azx_get_pos_posbuf(struct hdac *hdac, struct hdac_stream *hstr)
 {
 	return snd_hdac_stream_get_pos_posbuf(hstr);
 }
@@ -349,7 +349,7 @@ static unsigned int azx_get_position(struct hdac *hdac,
 	if (hdac->get_position[stream])
 		pos = hdac->get_position[stream](hdac, hstr);
 	else /* use the position buffer as default */
-		pos = azx_get_pos_posbuf(hdac, hstr);
+		pos = cix_azx_get_pos_posbuf(hdac, hstr);
 
 	pos = snd_hdac_stream_readl(hstr, SD_LPIB);
 

--- a/sound/soc/cix/hdacodec.c
+++ b/sound/soc/cix/hdacodec.c
@@ -23,7 +23,7 @@
 
 static struct hda_codec *hda_codec_device_init(struct hdac_bus *bus, int addr);
 
-int snd_hda_codec_set_name(struct hda_codec *codec, const char *name)
+int cix_snd_hda_codec_set_name(struct hda_codec *codec, const char *name)
 {
 	int err;
 
@@ -164,7 +164,7 @@ static void snd_hda_codec_dev_release(struct device *dev)
 }
 
 
-struct hda_codec *snd_hda_codec_device_init(struct hda_bus *bus,
+struct hda_codec *cix_snd_hda_codec_device_init(struct hda_bus *bus,
 	unsigned int codec_addr,
 	const char *fmt, ...)
 {
@@ -205,7 +205,7 @@ static struct hda_codec *hda_codec_device_init(struct hdac_bus *bus, int addr)
 	struct hda_codec *codec;
 	int ret;
 
-	codec = snd_hda_codec_device_init(to_hda_bus(bus), addr,
+	codec = cix_snd_hda_codec_device_init(to_hda_bus(bus), addr,
 					  "hdaudio%dD%d", bus->idx, addr);
 	if (IS_ERR(codec)) {
 		dev_err(bus->dev,
@@ -328,7 +328,7 @@ int __maybe_unused hda_codec_runtime_resume(struct device *dev)
 	}
 	hcp->codec = codec;
 
-	snd_hda_codec_set_name(codec, dev_name(dev));
+	cix_snd_hda_codec_set_name(codec, dev_name(dev));
 
 	if (codec && patch) {
 		ret = patch(codec);

--- a/sound/soc/qcom/sc8280xp.c
+++ b/sound/soc/qcom/sc8280xp.c
@@ -27,7 +27,7 @@ struct sc8280xp_snd_data {
 static int sc8280xp_snd_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct sc8280xp_snd_data *data = snd_soc_card_get_drvdata(rtd->card);
-	struct snd_soc_dai *cpu_dai = asoc_rtd_to_cpu(rtd, 0);
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
 	struct snd_soc_card *card = rtd->card;
 
 	switch (cpu_dai->id) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes link errors during "make allyesconfig" on x86 by renaming static functions to avoid naming conflicts.