### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] locking/osq_lock: Use atomic_try_cmpxchg_release() in osq_unlock()

### DIFF
--- a/kernel/locking/osq_lock.c
+++ b/kernel/locking/osq_lock.c
@@ -212,8 +212,7 @@ void osq_unlock(struct optimistic_spin_queue *lock)
 	/*
 	 * Fast path for the uncontended case.
 	 */
-	if (likely(atomic_cmpxchg_release(&lock->tail, curr,
-					  OSQ_UNLOCKED_VAL) == curr))
+	if (atomic_try_cmpxchg_release(&lock->tail, &curr, OSQ_UNLOCKED_VAL))
 		return;
 
 	/*


### PR DESCRIPTION
mainline inclusion
from mainline-v6.13-rc1
category: performance

Replace this pattern in osq_unlock():

    atomic_cmpxchg(*ptr, old, new) == old

... with the simpler and faster:

    atomic_try_cmpxchg(*ptr, &old, new)

The x86 CMPXCHG instruction returns success in the ZF flag, so this change saves a compare after the CMPXCHG.  The code in the fast path of osq_unlock() improves from:

 11b:	31 c9                	xor    %ecx,%ecx
 11d:	8d 50 01             	lea    0x1(%rax),%edx
 120:	89 d0                	mov    %edx,%eax
 122:	f0 0f b1 0f          	lock cmpxchg %ecx,(%rdi)
 126:	39 c2                	cmp    %eax,%edx
 128:	75 05                	jne    12f <...>

to:

 12b:	31 d2                	xor    %edx,%edx
 12d:	83 c0 01             	add    $0x1,%eax
 130:	f0 0f b1 17          	lock cmpxchg %edx,(%rdi)
 134:	75 05                	jne    13b <...>



Acked-by: Waiman Long <longman@redhat.com>
Link: https://lore.kernel.org/r/20241001114606.820277-1-ubizjak@gmail.com (cherry picked from commit 0d75e0c420e52b4057a2de274054a5274209a2ae)

## Summary by Sourcery

Enhancements:
- Improve the performance of the fast path of osq_unlock() by using atomic_try_cmpxchg_release().