### PR TITLE
DEEPIN: Kconfig: remove KABI default y

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1955,7 +1955,6 @@ config TRACEPOINTS
 
 config DEEPIN_KABI_RESERVE
 	bool "Support for KABI RESERVE"
-	default y
 	help
 	 This option can be turned off for images that clearly do not require
 	 kabi compatibility.


### PR DESCRIPTION
Deepin defaultconfig not need kabi,
it is a mistake, remove default y.

## Summary by Sourcery

Chores:
- Removes the default selection of KABI in the Deepin default configuration.