### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Bugfix] [zhaoxin] PCI: Fix PCIe unplug Enumeration Long Blocking Issue

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -591,6 +591,9 @@ u16 pci_find_next_ext_capability(struct pci_dev *dev, u16 start, int cap)
 		return 0;
 
 	while (ttl-- > 0) {
+		if (header == 0xffffffff)
+			return 0;
+
 		if (PCI_EXT_CAP_ID(header) == cap && pos != start)
 			return pos;
 


### PR DESCRIPTION
When a USB4 device is inserted, a PCIe tunnel will be established. Then, the PCIe hierarchy within the USB4 device will be enumerated. If the device is suddenly unplugged during the enumeration process, it is possible that the function pci_find_next_ext_capability called when the PCI driver scans the PCIe extended capability may take a very long time, perhaps more than 20 seconds.

## Summary by Sourcery

Bug Fixes:
- Add a check to prevent infinite looping when reading PCIe extended capabilities of an unplugged device by detecting invalid header values