### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [FROMLIST] LoongArch: Increase MAX_IO_PICS up to 8

### DIFF
--- a/arch/loongarch/include/asm/irq.h
+++ b/arch/loongarch/include/asm/irq.h
@@ -53,7 +53,7 @@ void spurious_interrupt(void);
 #define arch_trigger_cpumask_backtrace arch_trigger_cpumask_backtrace
 void arch_trigger_cpumask_backtrace(const struct cpumask *mask, int exclude_cpu);
 
-#define MAX_IO_PICS 2
+#define MAX_IO_PICS 8
 #define NR_IRQS	(64 + (256 * MAX_IO_PICS))
 
 struct acpi_vector_group {


### PR DESCRIPTION
Begin with Loongson-3C6000, the number of PCI host can be as many as 8 for multi-chip machines, and this number should be the same for I/O interrupt controllers. To support these machines we also increase the MAX_IO_PICS up to 8.

Cc: stable@vger.kernel.org
Tested-by: Mingcong Bai <baimingcong@loongson.cn>

## Summary by Sourcery

Enhancements:
- Extend MAX_IO_PICS from 2 to 8 to accommodate up to 8 PCI hosts in multi-chip LoongArch machines