### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] wifi: mt76: mt76x2u: add TP-Link TL-WDN6200 ID to device table

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt76x2/usb.c
+++ b/drivers/net/wireless/mediatek/mt76/mt76x2/usb.c
@@ -21,6 +21,7 @@ static const struct usb_device_id mt76x2u_device_table[] = {
 	{ USB_DEVICE(0x0846, 0x9053) },	/* Netgear A6210 */
 	{ USB_DEVICE(0x045e, 0x02e6) },	/* XBox One Wireless Adapter */
 	{ USB_DEVICE(0x045e, 0x02fe) },	/* XBox One Wireless Adapter */
+	{ USB_DEVICE(0x2357, 0x0137) },	/* TP-Link TL-WDN6200 */
 	{ },
 };
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.15-rc1
category: bugfix

The TP-Link TL-WDN6200 "Driverless" version cards use a MT7612U chipset.

Add the USB ID to mt76x2u driver.


Link: https://patch.msgid.link/20250317102235.1421726-1-uwu@icenowy.me

(cherry picked from commit 06cccc2ebbe6c8a20f714f3a0ff3ff489d3004bb)

## Summary by Sourcery

Bug Fixes:
- Add support for TP-Link TL-WDN6200 'Driverless' version wireless adapter with MT7612U chipset