### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] backport mm fixes 6.6.85

### DIFF
--- a/mm/filemap.c
+++ b/mm/filemap.c
@@ -1976,8 +1976,19 @@ no_page:
 
 		if (err == -EEXIST)
 			goto repeat;
-		if (err)
+		if (err) {
+			/*
+			 * When NOWAIT I/O fails to allocate folios this could
+			 * be due to a nonblocking memory allocation and not
+			 * because the system actually is out of memory.
+			 * Return -EAGAIN so that there caller retries in a
+			 * blocking fashion instead of propagating -ENOMEM
+			 * to the application.
+			 */
+			if ((fgp_flags & FGP_NOWAIT) && err == -ENOMEM)
+				err = -EAGAIN;
 			return ERR_PTR(err);
+		}
 		/*
 		 * filemap_add_folio locks the page, and for mmap
 		 * we expect an unlocked page.

--- a/mm/migrate.c
+++ b/mm/migrate.c
@@ -437,15 +437,13 @@ int folio_migrate_mapping(struct address_space *mapping,
 	newfolio->index = folio->index;
 	newfolio->mapping = folio->mapping;
 	folio_ref_add(newfolio, nr); /* add cache reference */
-	if (folio_test_swapbacked(folio)) {
+	if (folio_test_swapbacked(folio))
 		__folio_set_swapbacked(newfolio);
-		if (folio_test_swapcache(folio)) {
-			folio_set_swapcache(newfolio);
-			newfolio->private = folio_get_private(folio);
-		}
+	if (folio_test_swapcache(folio)) {
+		folio_set_swapcache(newfolio);
+		newfolio->private = folio_get_private(folio);
 		entries = nr;
 	} else {
-		VM_BUG_ON_FOLIO(folio_test_swapcache(folio), folio);
 		entries = 1;
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Backport memory management (mm) fixes for Linux kernel 6.6.85, addressing memory allocation and page migration handling

Bug Fixes:
- Improve error handling in file mapping allocation to prevent unnecessary ENOMEM propagation for non-blocking I/O
- Simplify and correct swap cache handling during page migration

Enhancements:
- Modify memory allocation error handling to provide more graceful retry mechanism
- Streamline folio migration logic for swap-backed pages