### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [DEEPIN] deepin: KABI: add a ifdef for task_struct_extend

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -740,8 +740,10 @@ struct kmap_ctrl {
 struct task_struct_deepin {
 };
 
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
 struct task_struct_extend {
 };
+#endif
 
 struct task_struct {
 #ifdef CONFIG_THREAD_INFO_IN_TASK
@@ -1542,8 +1544,10 @@ struct task_struct {
 	struct user_event_mm		*user_event_mm;
 #endif
 
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
 	/* reserve extra field for randomized used */
 	struct task_struct_extend	*task_struct_extend;
+#endif
 
 	/*
 	 * New fields for task_struct should be added above here, so that


### PR DESCRIPTION
We now disable the KABI default in deepin
use #ifdef CONFIG_DEEPIN_KABI_RESERVE to control the extra struct

Fixes: 34aa3d7fde83 ("deepin: KABI: KABI reservation for sched structures")

## Summary by Sourcery

Add conditional compilation for Deepin kernel KABI (Kernel Application Binary Interface) reservation structures

Bug Fixes:
- Modify task_struct definition to use conditional compilation for Deepin-specific KABI extensions

Enhancements:
- Introduce CONFIG_DEEPIN_KABI_RESERVE preprocessor macro to conditionally include task struct extension fields