### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [DEEPIN] Revert "block: cleanup and fix batch completion adding conditions"

### DIFF
--- a/include/linux/blk-mq.h
+++ b/include/linux/blk-mq.h
@@ -849,22 +849,12 @@ static inline bool blk_mq_add_to_batch(struct request *req,
 				       void (*complete)(struct io_comp_batch *))
 {
 	/*
-	 * Check various conditions that exclude batch processing:
-	 * 1) No batch container
-	 * 2) Has scheduler data attached
-	 * 3) Not a passthrough request and end_io set
-	 * 4) Not a passthrough request and an ioerror
+	 * blk_mq_end_request_batch() can't end request allocated from
+	 * sched tags
 	 */
-	if (!iob)
+	if (!iob || (req->rq_flags & RQF_SCHED_TAGS) || ioerror ||
+			(req->end_io && !blk_rq_is_passthrough(req)))
 		return false;
-	if (req->rq_flags & RQF_SCHED_TAGS)
-		return false;
-	if (!blk_rq_is_passthrough(req)) {
-		if (req->end_io)
-			return false;
-		if (ioerror < 0)
-			return false;
-	}
 
 	if (!iob->complete)
 		iob->complete = complete;


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20250319235024-4cd52346f17913d4@stable.kernel.org/ check-depends failed,temp revert.
new bugfix 9bce6b5f8987 ("block: change blk_mq_add_to_batch() third argument type to bool") exists new bugfix e5c2bcc0cd47 ("nvme: move error logging from nvme_end_req() to __nvme_end_req()") exists This reverts commit 5812a23a51b3aab2ac385d5a20f105344e698407.

## Summary by Sourcery

Bug Fixes:
- Reverted changes to block request batch processing conditions to address potential compatibility or regression issues