### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [FROMLIST] Bluetooth: Revert vendor-specific ISO classification for no…

### DIFF
--- a/drivers/bluetooth/btintel.c
+++ b/drivers/bluetooth/btintel.c
@@ -2656,24 +2656,6 @@ static void btintel_set_dsm_reset_method(struct hci_dev *hdev,
 	data->acpi_reset_method = btintel_acpi_reset_method;
 }
 
-#define BTINTEL_ISODATA_HANDLE_BASE 0x900
-
-static u8 btintel_classify_pkt_type(struct hci_dev *hdev, struct sk_buff *skb)
-{
-	/*
-	 * Distinguish ISO data packets form ACL data packets
-	 * based on their connection handle value range.
-	 */
-	if (hci_skb_pkt_type(skb) == HCI_ACLDATA_PKT) {
-		__u16 handle = __le16_to_cpu(hci_acl_hdr(skb)->handle);
-
-		if (hci_handle(handle) >= BTINTEL_ISODATA_HANDLE_BASE)
-			return HCI_ISODATA_PKT;
-	}
-
-	return hci_skb_pkt_type(skb);
-}
-
 /*
  * UefiCnvCommonDSBR UEFI variable provides information from the OEM platforms
  * if they have replaced the BRI (Bluetooth Radio Interface) resistor to
@@ -3244,15 +3226,12 @@ static int btintel_setup_combined(struct hci_dev *hdev)
 		err = btintel_bootloader_setup(hdev, &ver);
 		btintel_register_devcoredump_support(hdev);
 		break;
-	case 0x18: /* GfP2 */
-	case 0x1c: /* GaP */
-		/* Re-classify packet type for controllers with LE audio */
-		hdev->classify_pkt_type = btintel_classify_pkt_type;
-		fallthrough;
 	case 0x17:
+	case 0x18:
 	case 0x19:
 	case 0x1b:
 	case 0x1d:
+	case 0x1c:
 	case 0x1e:
 	case 0x1f:
 		/* Display version information of TLV type */

--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -644,7 +644,6 @@ struct hci_dev {
 	int (*get_codec_config_data)(struct hci_dev *hdev, __u8 type,
 				     struct bt_codec *codec, __u8 *vnd_len,
 				     __u8 **vnd_data);
-	u8 (*classify_pkt_type)(struct hci_dev *hdev, struct sk_buff *skb);
 };
 
 #define HCI_PHY_HANDLE(handle)	(handle & 0xff)

--- a/net/bluetooth/hci_core.c
+++ b/net/bluetooth/hci_core.c
@@ -2868,29 +2868,13 @@ int hci_reset_dev(struct hci_dev *hdev)
 }
 EXPORT_SYMBOL(hci_reset_dev);
 
-static u8 hci_dev_classify_pkt_type(struct hci_dev *hdev, struct sk_buff *skb)
-{
-	if (hdev->classify_pkt_type)
-		return hdev->classify_pkt_type(hdev, skb);
-
-	return hci_skb_pkt_type(skb);
-}
-
 /* Receive frame from HCI drivers */
 int hci_recv_frame(struct hci_dev *hdev, struct sk_buff *skb)
 {
-	u8 dev_pkt_type;
-
 	if (!hdev || (!test_bit(HCI_UP, &hdev->flags)
 		      && !test_bit(HCI_INIT, &hdev->flags))) {
 		kfree_skb(skb);
 		return -ENXIO;
-	}
-
-	/* Check if the driver agree with packet type classification */
-	dev_pkt_type = hci_dev_classify_pkt_type(hdev, skb);
-	if (hci_skb_pkt_type(skb) != dev_pkt_type) {
-		hci_skb_pkt_type(skb) = dev_pkt_type;
 	}
 
 	switch (hci_skb_pkt_type(skb)) {


### PR DESCRIPTION
…n-offload cards

stable list inclusion
link:https://lore.kernel.org/stable/CABtds-0a9d5OMjOTO2Juf6zTvK5inq9BKnKUkWE1of-gnk7TDQ@mail.gmail.com/T/#u

This reverts commit f25b7fd36cc3a850e006aed686f5bbecd200de1b.

The commit introduces vendor-specific classification of ISO data, but breaks Bluetooth functionality on certain Intel cards that do not support audio offload, such as the 9462. Affected devices are unable to discover new Bluetooth peripherals, and previously paired devices fail to reconnect.

This issue does not affect newer cards (e.g., AX201+) that support audio offload. A conditional check using AOLD() could be used in the future to reintroduce this behavior only on supported hardware.

Cc: Ying Hsu <yinghsu@chromium.org>
Cc: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
Cc: <stable@vger.kernel.org>

## Summary by Sourcery

Revert vendor-specific ISO packet type classification for Intel Bluetooth devices to fix connectivity issues on older hardware

Bug Fixes:
- Resolves Bluetooth functionality problems on older Intel cards (e.g., 9462) that do not support audio offload, which were unable to discover or reconnect to Bluetooth peripherals

Enhancements:
- Removed vendor-specific packet type classification logic that was causing compatibility issues with certain Bluetooth adapters