### PR TITLE
KVM: SVM: CSV: Return 0 at the beginning of csv_guest_hygon_coco_exte…

### DIFF
--- a/arch/x86/kvm/svm/csv.c
+++ b/arch/x86/kvm/svm/csv.c
@@ -3066,7 +3066,7 @@ static int csv_get_hygon_coco_extension(struct kvm *kvm)
 	size_t len = sizeof(uint32_t);
 	int ret = 0;
 
-	if (!kvm)
+	if (!kvm || !csv3_guest(kvm))
 		return 0;
 
 	csv = &to_kvm_svm_csv(kvm)->csv_info;


### PR DESCRIPTION
…nsion() for non-CSV3 VMs

hygon inclusion
category: bugfix
CVE: NA

---------------------------

The commit 593e0144ea2a ("KVM: SVM: CSV: Provide KVM_CAP_HYGON_COCO_EXT interface") provides a helper function csv_guest_hygon_coco_extension() to express that the available Hygon Confidential-Computing extensions can be used by the current VM. Obviously, a Non-Confidential-Computing VM will not be able to use these extensions, so return 0 at the beginning of csv_guest_hygon_coco_extension() for Non-CSV3 VMs.

Fixes: 593e0144ea2a ("KVM: SVM: CSV: Provide KVM_CAP_HYGON_COCO_EXT interface")

## Summary by Sourcery

Bug Fixes:
- Ensure csv_guest_hygon_coco_extension() returns 0 for non-Confidential-Computing VMs to prevent incorrect extension reporting