### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] CI: check-config: update generic config whitelist

### DIFF
--- a/.github/workflows/generic_config_whitelist
+++ b/.github/workflows/generic_config_whitelist
@@ -15,3 +15,5 @@ CONFIG_SCHED_DEBUG
 CONFIG_FB_EFI
 # driver for CAN bus
 CONFIG_CAN
+# driver for USB serial
+CONFIG_USB_SERIAL


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the generic configuration whitelist used in kernel configuration validation checks