### PR TITLE
Revert "HID: i2c-hid: improve i2c_hid_get_report error message"

### DIFF
--- a/drivers/hid/i2c-hid/i2c-hid-core.c
+++ b/drivers/hid/i2c-hid/i2c-hid-core.c
@@ -389,7 +389,7 @@ static int i2c_hid_set_or_send_report(struct i2c_hid *ihid,
 	error = i2c_hid_xfer(ihid, ihid->cmdbuf, length, NULL, 0);
 	if (error) {
 		dev_err(&ihid->client->dev,
-			"failed to get a report from device: %d\n", error);
+			"failed to set a report to device: %d\n", error);
 		return error;
 	}
 


### PR DESCRIPTION
It patch wrong context, and the patch has already patched in commit e3db0d575c0125d7fa539dde68a2a91db15f3872.

This reverts commit af7a17363aa20f300ba5c063d3fe7bf314168319. Link: https://github.com/deepin-community/kernel/pull/734
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Corrected an error message in the i2c_hid_set_or_send_report function to accurately reflect the operation being performed