### PR TITLE
nand: phytium: Resolved a call trace warning message

### DIFF
--- a/drivers/mtd/nand/raw/phytium_nand.c
+++ b/drivers/mtd/nand/raw/phytium_nand.c
@@ -2023,6 +2023,8 @@ int phytium_nand_init(struct phytium_nfc *nfc)
 	nfc->controller.ops = &phytium_nand_controller_ops;
 	INIT_LIST_HEAD(&nfc->chips);
 
+	spin_lock_init(&nfc->spinlock);
+
 	/* Init the controller and then probe the chips */
 	ret = phytium_nfc_init(nfc);
 	if (ret)
@@ -2031,8 +2033,6 @@ int phytium_nand_init(struct phytium_nfc *nfc)
 	ret = phytium_nand_chip_init(nfc);
 	if (ret)
 		goto out;
-
-	spin_lock_init(&nfc->spinlock);
 
 out:
 	return ret;

--- a/drivers/mtd/nand/raw/phytium_nand_pci.c
+++ b/drivers/mtd/nand/raw/phytium_nand_pci.c
@@ -11,6 +11,7 @@
 #include "phytium_nand.h"
 
 #define DRV_NAME	"phytium_nand_pci"
+#define DRV_VERSION	"1.0.0"
 
 static struct mtd_partition partition_info[] = {
 	{
@@ -148,3 +149,4 @@ module_pci_driver(phytium_pci_driver);
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("PCI driver for Phytium NAND controller");
 MODULE_AUTHOR("Zhu Mingshuai <zhumingshuai@phytium.com.cn>");
+MODULE_VERSION(DRV_VERSION);

--- a/drivers/mtd/nand/raw/phytium_nand_plat.c
+++ b/drivers/mtd/nand/raw/phytium_nand_plat.c
@@ -20,6 +20,7 @@
 #include "phytium_nand.h"
 
 #define DRV_NAME	"phytium_nand_plat"
+#define DRV_VERSION	"1.0.0"
 
 static int phytium_nfc_plat_probe(struct platform_device *pdev)
 {
@@ -136,3 +137,4 @@ module_platform_driver(phytium_nfc_plat_driver)
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Phytium NAND controller Platform driver");
 MODULE_AUTHOR("Zhu Mingshuai <zhumingshuai@phytium.com.cn>");
+MODULE_VERSION(DRV_VERSION);


### PR DESCRIPTION
Resolved a call trace warning message in the driver registration times.
Also add the driver version description.

## Summary by Sourcery

Fix a potential race condition in the Phytium NAND driver initialization and add module version information.

Bug Fixes:
- Initialize the NAND controller spinlock earlier to prevent a potential race condition during driver registration.

Chores:
- Add module version information to the PCI and platform NAND drivers.