### PR TITLE
phytium: Add DT bindings for PCIe endpoint controller and driver version message

### DIFF
--- a/Documentation/devicetree/bindings/pci/phytium,pd2008-pcie-ep.yaml
+++ b/Documentation/devicetree/bindings/pci/phytium,pd2008-pcie-ep.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/pci/phytium,pd2008-pcie-ep.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium PCIe endpoint controller
+
+maintainers:
+  - Chen Baozi <chenbaozi@phytium.com.cn>
+
+allOf:
+  - $ref: "pci-ep.yaml#"
+
+properties:
+  compatible:
+    const: phytium,pd2008-pcie-ep
+
+  reg:
+    maxItems: 2
+
+  reg-names:
+    items:
+      - const: reg
+      - const: mem
+
+required:
+  - compatible
+  - reg
+  - reg-names
+
+examples:
+  - |
+    ep0: ep@0x29030000 {
+      compatible = "phytium,pd2008-pcie-ep";
+      reg = <0x0 0x29030000 0x0 0x10000>,
+            <0x11 0x00000000 0x1 0x00000000>,
+            <0x0 0x29101000 0x0 0x1000>;
+      reg-names = "reg", "mem", "hpb";
+      max-outbound-regions = <3>;
+      max-functions = /bits/ 8 <1>;
+    };

--- a/drivers/pci/controller/pcie-phytium-ep.c
+++ b/drivers/pci/controller/pcie-phytium-ep.c
@@ -19,6 +19,8 @@
 #include "pcie-phytium-ep.h"
 #include "pcie-phytium-register.h"
 
+#define PHYTIUM_PCIE_RP_DRIVER_VERSION		"1.1.1"
+
 #define PHYTIUM_PCIE_EP_IRQ_PCI_ADDR_NONE	0x0
 #define PHYTIUM_PCIE_EP_IRQ_PCI_ADDR_LEGACY	0x1
 
@@ -462,9 +464,10 @@ static struct platform_driver phytium_pcie_ep_driver = {
 	.probe = phytium_pcie_ep_probe,
 	.remove = phytium_pcie_ep_remove,
 };
-
+MODULE_DEVICE_TABLE(of, phytium_pcie_ep_of_match);
 module_platform_driver(phytium_pcie_ep_driver);
 
 MODULE_LICENSE("GPL");
+MODULE_VERSION(PHYTIUM_PCIE_RP_DRIVER_VERSION);
 MODULE_AUTHOR("Yang Xun <yangxun@phytium.com.cn>");
 MODULE_DESCRIPTION("Phytium PCIe Controller Endpoint driver");


### PR DESCRIPTION
This patch documents the DT bindings for the Phytium PCIe controller when configured in endpoint mode.
Also Add phytium pcie ep driver version information.