### PR TITLE
phytium:  macb update to phytium 6.6.0.2 version

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -112,6 +112,8 @@ struct sifive_fu540_macb_mgmt {
 static void macb_tx_unmap(struct macb *bp,
 			  struct macb_tx_skb *tx_skb,
 			  int budget);
+static void macb_set_addr(struct macb *bp, struct macb_dma_desc *desc,
+			  dma_addr_t addr);
 
 /* DMA buffer descriptor might be different size
  * depends on hardware configuration:
@@ -744,6 +746,7 @@ static void macb_mac_link_down(struct phylink_config *config, unsigned int mode,
 	struct macb *bp = netdev_priv(ndev);
 	struct macb_tx_skb *tx_skb;
 	struct macb_queue *queue;
+	struct macb_dma_desc *tx_desc = NULL;
 	unsigned int q;
 	u32 ctrl;
 	int i;
@@ -763,12 +766,18 @@ static void macb_mac_link_down(struct phylink_config *config, unsigned int mode,
 
 	/* Tx clean */
 	for (q = 0, queue = bp->queues; q < bp->num_queues; ++q, ++queue) {
+		spin_lock(&queue->tx_ptr_lock);
 		for (i = 0; i < bp->tx_ring_size; i++) {
 			tx_skb = macb_tx_skb(queue, i);
 			/* free unsent skb buffers */
 			if (tx_skb)
 				macb_tx_unmap(bp, tx_skb, 0);
+
+			tx_desc = macb_tx_desc(queue, i);
+			macb_set_addr(bp, tx_desc, 0);
+			tx_desc->ctrl &= ~MACB_BIT(TX_USED);
 		}
+		spin_unlock(&queue->tx_ptr_lock);
 	}
 
 	netif_tx_stop_all_queues(ndev);

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -5978,9 +5978,6 @@ static int __maybe_unused macb_resume(struct device *dev)
 	macb_set_rx_mode(netdev);
 	macb_restore_features(bp);
 	rtnl_lock();
-	if (!device_may_wakeup(&bp->dev->dev))
-		phy_init(bp->sgmii_phy);
-
 	phylink_start(bp->phylink);
 	rtnl_unlock();
 

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -1608,7 +1608,6 @@ static void gem_rx_refill(struct macb_queue *queue)
 		/* Make hw descriptor updates visible to CPU */
 		rmb();
 
-		queue->rx_prepared_head++;
 		desc = macb_rx_desc(queue, entry);
 
 		if (!queue->rx_skbuff[entry]) {
@@ -1647,6 +1646,7 @@ static void gem_rx_refill(struct macb_queue *queue)
 			dma_wmb();
 			desc->addr &= ~MACB_BIT(RX_USED);
 		}
+		queue->rx_prepared_head++;
 	}
 
 	/* Make descriptor updates visible to hardware */

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -809,7 +809,21 @@ static void phytium_gem1p0_sel_clk(struct macb *bp, int speed)
 		gem_writel(bp, RX_CLK_SEL3_0, 0x0); /*0x1c78*/
 		gem_writel(bp, RX_CLK_SEL4_0, 0x0); /*0x1c7c*/
 	} else if (bp->phy_interface == PHY_INTERFACE_MODE_SGMII) {
-		if (speed == SPEED_1000) {
+		if (speed == SPEED_2500) {
+			gem_writel(bp, DIV_SEL0_LN, 0x1);		   /*0x1c08*/
+			gem_writel(bp, DIV_SEL1_LN, 0x2);		   /*0x1c0c*/
+			gem_writel(bp, PMA_XCVR_POWER_STATE, 0x1); /*0x1c10*/
+			gem_writel(bp, TX_CLK_SEL0, 0x0);		   /*0x1c20*/
+			gem_writel(bp, TX_CLK_SEL1, 0x1);		   /*0x1c24*/
+			gem_writel(bp, TX_CLK_SEL2, 0x1);		   /*0x1c28*/
+			gem_writel(bp, TX_CLK_SEL3, 0x1);		   /*0x1c2c*/
+			gem_writel(bp, RX_CLK_SEL0, 0x1);		   /*0x1c30*/
+			gem_writel(bp, RX_CLK_SEL1, 0x0);		   /*0x1c34*/
+			gem_writel(bp, TX_CLK_SEL3_0, 0x0);		   /*0x1c70*/
+			gem_writel(bp, TX_CLK_SEL4_0, 0x0);		   /*0x1c74*/
+			gem_writel(bp, RX_CLK_SEL3_0, 0x0);		   /*0x1c78*/
+			gem_writel(bp, RX_CLK_SEL4_0, 0x0);		   /*0x1c7c*/
+		} else if (speed == SPEED_1000) {
 			gem_writel(bp, SRC_SEL_LN, 0x1); /*0x1c04*/
 			gem_writel(bp, DIV_SEL0_LN, 0x4); /*0x1c08*/
 			gem_writel(bp, DIV_SEL1_LN, 0x8); /*0x1c0c*/
@@ -983,10 +997,16 @@ static void macb_mac_link_up(struct phylink_config *config,
 
 	if (speed == SPEED_2500) {
 		u32 network_ctrl;
+		u32 pcsctrl, old_pcsctrl;
 
 		network_ctrl = macb_readl(bp, NCR);
 		network_ctrl |= MACB_BIT(2PT5G);
 		macb_writel(bp, NCR, network_ctrl);
+
+		old_pcsctrl = gem_readl(bp, PCSCNTRL);
+		pcsctrl = old_pcsctrl & ~GEM_BIT(PCSAUTONEG);
+		if (old_pcsctrl != pcsctrl)
+			gem_writel(bp, PCSCNTRL, pcsctrl);
 	}
 
 	if (bp->phy_interface == PHY_INTERFACE_MODE_10GBASER ||
@@ -1128,11 +1148,11 @@ static int macb_mii_probe(struct net_device *dev)
 	bp->phylink_config.type = PHYLINK_NETDEV;
 	bp->phylink_config.mac_managed_pm = true;
 
-	if (bp->phy_interface == PHY_INTERFACE_MODE_SGMII) {
+	if (bp->phy_interface == PHY_INTERFACE_MODE_SGMII ||
+	    bp->phy_interface == PHY_INTERFACE_MODE_2500BASEX) {
 		bp->phylink_config.poll_fixed_state = true;
 		bp->phylink_config.get_fixed_state = macb_get_pcs_fixed_state;
-	} else if (bp->phy_interface == PHY_INTERFACE_MODE_2500BASEX ||
-			bp->phy_interface == PHY_INTERFACE_MODE_USXGMII) {
+	} else if (bp->phy_interface == PHY_INTERFACE_MODE_USXGMII) {
 		bp->phylink_config.poll_fixed_state = true;
 		bp->phylink_config.get_fixed_state = macb_get_usx_pcs_fixed_state;
 	}
@@ -1166,12 +1186,6 @@ static int macb_mii_probe(struct net_device *dev)
 				  bp->phylink_config.supported_interfaces);
 			bp->phylink_config.mac_capabilities |= MAC_10000FD;
 		}
-	}
-
-	if (bp->phy_interface == PHY_INTERFACE_MODE_SGMII ||
-	    bp->phy_interface == PHY_INTERFACE_MODE_2500BASEX) {
-		bp->phylink_config.poll_fixed_state = true;
-		bp->phylink_config.get_fixed_state = macb_get_pcs_fixed_state;
 	}
 
 	bp->phylink = phylink_create(&bp->phylink_config, bp->pdev->dev.fwnode,

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -5799,16 +5799,24 @@ static int macb_remove(struct platform_device *pdev)
 	if (dev) {
 		bp = netdev_priv(dev);
 		phy_exit(bp->sgmii_phy);
+		unregister_netdev(dev);
 		mdiobus_unregister(bp->mii_bus);
 		mdiobus_free(bp->mii_bus);
 
-		unregister_netdev(dev);
 		tasklet_kill(&bp->hresp_err_tasklet);
 		pm_runtime_disable(&pdev->dev);
 		pm_runtime_dont_use_autosuspend(&pdev->dev);
 		if (!pm_runtime_suspended(&pdev->dev)) {
-			macb_clks_disable(bp->pclk, bp->hclk, bp->tx_clk,
-					  bp->rx_clk, bp->tsu_clk);
+			if (__clk_is_enabled(bp->pclk))
+				clk_disable_unprepare(bp->pclk);
+			if (__clk_is_enabled(bp->hclk))
+				clk_disable_unprepare(bp->hclk);
+			if (__clk_is_enabled(bp->tx_clk))
+				clk_disable_unprepare(bp->tx_clk);
+			if (__clk_is_enabled(bp->rx_clk))
+				clk_disable_unprepare(bp->rx_clk);
+			if (__clk_is_enabled(bp->tsu_clk))
+				clk_disable_unprepare(bp->tsu_clk);
 			pm_runtime_set_suspended(&pdev->dev);
 		}
 		phylink_destroy(bp->phylink);
@@ -5997,10 +6005,21 @@ static int __maybe_unused macb_runtime_suspend(struct device *dev)
 	struct net_device *netdev = dev_get_drvdata(dev);
 	struct macb *bp = netdev_priv(netdev);
 
-	if (!(device_may_wakeup(dev)))
-		macb_clks_disable(bp->pclk, bp->hclk, bp->tx_clk, bp->rx_clk, bp->tsu_clk);
-	else if (!(bp->caps & MACB_CAPS_NEED_TSUCLK))
-		macb_clks_disable(NULL, NULL, NULL, NULL, bp->tsu_clk);
+	if (!(device_may_wakeup(dev))) {
+		if (__clk_is_enabled(bp->pclk))
+			clk_disable_unprepare(bp->pclk);
+		if (__clk_is_enabled(bp->hclk))
+			clk_disable_unprepare(bp->hclk);
+		if (__clk_is_enabled(bp->tx_clk))
+			clk_disable_unprepare(bp->tx_clk);
+		if (__clk_is_enabled(bp->rx_clk))
+			clk_disable_unprepare(bp->rx_clk);
+		if (__clk_is_enabled(bp->tsu_clk))
+			clk_disable_unprepare(bp->tsu_clk);
+	} else if (!(bp->caps & MACB_CAPS_NEED_TSUCLK)) {
+		if (__clk_is_enabled(bp->tsu_clk))
+			clk_disable_unprepare(bp->tsu_clk);
+	}
 
 	return 0;
 }

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -3194,6 +3194,10 @@ static void macb_init_hw(struct macb *bp)
 	macb_reset_hw(bp);
 	macb_set_hwaddr(bp);
 
+	config = macb_readl(bp, NCR);
+	config |= MACB_BIT(MPE);
+	macb_writel(bp, NCR, config);
+
 	config = macb_mdc_clk_div(bp);
 	config |= MACB_BF(RBOF, NET_IP_ALIGN);	/* Make eth data aligned */
 	config |= MACB_BIT(DRFCS);		/* Discard Rx FCS */


### PR DESCRIPTION
update to phytium 6.6.0.2 version

## Summary by Sourcery

Update the Cadence MACB driver for Phytium platforms, adding support for 2.5Gbps speed and refining clock management and link state handling.

Bug Fixes:
- Ensure transmit descriptors are properly cleared during link down events.
- Correct clock disable logic in suspend and remove paths by checking enablement state first.
- Remove redundant PHY initialization during system resume.

Enhancements:
- Add support for 2.5Gbps speed configuration over SGMII and 2500Base-X interfaces.
- Update clock selection logic to handle 2.5Gbps speed.
- Adjust link up/down procedures and PCS handling for 2.5Gbps operation.

Chores:
- Increase the minimum RX ring size from 64 to 128.
- Enable Management Port Enable (MPE) during hardware initialization.