### PR TITLE
net/stmmac: Add pm ops for phytium dwmac driver

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
@@ -46,6 +46,7 @@ static struct platform_driver phytium_dwmac_driver = {
 	.remove = phytium_dwmac_remove,
 	.driver = {
 		.name		= "phytium-dwmac",
+		.pm		= &stmmac_pltfr_pm_ops,
 		.of_match_table	= of_match_ptr(phytium_dwmac_of_match),
 		.acpi_match_table = ACPI_PTR(phytium_dwmac_acpi_ids),
 	},


### PR DESCRIPTION
If there is no PM Ops, the NIC will not work after waking up from suspend.

## Summary by Sourcery

Bug Fixes:
- Fix network interface failure after resuming from suspend.