### PR TITLE
[6.6.0.2] Some features and bugfixes of Phytium DDR and PCIe PMU driver

### DIFF
--- a/drivers/perf/phytium/phytium_ddr_pmu.c
+++ b/drivers/perf/phytium/phytium_ddr_pmu.c
@@ -32,6 +32,8 @@
 #undef pr_fmt
 #define pr_fmt(fmt) "phytium_ddr_pmu: " fmt
 
+#define DDR_PERF_DRIVER_VERSION "1.2.1"
+
 #define PHYTIUM_DDR_MAX_COUNTERS 8
 
 #define DDR_START_TIMER 0x000
@@ -725,4 +727,5 @@ module_exit(phytium_ddr_pmu_module_exit);
 
 MODULE_DESCRIPTION("Phytium DDR PMU driver");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(DDR_PERF_DRIVER_VERSION);
 MODULE_AUTHOR("Hu Xianghua <huxianghua@phytium.com.cn>");

--- a/drivers/perf/phytium/phytium_ddr_pmu.c
+++ b/drivers/perf/phytium/phytium_ddr_pmu.c
@@ -59,9 +59,13 @@
 #define DDR_CLK_FRE		0xe00
 #define DDR_DATA_WIDTH		0xe04
 
+#define DDR_PMU_OFL_STOP_TYPE_VAL  0x10
+
 #define SOC_ID_PS230XX		0x8
 #define SOC_ID_PS240XX		0x6
 #define MIDR_PSXX		0x700F8620
+
+#define to_phytium_ddr_pmu(p) (container_of(p, struct phytium_ddr_pmu, pmu))
 
 enum {
 	PS230XX			= 0x01,
@@ -70,21 +74,18 @@ enum {
 
 static inline int phytium_socs_type(void)
 {
-	unsigned int soc_id;
-	unsigned int midr;
+	unsigned int soc_id, cpu_id;
 
 	soc_id = read_sysreg_s(SYS_AIDR_EL1);
-	midr = read_cpuid_id();
+	cpu_id = read_cpuid_id();
 
-	if ((soc_id == SOC_ID_PS230XX) && (midr == MIDR_PSXX))
+	if ((soc_id == SOC_ID_PS230XX) && (cpu_id == MIDR_PSXX))
 		return PS230XX;
-	if ((soc_id == SOC_ID_PS240XX) && (midr == MIDR_PSXX))
+	else if ((soc_id == SOC_ID_PS240XX) && (cpu_id == MIDR_PSXX))
 		return PS240XX;
 	else
 		return 0;
 }
-
-#define to_phytium_ddr_pmu(p) (container_of(p, struct phytium_ddr_pmu, pmu))
 
 static int phytium_ddr_pmu_hp_state;
 
@@ -119,20 +120,20 @@ static const u32 ddr_counter_reg_offset[] = {
 	DDR_EVENT_RXREQ_WNSF, DDR_EVENT_BANDWIDTH
 };
 
+
 ssize_t phytium_ddr_pmu_format_sysfs_show(struct device *dev,
-					  struct device_attribute *attr,
-					  char *buf)
+				  struct device_attribute *attr,
+				  char *buf)
 {
 	struct dev_ext_attribute *eattr;
 
 	eattr = container_of(attr, struct dev_ext_attribute, attr);
-
 	return sprintf(buf, "%s\n", (char *)eattr->var);
 }
 
 ssize_t phytium_ddr_pmu_event_sysfs_show(struct device *dev,
-					 struct device_attribute *attr,
-					 char *page)
+				 struct device_attribute *attr,
+				 char *page)
 {
 	struct dev_ext_attribute *eattr;
 
@@ -142,7 +143,7 @@ ssize_t phytium_ddr_pmu_event_sysfs_show(struct device *dev,
 }
 
 static ssize_t cpumask_show(struct device *dev, struct device_attribute *attr,
-		     char *buf)
+			     char *buf)
 {
 	struct phytium_ddr_pmu *ddr_pmu =
 		to_phytium_ddr_pmu(dev_get_drvdata(dev));
@@ -151,17 +152,17 @@ static ssize_t cpumask_show(struct device *dev, struct device_attribute *attr,
 }
 
 #define PHYTIUM_PMU_ATTR(_name, _func, _config)                             \
-	(&((struct dev_ext_attribute[]){                                    \
-		{ __ATTR(_name, 0444, _func, NULL), (void *)_config } })[0] \
-		  .attr.attr)
+		(&((struct dev_ext_attribute[]){                                    \
+			{ __ATTR(_name, 0444, _func, NULL), (void *)_config } })[0] \
+			  .attr.attr)
 
 #define PHYTIUM_DDR_PMU_FORMAT_ATTR(_name, _config)                \
-	PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_format_sysfs_show, \
-			 (void *)_config)
+		PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_format_sysfs_show, \
+				 (void *)_config)
 
 #define PHYTIUM_DDR_PMU_EVENT_ATTR(_name, _config)                \
-	PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_event_sysfs_show, \
-			 (unsigned long)_config)
+		PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_event_sysfs_show, \
+				 (unsigned long)_config)
 
 static struct attribute *phytium_ddr_pmu_format_attr[] = {
 	PHYTIUM_DDR_PMU_FORMAT_ATTR(event, "config:0-2"),
@@ -247,6 +248,9 @@ static void phytium_ddr_pmu_enable_clk(struct phytium_ddr_pmu *ddr_pmu)
 {
 	u32 val;
 
+	if (ddr_pmu->soc_version == PS240XX)
+		return;
+
 	val = readl(ddr_pmu->cfg_base);
 	val |= 0xF;
 	writel(val, ddr_pmu->cfg_base);
@@ -255,6 +259,9 @@ static void phytium_ddr_pmu_enable_clk(struct phytium_ddr_pmu *ddr_pmu)
 static void phytium_ddr_pmu_disable_clk(struct phytium_ddr_pmu *ddr_pmu)
 {
 	u32 val;
+
+	if (ddr_pmu->soc_version == PS240XX)
+		return;
 
 	val = readl(ddr_pmu->cfg_base);
 	val &= ~(0xF);
@@ -410,7 +417,6 @@ void phytium_ddr_pmu_event_del(struct perf_event *event, int flags)
 	val = phytium_ddr_pmu_get_stop_state(ddr_pmu);
 	phytium_ddr_pmu_unmark_event(ddr_pmu, hwc->idx);
 
-
 	perf_event_update_userpage(event);
 	ddr_pmu->pmu_events.hw_events[hwc->idx] = NULL;
 }
@@ -476,7 +482,7 @@ static irqreturn_t phytium_ddr_pmu_overflow_handler(int irq, void *dev_id)
 		}
 
 		phytium_ddr_pmu_clear_all_counters(ddr_pmu);
-		if ((stop_state & 0x10) == 0)
+		if ((stop_state & DDR_PMU_OFL_STOP_TYPE_VAL) == 0)
 			phytium_ddr_pmu_start_all_counters(ddr_pmu);
 
 		return IRQ_HANDLED;
@@ -522,8 +528,8 @@ static int phytium_ddr_pmu_init_data(struct platform_device *pdev,
 	ddr_pmu->soc_version = phytium_socs_type();
 
 
-	if ((ddr_pmu->soc_version != PS230XX) || (ddr_pmu->soc_version != PS240XX)) {
-		dev_err(&pdev->dev, "The DDR PMU driver can't be installed in this SoC.\n");
+	if (ddr_pmu->soc_version == 0) {
+		dev_err(&pdev->dev, "The DDR PMU driver can't be installed in this SoC!\n");
 		return -EINVAL;
 	}
 

--- a/drivers/perf/phytium/phytium_ddr_pmu.c
+++ b/drivers/perf/phytium/phytium_ddr_pmu.c
@@ -23,6 +23,7 @@
 #include <linux/platform_device.h>
 #include <linux/smp.h>
 #include <linux/types.h>
+#include <linux/version.h>
 
 #if IS_ENABLED(CONFIG_ARM || CONFIG_ARM64)
 #include <asm/cputype.h>
@@ -32,31 +33,56 @@
 #undef pr_fmt
 #define pr_fmt(fmt) "phytium_ddr_pmu: " fmt
 
-#define DDR_PERF_DRIVER_VERSION "1.2.1"
 
 #define PHYTIUM_DDR_MAX_COUNTERS 8
+#define DDR_PERF_DRIVER_VERSION "1.3.0"
 
-#define DDR_START_TIMER 0x000
-#define DDR_STOP_TIMER 0x004
-#define DDR_CLEAR_EVENT 0x008
-#define DDR_SET_TIMER_L 0x00c
-#define DDR_SET_TIMER_H 0x010
-#define DDR_TRIG_MODE 0x014
-#define DDR_NOW_STATE 0x0e0
-#define DDR_EVENT_CYCLES 0x0e4
-#define DDR_TPOINT_END_L 0x0e4
-#define DDR_TPOINT_END_H 0x0e8
-#define DDR_STATE_STOP 0x0ec
-#define DDR_EVENT_RXREQ 0x100
-#define DDR_EVENT_RXDAT 0x104
-#define DDR_EVENT_TXDAT 0x108
-#define DDR_EVENT_RXREQ_RNS 0x10c
-#define DDR_EVENT_RXREQ_WNSP 0x110
-#define DDR_EVENT_RXREQ_WNSF 0x114
-#define DDR_EVENT_BANDWIDTH 0x200
-#define DDR_W_DATA_BASE 0x200
-#define DDR_CLK_FRE 0xe00
-#define DDR_DATA_WIDTH 0xe04
+#define DDR_START_TIMER		0x000
+#define DDR_STOP_TIMER		0x004
+#define DDR_CLEAR_EVENT		0x008
+#define DDR_SET_TIMER_L		0x00c
+#define DDR_SET_TIMER_H		0x010
+#define DDR_TRIG_MODE		0x014
+#define DDR_NOW_STATE		0x0e0
+#define DDR_EVENT_CYCLES	0x0e4
+#define DDR_TPOINT_END_L	0x0e4
+#define DDR_TPOINT_END_H	0x0e8
+#define DDR_STATE_STOP		0x0ec
+#define DDR_EVENT_RXREQ		0x100
+#define DDR_EVENT_RXDAT		0x104
+#define DDR_EVENT_TXDAT		0x108
+#define DDR_EVENT_RXREQ_RNS	0x10c
+#define DDR_EVENT_RXREQ_WNSP	0x110
+#define DDR_EVENT_RXREQ_WNSF	0x114
+#define DDR_EVENT_BANDWIDTH	0x200
+#define DDR_W_DATA_BASE		0x200
+#define DDR_CLK_FRE		0xe00
+#define DDR_DATA_WIDTH		0xe04
+
+#define SOC_ID_PS230XX		0x8
+#define SOC_ID_PS240XX		0x6
+#define MIDR_PSXX		0x700F8620
+
+enum {
+	PS230XX			= 0x01,
+	PS240XX			= 0x02,
+};
+
+static inline int phytium_socs_type(void)
+{
+	unsigned int soc_id;
+	unsigned int midr;
+
+	soc_id = read_sysreg_s(SYS_AIDR_EL1);
+	midr = read_cpuid_id();
+
+	if ((soc_id == SOC_ID_PS230XX) && (midr == MIDR_PSXX))
+		return PS230XX;
+	if ((soc_id == SOC_ID_PS240XX) && (midr == MIDR_PSXX))
+		return PS240XX;
+	else
+		return 0;
+}
 
 #define to_phytium_ddr_pmu(p) (container_of(p, struct phytium_ddr_pmu, pmu))
 
@@ -70,15 +96,17 @@ struct phytium_ddr_pmu_hwevents {
 struct phytium_ddr_pmu {
 	struct device *dev;
 	void __iomem *base;
-	void __iomem *csr_base;
+	void __iomem *cfg_base;
+	void __iomem *irq_reg;
 	struct pmu pmu;
 	struct phytium_ddr_pmu_hwevents pmu_events;
 	u32 die_id;
 	u32 ddr_id;
 	u32 pmu_id;
-	int bit_idx;
+	int irq_bit;
 	int on_cpu;
 	int irq;
+	int soc_version;
 	struct hlist_node node;
 };
 
@@ -122,22 +150,21 @@ static ssize_t cpumask_show(struct device *dev, struct device_attribute *attr,
 	return cpumap_print_to_pagebuf(true, buf, cpumask_of(ddr_pmu->on_cpu));
 }
 
-#define PHYTIUM_PMU_ATTR(_name, _func, _config)				    \
-	(&((struct dev_ext_attribute[]){				    \
+#define PHYTIUM_PMU_ATTR(_name, _func, _config)                             \
+	(&((struct dev_ext_attribute[]){                                    \
 		{ __ATTR(_name, 0444, _func, NULL), (void *)_config } })[0] \
 		  .attr.attr)
 
-#define PHYTIUM_DDR_PMU_FORMAT_ATTR(_name, _config)		   \
+#define PHYTIUM_DDR_PMU_FORMAT_ATTR(_name, _config)                \
 	PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_format_sysfs_show, \
 			 (void *)_config)
 
-#define PHYTIUM_DDR_PMU_EVENT_ATTR(_name, _config)		  \
+#define PHYTIUM_DDR_PMU_EVENT_ATTR(_name, _config)                \
 	PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_event_sysfs_show, \
 			 (unsigned long)_config)
 
 static struct attribute *phytium_ddr_pmu_format_attr[] = {
 	PHYTIUM_DDR_PMU_FORMAT_ATTR(event, "config:0-2"),
-	PHYTIUM_DDR_PMU_FORMAT_ATTR(timer, "config1:0-31"),
 	NULL,
 };
 
@@ -181,11 +208,6 @@ static const struct attribute_group *phytium_ddr_pmu_attr_groups[] = {
 	NULL,
 };
 
-static u32 phytium_ddr_pmu_get_event_timer(struct perf_event *event)
-{
-	return FIELD_GET(GENMASK(31, 0), event->attr.config1);
-}
-
 static u64 phytium_ddr_pmu_read_counter(struct phytium_ddr_pmu *ddr_pmu,
 					   struct hw_perf_event *hwc)
 {
@@ -225,18 +247,18 @@ static void phytium_ddr_pmu_enable_clk(struct phytium_ddr_pmu *ddr_pmu)
 {
 	u32 val;
 
-	val = readl(ddr_pmu->csr_base);
+	val = readl(ddr_pmu->cfg_base);
 	val |= 0xF;
-	writel(val, ddr_pmu->csr_base);
+	writel(val, ddr_pmu->cfg_base);
 }
 
 static void phytium_ddr_pmu_disable_clk(struct phytium_ddr_pmu *ddr_pmu)
 {
 	u32 val;
 
-	val = readl(ddr_pmu->csr_base);
+	val = readl(ddr_pmu->cfg_base);
 	val &= ~(0xF);
-	writel(val, ddr_pmu->csr_base);
+	writel(val, ddr_pmu->cfg_base);
 }
 
 static void phytium_ddr_pmu_clear_all_counters(struct phytium_ddr_pmu *ddr_pmu)
@@ -254,29 +276,6 @@ static void phytium_ddr_pmu_stop_all_counters(struct phytium_ddr_pmu *ddr_pmu)
 	writel(0x1, ddr_pmu->base + DDR_STOP_TIMER);
 }
 
-static void phytium_ddr_pmu_set_timer(struct phytium_ddr_pmu *ddr_pmu,
-				      u32 th_val)
-{
-	u32 val;
-
-	val = readl(ddr_pmu->base + DDR_SET_TIMER_L);
-	val = readl(ddr_pmu->base + DDR_SET_TIMER_H);
-
-	writel(th_val, ddr_pmu->base + DDR_SET_TIMER_L);
-	writel(0, ddr_pmu->base + DDR_SET_TIMER_H);
-}
-
-static void phytium_ddr_pmu_reset_timer(struct phytium_ddr_pmu *ddr_pmu)
-{
-	u32 val;
-
-	val = readl(ddr_pmu->base + DDR_SET_TIMER_L);
-	val = readl(ddr_pmu->base + DDR_SET_TIMER_H);
-
-	writel(0xFFFFFFFF, ddr_pmu->base + DDR_SET_TIMER_L);
-	writel(0xFFFFFFFF, ddr_pmu->base + DDR_SET_TIMER_H);
-}
-
 static unsigned long
 phytium_ddr_pmu_get_stop_state(struct phytium_ddr_pmu *ddr_pmu)
 {
@@ -291,7 +290,7 @@ phytium_ddr_pmu_get_irq_flag(struct phytium_ddr_pmu *ddr_pmu)
 {
 	unsigned long val;
 
-	val = (unsigned long)readl(ddr_pmu->csr_base + 4);
+	val = (unsigned long)readl(ddr_pmu->irq_reg);
 	return val;
 }
 
@@ -326,7 +325,6 @@ int phytium_ddr_pmu_event_init(struct perf_event *event)
 {
 	struct hw_perf_event *hwc = &event->hw;
 	struct phytium_ddr_pmu *ddr_pmu;
-	u32 event_timer;
 
 	if (event->attr.type != event->pmu->type)
 		return -ENOENT;
@@ -346,10 +344,6 @@ int phytium_ddr_pmu_event_init(struct perf_event *event)
 
 	if (ddr_pmu->on_cpu == -1)
 		return -EINVAL;
-
-	event_timer = phytium_ddr_pmu_get_event_timer(event);
-	if (event_timer != 0)
-		phytium_ddr_pmu_set_timer(ddr_pmu, event_timer);
 
 	hwc->idx = -1;
 	hwc->config_base = event->attr.config;
@@ -410,16 +404,12 @@ void phytium_ddr_pmu_event_del(struct perf_event *event, int flags)
 	struct phytium_ddr_pmu *ddr_pmu = to_phytium_ddr_pmu(event->pmu);
 	struct hw_perf_event *hwc = &event->hw;
 	unsigned long val;
-	u32 event_timer;
 
 	phytium_ddr_pmu_event_stop(event, PERF_EF_UPDATE);
 	val = phytium_ddr_pmu_get_irq_flag(ddr_pmu);
 	val = phytium_ddr_pmu_get_stop_state(ddr_pmu);
 	phytium_ddr_pmu_unmark_event(ddr_pmu, hwc->idx);
 
-	event_timer = phytium_ddr_pmu_get_event_timer(event);
-	if (event_timer != 0)
-		phytium_ddr_pmu_reset_timer(ddr_pmu);
 
 	perf_event_update_userpage(event);
 	ddr_pmu->pmu_events.hw_events[hwc->idx] = NULL;
@@ -447,6 +437,12 @@ void phytium_ddr_pmu_disable(struct pmu *pmu)
 		phytium_ddr_pmu_stop_all_counters(ddr_pmu);
 }
 
+void phytium_ddr_pmu_reset(struct phytium_ddr_pmu *ddr_pmu)
+{
+	phytium_ddr_pmu_disable_clk(ddr_pmu);
+	phytium_ddr_pmu_clear_all_counters(ddr_pmu);
+}
+
 static const struct acpi_device_id phytium_ddr_pmu_acpi_match[] = {
 	{
 		"PHYT0043",
@@ -460,14 +456,13 @@ static irqreturn_t phytium_ddr_pmu_overflow_handler(int irq, void *dev_id)
 	struct phytium_ddr_pmu *ddr_pmu = dev_id;
 	struct perf_event *event;
 	unsigned long overflown, stop_state;
-	int idx;
 	unsigned long *used_mask = ddr_pmu->pmu_events.used_mask;
-
+	int idx;
 	int event_added = bitmap_weight(used_mask, PHYTIUM_DDR_MAX_COUNTERS);
 
 	overflown = phytium_ddr_pmu_get_irq_flag(ddr_pmu);
 
-	if (!test_bit(ddr_pmu->bit_idx, &overflown))
+	if (!test_bit(ddr_pmu->irq_bit, &overflown))
 		return IRQ_NONE;
 
 	stop_state = phytium_ddr_pmu_get_stop_state(ddr_pmu);
@@ -479,8 +474,10 @@ static irqreturn_t phytium_ddr_pmu_overflow_handler(int irq, void *dev_id)
 				continue;
 			phytium_ddr_pmu_event_update(event);
 		}
+
 		phytium_ddr_pmu_clear_all_counters(ddr_pmu);
-		phytium_ddr_pmu_start_all_counters(ddr_pmu);
+		if ((stop_state & 0x10) == 0)
+			phytium_ddr_pmu_start_all_counters(ddr_pmu);
 
 		return IRQ_HANDLED;
 	}
@@ -520,7 +517,15 @@ static int phytium_ddr_pmu_init_irq(struct phytium_ddr_pmu *ddr_pmu,
 static int phytium_ddr_pmu_init_data(struct platform_device *pdev,
 					struct phytium_ddr_pmu *ddr_pmu)
 {
-	struct resource *res, *clkres;
+	struct resource *res, *clkres, *irqres;
+
+	ddr_pmu->soc_version = phytium_socs_type();
+
+
+	if ((ddr_pmu->soc_version != PS230XX) || (ddr_pmu->soc_version != PS240XX)) {
+		dev_err(&pdev->dev, "The DDR PMU driver can't be installed in this SoC.\n");
+		return -EINVAL;
+	}
 
 	if (device_property_read_u32(&pdev->dev, "phytium,die-id",
 				     &ddr_pmu->die_id)) {
@@ -540,7 +545,7 @@ static int phytium_ddr_pmu_init_data(struct platform_device *pdev,
 		return -EINVAL;
 	}
 
-	ddr_pmu->bit_idx = ddr_pmu->ddr_id * 2 + ddr_pmu->pmu_id;
+	ddr_pmu->irq_bit = ddr_pmu->ddr_id * 2 + ddr_pmu->pmu_id;
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	ddr_pmu->base = devm_ioremap_resource(&pdev->dev, res);
@@ -556,14 +561,28 @@ static int phytium_ddr_pmu_init_data(struct platform_device *pdev,
 		dev_err(&pdev->dev, "failed for get ddr_pmu clk resource.\n");
 		return -EINVAL;
 	}
-
-	ddr_pmu->csr_base =
-		devm_ioremap(&pdev->dev, clkres->start, resource_size(clkres));
-	if (IS_ERR(ddr_pmu->csr_base)) {
-		dev_err(&pdev->dev,
-			"ioremap failed for ddr_pmu csr resource\n");
-		return PTR_ERR(ddr_pmu->csr_base);
+	ddr_pmu->cfg_base = devm_ioremap(&pdev->dev, clkres->start, resource_size(clkres));
+	if (IS_ERR(ddr_pmu->cfg_base)) {
+		dev_err(&pdev->dev, "ioremap failed for ddr_pmu clk resource\n");
+		return PTR_ERR(ddr_pmu->cfg_base);
 	}
+
+	if (ddr_pmu->soc_version == PS240XX) {
+		irqres = platform_get_resource(pdev, IORESOURCE_MEM, 2);
+		if (!irqres) {
+			dev_err(&pdev->dev, "failed for get ddr_pmu irq resource.\n");
+			return -EINVAL;
+		}
+		ddr_pmu->irq_reg = devm_ioremap(&pdev->dev, irqres->start, resource_size(irqres));
+		if (IS_ERR(ddr_pmu->irq_reg)) {
+			dev_err(&pdev->dev, "ioremap failed for ddr_pmu irq resource\n");
+			return PTR_ERR(ddr_pmu->irq_reg);
+		}
+	} else {
+		ddr_pmu->irq_reg = ddr_pmu->cfg_base + 0x4;
+	}
+
+	phytium_ddr_pmu_reset(ddr_pmu);
 
 	return 0;
 }
@@ -603,8 +622,8 @@ static int phytium_ddr_pmu_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	ret = cpuhp_state_add_instance(
-		phytium_ddr_pmu_hp_state, &ddr_pmu->node);
+	ret = cpuhp_state_add_instance(phytium_ddr_pmu_hp_state,
+					&ddr_pmu->node);
 	if (ret) {
 		dev_err(&pdev->dev, "Error %d registering hotplug;\n", ret);
 		return ret;
@@ -626,22 +645,19 @@ static int phytium_ddr_pmu_probe(struct platform_device *pdev)
 		.stop = phytium_ddr_pmu_event_stop,
 		.read = phytium_ddr_pmu_event_update,
 		.attr_groups = phytium_ddr_pmu_attr_groups,
-		.capabilities = PERF_PMU_CAP_NO_EXCLUDE,
 	};
 
 	ret = perf_pmu_register(&ddr_pmu->pmu, name, -1);
 	if (ret) {
 		dev_err(ddr_pmu->dev, "DDR PMU register failed!\n");
-		cpuhp_state_remove_instance_nocalls(
-			phytium_ddr_pmu_hp_state,
+		cpuhp_state_remove_instance_nocalls(phytium_ddr_pmu_hp_state,
 			&ddr_pmu->node);
 	}
 
 	phytium_ddr_pmu_enable_clk(ddr_pmu);
 
-	pr_info("Phytium DDR PMU: ");
-	pr_info(" die_id = %d ddr_id = %d pmu_id = %d.\n", ddr_pmu->die_id,
-		ddr_pmu->ddr_id, ddr_pmu->pmu_id);
+	pr_info("die%d_ddr%d_pmu%d on cpu%d.\n", ddr_pmu->die_id,
+		ddr_pmu->ddr_id, ddr_pmu->pmu_id, ddr_pmu->on_cpu);
 
 	return ret;
 }
@@ -653,8 +669,8 @@ static int phytium_ddr_pmu_remove(struct platform_device *pdev)
 	phytium_ddr_pmu_disable_clk(ddr_pmu);
 
 	perf_pmu_unregister(&ddr_pmu->pmu);
-	cpuhp_state_remove_instance_nocalls(
-		phytium_ddr_pmu_hp_state, &ddr_pmu->node);
+	cpuhp_state_remove_instance_nocalls(phytium_ddr_pmu_hp_state,
+					&ddr_pmu->node);
 
 	return 0;
 }
@@ -756,3 +772,4 @@ MODULE_DESCRIPTION("Phytium DDR PMU driver");
 MODULE_LICENSE("GPL");
 MODULE_VERSION(DDR_PERF_DRIVER_VERSION);
 MODULE_AUTHOR("Hu Xianghua <huxianghua@phytium.com.cn>");
+MODULE_AUTHOR("Tan Rui <tanrui2142@phytium.com.cn>");

--- a/drivers/perf/phytium/phytium_ddr_pmu.c
+++ b/drivers/perf/phytium/phytium_ddr_pmu.c
@@ -122,16 +122,16 @@ static ssize_t cpumask_show(struct device *dev, struct device_attribute *attr,
 	return cpumap_print_to_pagebuf(true, buf, cpumask_of(ddr_pmu->on_cpu));
 }
 
-#define PHYTIUM_PMU_ATTR(_name, _func, _config)                             \
-	(&((struct dev_ext_attribute[]){                                    \
+#define PHYTIUM_PMU_ATTR(_name, _func, _config)				    \
+	(&((struct dev_ext_attribute[]){				    \
 		{ __ATTR(_name, 0444, _func, NULL), (void *)_config } })[0] \
 		  .attr.attr)
 
-#define PHYTIUM_DDR_PMU_FORMAT_ATTR(_name, _config)                \
+#define PHYTIUM_DDR_PMU_FORMAT_ATTR(_name, _config)		   \
 	PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_format_sysfs_show, \
 			 (void *)_config)
 
-#define PHYTIUM_DDR_PMU_EVENT_ATTR(_name, _config)                \
+#define PHYTIUM_DDR_PMU_EVENT_ATTR(_name, _config)		  \
 	PHYTIUM_PMU_ATTR(_name, phytium_ddr_pmu_event_sysfs_show, \
 			 (unsigned long)_config)
 
@@ -582,8 +582,7 @@ static int phytium_ddr_pmu_dev_probe(struct platform_device *pdev,
 		return ret;
 
 	ddr_pmu->dev = &pdev->dev;
-	ddr_pmu->on_cpu = raw_smp_processor_id();
-	WARN_ON(irq_set_affinity(ddr_pmu->irq, cpumask_of(ddr_pmu->on_cpu)));
+	ddr_pmu->on_cpu = -1;
 
 	return 0;
 }
@@ -604,7 +603,7 @@ static int phytium_ddr_pmu_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	ret = cpuhp_state_add_instance_nocalls(
+	ret = cpuhp_state_add_instance(
 		phytium_ddr_pmu_hp_state, &ddr_pmu->node);
 	if (ret) {
 		dev_err(&pdev->dev, "Error %d registering hotplug;\n", ret);
@@ -670,6 +669,29 @@ static struct platform_driver phytium_ddr_pmu_driver = {
 	.remove = phytium_ddr_pmu_remove,
 };
 
+int phytium_ddr_pmu_online_cpu(unsigned int cpu, struct hlist_node *node)
+{
+	struct phytium_ddr_pmu *ddr_pmu =
+		hlist_entry_safe(node, struct phytium_ddr_pmu, node);
+
+	if (!cpumask_test_cpu(cpu, cpumask_of_node(ddr_pmu->die_id)))
+		return 0;
+
+	if (ddr_pmu->on_cpu != -1) {
+		if (!cpumask_test_cpu(ddr_pmu->on_cpu, cpumask_of_node(ddr_pmu->die_id))) {
+			perf_pmu_migrate_context(&ddr_pmu->pmu, ddr_pmu->on_cpu, cpu);
+			ddr_pmu->on_cpu = cpu;
+			WARN_ON(irq_set_affinity_hint(ddr_pmu->irq, cpumask_of(cpu)));
+		}
+		return 0;
+	}
+
+	ddr_pmu->on_cpu = cpu;
+	WARN_ON(irq_set_affinity_hint(ddr_pmu->irq, cpumask_of(cpu)));
+
+	return 0;
+}
+
 int phytium_ddr_pmu_offline_cpu(unsigned int cpu, struct hlist_node *node)
 {
 	struct phytium_ddr_pmu *ddr_pmu =
@@ -680,17 +702,22 @@ int phytium_ddr_pmu_offline_cpu(unsigned int cpu, struct hlist_node *node)
 	if (ddr_pmu->on_cpu != cpu)
 		return 0;
 
-	cpumask_and(&available_cpus,
-			  cpumask_of_node(ddr_pmu->die_id), cpu_online_mask);
-	target = cpumask_any_but(&available_cpus, cpu);
+	if (cpumask_and(&available_cpus, cpumask_of_node(ddr_pmu->die_id), cpu_online_mask) &&
+		cpumask_andnot(&available_cpus, &available_cpus, cpumask_of(cpu)))
+		target = cpumask_last(&available_cpus);
+	else {
+		cpumask_andnot(&available_cpus, cpu_online_mask, cpumask_of(cpu));
+		target = cpumask_last(&available_cpus);
+	}
+
 	if (target >= nr_cpu_ids) {
-		target = cpumask_any_but(cpu_online_mask, cpu);
-		if (target >= nr_cpu_ids)
-			return 0;
+		dev_err(ddr_pmu->dev, "offline cpu%d with no target to migrate.\n",
+			cpu);
+		return 0;
 	}
 
 	perf_pmu_migrate_context(&ddr_pmu->pmu, cpu, target);
-	WARN_ON(irq_set_affinity(ddr_pmu->irq, cpumask_of(target)));
+	WARN_ON(irq_set_affinity_hint(ddr_pmu->irq, cpumask_of(target)));
 	ddr_pmu->on_cpu = target;
 
 	return 0;
@@ -701,8 +728,8 @@ static int __init phytium_ddr_pmu_module_init(void)
 	int ret;
 
 	phytium_ddr_pmu_hp_state = cpuhp_setup_state_multi(CPUHP_AP_ONLINE_DYN,
-				      "perf/phytium/ddrpmu:offline",
-				      NULL, phytium_ddr_pmu_offline_cpu);
+				      "perf/phytium/ddrpmu:online",
+				      phytium_ddr_pmu_online_cpu, phytium_ddr_pmu_offline_cpu);
 	if (phytium_ddr_pmu_hp_state < 0) {
 		pr_err("DDR PMU: setup hotplug, phytium_ddr_pmu_hp_state = %d\n",
 			phytium_ddr_pmu_hp_state);

--- a/drivers/perf/phytium/phytium_pcie_pmu.c
+++ b/drivers/perf/phytium/phytium_pcie_pmu.c
@@ -71,6 +71,8 @@
 
 #define PCIE_DATA_WIDTH		0xe04
 
+#define PCIE_PMU_OFL_STOP_TYPE_VAL	0x10
+
 #define SYS_AIDR_EL1		sys_reg(3, 1, 0, 0, 7)
 #define SOC_ID_PS230XX		0x8
 #define SOC_ID_PS240XX		0x6
@@ -634,7 +636,7 @@ static irqreturn_t phytium_pcie_pmu_overflow_handler(int irq, void *dev_id)
 			phytium_pcie_pmu_event_update(event);
 		}
 		phytium_pcie_pmu_clear_all_counters(pcie_pmu);
-		if ((stop_state & 0x10) == 0)
+		if ((stop_state & PCIE_PMU_OFL_STOP_TYPE_VAL) == 0)
 			phytium_pcie_pmu_start_all_counters(pcie_pmu);
 
 		return IRQ_HANDLED;

--- a/drivers/perf/phytium/phytium_pcie_pmu.c
+++ b/drivers/perf/phytium/phytium_pcie_pmu.c
@@ -32,6 +32,8 @@
 #undef pr_fmt
 #define pr_fmt(fmt) "phytium_pcie_pmu: " fmt
 
+#define PCIE_PERF_DRIVER_VERSION "1.2.1"
+
 #define PHYTIUM_PCIE_MAX_COUNTERS 18
 
 #define PCIE_START_TIMER 0x000
@@ -872,4 +874,5 @@ module_exit(phytium_pcie_pmu_module_exit);
 
 MODULE_DESCRIPTION("Phytium PCIe PMU driver");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(PCIE_PERF_DRIVER_VERSION);
 MODULE_AUTHOR("Hu Xianghua <huxianghua@phytium.com.cn>");

--- a/drivers/perf/phytium/phytium_pcie_pmu.c
+++ b/drivers/perf/phytium/phytium_pcie_pmu.c
@@ -23,6 +23,7 @@
 #include <linux/platform_device.h>
 #include <linux/smp.h>
 #include <linux/types.h>
+#include <linux/version.h>
 
 #if IS_ENABLED(CONFIG_ARM || CONFIG_ARM64)
 #include <asm/cputype.h>
@@ -32,51 +33,70 @@
 #undef pr_fmt
 #define pr_fmt(fmt) "phytium_pcie_pmu: " fmt
 
-#define PCIE_PERF_DRIVER_VERSION "1.2.1"
-
 #define PHYTIUM_PCIE_MAX_COUNTERS 18
+#define PCIE_PERF_DRIVER_VERSION "1.3.0"
 
-#define PCIE_START_TIMER 0x000
-#define PCIE_STOP_TIMER 0x004
-#define PCIE_CLEAR_EVENT 0x008
-#define PCIE_SET_TIMER_L 0x00c
-#define PCIE_SET_TIMER_H 0x010
-#define PCIE_TRIG_MODE 0x014
+#define PCIE_START_TIMER	0x000
+#define PCIE_STOP_TIMER		0x004
+#define PCIE_CLEAR_EVENT	0x008
 
-#define PCIE_NOW_STATE 0x0e0
-#define PCIE_EVENT_CYCLES 0x0e4
-#define PCIE_TPOINT_END_L 0x0e4
-#define PCIE_TPOINT_END_H 0x0e8
-#define PCIE_STATE_STOP 0x0ec
+#define PCIE_EVENT_CYCLES	0x0e4
+#define PCIE_TPOINT_END_L	0x0e4
+#define PCIE_TPOINT_END_H	0x0e8
+#define PCIE_STATE_STOP		0x0ec
 
-#define PCIE_EVENT_AW 0x100
-#define PCIE_EVENT_W_LAST 0x104
-#define PCIE_EVENT_B 0x108
-#define PCIE_EVENT_AR 0x10c
-#define PCIE_EVENT_R_LAST 0x110
-#define PCIE_EVENT_R_FULL 0x114
-#define PCIE_EVENT_R_ERR 0x118
-#define PCIE_EVENT_W_ERR 0x11c
-#define PCIE_EVENT_DELAY_RD 0x120
-#define PCIE_EVENT_DELAY_WR 0x124
-#define PCIE_EVENT_RD_MAX 0x128
-#define PCIE_EVENT_RD_MIN 0x12c
-#define PCIE_EVENT_WR_MAX 0x130
-#define PCIE_EVENT_WR_MIN 0x134
+#define PCIE_EVENT_AW		0x100
+#define PCIE_EVENT_W_LAST	0x104
+#define PCIE_EVENT_B		0x108
+#define PCIE_EVENT_AR		0x10c
+#define PCIE_EVENT_R_LAST	0x110
+#define PCIE_EVENT_R_FULL	0x114
+#define PCIE_EVENT_R_ERR	0x118
+#define PCIE_EVENT_W_ERR	0x11c
+#define PCIE_EVENT_DELAY_RD	0x120
+#define PCIE_EVENT_DELAY_WR	0x124
+#define PCIE_EVENT_RD_MAX	0x128
+#define PCIE_EVENT_RD_MIN	0x12c
+#define PCIE_EVENT_WR_MAX	0x130
+#define PCIE_EVENT_WR_MIN	0x134
 
-#define PCIE_EVENT_W_DATA 0x200
-#define PCIE_W_DATA_BASE 0x200
+#define PCIE_EVENT_W_DATA	0x200
+#define PCIE_W_DATA_BASE	0x200
 
-#define PCIE_EVENT_RDELAY_TIME 0x300
-#define PCIE_RDELAY_TIME_BASE 0x300
+#define PCIE_EVENT_RDELAY_TIME	0x300
+#define PCIE_RDELAY_TIME_BASE	0x300
 
-#define PCIE_EVENT_WDELAY_TIME 0x700
-#define PCIE_WDELAY_TIME_BASE 0x700
+#define PCIE_EVENT_WDELAY_TIME	0x700
+#define PCIE_WDELAY_TIME_BASE	0x700
 
-#define PCIE_CLK_FRE 0xe00
-#define PCIE_DATA_WIDTH 0xe04
+#define PCIE_DATA_WIDTH		0xe04
+
+#define SYS_AIDR_EL1		sys_reg(3, 1, 0, 0, 7)
+#define SOC_ID_PS230XX		0x8
+#define SOC_ID_PS240XX		0x6
+#define MIDR_PSXX		0x700f8620
 
 #define to_phytium_pcie_pmu(p) (container_of(p, struct phytium_pcie_pmu, pmu))
+
+enum {
+	PS230XX = 0x1,
+	PS240XX = 0x2,
+};
+
+static inline int phytium_socs_type(void)
+{
+	unsigned int soc_id, cpu_id;
+
+	soc_id = read_sysreg_s(SYS_AIDR_EL1);
+	cpu_id = read_cpuid_id();
+
+	if ((soc_id == SOC_ID_PS230XX) && (cpu_id == MIDR_PSXX))
+		return PS230XX;
+	else if ((soc_id == SOC_ID_PS240XX) && (cpu_id == MIDR_PSXX))
+		return PS240XX;
+	else
+		return 0;
+}
 
 static int phytium_pcie_pmu_hp_state;
 
@@ -88,18 +108,21 @@ struct phytium_pcie_pmu_hwevents {
 struct phytium_pcie_pmu {
 	struct device *dev;
 	void __iomem *base;
-	void __iomem *csr_base;
+	void __iomem *cfg_base;
 	void __iomem *irq_reg;
 	struct pmu pmu;
 	struct phytium_pcie_pmu_hwevents pmu_events;
 	u32 die_id;
+	u32 pcie_id;
 	u32 pmu_id;
 	int on_cpu;
 	int irq;
+	int irq_bit;
 	struct hlist_node node;
 	int ctrler_id;
 	int real_ctrler;
 	u32 clk_bits;
+	u32 soc_version;
 };
 
 #define GET_PCIE_EVENTID(hwc) (hwc->config_base & 0x1F)
@@ -162,7 +185,6 @@ static ssize_t cpumask_show(struct device *dev, struct device_attribute *attr,
 static struct attribute *phytium_pcie_pmu_format_attr[] = {
 	PHYTIUM_PCIE_PMU_FORMAT_ATTR(event, "config:0-4"),
 	PHYTIUM_PCIE_PMU_FORMAT_ATTR(ctrler, "config:8-10"),
-	PHYTIUM_PCIE_PMU_FORMAT_ATTR(timer, "config1:0-31"),
 	NULL,
 };
 
@@ -221,11 +243,6 @@ static u32 phytium_pcie_pmu_get_event_ctrler(struct perf_event *event)
 	return FIELD_GET(GENMASK(10, 8), event->attr.config);
 }
 
-static u32 phytium_pcie_pmu_get_event_timer(struct perf_event *event)
-{
-	return FIELD_GET(GENMASK(31, 0), event->attr.config1);
-}
-
 static u64 phytium_pcie_pmu_read_counter(struct phytium_pcie_pmu *pcie_pmu,
 					 struct hw_perf_event *hwc)
 {
@@ -235,11 +252,15 @@ static u64 phytium_pcie_pmu_read_counter(struct phytium_pcie_pmu *pcie_pmu,
 	u64 val64 = 0;
 	int i;
 	u32 counter_offset = pcie_counter_reg_offset[idx];
+	u32 rdelay_num = 127;
 
 	if (!EVENT_VALID(idx)) {
 		dev_err(pcie_pmu->dev, "Unsupported event index:%d!\n", idx);
 		return 0;
 	}
+
+	if (pcie_pmu->soc_version == PS240XX && pcie_pmu->pmu_id == 3)
+		rdelay_num = 63;
 
 	switch (idx) {
 	case 0:
@@ -255,7 +276,7 @@ static u64 phytium_pcie_pmu_read_counter(struct phytium_pcie_pmu *pcie_pmu,
 		}
 		break;
 	case 16:
-		for (i = 0; i <= 127; i = i + 2) {
+		for (i = 0; i <= rdelay_num; i = i + 2) {
 			rdelay_l =
 				readl(pcie_pmu->base + counter_offset + 4 * i);
 			rdelay_h = readl(pcie_pmu->base + counter_offset +
@@ -283,38 +304,40 @@ static void phytium_pcie_pmu_enable_clk(struct phytium_pcie_pmu *pcie_pmu)
 {
 	u32 val;
 
-	val = readl(pcie_pmu->csr_base);
+	val = readl(pcie_pmu->cfg_base);
 	val |= (pcie_pmu->clk_bits);
-	writel(val, pcie_pmu->csr_base);
+	writel(val, pcie_pmu->cfg_base);
 }
 
 static void phytium_pcie_pmu_disable_clk(struct phytium_pcie_pmu *pcie_pmu)
 {
 	u32 val;
 
-	val = readl(pcie_pmu->csr_base);
+	val = readl(pcie_pmu->cfg_base);
 	val &= ~(pcie_pmu->clk_bits);
-	writel(val, pcie_pmu->csr_base);
+	writel(val, pcie_pmu->cfg_base);
 }
 
 static void phytium_pcie_pmu_select_ctrler(struct phytium_pcie_pmu *pcie_pmu)
 {
-	u32 val, offset = 0;
+	u32 val, offset;
+	u32 mask = 0xfffffffc;
 
-	if (pcie_pmu->pmu_id != 2)
-		offset = 0xc;
-
-	val = readl(pcie_pmu->csr_base + offset);
-
-	if (pcie_pmu->pmu_id == 2) {
-		val &= 0xffffffcf;
-		val |= pcie_pmu->real_ctrler;
+	if (pcie_pmu->soc_version == PS230XX) {
+		if (pcie_pmu->pmu_id == 2) {
+			mask = 0xffffffcf;
+			offset = 0x0;
+		} else
+			offset = 0xc;
 	} else {
-		val &= 0xfffffffc;
-		val |= pcie_pmu->real_ctrler;
+		offset = 0x170;
 	}
 
-	writel(val, pcie_pmu->csr_base + offset);
+	val = readl(pcie_pmu->cfg_base + offset);
+	val &= mask;
+	val |= pcie_pmu->real_ctrler;
+	writel(val, pcie_pmu->cfg_base + offset);
+
 }
 
 static void
@@ -333,29 +356,6 @@ static void
 phytium_pcie_pmu_stop_all_counters(struct phytium_pcie_pmu *pcie_pmu)
 {
 	writel(0x1, pcie_pmu->base + PCIE_STOP_TIMER);
-}
-
-static void phytium_pcie_pmu_set_timer(struct phytium_pcie_pmu *pcie_pmu,
-					u32 th_val)
-{
-	u32 val;
-
-	val = readl(pcie_pmu->base + PCIE_SET_TIMER_L);
-	val = readl(pcie_pmu->base + PCIE_SET_TIMER_H);
-
-	writel(th_val, pcie_pmu->base + PCIE_SET_TIMER_L);
-	writel(0, pcie_pmu->base + PCIE_SET_TIMER_H);
-}
-
-static void phytium_pcie_pmu_reset_timer(struct phytium_pcie_pmu *pcie_pmu)
-{
-	u32 val;
-
-	val = readl(pcie_pmu->base + PCIE_SET_TIMER_L);
-	val = readl(pcie_pmu->base + PCIE_SET_TIMER_H);
-
-	writel(0xFFFFFFFF, pcie_pmu->base + PCIE_SET_TIMER_L);
-	writel(0xFFFFFFFF, pcie_pmu->base + PCIE_SET_TIMER_H);
 }
 
 static unsigned long
@@ -407,7 +407,7 @@ int phytium_pcie_pmu_event_init(struct perf_event *event)
 {
 	struct hw_perf_event *hwc = &event->hw;
 	struct phytium_pcie_pmu *pcie_pmu;
-	u32 event_ctrler, event_timer;
+	u32 event_ctrler;
 
 	if (event->attr.type != event->pmu->type)
 		return -ENOENT;
@@ -428,57 +428,83 @@ int phytium_pcie_pmu_event_init(struct perf_event *event)
 	if (pcie_pmu->on_cpu == -1)
 		return -EINVAL;
 
-	event_timer = phytium_pcie_pmu_get_event_timer(event);
-	if (event_timer != 0)
-		phytium_pcie_pmu_set_timer(pcie_pmu, event_timer);
+	if (pcie_pmu->soc_version == PS240XX) {
+		event_ctrler = phytium_pcie_pmu_get_event_ctrler(event);
+		if (pcie_pmu->pmu_id == 2) {
+			if (event_ctrler == 0)
+				event_ctrler = 2;
+			else if ((event_ctrler < 2) || (event_ctrler > 3)) {
+				dev_warn(pcie_pmu->dev, "Wrong ctrler id(%d) for pcie-pmu2!\n",
+						event_ctrler);
+				return -EINVAL;
+			}
+			if (pcie_pmu->ctrler_id != event_ctrler) {
+				pcie_pmu->ctrler_id = event_ctrler;
+				pcie_pmu->real_ctrler = pcie_pmu->ctrler_id;
+				phytium_pcie_pmu_select_ctrler(pcie_pmu);
+			}
+		} else {
+			if (event_ctrler != 0) {
+				dev_warn(pcie_pmu->dev, "Don't need to set ctrler id(%d) for pcie-pmu%d!\n",
+						event_ctrler, pcie_pmu->pmu_id);
+				return -EINVAL;
+			}
+			pcie_pmu->ctrler_id = pcie_pmu->pmu_id;
+			pcie_pmu->real_ctrler = pcie_pmu->ctrler_id;
+		}
+	} else {
+		event_ctrler = phytium_pcie_pmu_get_event_ctrler(event);
+		switch (pcie_pmu->pmu_id) {
+		case 0:
+			if (event_ctrler != 0) {
+				dev_warn(pcie_pmu->dev,
+					"Wrong ctrler id(%d) for pcie-pmu0!\n",
+					event_ctrler);
+				return -EINVAL;
+			}
+			break;
+		case 1:
+			if (event_ctrler == 0)
+				event_ctrler = 1;
+			else if ((event_ctrler < 1) || (event_ctrler > 3)) {
+				dev_warn(pcie_pmu->dev,
+					"Wrong ctrler id(%d) for pcie-pmu1!\n",
+					event_ctrler);
+				return -EINVAL;
+			}
+			break;
+		case 2:
+			if (event_ctrler == 0)
+				event_ctrler = 4;
+			else if ((event_ctrler < 4) || (event_ctrler > 7)) {
+				dev_warn(pcie_pmu->dev,
+					"Wrong ctrler id(%d) for pcie-pmu2!\n",
+					event_ctrler);
+				return -EINVAL;
+			}
+			break;
+		default:
+			dev_err(pcie_pmu->dev, "Unsupported pmu id:%d!\n",
+				pcie_pmu->pmu_id);
+			return -EINVAL;
+		}
 
-	event_ctrler = phytium_pcie_pmu_get_event_ctrler(event);
-	switch (pcie_pmu->pmu_id) {
-	case 0:
-		if (event_ctrler != 0) {
-			dev_warn(pcie_pmu->dev,
-				 "Wrong ctrler id(%d) for pcie-pmu0!\n",
-				 event_ctrler);
+		pcie_pmu->ctrler_id = event_ctrler;
+		switch (pcie_pmu->pmu_id) {
+		case 0:
+		case 1:
+			pcie_pmu->real_ctrler = pcie_pmu->ctrler_id;
+			break;
+		case 2:
+			pcie_pmu->real_ctrler = (pcie_pmu->ctrler_id - 4) * 16;
+			break;
+		default:
+			dev_err(pcie_pmu->dev, "Unsupported pmu id:%d!\n",
+				pcie_pmu->pmu_id);
 			return -EINVAL;
 		}
-		break;
-	case 1:
-		if ((event_ctrler < 1) || (event_ctrler > 3)) {
-			dev_warn(pcie_pmu->dev,
-				 "Wrong ctrler id(%d) for pcie-pmu1!\n",
-				 event_ctrler);
-			return -EINVAL;
-		}
-		break;
-	case 2:
-		if ((event_ctrler < 4) || (event_ctrler > 7)) {
-			dev_warn(pcie_pmu->dev,
-				 "Wrong ctrler id(%d) for pcie-pmu2!\n",
-				 event_ctrler);
-			return -EINVAL;
-		}
-		break;
-	default:
-		dev_err(pcie_pmu->dev, "Unsupported pmu id:%d!\n",
-			pcie_pmu->pmu_id);
-		return -EINVAL;
+		phytium_pcie_pmu_select_ctrler(pcie_pmu);
 	}
-
-	pcie_pmu->ctrler_id = event_ctrler;
-	switch (pcie_pmu->pmu_id) {
-	case 0:
-	case 1:
-		pcie_pmu->real_ctrler = pcie_pmu->ctrler_id;
-		break;
-	case 2:
-		pcie_pmu->real_ctrler = (pcie_pmu->ctrler_id - 4) * 16;
-		break;
-	default:
-		dev_err(pcie_pmu->dev, "Unsupported pmu id:%d!\n",
-			pcie_pmu->pmu_id);
-		return -EINVAL;
-	}
-	phytium_pcie_pmu_select_ctrler(pcie_pmu);
 
 	hwc->idx = -1;
 	hwc->config_base = event->attr.config;
@@ -538,16 +564,11 @@ void phytium_pcie_pmu_event_del(struct perf_event *event, int flags)
 	struct phytium_pcie_pmu *pcie_pmu = to_phytium_pcie_pmu(event->pmu);
 	struct hw_perf_event *hwc = &event->hw;
 	unsigned long val;
-	u32 event_timer;
 
 	phytium_pcie_pmu_event_stop(event, PERF_EF_UPDATE);
 	val = phytium_pcie_pmu_get_irq_flag(pcie_pmu);
 	val = phytium_pcie_pmu_get_stop_state(pcie_pmu);
 	phytium_pcie_pmu_unmark_event(pcie_pmu, hwc->idx);
-
-	event_timer = phytium_pcie_pmu_get_event_timer(event);
-	if (event_timer != 0)
-		phytium_pcie_pmu_reset_timer(pcie_pmu);
 
 	perf_event_update_userpage(event);
 	pcie_pmu->pmu_events.hw_events[hwc->idx] = NULL;
@@ -575,6 +596,12 @@ void phytium_pcie_pmu_disable(struct pmu *pmu)
 		phytium_pcie_pmu_stop_all_counters(pcie_pmu);
 }
 
+void phytium_pcie_pmu_reset(struct phytium_pcie_pmu *pcie_pmu)
+{
+	phytium_pcie_pmu_disable_clk(pcie_pmu);
+	phytium_pcie_pmu_clear_all_counters(pcie_pmu);
+}
+
 static const struct acpi_device_id phytium_pcie_pmu_acpi_match[] = {
 	{
 		"PHYT0044",
@@ -594,7 +621,7 @@ static irqreturn_t phytium_pcie_pmu_overflow_handler(int irq, void *dev_id)
 
 	overflown = phytium_pcie_pmu_get_irq_flag(pcie_pmu);
 
-	if (!test_bit(pcie_pmu->pmu_id + 4, &overflown))
+	if (!test_bit(pcie_pmu->irq_bit, &overflown))
 		return IRQ_NONE;
 
 	stop_state = phytium_pcie_pmu_get_stop_state(pcie_pmu);
@@ -607,7 +634,8 @@ static irqreturn_t phytium_pcie_pmu_overflow_handler(int irq, void *dev_id)
 			phytium_pcie_pmu_event_update(event);
 		}
 		phytium_pcie_pmu_clear_all_counters(pcie_pmu);
-		phytium_pcie_pmu_start_all_counters(pcie_pmu);
+		if ((stop_state & 0x10) == 0)
+			phytium_pcie_pmu_start_all_counters(pcie_pmu);
 
 		return IRQ_HANDLED;
 	}
@@ -643,9 +671,14 @@ static int phytium_pcie_pmu_init_irq(struct phytium_pcie_pmu *pcie_pmu,
 }
 
 static int phytium_pcie_pmu_init_data(struct platform_device *pdev,
-				      struct phytium_pcie_pmu *pcie_pmu)
+		struct phytium_pcie_pmu *pcie_pmu)
 {
 	struct resource *res, *clkres, *irqres;
+	pcie_pmu->soc_version = phytium_socs_type();
+	if (pcie_pmu->soc_version == 0) {
+		dev_err(&pdev->dev, "The PCIe PMU driver can't be installed in this SoC.\n");
+		return -EINVAL;
+	}
 
 	if (device_property_read_u32(&pdev->dev, "phytium,die-id",
 				     &pcie_pmu->die_id)) {
@@ -659,20 +692,46 @@ static int phytium_pcie_pmu_init_data(struct platform_device *pdev,
 		return -EINVAL;
 	}
 
-	switch (pcie_pmu->pmu_id) {
-	case 0:
-		pcie_pmu->clk_bits = 0x1;
-		break;
-	case 1:
-		pcie_pmu->clk_bits = 0xe;
-		break;
-	case 2:
-		pcie_pmu->clk_bits = 0xf;
-		break;
-	default:
-		dev_err(&pdev->dev, "Unsupported pmu id:%d!\n",
-			pcie_pmu->pmu_id);
-		break;
+	if (pcie_pmu->soc_version == PS230XX) {
+		switch (pcie_pmu->pmu_id) {
+		case 0:
+			pcie_pmu->clk_bits = 0x1;
+			break;
+		case 1:
+			pcie_pmu->clk_bits = 0xe;
+			break;
+		case 2:
+			pcie_pmu->clk_bits = 0xf;
+			break;
+		default:
+			dev_err(&pdev->dev, "Unsupported pmu id:%d!\n", pcie_pmu->pmu_id);
+			break;
+		}
+
+		pcie_pmu->irq_bit = pcie_pmu->pmu_id + 4;
+	} else {
+		if (device_property_read_u32(&pdev->dev, "phytium,pcie-id", &pcie_pmu->pcie_id)) {
+			dev_err(&pdev->dev, "Can not read phytium,pcie-id!\n");
+			return -EINVAL;
+		}
+
+		switch (pcie_pmu->pmu_id) {
+		case 0:
+		case 3:
+			pcie_pmu->clk_bits = 0x1;
+			break;
+		case 1:
+			pcie_pmu->clk_bits = 0x2;
+			break;
+		case 2:
+			pcie_pmu->clk_bits = 0xc;
+			break;
+		default:
+			dev_err(&pdev->dev, "Unsupported pmu id:%d!\n", pcie_pmu->pmu_id);
+			break;
+		}
+
+		pcie_pmu->irq_bit = pcie_pmu->pcie_id * 4 + pcie_pmu->pmu_id + 16;
 	}
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
@@ -688,12 +747,12 @@ static int phytium_pcie_pmu_init_data(struct platform_device *pdev,
 		return -EINVAL;
 	}
 
-	pcie_pmu->csr_base =
+	pcie_pmu->cfg_base =
 		devm_ioremap(&pdev->dev, clkres->start, resource_size(clkres));
-	if (IS_ERR(pcie_pmu->csr_base)) {
+	if (IS_ERR(pcie_pmu->cfg_base)) {
 		dev_err(&pdev->dev,
 			"ioremap failed for pcie_pmu csr resource\n");
-		return PTR_ERR(pcie_pmu->csr_base);
+		return PTR_ERR(pcie_pmu->cfg_base);
 	}
 
 	irqres = platform_get_resource(pdev, IORESOURCE_MEM, 2);
@@ -711,11 +770,13 @@ static int phytium_pcie_pmu_init_data(struct platform_device *pdev,
 		return PTR_ERR(pcie_pmu->irq_reg);
 	}
 
+	phytium_pcie_pmu_reset(pcie_pmu);
+
 	return 0;
 }
 
 static int phytium_pcie_pmu_dev_probe(struct platform_device *pdev,
-				      struct phytium_pcie_pmu *pcie_pmu)
+		struct phytium_pcie_pmu *pcie_pmu)
 {
 	int ret;
 
@@ -756,8 +817,12 @@ static int phytium_pcie_pmu_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	name = devm_kasprintf(&pdev->dev, GFP_KERNEL, "phyt%u_pcie_pmu%u",
-			      pcie_pmu->die_id, pcie_pmu->pmu_id);
+	if (pcie_pmu->soc_version == PS230XX)
+		name = devm_kasprintf(&pdev->dev, GFP_KERNEL, "phyt%u_pcie_pmu%u",
+					pcie_pmu->die_id, pcie_pmu->pmu_id);
+	else
+		name = devm_kasprintf(&pdev->dev, GFP_KERNEL, "phyt%u_pcie%u_pmu%u",
+					pcie_pmu->die_id, pcie_pmu->pcie_id, pcie_pmu->pmu_id);
 	pcie_pmu->pmu = (struct pmu){
 		.name = name,
 		.module = THIS_MODULE,
@@ -771,7 +836,6 @@ static int phytium_pcie_pmu_probe(struct platform_device *pdev)
 		.stop = phytium_pcie_pmu_event_stop,
 		.read = phytium_pcie_pmu_event_update,
 		.attr_groups = phytium_pcie_pmu_attr_groups,
-		.capabilities = PERF_PMU_CAP_NO_EXCLUDE,
 	};
 
 	ret = perf_pmu_register(&pcie_pmu->pmu, name, -1);
@@ -784,9 +848,12 @@ static int phytium_pcie_pmu_probe(struct platform_device *pdev)
 
 	phytium_pcie_pmu_enable_clk(pcie_pmu);
 
-	pr_info("Phytium PCIe PMU: ");
-	pr_info("die_id = %d pmu_id = %d.\n", pcie_pmu->die_id,
-		pcie_pmu->pmu_id);
+	if (pcie_pmu->soc_version == PS230XX)
+		pr_info("die%d_pcie_pmu%d on cpu%d.\n",
+			pcie_pmu->die_id, pcie_pmu->pmu_id, pcie_pmu->on_cpu);
+	else
+		pr_info("die%d_pcie%d_pmu%d on cpu%d.\n",
+			pcie_pmu->die_id, pcie_pmu->pcie_id, pcie_pmu->pmu_id, pcie_pmu->on_cpu);
 
 	return ret;
 }
@@ -828,6 +895,7 @@ int phytium_pcie_pmu_online_cpu(unsigned int cpu, struct hlist_node *node)
 			pcie_pmu->on_cpu = cpu;
 			WARN_ON(irq_set_affinity_hint(pcie_pmu->irq, cpumask_of(cpu)));
 		}
+
 		return 0;
 	}
 
@@ -874,8 +942,8 @@ static int __init phytium_pcie_pmu_module_init(void)
 
 	phytium_pcie_pmu_hp_state =
 		cpuhp_setup_state_multi(CPUHP_AP_ONLINE_DYN,
-					"perf/phytium/pciepmu:online",
-					phytium_pcie_pmu_online_cpu, phytium_pcie_pmu_offline_cpu);
+					"perf/phytium/pciepmu:online", phytium_pcie_pmu_online_cpu,
+					phytium_pcie_pmu_offline_cpu);
 	if (phytium_pcie_pmu_hp_state < 0) {
 		pr_err("PCIE PMU: setup hotplug, ret = %d\n",
 			phytium_pcie_pmu_hp_state);
@@ -902,3 +970,4 @@ MODULE_DESCRIPTION("Phytium PCIe PMU driver");
 MODULE_LICENSE("GPL");
 MODULE_VERSION(PCIE_PERF_DRIVER_VERSION);
 MODULE_AUTHOR("Hu Xianghua <huxianghua@phytium.com.cn>");
+MODULE_AUTHOR("Tan Rui <tanrui2142@phytium.com.cn>");

--- a/drivers/perf/phytium/phytium_pcie_pmu.c
+++ b/drivers/perf/phytium/phytium_pcie_pmu.c
@@ -727,8 +727,7 @@ static int phytium_pcie_pmu_dev_probe(struct platform_device *pdev,
 	if (ret)
 		return ret;
 	pcie_pmu->dev = &pdev->dev;
-	pcie_pmu->on_cpu = raw_smp_processor_id();
-	WARN_ON(irq_set_affinity(pcie_pmu->irq, cpumask_of(pcie_pmu->on_cpu)));
+	pcie_pmu->on_cpu = -1;
 	pcie_pmu->ctrler_id = -1;
 
 	return 0;
@@ -750,7 +749,7 @@ static int phytium_pcie_pmu_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	ret = cpuhp_state_add_instance_nocalls(
+	ret = cpuhp_state_add_instance(
 		phytium_pcie_pmu_hp_state, &pcie_pmu->node);
 	if (ret) {
 		dev_err(&pdev->dev, "Error %d registering hotplug;\n", ret);
@@ -815,6 +814,29 @@ static struct platform_driver phytium_pcie_pmu_driver = {
 	.remove = phytium_pcie_pmu_remove,
 };
 
+int phytium_pcie_pmu_online_cpu(unsigned int cpu, struct hlist_node *node)
+{
+	struct phytium_pcie_pmu *pcie_pmu =
+		hlist_entry_safe(node, struct phytium_pcie_pmu, node);
+
+	if (!cpumask_test_cpu(cpu, cpumask_of_node(pcie_pmu->die_id)))
+		return 0;
+
+	if (pcie_pmu->on_cpu != -1) {
+		if (!cpumask_test_cpu(pcie_pmu->on_cpu, cpumask_of_node(pcie_pmu->die_id))) {
+			perf_pmu_migrate_context(&pcie_pmu->pmu, pcie_pmu->on_cpu, cpu);
+			pcie_pmu->on_cpu = cpu;
+			WARN_ON(irq_set_affinity_hint(pcie_pmu->irq, cpumask_of(cpu)));
+		}
+		return 0;
+	}
+
+	pcie_pmu->on_cpu = cpu;
+	WARN_ON(irq_set_affinity_hint(pcie_pmu->irq, cpumask_of(cpu)));
+
+	return 0;
+}
+
 int phytium_pcie_pmu_offline_cpu(unsigned int cpu, struct hlist_node *node)
 {
 	struct phytium_pcie_pmu *pcie_pmu =
@@ -825,18 +847,22 @@ int phytium_pcie_pmu_offline_cpu(unsigned int cpu, struct hlist_node *node)
 	if (pcie_pmu->on_cpu != cpu)
 		return 0;
 
-	cpumask_and(&available_cpus,
-			cpumask_of_node(pcie_pmu->die_id), cpu_online_mask);
+	if (cpumask_and(&available_cpus, cpumask_of_node(pcie_pmu->die_id), cpu_online_mask) &&
+		cpumask_andnot(&available_cpus, &available_cpus, cpumask_of(cpu)))
+		target = cpumask_last(&available_cpus);
+	else {
+		cpumask_andnot(&available_cpus, cpu_online_mask, cpumask_of(cpu));
+		target = cpumask_last(&available_cpus);
+	}
 
-	target = cpumask_any_but(&available_cpus, cpu);
 	if (target >= nr_cpu_ids) {
-		target = cpumask_any_but(cpu_online_mask, cpu);
-		if (target >= nr_cpu_ids)
-			return 0;
+		dev_err(pcie_pmu->dev, "offline cpu%d with no target to migrate.\n",
+			cpu);
+		return 0;
 	}
 
 	perf_pmu_migrate_context(&pcie_pmu->pmu, cpu, target);
-	WARN_ON(irq_set_affinity(pcie_pmu->irq, cpumask_of(target)));
+	WARN_ON(irq_set_affinity_hint(pcie_pmu->irq, cpumask_of(target)));
 	pcie_pmu->on_cpu = target;
 
 	return 0;
@@ -848,8 +874,8 @@ static int __init phytium_pcie_pmu_module_init(void)
 
 	phytium_pcie_pmu_hp_state =
 		cpuhp_setup_state_multi(CPUHP_AP_ONLINE_DYN,
-					"perf/phytium/pciepmu:offline", NULL,
-					phytium_pcie_pmu_offline_cpu);
+					"perf/phytium/pciepmu:online",
+					phytium_pcie_pmu_online_cpu, phytium_pcie_pmu_offline_cpu);
 	if (phytium_pcie_pmu_hp_state < 0) {
 		pr_err("PCIE PMU: setup hotplug, ret = %d\n",
 			phytium_pcie_pmu_hp_state);


### PR DESCRIPTION
## Summary by Sourcery

Add support for Phytium PS240XX SoCs to the PCIe and DDR PMU drivers, improve CPU hotplug handling, and fix bugs related to IRQ handling and context migration.

Bug Fixes:
- Correct IRQ bit usage in overflow handlers.
- Prevent unnecessary counter restarts after specific overflow conditions.
- Improve target CPU selection logic for PMU migration during CPU offline events.

Enhancements:
- Detect SoC type (PS230XX/PS240XX) and apply SoC-specific configurations for registers, clocks, and naming.
- Implement `online_cpu` callback for CPU hotplug and refine `offline_cpu` migration logic.
- Reset PMU hardware state during driver initialization.
- Use `irq_set_affinity_hint` for IRQ affinity setting.

Chores:
- Remove unused timer configuration code and sysfs attributes.
- Remove the `PERF_PMU_CAP_NO_EXCLUDE` flag.
- Add driver version macros and update module author information.
- Rename internal base address variable for configuration variable for configuration registers for clarity.