### PR TITLE
drm/phytium: Fix some Bugs in Phytium Display Engine

### DIFF
--- a/drivers/gpu/drm/phytium/Kconfig
+++ b/drivers/gpu/drm/phytium/Kconfig
@@ -1,12 +1,10 @@
 config DRM_PHYTIUM
 	tristate "DRM Support for Phytium Graphics Card"
-	depends on DRM && ARCH_PHYTIUM
+	depends on DRM
 	select DRM_KMS_HELPER
 	select DRM_DISPLAY_HELPER
 	select DRM_DISPLAY_DP_HELPER
 	select DRM_DISPLAY_HDCP_HELPER
 	help
 	  Choose this option if you have a phytium graphics card.
-	  Phytium graphics card include display controller for X100 and E2000 devices.
-	  In addition,the driver also supports the display of E2000S BMC.
 	  This driver provides kernel mode setting and buffer management to userspace.

--- a/drivers/gpu/drm/phytium/Makefile
+++ b/drivers/gpu/drm/phytium/Makefile
@@ -16,3 +16,7 @@ phytium-dc-drm-y := phytium_display_drv.o \
 
 obj-$(CONFIG_DRM_PHYTIUM) += phytium-dc-drm.o
 CFLAGS_REMOVE_phytium_crtc.o += -mgeneral-regs-only
+ifeq ($(ARCH), x86)
+	FPU_CFLAGS += -msse -msse2
+	CFLAGS_phytium_crtc.o += $(FPU_CFLAGS)
+endif

--- a/drivers/gpu/drm/phytium/pe220x_dc.c
+++ b/drivers/gpu/drm/phytium/pe220x_dc.c
@@ -7,7 +7,9 @@
 
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_atomic.h>
+#if defined(__arm__) || defined(__aarch64__)
 #include <asm/neon.h>
+#endif
 #include <linux/delay.h>
 #include "phytium_display_drv.h"
 #include "pe220x_reg.h"
@@ -54,6 +56,10 @@ static const unsigned int pe220x_primary_formats[] = {
 	DRM_FORMAT_NV16,
 	DRM_FORMAT_NV12,
 	DRM_FORMAT_NV21,
+};
+
+static const unsigned int pe220x_bmc_primary_formats[] = {
+	DRM_FORMAT_XRGB8888,
 };
 
 static uint64_t pe220x_primary_formats_modifiers[] = {
@@ -109,49 +115,76 @@ void pe220x_dc_hw_reset(struct drm_crtc *crtc)
 	int config = 0;
 	int phys_pipe = phytium_crtc->phys_pipe;
 
-	/* disable pixel clock for bmc mode */
-	if (phys_pipe == 0)
-		pe220x_dc_hw_disable(crtc);
-
 	config = phytium_readl_reg(priv, 0, PE220X_DC_CLOCK_CONTROL);
-	config &= (~(DC0_CORE_RESET | DC1_CORE_RESET | AXI_RESET | AHB_RESET));
 
-	if (phys_pipe == 0) {
-		phytium_writel_reg(priv, config | DC0_CORE_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC0_CORE_RESET | AXI_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC0_CORE_RESET | AXI_RESET | AHB_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC0_CORE_RESET | AXI_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC0_CORE_RESET,
-				      0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config, 0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
+	if (priv->info.bmc_mode) {
+		pe220x_dc_hw_disable(crtc);
+		config &= (~(DC0_CORE_RESET | DC1_CORE_RESET | AHB_RESET));
+		if (phys_pipe == 0) {
+			phytium_writel_reg(priv, config | DC0_CORE_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC0_CORE_RESET | AHB_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC0_CORE_RESET,
+					      0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config, 0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+		} else {
+			phytium_writel_reg(priv, config | DC1_CORE_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC1_CORE_RESET | AHB_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC1_CORE_RESET,
+					      0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config, 0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+		}
+
 	} else {
-		phytium_writel_reg(priv, config | DC1_CORE_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC1_CORE_RESET | AXI_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC1_CORE_RESET | AXI_RESET | AHB_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC1_CORE_RESET | AXI_RESET,
-				   0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config | DC1_CORE_RESET,
-				      0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
-		phytium_writel_reg(priv, config, 0, PE220X_DC_CLOCK_CONTROL);
-		udelay(20);
+		config &= (~(DC0_CORE_RESET | DC1_CORE_RESET | AXI_RESET | AHB_RESET));
+		if (phys_pipe == 0) {
+			phytium_writel_reg(priv, config | DC0_CORE_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC0_CORE_RESET | AXI_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC0_CORE_RESET | AXI_RESET | AHB_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC0_CORE_RESET | AXI_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC0_CORE_RESET,
+					      0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config, 0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+		} else {
+			phytium_writel_reg(priv, config | DC1_CORE_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC1_CORE_RESET | AXI_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC1_CORE_RESET | AXI_RESET | AHB_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC1_CORE_RESET | AXI_RESET,
+					   0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config | DC1_CORE_RESET,
+					      0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+			phytium_writel_reg(priv, config, 0, PE220X_DC_CLOCK_CONTROL);
+			udelay(20);
+		}
 	}
 }
 
@@ -214,6 +247,15 @@ void pe220x_dc_hw_plane_get_primary_format(const uint64_t **format_modifiers,
 	*format_modifiers = pe220x_primary_formats_modifiers;
 	*formats = pe220x_primary_formats;
 	*format_count = ARRAY_SIZE(pe220x_primary_formats);
+}
+
+void pe220x_dc_bmc_hw_plane_get_primary_format(const uint64_t **format_modifiers,
+					    const uint32_t **formats,
+					    uint32_t *format_count)
+{
+	  *format_modifiers = pe220x_primary_formats_modifiers;
+	  *formats = pe220x_bmc_primary_formats;
+	  *format_count = ARRAY_SIZE(pe220x_bmc_primary_formats);
 }
 
 void pe220x_dc_hw_plane_get_cursor_format(const uint64_t **format_modifiers,

--- a/drivers/gpu/drm/phytium/pe220x_dc.h
+++ b/drivers/gpu/drm/phytium/pe220x_dc.h
@@ -9,8 +9,8 @@
 #define __PE220X_DC_H__
 
 #define PE220X_DC_PIX_CLOCK_MAX				(594000)
-#define PE220X_DC_HDISPLAY_MAX				3840
-#define PE220X_DC_VDISPLAY_MAX				2160
+#define PE220X_DC_HDISPLAY_MAX				1920
+#define PE220X_DC_VDISPLAY_MAX				1080
 #define PE220X_DC_ADDRESS_MASK				0x7f
 
 extern void pe220x_dc_hw_vram_init(struct phytium_display_private *priv,
@@ -20,6 +20,9 @@ extern void pe220x_dc_hw_config_pix_clock(struct drm_crtc *crtc, int clock);
 extern void pe220x_dc_hw_disable(struct drm_crtc *crtc);
 extern int pe220x_dc_hw_fb_format_check(const struct drm_mode_fb_cmd2 *mode_cmd, int count);
 extern void pe220x_dc_hw_plane_get_primary_format(const uint64_t **format_modifiers,
+						 const uint32_t **formats,
+						 uint32_t *format_count);
+extern void pe220x_dc_bmc_hw_plane_get_primary_format(const uint64_t **format_modifiers,
 						 const uint32_t **formats,
 						 uint32_t *format_count);
 extern void pe220x_dc_hw_plane_get_cursor_format(const uint64_t **format_modifiers,

--- a/drivers/gpu/drm/phytium/pe220x_dp.c
+++ b/drivers/gpu/drm/phytium/pe220x_dp.c
@@ -5,6 +5,9 @@
  * Copyright (C) 2021-2023, Phytium Technology Co., Ltd.
  */
 
+#include <linux/pwm.h>
+#include <linux/gpio.h>
+#include <linux/gpio/consumer.h>
 #include "phytium_display_drv.h"
 #include "pe220x_reg.h"
 #include "phytium_dp.h"
@@ -379,13 +382,9 @@ static void pe220x_dp_hw_poweron_panel(struct phytium_dp_device *phytium_dp)
 {
 	struct drm_device *dev = phytium_dp->dev;
 	struct phytium_display_private *priv = dev->dev_private;
-	int port = phytium_dp->port;
 	int ret = 0;
 
-	phytium_writel_reg(priv, FLAG_REQUEST | CMD_BACKLIGHT | PANEL_POWER_ENABLE,
-			   0, PE220X_DC_CMD_REGISTER(port));
-	ret = phytium_wait_cmd_done(priv, PE220X_DC_CMD_REGISTER(port),
-				    FLAG_REQUEST, FLAG_REPLY);
+	gpiod_set_value(priv->edp_power_en, 1);
 	if (ret < 0)
 		DRM_ERROR("%s: failed to poweron panel\n", __func__);
 }
@@ -394,13 +393,9 @@ static void pe220x_dp_hw_poweroff_panel(struct phytium_dp_device *phytium_dp)
 {
 	struct drm_device *dev = phytium_dp->dev;
 	struct phytium_display_private *priv = dev->dev_private;
-	int port = phytium_dp->port;
 	int ret = 0;
 
-	phytium_writel_reg(priv, FLAG_REQUEST | CMD_BACKLIGHT | PANEL_POWER_DISABLE,
-			   0, PE220X_DC_CMD_REGISTER(port));
-	ret = phytium_wait_cmd_done(priv, PE220X_DC_CMD_REGISTER(port),
-				    FLAG_REQUEST, FLAG_REPLY);
+	gpiod_set_value(priv->edp_power_en, 0);
 	if (ret < 0)
 		DRM_ERROR("%s: failed to poweroff panel\n", __func__);
 }
@@ -409,12 +404,14 @@ static void pe220x_dp_hw_enable_backlight(struct phytium_dp_device *phytium_dp)
 {
 	struct drm_device *dev = phytium_dp->dev;
 	struct phytium_display_private *priv = dev->dev_private;
-	int port = phytium_dp->port, ret = 0;
+	struct pwm_state state;
+	int ret = 0;
 
-	phytium_writel_reg(priv, FLAG_REQUEST | CMD_BACKLIGHT | BACKLIGHT_ENABLE,
-			   0, PE220X_DC_CMD_REGISTER(port));
-	ret = phytium_wait_cmd_done(priv, PE220X_DC_CMD_REGISTER(port),
-				    FLAG_REQUEST, FLAG_REPLY);
+	pwm_get_state(phytium_dp->pwm, &state);
+	state.enabled = true;
+	pwm_set_relative_duty_cycle(&state, 50, 100);
+	ret = pwm_apply_might_sleep(phytium_dp->pwm, &state);
+	gpiod_set_value(priv->edp_bl_en, 1);
 	if (ret < 0)
 		DRM_ERROR("%s: failed to enable backlight\n", __func__);
 }
@@ -423,45 +420,41 @@ static void pe220x_dp_hw_disable_backlight(struct phytium_dp_device *phytium_dp)
 {
 	struct drm_device *dev = phytium_dp->dev;
 	struct phytium_display_private *priv = dev->dev_private;
-	int port = phytium_dp->port;
 	int ret = 0;
 
-	phytium_writel_reg(priv, FLAG_REQUEST | CMD_BACKLIGHT | BACKLIGHT_DISABLE,
-			   0, PE220X_DC_CMD_REGISTER(port));
-	ret = phytium_wait_cmd_done(priv, PE220X_DC_CMD_REGISTER(port),
-				    FLAG_REQUEST, FLAG_REPLY);
+	gpiod_set_value(priv->edp_bl_en, 0);
 	if (ret < 0)
-		DRM_ERROR("%s: failed to disable backlight\n", __func__);
+		DRM_ERROR("%s: failed to disable backlight, ret = %d\n", __func__, ret);
 }
 
 static uint32_t pe220x_dp_hw_get_backlight(struct phytium_dp_device *phytium_dp)
 {
-	struct drm_device *dev = phytium_dp->dev;
-	struct phytium_display_private *priv = dev->dev_private;
-	int config;
-	uint32_t group_offset = priv->address_transform_base;
+	struct pwm_state state;
+	uint32_t level;
 
-	config = phytium_readl_reg(priv, group_offset, PE220X_DC_ADDRESS_TRANSFORM_BACKLIGHT_VALUE);
-	return ((config >> BACKLIGHT_VALUE_SHIFT) & BACKLIGHT_VALUE_MASK);
+	pwm_get_state(phytium_dp->pwm, &state);
+	level = pwm_get_relative_duty_cycle(&state, 100);
+	return level;
 }
 
 static int pe220x_dp_hw_set_backlight(struct phytium_dp_device *phytium_dp, uint32_t level)
 {
-	struct drm_device *dev = phytium_dp->dev;
-	struct phytium_display_private *priv = dev->dev_private;
-	int port = phytium_dp->port;
-	int config = 0;
+	struct pwm_state state;
 	int ret = 0;
 
 	if (level > PE220X_DP_BACKLIGHT_MAX) {
 		ret = -EINVAL;
 		goto out;
 	}
+	pwm_get_state(phytium_dp->pwm, &state);
+	state.enabled = true;
+	state.period = phytium_dp->pwm->args.period;
+	if (state.period == 0)
+		DRM_ERROR("%s: set pwm period to 0\n", __func__);
 
-	config = FLAG_REQUEST | CMD_BACKLIGHT | ((level & BACKLIGHT_MASK) << BACKLIGHT_SHIFT);
-	phytium_writel_reg(priv, config, 0, PE220X_DC_CMD_REGISTER(port));
-	ret = phytium_wait_cmd_done(priv, PE220X_DC_CMD_REGISTER(port),
-				    FLAG_REQUEST, FLAG_REPLY);
+	pwm_set_relative_duty_cycle(&state, level, 100);
+
+	ret = pwm_apply_might_sleep(phytium_dp->pwm, &state);
 	if (ret < 0)
 		DRM_ERROR("%s: failed to set backlight\n", __func__);
 out:

--- a/drivers/gpu/drm/phytium/pe220x_dp.h
+++ b/drivers/gpu/drm/phytium/pe220x_dp.h
@@ -8,7 +8,8 @@
 #ifndef __PE220X_DP_H__
 #define __PE220X_DP_H__
 
-#define PE220X_DP_BACKLIGHT_MAX				100
+#define PE220X_DP_BACKLIGHT_MAX				99
+#define PE220X_DP_BACKLIGHT_MIN				2
 
 void pe220x_dp_func_register(struct phytium_dp_device *phytium_dp);
 #endif /* __PE220X_DP_H__ */

--- a/drivers/gpu/drm/phytium/phytium_crtc.c
+++ b/drivers/gpu/drm/phytium/phytium_crtc.c
@@ -6,7 +6,11 @@
 
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_atomic.h>
+#if defined(__arm__) || defined(__aarch64__)
 #include <asm/neon.h>
+#elif defined(__x86_64)
+#include <asm/fpu/api.h>
+#endif
 #include <drm/drm_vblank.h>
 #include "phytium_display_drv.h"
 #include "phytium_crtc.h"
@@ -37,6 +41,298 @@ struct filter_blit_array {
 	uint32_t scaleFactor;
 	uint32_t *kernelStates;
 };
+
+static uint32_t dc_scaling_get_factor(uint32_t src_size, uint32_t dst_size)
+{
+	uint32_t factor = 0;
+
+	factor = ((src_size - 1) << SCALE_FACTOR_SRC_OFFSET) / (dst_size - 1);
+
+	return factor;
+}
+
+static float dc_sint(float x)
+{
+	const float B = 1.2732395477;
+	const float C = -0.4052847346;
+	const float P = 0.2310792853;
+	float y;
+
+	if (x < 0)
+		y = B*x - C*x*x;
+	else
+		y = B*x + C*x*x;
+	if (y < 0)
+		y = P * (y * (0 - y) - y) + y;
+	else
+		y = P * (y * y - y) + y;
+	return y;
+}
+
+static float dc_sinc_filter(float x, int radius)
+{
+	float pit, pitd, f1, f2, result;
+	float f_radius = MATH_I2Float(radius);
+
+	if (x == 0.0f) {
+		result = 1.0f;
+	} else if ((x < -f_radius) || (x > f_radius)) {
+		result = 0.0f;
+	} else {
+		pit  = MATH_Multiply(PHYPI, x);
+		pitd = MATH_Divide(pit, f_radius);
+		f1 = MATH_Divide(dc_sint(pit), pit);
+		f2 = MATH_Divide(dc_sint(pitd), pitd);
+		result = MATH_Multiply(f1, f2);
+	}
+
+	return result;
+}
+
+static int dc_calculate_sync_table(
+	uint8_t kernel_size,
+	uint32_t src_size,
+	uint32_t dst_size,
+	struct filter_blit_array *kernel_info)
+{
+	uint32_t scale_factor;
+	float f_scale;
+	int kernel_half;
+	float f_subpixel_step;
+	float f_subpixel_offset;
+	uint32_t subpixel_pos;
+	int kernel_pos;
+	int padding;
+	uint16_t *kernel_array;
+	int range = 0;
+
+	do {
+		/* Compute the scale factor. */
+		scale_factor = dc_scaling_get_factor(src_size, dst_size);
+
+		/* Same kernel size and ratio as before? */
+		if ((kernel_info->kernelSize  == kernel_size) &&
+		(kernel_info->scaleFactor == kernel_size)) {
+			break;
+		}
+
+		/* check the array */
+		if (kernel_info->kernelStates == NULL)
+			break;
+
+		/* Store new parameters. */
+		kernel_info->kernelSize  = kernel_size;
+		kernel_info->scaleFactor = scale_factor;
+
+		/* Compute the scale factor. */
+		f_scale = MATH_DivideFromUInteger(dst_size, src_size);
+
+		/* Adjust the factor for magnification. */
+		if (f_scale > 1.0f)
+			f_scale = 1.0f;
+
+		/* Calculate the kernel half. */
+		kernel_half = (int) (kernel_info->kernelSize >> 1);
+
+		/* Calculate the subpixel step. */
+		f_subpixel_step = MATH_Divide(1.0f, MATH_I2Float(SUBPIXELCOUNT));
+
+		/* Init the subpixel offset. */
+		f_subpixel_offset = 0.5f;
+
+		/* Determine kernel padding size. */
+		padding = (MAXKERNELSIZE - kernel_info->kernelSize) / 2;
+
+		/* Set initial kernel array pointer. */
+		kernel_array = (uint16_t *) (kernel_info->kernelStates + 1);
+
+		/* Loop through each subpixel. */
+		for (subpixel_pos = 0; subpixel_pos < SUBPIXELLOADCOUNT; subpixel_pos++) {
+			/* Define a temporary set of weights. */
+			float fSubpixelSet[MAXKERNELSIZE];
+
+			/* Init the sum of all weights for the current subpixel. */
+			float fWeightSum = 0.0f;
+			uint16_t weightSum = 0;
+			short int adjustCount, adjustFrom;
+			short int adjustment;
+
+			/* Compute weights. */
+			for (kernel_pos = 0; kernel_pos < MAXKERNELSIZE; kernel_pos++) {
+				/* Determine the current index. */
+				int index = kernel_pos - padding;
+
+				/* Pad with zeros. */
+				if ((index < 0) || (index >= kernel_info->kernelSize)) {
+					fSubpixelSet[kernel_pos] = 0.0f;
+				} else {
+					if (kernel_info->kernelSize == 1) {
+						fSubpixelSet[kernel_pos] = 1.0f;
+					} else {
+						/* Compute the x position for filter function. */
+						float fX = MATH_Add(
+							MATH_I2Float(index - kernel_half),
+							f_subpixel_offset);
+						fX = MATH_Multiply(fX, f_scale);
+
+						/* Compute the weight. */
+						fSubpixelSet[kernel_pos] = dc_sinc_filter(fX,
+									   kernel_half);
+					}
+
+					/* Update the sum of weights. */
+					fWeightSum = MATH_Add(fWeightSum,
+								      fSubpixelSet[kernel_pos]);
+				}
+			}
+
+			/* Adjust weights so that the sum will be 1.0. */
+			for (kernel_pos = 0; kernel_pos < MAXKERNELSIZE; kernel_pos++) {
+				/* Normalize the current weight. */
+				float fWeight = MATH_Divide(fSubpixelSet[kernel_pos],
+								    fWeightSum);
+
+				/* Convert the weight to fixed point and store in the table. */
+				if (fWeight == 0.0f)
+					kernel_array[kernel_pos] = 0x0000;
+				else if (fWeight >= 1.0f)
+					kernel_array[kernel_pos] = 0x4000;
+				else if (fWeight <= -1.0f)
+					kernel_array[kernel_pos] = 0xC000;
+				else
+					kernel_array[kernel_pos] =
+						(int16_t) MATH_Multiply(fWeight, 16384.0f);
+				weightSum += kernel_array[kernel_pos];
+			}
+
+			/* Adjust the fixed point coefficients. */
+			adjustCount = 0x4000 - weightSum;
+			if (adjustCount < 0) {
+				adjustCount = -adjustCount;
+				adjustment = -1;
+			} else {
+				adjustment = 1;
+			}
+
+			adjustFrom = (MAXKERNELSIZE - adjustCount) / 2;
+			for (kernel_pos = 0; kernel_pos < adjustCount; kernel_pos++) {
+				range = (MAXKERNELSIZE*subpixel_pos + adjustFrom + kernel_pos) *
+					sizeof(uint16_t);
+				if ((range >= 0) && (range < KERNELTABLESIZE))
+					kernel_array[adjustFrom + kernel_pos] += adjustment;
+				else
+					DRM_ERROR("%s failed\n", __func__);
+			}
+
+			kernel_array += MAXKERNELSIZE;
+
+			/* Advance to the next subpixel. */
+			f_subpixel_offset = MATH_Add(f_subpixel_offset, -f_subpixel_step);
+		}
+	} while (0);
+
+	return 0;
+}
+
+static void phytium_dc_scaling_config(struct drm_crtc *crtc,
+				     struct drm_crtc_state *old_state)
+{
+	struct drm_device *dev = crtc->dev;
+	struct phytium_display_private *priv = dev->dev_private;
+	struct drm_display_mode *mode = &crtc->state->adjusted_mode;
+	struct phytium_crtc *phytium_crtc = to_phytium_crtc(crtc);
+	int phys_pipe = phytium_crtc->phys_pipe;
+	uint32_t group_offset = priv->dc_reg_base[phys_pipe];
+	uint32_t scale_factor_x, scale_factor_y, i;
+	uint32_t kernelStates[128];
+	struct filter_blit_array kernel_info_width;
+	void *tmp =  NULL;
+
+	if (mode->hdisplay != mode->crtc_hdisplay || mode->vdisplay != mode->crtc_vdisplay) {
+		phytium_crtc->src_width = mode->hdisplay;
+		phytium_crtc->src_height = mode->vdisplay;
+		phytium_crtc->dst_width = mode->crtc_hdisplay;
+		phytium_crtc->dst_height = mode->crtc_vdisplay;
+
+		phytium_crtc->dst_x = (mode->crtc_hdisplay - phytium_crtc->dst_width) / 2;
+		phytium_crtc->dst_y = (mode->crtc_vdisplay - phytium_crtc->dst_height) / 2;
+
+		scale_factor_x = dc_scaling_get_factor(phytium_crtc->src_width,
+								 phytium_crtc->dst_width);
+		scale_factor_y = dc_scaling_get_factor(phytium_crtc->src_height,
+								 phytium_crtc->dst_height);
+		if (scale_factor_y > (SCALE_FACTOR_Y_MAX << SCALE_FACTOR_SRC_OFFSET))
+			scale_factor_y = (SCALE_FACTOR_Y_MAX << SCALE_FACTOR_SRC_OFFSET);
+
+		phytium_writel_reg(priv, scale_factor_x & SCALE_FACTOR_X_MASK,
+				   group_offset, PHYTIUM_DC_FRAMEBUFFER_SCALE_FACTOR_X);
+		phytium_writel_reg(priv, scale_factor_y & SCALE_FACTOR_Y_MASK,
+				   group_offset, PHYTIUM_DC_FRAMEBUFFER_SCALE_FACTOR_Y);
+		phytium_writel_reg(priv, FRAMEBUFFER_TAP,
+				   group_offset, PHYTIUM_DC_FRAMEBUFFER_SCALECONFIG);
+
+		tmp = kmalloc(KERNELSTATES, GFP_KERNEL);
+		if (!tmp) {
+			DRM_ERROR("malloc %ld failed\n", KERNELSTATES);
+			return;
+		}
+
+		memset(&kernel_info_width, 0, sizeof(struct filter_blit_array));
+		kernel_info_width.kernelStates = tmp;
+		memset(kernel_info_width.kernelStates, 0, KERNELSTATES);
+#if defined(__arm__) || defined(__aarch64__)
+		kernel_neon_begin();
+#elif defined(__x86_64__)
+		kernel_fpu_begin();
+#endif
+		dc_calculate_sync_table(FRAMEBUFFER_HORIZONTAL_FILTER_TAP,
+					phytium_crtc->src_width,
+					phytium_crtc->dst_width,
+					&kernel_info_width);
+		memset(kernelStates, 0, sizeof(kernelStates));
+		memcpy(kernelStates, kernel_info_width.kernelStates + 1, KERNELSTATES - 4);
+#if defined(__arm__) || defined(__aarch64__)
+		kernel_neon_end();
+#elif defined(__x86_64__)
+		kernel_fpu_end();
+#endif
+		phytium_writel_reg(priv, HORI_FILTER_INDEX,
+				   group_offset, PHYTIUM_DC_FRAMEBUFFER_HORI_FILTER_INDEX);
+		for (i = 0; i < 128; i++) {
+			phytium_writel_reg(priv, kernelStates[i],
+					   group_offset, PHYTIUM_DC_FRAMEBUFFER_HORI_FILTER);
+		}
+
+		memset(&kernel_info_width, 0, sizeof(struct filter_blit_array));
+		kernel_info_width.kernelStates = tmp;
+		memset(kernel_info_width.kernelStates, 0, KERNELSTATES);
+#if defined(__arm__) || defined(__aarch64__)
+		kernel_neon_begin();
+#elif defined(__x86_64__)
+		kernel_fpu_begin();
+#endif
+		dc_calculate_sync_table(FRAMEBUFFER_FILTER_TAP, phytium_crtc->src_height,
+				     phytium_crtc->dst_height, &kernel_info_width);
+		memset(kernelStates, 0, sizeof(kernelStates));
+		memcpy(kernelStates, kernel_info_width.kernelStates + 1, KERNELSTATES - 4);
+#if defined(__arm__) || defined(__aarch64__)
+		kernel_neon_end();
+#elif defined(__x86_64__)
+		kernel_fpu_end();
+#endif
+		phytium_writel_reg(priv, VERT_FILTER_INDEX,
+				   group_offset, PHYTIUM_DC_FRAMEBUFFER_VERT_FILTER_INDEX);
+		for (i = 0; i < 128; i++)
+			phytium_writel_reg(priv, kernelStates[i],
+					   group_offset, PHYTIUM_DC_FRAMEBUFFER_VERT_FILTER);
+		phytium_writel_reg(priv, INITIALOFFSET,
+				   group_offset, PHYTIUM_DC_FRAMEBUFFER_INITIALOFFSET);
+		kfree(tmp);
+		phytium_crtc->scale_enable = true;
+	} else {
+		phytium_crtc->scale_enable = false;
+	}
+}
 
 static void phytium_crtc_gamma_set(struct drm_crtc *crtc)
 {
@@ -230,6 +526,7 @@ static void
 phytium_crtc_atomic_enable(struct drm_crtc *crtc,
 				     struct drm_atomic_state *state)
 {
+	struct drm_crtc_state *old_state = drm_atomic_get_old_crtc_state(state, crtc);
 	struct drm_device *dev = crtc->dev;
 	struct phytium_display_private *priv = dev->dev_private;
 	struct drm_display_mode *mode = &crtc->state->adjusted_mode;
@@ -260,6 +557,7 @@ phytium_crtc_atomic_enable(struct drm_crtc *crtc,
 	/* config pix clock */
 	phytium_crtc->dc_hw_config_pix_clock(crtc, mode->clock);
 
+	phytium_dc_scaling_config(crtc, old_state);
 	config = ((mode->crtc_hdisplay & HDISPLAY_END_MASK) << HDISPLAY_END_SHIFT)
 		| ((mode->crtc_htotal&HDISPLAY_TOTAL_MASK) << HDISPLAY_TOTAL_SHIFT);
 	phytium_writel_reg(priv, config, group_offset, PHYTIUM_DC_HDISPLAY);
@@ -293,7 +591,8 @@ phytium_crtc_atomic_enable(struct drm_crtc *crtc,
 	else
 		config &= (~FRAMEBUFFER_SCALE_ENABLE);
 
-	config |= FRAMEBUFFER_GAMMA_ENABLE;
+	if (!priv->info.bmc_mode)
+		config |= FRAMEBUFFER_GAMMA_ENABLE;
 
 	if (crtc->state->gamma_lut)
 		phytium_crtc_gamma_set(crtc);
@@ -470,6 +769,7 @@ int phytium_crtc_init(struct drm_device *dev, int phys_pipe)
 	struct phytium_crtc_state *phytium_crtc_state;
 	struct phytium_plane *phytium_primary_plane = NULL;
 	struct phytium_plane *phytium_cursor_plane = NULL;
+	struct drm_plane *cursor_base = NULL;
 	struct phytium_display_private *priv = dev->dev_private;
 	int ret;
 
@@ -512,16 +812,21 @@ int phytium_crtc_init(struct drm_device *dev, int phys_pipe)
 		goto failed_create_primary;
 	}
 
-	phytium_cursor_plane = phytium_cursor_plane_create(dev, phys_pipe);
-	if (IS_ERR(phytium_cursor_plane)) {
-		ret = PTR_ERR(phytium_cursor_plane);
-		DRM_ERROR("create cursor plane failed, phys_pipe(%d)\n", phys_pipe);
-		goto failed_create_cursor;
+	if (priv->info.bmc_mode) {
+		cursor_base = NULL;
+	} else {
+		phytium_cursor_plane = phytium_cursor_plane_create(dev, phys_pipe);
+		if (IS_ERR(phytium_cursor_plane)) {
+			ret = PTR_ERR(phytium_cursor_plane);
+			DRM_ERROR("create cursor plane failed, phys_pipe(%d)\n", phys_pipe);
+			goto failed_create_cursor;
+		}
+		cursor_base = &phytium_cursor_plane->base;
 	}
 
 	ret = drm_crtc_init_with_planes(dev, &phytium_crtc->base,
 					&phytium_primary_plane->base,
-					&phytium_cursor_plane->base,
+					cursor_base,
 					&phytium_crtc_funcs,
 					"phys_pipe %d", phys_pipe);
 

--- a/drivers/gpu/drm/phytium/phytium_display_drv.c
+++ b/drivers/gpu/drm/phytium/phytium_display_drv.c
@@ -289,8 +289,11 @@ static void phytium_display_unload(struct drm_device *dev)
  * The device specific ioctl range is 0x40 to 0x79.
  */
 #define DRM_PHYTIUM_VRAM_TYPE_DEVICE	0x0
+#define DRM_PHYTIUM_BMC_DEVICE	0x1
 #define DRM_IOCTL_PHYTIUM_VRAM_TYPE_DEVICE	DRM_IO(DRM_COMMAND_BASE\
 	+ DRM_PHYTIUM_VRAM_TYPE_DEVICE)
+#define DRM_IOCTL_PHYTIUM_IS_BMC_DEVICE	DRM_IO(DRM_COMMAND_BASE\
+	+ DRM_PHYTIUM_BMC_DEVICE)
 
 static int phytium_ioctl_check_vram_device(struct drm_device *dev, void *data,
 				struct drm_file *file_priv)
@@ -300,9 +303,19 @@ static int phytium_ioctl_check_vram_device(struct drm_device *dev, void *data,
 	return ((priv->support_memory_type == MEMORY_TYPE_VRAM_DEVICE) ? 1 : 0);
 }
 
+static int phytium_ioctl_check_bmc_device(struct drm_device *dev, void *data,
+				struct drm_file *file_priv)
+{
+	struct phytium_display_private *priv = dev->dev_private;
+
+	return priv->info.bmc_mode ? 1 : 0;
+}
+
 static const struct drm_ioctl_desc phytium_ioctls[] = {
 	/* for test, none so far */
 	DRM_IOCTL_DEF_DRV(PHYTIUM_VRAM_TYPE_DEVICE, phytium_ioctl_check_vram_device,
+						DRM_AUTH|DRM_UNLOCKED),
+	DRM_IOCTL_DEF_DRV(PHYTIUM_IS_BMC_DEVICE, phytium_ioctl_check_bmc_device,
 						DRM_AUTH|DRM_UNLOCKED),
 };
 
@@ -447,5 +460,6 @@ module_init(phytium_display_init);
 module_exit(phytium_display_exit);
 
 MODULE_LICENSE("GPL");
+MODULE_VERSION(DC_DRIVER_VERSION);
 MODULE_AUTHOR("Yang Xun <yangxun@phytium.com.cn>");
 MODULE_DESCRIPTION("Phytium Display Controller");

--- a/drivers/gpu/drm/phytium/phytium_display_drv.h
+++ b/drivers/gpu/drm/phytium/phytium_display_drv.h
@@ -8,6 +8,7 @@
 #define __PHYTIUM_DISPLAY_DRV_H__
 
 #include <drm/drm_print.h>
+#include <linux/pwm.h>
 #include <drm/drm_fb_helper.h>
 
 #define DEBUG_LOG 0
@@ -20,6 +21,7 @@
 #define DRV_DATE	"20201220"
 #define DRV_MAJOR	1
 #define DRV_MINOR	1
+#define DC_DRIVER_VERSION "1.0.0"
 
 /* come from GPU */
 #define	DRM_FORMAT_MOD_VENDOR_PHYTIUM	0x92
@@ -65,11 +67,15 @@ struct phytium_device_info {
 	unsigned char num_pipes;
 	unsigned char total_pipes;
 	unsigned char edp_mask;
+	bool bmc_mode;
+	unsigned char reserve[2];
 	unsigned int crtc_clock_max;
 	unsigned int hdisplay_max;
 	unsigned int vdisplay_max;
 	unsigned int backlight_max;
+	unsigned int backlight_min;
 	unsigned long address_mask;
+	struct pwm_device *pwm;
 };
 
 struct phytium_display_private {
@@ -115,6 +121,8 @@ struct phytium_display_private {
 	/* DMA info */
 	int dma_inited;
 	struct dma_chan *dma_chan;
+	/*BL GPIO info*/
+	struct gpio_desc *edp_bl_en, *edp_power_en;
 };
 
 static inline unsigned int

--- a/drivers/gpu/drm/phytium/phytium_dp.c
+++ b/drivers/gpu/drm/phytium/phytium_dp.c
@@ -2222,13 +2222,13 @@ phytium_encoder_mode_valid(struct drm_encoder *encoder, const struct drm_display
 	case 8:
 		break;
 	default:
-		DRM_INFO("not support bpc(%d)\n", display_info->bpc);
+		DRM_DEBUG_KMS("not support bpc(%d)\n", display_info->bpc);
 		display_info->bpc = 8;
 		break;
 	}
 
 	if ((display_info->color_formats & DRM_COLOR_FORMAT_RGB444) == 0) {
-		DRM_INFO("not support color_format(%d)\n", display_info->color_formats);
+		DRM_DEBUG_KMS("not support color_format(%d)\n", display_info->color_formats);
 		display_info->color_formats = DRM_COLOR_FORMAT_RGB444;
 	}
 
@@ -2595,6 +2595,7 @@ int phytium_dp_init(struct drm_device *dev, int port)
 	if (phytium_dp_is_edp(phytium_dp, port)) {
 		phytium_dp->is_edp = true;
 		type = DRM_MODE_CONNECTOR_eDP;
+		phytium_dp->pwm = priv->info.pwm;
 		phytium_dp_panel_init_backlight_funcs(phytium_dp);
 		phytium_edp_backlight_off(phytium_dp);
 		phytium_edp_panel_poweroff(phytium_dp);

--- a/drivers/gpu/drm/phytium/phytium_dp.h
+++ b/drivers/gpu/drm/phytium/phytium_dp.h
@@ -113,6 +113,7 @@ struct phytium_dp_device {
 
 	struct phytium_panel panel;
 	struct drm_display_mode native_mode;
+	struct pwm_device *pwm;
 };
 
 union phytium_phy_tp {

--- a/drivers/gpu/drm/phytium/phytium_fbdev.c
+++ b/drivers/gpu/drm/phytium/phytium_fbdev.c
@@ -16,14 +16,6 @@
 #define	PHYTIUM_MAX_CONNECTOR	1
 #define	helper_to_drm_private(x) container_of(x, struct phytium_display_private, fbdev_helper)
 
-static void phytium_fbdev_destroy(struct fb_info *info)
-{
-	struct drm_fb_helper *helper = info->par;
-	struct phytium_display_private *priv = helper_to_drm_private(helper);
-
-	phytium_gem_free_object(&priv->fbdev_phytium_gem->base);
-}
-
 static int phytium_fbdev_mmap(struct fb_info *info, struct vm_area_struct *vma)
 {
 	struct drm_fb_helper *helper = info->par;
@@ -35,7 +27,6 @@ static int phytium_fbdev_mmap(struct fb_info *info, struct vm_area_struct *vma)
 static const struct fb_ops phytium_fbdev_ops = {
 	.owner = THIS_MODULE,
 	.fb_mmap = phytium_fbdev_mmap,
-	.fb_destroy = phytium_fbdev_destroy,
 	 DRM_FB_HELPER_DEFAULT_OPS,
 	 FB_DEFAULT_IOMEM_OPS,
 };

--- a/drivers/gpu/drm/phytium/phytium_gem.c
+++ b/drivers/gpu/drm/phytium/phytium_gem.c
@@ -95,7 +95,7 @@ phytium_gem_prime_get_sg_table(struct drm_gem_object *obj)
 			DRM_ERROR("failed to allocate sg\n");
 			goto sgt_free;
 		}
-		page = phys_to_page(phytium_gem_obj->phys_addr);
+		page = pfn_to_page(__phys_to_pfn(phytium_gem_obj->phys_addr));
 		sg_set_page(sgt->sgl, page, PAGE_ALIGN(phytium_gem_obj->size), 0);
 	} else if (phytium_gem_obj->memory_type == MEMORY_TYPE_SYSTEM_UNIFIED) {
 		ret = dma_get_sgtable_attrs(dev->dev, sgt, phytium_gem_obj->vaddr,
@@ -449,7 +449,7 @@ struct phytium_gem_object *phytium_gem_create_object(struct drm_device *dev, uns
 			DRM_ERROR("fail to allocate carveout memory with size %lx\n", size);
 			goto failed_dma_alloc;
 		}
-		page = phys_to_page(phytium_gem_obj->phys_addr);
+		page = pfn_to_page(__phys_to_pfn(phytium_gem_obj->phys_addr));
 		phytium_gem_obj->iova = dma_map_page(dev->dev, page, 0, size, DMA_TO_DEVICE);
 		if (dma_mapping_error(dev->dev, phytium_gem_obj->iova)) {
 			DRM_ERROR("fail to dma map carveout memory with size %lx\n", size);

--- a/drivers/gpu/drm/phytium/phytium_panel.c
+++ b/drivers/gpu/drm/phytium/phytium_panel.c
@@ -195,7 +195,7 @@ static void phytium_dp_hw_setup_backlight(struct phytium_panel *panel)
 	struct phytium_display_private *priv = dev->dev_private;
 
 	panel->max = priv->info.backlight_max;
-	panel->min = 0;
+	panel->min = priv->info.backlight_min;
 	panel->level = phytium_dp_hw_get_backlight(panel);
 }
 
@@ -211,7 +211,7 @@ void phytium_dp_panel_init_backlight_funcs(struct phytium_dp_device *phytium_dp)
 		phytium_dp->panel.set_backlight = phytium_dp_aux_set_backlight;
 		phytium_dp->panel.get_backlight = phytium_dp_aux_get_backlight;
 	} else {
-		DRM_DEBUG_KMS("SE Backlight Control Supported!\n");
+		DRM_DEBUG_KMS("PWM Backlight Control Supported!\n");
 		phytium_dp->panel.setup_backlight = phytium_dp_hw_setup_backlight;
 		phytium_dp->panel.enable_backlight = phytium_dp_hw_enable_backlight;
 		phytium_dp->panel.disable_backlight = phytium_dp_hw_disable_backlight;

--- a/drivers/gpu/drm/phytium/phytium_pci.c
+++ b/drivers/gpu/drm/phytium/phytium_pci.c
@@ -256,6 +256,12 @@ static int phytium_pci_probe(struct pci_dev *pdev, const struct pci_device_id *e
 	struct phytium_display_private *priv = NULL;
 	struct drm_device *dev = NULL;
 	int ret = 0;
+	struct phytium_device_info *phytium_info = (struct phytium_device_info *)ent->driver_data;
+
+	if (phytium_info) {
+		if (phytium_info->platform_mask & BIT(PHYTIUM_PLATFORM_PE220X))
+			phytium_display_drm_driver.name = "pe220x";
+	}
 
 	ret = phytium_remove_conflicting_framebuffers(pdev);
 	if (ret) {
@@ -402,6 +408,8 @@ static const struct phytium_device_info px210_info = {
 	.vdisplay_max = PX210_DC_VDISPLAY_MAX,
 	.address_mask = PX210_DC_ADDRESS_MASK,
 	.backlight_max = PX210_DP_BACKLIGHT_MAX,
+	.backlight_min = PX210_DP_BACKLIGHT_MIN,
+	.bmc_mode = false,
 };
 
 static const struct phytium_device_info pe220x_info = {
@@ -412,6 +420,8 @@ static const struct phytium_device_info pe220x_info = {
 	.vdisplay_max = PE220X_DC_VDISPLAY_MAX,
 	.address_mask = PE220X_DC_ADDRESS_MASK,
 	.backlight_max = PE220X_DP_BACKLIGHT_MAX,
+	.backlight_min = PE220X_DP_BACKLIGHT_MIN,
+	.bmc_mode = true,
 };
 
 static const struct pci_device_id phytium_display_pci_ids[] = {

--- a/drivers/gpu/drm/phytium/phytium_plane.c
+++ b/drivers/gpu/drm/phytium/phytium_plane.c
@@ -448,16 +448,15 @@ static void phytium_dc_cursor_plane_update(struct drm_plane *plane)
 	struct drm_device *dev = plane->dev;
 	struct phytium_display_private *priv = dev->dev_private;
 	struct phytium_plane *phytium_plane = to_phytium_plane(plane);
-	struct drm_framebuffer *fb = plane->state->fb;
 	int phys_pipe = phytium_plane->phys_pipe;
 	int config;
 	unsigned long iova;
 
 	phytium_plane->enable = 1;
-	phytium_plane->cursor_hot_x = fb->hot_x;
-	phytium_plane->cursor_hot_y = fb->hot_y;
-	phytium_plane->cursor_x = plane->state->crtc_x + fb->hot_x;
-	phytium_plane->cursor_y = plane->state->crtc_y + fb->hot_y;
+	phytium_plane->cursor_hot_x = plane->state->hotspot_x;
+	phytium_plane->cursor_hot_y = plane->state->hotspot_x;
+	phytium_plane->cursor_x = plane->state->crtc_x + plane->state->hotspot_x ;
+	phytium_plane->cursor_y = plane->state->crtc_y + plane->state->hotspot_x;
 
 	if (phytium_plane->cursor_x < 0) {
 		phytium_plane->cursor_hot_x = plane->state->crtc_w - 1;
@@ -580,7 +579,12 @@ struct phytium_plane *phytium_primary_plane_create(struct drm_device *dev, int p
 		phytium_plane->dc_hw_update_primary_hi_addr = px210_dc_hw_update_primary_hi_addr;
 		phytium_plane->dc_hw_update_cursor_hi_addr = NULL;
 	}  else if (IS_PE220X(priv)) {
-		phytium_plane->dc_hw_plane_get_format = pe220x_dc_hw_plane_get_primary_format;
+		if (priv->info.bmc_mode)
+			phytium_plane->dc_hw_plane_get_format =
+				pe220x_dc_bmc_hw_plane_get_primary_format;
+		else
+			phytium_plane->dc_hw_plane_get_format =
+				pe220x_dc_hw_plane_get_primary_format;
 		phytium_plane->dc_hw_update_dcreq = NULL;
 		phytium_plane->dc_hw_update_primary_hi_addr = pe220x_dc_hw_update_primary_hi_addr;
 		phytium_plane->dc_hw_update_cursor_hi_addr = NULL;

--- a/drivers/gpu/drm/phytium/phytium_platform.c
+++ b/drivers/gpu/drm/phytium/phytium_platform.c
@@ -9,6 +9,9 @@
 #include <linux/acpi.h>
 #include <drm/drm_drv.h>
 #include <linux/dma-mapping.h>
+#include <linux/pwm.h>
+#include <linux/gpio.h>
+#include <linux/gpio/consumer.h>
 #include "phytium_display_drv.h"
 #include "phytium_platform.h"
 #include "phytium_dp.h"
@@ -108,6 +111,29 @@ phytium_platform_private_init(struct platform_device *pdev)
 			dev_err(&pdev->dev, "missing edp_mask property from dts\n");
 			goto failed;
 		}
+		if (priv->info.edp_mask) {
+			priv->info.pwm = devm_pwm_get(&pdev->dev, NULL);
+			if (IS_ERR(priv->info.pwm)) {
+				dev_err(&pdev->dev, "Failed to request PWM device: %ld\n",
+							PTR_ERR(priv->info.pwm));
+				goto failed;
+			}
+			priv->edp_bl_en = gpiod_get(&pdev->dev, "edp-bl-en", GPIOD_OUT_HIGH);
+			if (IS_ERR(priv->edp_bl_en)) {
+				dev_err(&pdev->dev, "Failed to get edp_en gpio\n");
+				priv->edp_bl_en = NULL;
+				goto failed;
+			}
+			priv->edp_power_en = gpiod_get(&pdev->dev, "edp-power-en", GPIOD_OUT_HIGH);
+			if (IS_ERR(priv->edp_power_en)) {
+				dev_err(&pdev->dev, "Failed to get edp_pwr_en gpio\n");
+				priv->edp_power_en = NULL;
+				goto failed_gpio_power_init;
+			}
+			// set GPIO pin output
+			gpiod_direction_output(priv->edp_power_en, 0);
+			gpiod_direction_output(priv->edp_bl_en, 0);
+		}
 	} else if (has_acpi_companion(&pdev->dev)) {
 		phytium_info = (struct phytium_device_info *)acpi_device_get_match_data(&pdev->dev);
 		if (!phytium_info) {
@@ -126,6 +152,29 @@ phytium_platform_private_init(struct platform_device *pdev)
 		if (ret < 0) {
 			dev_err(&pdev->dev, "missing edp_mask property from acpi\n");
 			goto failed;
+		}
+		if (priv->info.edp_mask) {
+			priv->info.pwm = devm_pwm_get(&pdev->dev, NULL);
+			if (IS_ERR(priv->info.pwm)) {
+				dev_err(&pdev->dev, "Failed to request PWM device: %ld\n",
+						PTR_ERR(priv->info.pwm));
+				goto failed;
+			}
+			priv->edp_bl_en = gpiod_get(&pdev->dev, "edp-bl-en", GPIOD_OUT_HIGH);
+			if (IS_ERR(priv->edp_bl_en)) {
+				dev_err(&pdev->dev, "Failed to get edp_en gpio\n");
+				priv->edp_bl_en = NULL;
+				goto failed;
+			}
+			priv->edp_power_en = gpiod_get(&pdev->dev, "edp-power-en", GPIOD_OUT_HIGH);
+			if (IS_ERR(priv->edp_power_en)) {
+				dev_err(&pdev->dev, "Failed to get edp_pwr_en gpio\n");
+				priv->edp_power_en = NULL;
+				goto failed_gpio_power_init;
+			}
+			// set GPIO pin output
+			gpiod_direction_output(priv->edp_power_en, 0);
+			gpiod_direction_output(priv->edp_bl_en, 0);
 		}
 	}
 
@@ -157,6 +206,8 @@ phytium_platform_private_init(struct platform_device *pdev)
 
 	return priv;
 
+failed_gpio_power_init:
+	gpiod_put(priv->edp_bl_en);
 failed:
 	devm_kfree(&pdev->dev, platform_priv);
 exit:
@@ -169,6 +220,11 @@ static void phytium_platform_private_fini(struct platform_device *pdev)
 	struct phytium_display_private *priv = dev->dev_private;
 	struct phytium_platform_private *platform_priv = to_platform_priv(priv);
 
+	if (priv->edp_power_en)
+		gpiod_put(priv->edp_power_en);
+	if (priv->edp_bl_en)
+		gpiod_put(priv->edp_bl_en);
+
 	devm_kfree(&pdev->dev, platform_priv);
 }
 
@@ -176,7 +232,22 @@ static int phytium_platform_probe(struct platform_device *pdev)
 {
 	struct phytium_display_private *priv = NULL;
 	struct drm_device *dev = NULL;
+	struct phytium_device_info *phytium_info = NULL;
 	int ret = 0;
+
+	if (pdev->dev.of_node) {
+		phytium_info = (struct phytium_device_info *)of_device_get_match_data(&pdev->dev);
+		if (phytium_info) {
+			if (phytium_info->platform_mask & BIT(PHYTIUM_PLATFORM_PE220X))
+				phytium_display_drm_driver.name = "pe220x";
+		}
+	} else if (has_acpi_companion(&pdev->dev)) {
+		phytium_info = (struct phytium_device_info *)acpi_device_get_match_data(&pdev->dev);
+		if (phytium_info) {
+			if (phytium_info->platform_mask & BIT(PHYTIUM_PLATFORM_PE220X))
+				phytium_display_drm_driver.name = "pe220x";
+		}
+	}
 
 	dev = drm_dev_alloc(&phytium_display_drm_driver, &pdev->dev);
 	if (IS_ERR(dev)) {
@@ -270,6 +341,8 @@ static const struct phytium_device_info pe220x_info = {
 	.vdisplay_max = PE220X_DC_VDISPLAY_MAX,
 	.address_mask = PE220X_DC_ADDRESS_MASK,
 	.backlight_max = PE220X_DP_BACKLIGHT_MAX,
+	.backlight_min = PE220X_DP_BACKLIGHT_MIN,
+	.bmc_mode = false,
 };
 
 static const struct of_device_id display_of_match[] = {

--- a/drivers/gpu/drm/phytium/phytium_reg.h
+++ b/drivers/gpu/drm/phytium/phytium_reg.h
@@ -268,7 +268,7 @@
 #define PHYTIUM_DP_INTERRUPT_MASK			0x0144
 	#define HPD_IRQ_MASK					(1<<1)
 	#define HPD_EVENT_MASK					(1<<0)
-	#define HPD_OTHER_MASK					0x5c
+	#define HPD_OTHER_MASK					0x7c
 #define PHYTIUM_DP_AUX_REPLY_DATA_COUNT			0x0148
 #define PHYTIUM_DP_AUX_STATUS				0x014C
 	#define REPLY_RECEIVED					0x1

--- a/drivers/gpu/drm/phytium/px210_dc.c
+++ b/drivers/gpu/drm/phytium/px210_dc.c
@@ -6,7 +6,9 @@
 
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_atomic.h>
+#if defined(__arm__) || defined(__aarch64__)
 #include <asm/neon.h>
+#endif
 #include <linux/delay.h>
 #include "phytium_display_drv.h"
 #include "px210_reg.h"

--- a/drivers/gpu/drm/phytium/px210_dp.h
+++ b/drivers/gpu/drm/phytium/px210_dp.h
@@ -8,6 +8,7 @@
 #define __PX210_DP_H__
 
 #define PX210_DP_BACKLIGHT_MAX				100
+#define PX210_DP_BACKLIGHT_MIN				0
 
 void px210_dp_func_register(struct phytium_dp_device *phytium_dp);
 #endif /* __PX210_DP_H__ */


### PR DESCRIPTION
modified this files to support Phytium Display Engine  more.

## Summary by Sourcery

Add display scaling, BMC mode support, and PWM backlight control for Phytium display driver, along with various fixes and improvements.

New Features:
- Implement display scaling using sinc filters.
- Introduce support for BMC (Baseboard Management Controller) mode, affecting plane formats, CRTC initialization, and reset logic.
- Add eDP backlight control via PWM and GPIO.
- Add an ioctl to query if the device is operating in BMC mode.

Bug Fixes:
- Use pfn_to_page for physical address translation in GEM.
- Correct eDP backlight minimum and maximum level definitions.
- Fix incorrect Hot Plug Detect (HPD) interrupt mask value.
- Remove potentially incorrect framebuffer device destroy callback.

Enhancements:
- Conditionally utilize NEON/FPU instructions for scaling calculations on relevant architectures.
- Set the DRM driver name dynamically based on the detected hardware platform (e.g., PE220X).
- Adjust the maximum reported display resolution for the PE220X platform.

Build:
- Add specific FPU compiler flags for x86 architecture when building scaling code.

Chores:
- Add a driver version string.