### PR TITLE
mmc: Add Phytium mmc support

### DIFF
--- a/Documentation/devicetree/bindings/mmc/phytium,mci_v2.yaml
+++ b/Documentation/devicetree/bindings/mmc/phytium,mci_v2.yaml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/mmc/phytium,mci_v2.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium Multimedia Card Interface controller
+
+description: |
+  The highspeed MMC host V2 controller on Phytium SoCs provides an interface
+  for MMC, SD and SDIO types of memory cards.
+
+maintainers:
+  - Lai Xueyu <laixueyu1280@phytium.com.cn>
+
+allOf:
+  - $ref: "mmc-controller.yaml"
+
+properties:
+  compatible:
+    const: phytium,mci_2.0
+
+  reg:
+    maxItems: 2
+    description: mmc controller regfile base registers.
+    description: mmc controller share memory base registers.
+
+  interrupts:
+    maxItems: 1
+    description: mmc controller v2 interrupt.
+
+  clocks:
+    maxItems: 1
+    description: phandles to input clocks.
+
+  clock-names:
+    items:
+      - const: phytium_mci_clk
+
+required:
+  - compatible
+  - reg
+  - interrupts
+  - clocks
+  - clock-names
+
+examples:
+  - |
+    mmc0_v2: mmc@27018000 {
+      compatible = "phytium,mci_2.0";
+      reg = <0x0 0x27018000 0x0 0x1000>,
+           <0x0 0x26fea000 0x0 0x1000>;
+      interrupts = <GIC_SPI 89 IRQ_TYPE_LEVEL_HIGH>;
+      clocks = <&sysclk_1200mhz>;
+      clock-names = "phytium_mci_clk";
+      status = "disabled";
+    };
+
+    &mmc0 {
+      bus-width = <4>;
+      max-frequency = <50000000>;
+      cap-sdio-irq;
+      cap-sd-highspeed;
+      sd-uhs-sdr12;
+      sd-uhs-sdr25;
+      sd-uhs-sdr50;
+      no-mmc;
+      status = "ok";
+    };

--- a/drivers/mmc/host/Kconfig
+++ b/drivers/mmc/host/Kconfig
@@ -1106,3 +1106,14 @@ config MMC_PHYTIUM_MCI_PLTFM
           If you have a controller with this interface, say Y or M here.
 
           If unsure, say N.
+
+config MMC_PHYTIUM_MCI_PLTFM_V2
+       tristate "Phytium V2 MultiMedia Card Interface support"
+       depends on ARCH_PHYTIUM && OF
+       default y if ARCH_PHYTIUM
+       help
+         This selects support for the V2 MultiMedia Card Interface on Phytium SoCs.
+         If you have a controller with this interface, say Y or M here.
+
+         If unsure, say N.
+

--- a/drivers/mmc/host/Makefile
+++ b/drivers/mmc/host/Makefile
@@ -73,6 +73,7 @@ obj-$(CONFIG_MMC_OWL)		+= owl-mmc.o
 obj-$(CONFIG_MMC_PHYTIUM_SDCI)  += phytium-sdci.o
 obj-$(CONFIG_MMC_PHYTIUM_MCI_PCI)       += phytium-mci-pci.o phytium-mci.o
 obj-$(CONFIG_MMC_PHYTIUM_MCI_PLTFM)     += phytium-mci-plat.o phytium-mci.o
+obj-$(CONFIG_MMC_PHYTIUM_MCI_PLTFM_V2) += phytium-mci-plat-v2.o phytium-mci-v2.o
 
 obj-$(CONFIG_MMC_REALTEK_PCI)	+= rtsx_pci_sdmmc.o
 obj-$(CONFIG_MMC_REALTEK_USB)	+= rtsx_usb_sdmmc.o

--- a/drivers/mmc/host/phytium-mci-plat-v2.c
+++ b/drivers/mmc/host/phytium-mci-plat-v2.c
@@ -2,7 +2,7 @@
 /*
  * Phytium Multimedia Card Interface PCI driver
  *
- * Copyright (C) 2021-2023, Phytium Technology Co., Ltd.
+ * Copyright (C) 2024 Phytium Technology Co.,Ltd.
  */
 
 #include <linux/module.h>
@@ -12,21 +12,84 @@
 #include <linux/pm_runtime.h>
 #include <linux/acpi.h>
 #include <linux/dma-mapping.h>
-#include "phytium-mci.h"
+#include "phytium-mci-v2.h"
 
 static u32 mci_caps = MMC_CAP_CMD23;
 
 #if defined CONFIG_PM && defined CONFIG_PM_SLEEP
 
 static const struct dev_pm_ops phytium_mci_dev_pm_ops = {
-	SET_SYSTEM_SLEEP_PM_OPS(phytium_mci_suspend,
-				phytium_mci_resume)
-	SET_RUNTIME_PM_OPS(phytium_mci_runtime_suspend,
-			   phytium_mci_runtime_resume, NULL)
+	SET_SYSTEM_SLEEP_PM_OPS(phyt_mci_suspend,
+				phyt_mci_resume)
+	SET_RUNTIME_PM_OPS(phyt_mci_runtime_suspend,
+			   phyt_mci_runtime_resume, NULL)
 };
 #else
 #define phytium_mci_dev_pm_ops NULL
 #endif
+
+static ssize_t debug_enable_show(struct device *dev, struct device_attribute *attr,
+			     char *buf)
+{
+	struct mmc_host *mmc = container_of(dev, struct mmc_host, class_dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	return sprintf(buf, "%d\n", host->debug_enable);
+}
+
+static ssize_t debug_enable_store(struct device *dev, struct device_attribute *attr,
+			      const char *buf, size_t count)
+{
+	struct mmc_host *mmc = container_of(dev, struct mmc_host, class_dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	int enable;
+	int ret;
+
+	ret = sscanf(buf, "%d\n", &enable);
+	if (ret == 0) {
+		ret = -EINVAL;
+		return ret;
+	}
+
+	host->debug_enable = enable;
+
+	phytium_mci_set_debug_enable(host, host->debug_enable);
+
+	return count;
+}
+
+static ssize_t alive_enable_show(struct device *dev, struct device_attribute *attr,
+			     char *buf)
+{
+	struct mmc_host *mmc = container_of(dev, struct mmc_host, class_dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	return sprintf(buf, "%d\n", host->alive_enable);
+}
+
+static ssize_t alive_enable_store(struct device *dev, struct device_attribute *attr,
+			      const char *buf, size_t count)
+{
+	struct mmc_host *mmc = container_of(dev, struct mmc_host, class_dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	int enable;
+	int ret;
+
+	ret = sscanf(buf, "%d\n", &enable);
+	if (ret == 0) {
+		ret = -EINVAL;
+		return ret;
+	}
+
+	host->alive_enable = enable;
+
+	phytium_mci_set_alive_enable(host, host->alive_enable);
+
+	return count;
+}
+
+static DEVICE_ATTR_RW(debug_enable);
+static DEVICE_ATTR_RW(alive_enable);
 
 static int phytium_mci_probe(struct platform_device *pdev)
 {
@@ -44,26 +107,6 @@ static int phytium_mci_probe(struct platform_device *pdev)
 	ret = mmc_of_parse(mmc);
 	if (ret)
 		goto host_free;
-
-	if (device_property_read_bool(dev, "use-hold"))
-		host->use_hold = 1;
-
-	if (device_property_read_bool(dev, "clk-set"))
-		host->clk_set = 1;
-
-	if (host->clk_set) {
-		host->clk_smpl_drv_25m = -1;
-		host->clk_smpl_drv_50m = -1;
-		host->clk_smpl_drv_66m = -1;
-		host->clk_smpl_drv_100m = -1;
-		device_property_read_u32(dev, "clk-smpl-drv-25m", &host->clk_smpl_drv_25m);
-		device_property_read_u32(dev, "clk-smpl-drv-50m", &host->clk_smpl_drv_50m);
-		device_property_read_u32(dev, "clk-smpl-drv-66m", &host->clk_smpl_drv_66m);
-		device_property_read_u32(dev, "clk-smpl-drv-100m", &host->clk_smpl_drv_100m);
-	}
-	dev_info(dev, "mci clk set %d %d 0x%x 0x%x 0x%x 0x%x\n",
-			host->use_hold, host->clk_set, host->clk_smpl_drv_25m,
-			host->clk_smpl_drv_50m, host->clk_smpl_drv_66m, host->clk_smpl_drv_100m);
 
 	if (dev->of_node) {
 		host->src_clk = devm_clk_get(&pdev->dev, "phytium_mci_clk");
@@ -86,6 +129,13 @@ static int phytium_mci_probe(struct platform_device *pdev)
 	host->is_device_x100 = 0;
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	host->regf_base = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(host->regf_base)) {
+		ret = PTR_ERR(host->regf_base);
+		goto host_free;
+	}
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
 	host->base = devm_ioremap_resource(&pdev->dev, res);
 	if (IS_ERR(host->base)) {
 		ret = PTR_ERR(host->base);
@@ -103,19 +153,34 @@ static int phytium_mci_probe(struct platform_device *pdev)
 	host->dev = &pdev->dev;
 	host->caps = mci_caps;
 	host->mmc = mmc;
-	ret = phytium_mci_common_probe(host);
+	ret = phyt_mci_common_probe(host);
 	if (ret == MCI_REALEASE_MEM) {
 		ret = -ENOMEM;
 		goto release_mem;
 	} else if (ret) {
 		goto release;
 	}
+
+	ret = device_create_file(&mmc->class_dev,
+				&dev_attr_debug_enable);
+	if (ret < 0)
+		goto debug_enable_free;
+
+	ret = device_create_file(&mmc->class_dev,
+				&dev_attr_alive_enable);
+	if (ret < 0)
+		goto alive_enable_free;
+
 	platform_set_drvdata(pdev, mmc);
 	dev_info(&pdev->dev, "%s %d: probe phytium mci successful.\n", __func__, __LINE__);
 	return 0;
 
+alive_enable_free:
+	device_remove_file(&mmc->class_dev, &dev_attr_alive_enable);
+debug_enable_free:
+	device_remove_file(&mmc->class_dev, &dev_attr_debug_enable);
 release:
-	phytium_mci_deinit_hw(host);
+	phyt_mci_deinit_hw(host);
 release_mem:
 	if (host->dma.adma_table) {
 		dma_free_coherent(&pdev->dev,
@@ -144,6 +209,7 @@ static int phytium_mci_remove(struct platform_device *pdev)
 		mmc_free_host(mmc);
 		return -1;
 	}
+	del_timer(&host->alive_timer);
 	del_timer(&host->hotplug_timer);
 	mmc_remove_host(host->mmc);
 
@@ -152,14 +218,14 @@ static int phytium_mci_remove(struct platform_device *pdev)
 				  MAX_BD_NUM * sizeof(struct phytium_adma2_64_desc),
 				  host->dma.adma_table, host->dma.adma_addr);
 	}
-	phytium_mci_deinit_hw(host);
+	phyt_mci_deinit_hw(host);
 	mmc_free_host(mmc);
 	platform_set_drvdata(pdev, NULL);
 	return 0;
 }
 
 static const struct of_device_id phytium_mci_of_ids[] = {
-	{ .compatible =  "phytium,mci", },
+	{   .compatible =  "phytium,mci_2.0", },
 	{}
 };
 
@@ -167,7 +233,7 @@ MODULE_DEVICE_TABLE(of, phytium_mci_of_ids);
 
 #ifdef CONFIG_ACPI
 static const struct acpi_device_id phytium_mci_acpi_ids[] = {
-	{ .id = "PHYT0017" },
+	{ .id = "PHYT0061" },
 	{ }
 };
 
@@ -180,7 +246,7 @@ static struct platform_driver phytium_mci_driver = {
 	.probe = phytium_mci_probe,
 	.remove = phytium_mci_remove,
 	.driver = {
-		.name = "phytium-mci-platform",
+		.name = "phytium-mci-platform-2.0",
 		.of_match_table = phytium_mci_of_ids,
 		.acpi_match_table = phytium_mci_acpi_ids,
 		.pm = &phytium_mci_dev_pm_ops,
@@ -191,4 +257,4 @@ module_platform_driver(phytium_mci_driver);
 
 MODULE_DESCRIPTION("Phytium Multimedia Card Interface driver");
 MODULE_LICENSE("GPL");
-MODULE_AUTHOR("Cheng Quan <chengquan@phytium.com.cn>");
+MODULE_AUTHOR("Lai Xueyu <laixueyu1280@phytium.com.cn>");

--- a/drivers/mmc/host/phytium-mci-v2.c
+++ b/drivers/mmc/host/phytium-mci-v2.c
@@ -1,0 +1,1076 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Driver for Phytium Multimedia Card Interface
+ *
+ * Copyright (C) 2024 Phytium Technology Co., Ltd.
+ */
+
+#include <linux/moduleparam.h>
+#include <linux/module.h>
+#include <linux/clk.h>
+#include <linux/delay.h>
+#include <linux/dma-mapping.h>
+#include <linux/ioport.h>
+#include <linux/irq.h>
+#include <linux/of_address.h>
+#include <linux/of_device.h>
+#include <linux/of_irq.h>
+#include <linux/of_gpio.h>
+#include <linux/pinctrl/consumer.h>
+#include <linux/platform_device.h>
+#include <linux/pm.h>
+#include <linux/pm_runtime.h>
+#include <linux/regulator/consumer.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/interrupt.h>
+#include <linux/acpi.h>
+#include <linux/timer.h>
+#include <linux/swab.h>
+#include <linux/pci.h>
+#include <linux/mmc/card.h>
+#include <linux/mmc/core.h>
+#include <linux/mmc/host.h>
+#include <linux/mmc/mmc.h>
+#include <linux/mmc/sd.h>
+#include <linux/mmc/sdio.h>
+#include <linux/delay.h>
+#include "phytium-mci-v2.h"
+
+struct init_data_t *init_data;
+struct start_command_data_t *start_command_data;
+struct start_data_data_t *start_data_data;
+struct set_ios_data_t *set_ios_data;
+struct cmd_next_data_t *cmd_next_data;
+struct err_irq_data_t *err_irq_data;
+
+static struct phytium_mci_host *shost;
+
+static const u32 rv2ap_int_mask = MMC_RXRING_TAIL_INT_MASK;
+
+static const u32 cmd_err_ints_mask = MCI_INT_MASK_RTO | MCI_INT_MASK_RCRC | MCI_INT_MASK_RE |
+				     MCI_INT_MASK_DCRC | MCI_INT_MASK_DRTO |
+				     MCI_MASKED_INTS_SBE_BCI;
+
+static int ap_phytium_mci_cmd_next(struct phyt_msg_info *rxmsg);
+static int ap_phytium_mci_data_xfer_next(struct phyt_msg_info *rxmsg);
+static void phytium_mci_adma_reset(struct phytium_mci_host *host);
+static void phytium_mci_init(struct phytium_mci_host *host);
+static void phytium_mci_init_adma_table(struct phytium_mci_host *host,
+					 struct phytium_mci_dma *dma);
+static void phytium_mci_init_hw(struct phytium_mci_host *host);
+static int phytium_mci_get_cd(struct mmc_host *mmc);
+static int phytium_mci_get_ro(struct mmc_host *mmc);
+static void phytium_mci_start_command(struct phytium_mci_host *host,
+		struct mmc_request *mrq,
+		struct mmc_command *cmd);
+static void
+phytium_mci_start_data(struct phytium_mci_host *host, struct mmc_request *mrq,
+		struct mmc_command *cmd, struct mmc_data *data);
+static void __phytium_mci_enable_sdio_irq(struct phytium_mci_host *host, int enable);
+static int phytium_check_msg(void);
+static int phytium_mci_card_busy(struct mmc_host *mmc);
+struct phyt_msg_info *shmem[RING_MAX];
+struct phyt_msg_info *rvshmem[RING_MAX_RV];
+
+static void phytium_mci_set_int_mask(struct phytium_mci_host *host)
+{
+	u32 int_mask;
+
+	int_mask = ~rv2ap_int_mask;
+
+	writel(int_mask, host->regf_base + MMC_RV2AP_INT_MASK);
+	dev_info(host->dev, "set int mask %x\n", int_mask);
+}
+
+static void phytium_mci_prepare_data(struct phytium_mci_host *host,
+				      struct mmc_request *mrq)
+{
+	struct mmc_data *data = mrq->data;
+
+	if (!(data->host_cookie & MCI_PREPARE_FLAG)) {
+		data->host_cookie |= MCI_PREPARE_FLAG;
+		data->sg_count = dma_map_sg(host->dev, data->sg, data->sg_len,
+					    mmc_get_dma_dir(data));
+	}
+}
+
+static void phytium_mci_unprepare_data(struct phytium_mci_host *host,
+					struct mmc_request *mrq)
+{
+	struct mmc_data *data = mrq->data;
+
+	if (data->host_cookie & MCI_ASYNC_FLAG)
+		return;
+
+	if (data->host_cookie & MCI_PREPARE_FLAG) {
+		dma_unmap_sg(host->dev, data->sg, data->sg_len, mmc_get_dma_dir(data));
+		data->host_cookie &= ~MCI_PREPARE_FLAG;
+	}
+}
+
+static inline u32
+phytium_mci_cmd_find_resp(struct phytium_mci_host *host,
+			  struct mmc_request *mrq,
+			  struct mmc_command *cmd)
+{
+	u32 resp;
+
+	switch (mmc_resp_type(cmd)) {
+	case MMC_RSP_R1:
+	case MMC_RSP_R1B:
+		resp = 0x5;
+		break;
+
+	case MMC_RSP_R2:
+		resp = 0x7;
+		break;
+
+	case MMC_RSP_R3:
+		resp = 0x1;
+		break;
+
+	case MMC_RSP_NONE:
+	default:
+		resp = 0x0;
+		break;
+	}
+
+	return resp;
+}
+
+static inline
+u32 phytium_mci_cmd_prepare_raw_cmd(struct phytium_mci_host *host,
+				     struct mmc_request *mrq,
+				     struct mmc_command *cmd)
+{
+	u32 opcode = cmd->opcode;
+	u32 resp = phytium_mci_cmd_find_resp(host, mrq, cmd);
+	u32 rawcmd = ((opcode & 0x3f) | ((resp & 0x7) << 6));
+
+	if (opcode == MMC_GO_INACTIVE_STATE ||
+	    (opcode == SD_IO_RW_DIRECT && ((cmd->arg >> 9) & 0x1FFFF) == SDIO_CCCR_ABORT))
+		rawcmd |= (0x1 << 14);
+	else if (opcode == SD_SWITCH_VOLTAGE)
+		rawcmd |= (0x1 << 28);
+
+	if (test_and_clear_bit(MCI_CARD_NEED_INIT, &host->flags))
+		rawcmd |= (0x1 << 15);
+
+	if (cmd->data) {
+		struct mmc_data *data = cmd->data;
+
+		rawcmd |= (0x1 << 9);
+
+		if (data->flags & MMC_DATA_WRITE)
+			rawcmd |= (0x1 << 10);
+	}
+
+	if (host->use_hold)
+		rawcmd |= (0x1 << 29);
+
+	return (rawcmd | (0x1 << 31));
+}
+
+static inline void
+phytium_mci_adma_write_desc(struct phytium_mci_host *host,
+			     struct phytium_adma2_64_desc *desc,
+			     dma_addr_t addr, u32 len, u32 attribute)
+{
+	desc->attribute = attribute;
+	desc->len = len;
+	desc->addr_lo = lower_32_bits(addr);
+	desc->addr_hi = upper_32_bits(addr);
+	dev_dbg(host->dev, "%s %d:addr_lo:0x%x ddr_hi:0x%x\n", __func__,
+		__LINE__,  desc->addr_lo, desc->addr_hi);
+
+	if ((attribute == 0x80000004) || (attribute == 0x8000000c)) {
+		desc->desc_lo = 0;
+		desc->desc_hi = 0;
+	}
+}
+
+static void
+phytium_mci_data_sg_write_2_admc_table(struct phytium_mci_host *host, struct mmc_data *data)
+{
+	struct phytium_adma2_64_desc *desc;
+	u32 dma_len, i;
+	dma_addr_t dma_address;
+	struct scatterlist *sg;
+
+	phytium_mci_init_adma_table(host, &host->dma);
+
+	desc = host->dma.adma_table;
+	for_each_sg(data->sg, sg, data->sg_count, i) {
+		dma_address = sg_dma_address(sg);
+		dma_len = sg_dma_len(sg);
+
+		if (i == 0) {
+			if (sg_is_last(sg) || (data->sg_count == 1 && dma_len == SD_BLOCK_SIZE))
+				phytium_mci_adma_write_desc(host, desc, dma_address,
+							     dma_len, 0x8000000c);
+			else
+				phytium_mci_adma_write_desc(host, desc, dma_address,
+							     dma_len, 0x8000001a);
+		} else if (sg_is_last(sg)) {
+			phytium_mci_adma_write_desc(host, desc, dma_address,
+						     dma_len, 0x80000004);
+		} else {
+			phytium_mci_adma_write_desc(host, desc, dma_address,
+						     dma_len, 0x80000012);
+		}
+
+		desc++;
+	}
+}
+
+static void phytium_mci_track_cmd_data(struct phytium_mci_host *host,
+					struct mmc_command *cmd,
+					struct mmc_data *data)
+{
+	if (host->error)
+		dev_dbg(host->dev, "%s: cmd=%d arg=%08X; host->error=0x%08X\n",
+			__func__, cmd->opcode, cmd->arg, host->error);
+}
+
+static void phytium_mci_request_done(struct phytium_mci_host *host, struct mmc_request *mrq)
+{
+	phytium_mci_track_cmd_data(host, mrq->cmd, mrq->data);
+
+	if (mrq->data)
+		phytium_mci_unprepare_data(host, mrq);
+
+	mmc_request_done(host->mmc, mrq);
+}
+
+static void phytium_mci_ops_request(struct mmc_host *mmc, struct mmc_request *mrq)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	host->error = 0;
+	host->mrq = NULL;
+	WARN_ON(host->mrq);
+	host->mrq = mrq;
+
+	dev_dbg(host->dev, "%s %d: cmd:%d arg:0x%x\n", __func__, __LINE__,
+		mrq->cmd->opcode, mrq->cmd->arg);
+
+	if (mrq->sbc) {
+		phytium_mci_start_command(host, mrq, mrq->sbc);
+		return;
+	}
+	if (mrq->data) {
+		phytium_mci_prepare_data(host, mrq);
+
+		if ((mrq->data->sg->length >= 512) && host->is_use_dma &&
+			((mrq->cmd->opcode == MMC_READ_MULTIPLE_BLOCK) ||
+			(mrq->cmd->opcode == MMC_READ_SINGLE_BLOCK) ||
+			(mrq->cmd->opcode == MMC_WRITE_MULTIPLE_BLOCK) ||
+			(mrq->cmd->opcode == MMC_WRITE_BLOCK) ||
+			(mrq->cmd->opcode == SD_IO_RW_EXTENDED)))
+
+			host->adtc_type = BLOCK_RW_ADTC;
+		else
+			host->adtc_type = COMMOM_ADTC;
+
+		phytium_mci_start_data(host, mrq, mrq->cmd, mrq->data);
+		return;
+	}
+	phytium_mci_start_command(host, mrq, mrq->cmd);
+}
+
+static void phytium_mci_pre_req(struct mmc_host *mmc, struct mmc_request *mrq)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	struct mmc_data *data = mrq->data;
+
+	if (!data)
+		return;
+
+	phytium_mci_prepare_data(host, mrq);
+	data->host_cookie |= MCI_ASYNC_FLAG;
+}
+
+static void phytium_mci_post_req(struct mmc_host *mmc, struct mmc_request *mrq,
+				  int err)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	struct mmc_data *data = mrq->data;
+
+	if (!data)
+		return;
+
+	if (data->host_cookie & MCI_ASYNC_FLAG) {
+		data->host_cookie &= ~MCI_ASYNC_FLAG;
+		phytium_mci_unprepare_data(host, mrq);
+	}
+}
+
+static void phytium_mci_data_read_without_dma(struct phytium_mci_host *host,
+					      struct mmc_data *data)
+{
+	u32 length, i, data_val, dma_len, tmp = 0;
+	u32 *virt_addr;
+	unsigned long flags;
+	struct scatterlist *sg;
+
+	length = data->blocks * data->blksz;
+
+	if (mmc_get_dma_dir(data) == DMA_FROM_DEVICE) {
+		spin_lock_irqsave(&host->lock, flags);
+		if (data->host_cookie & MCI_ASYNC_FLAG) {
+			tmp = MCI_ASYNC_FLAG;
+			phytium_mci_post_req(host->mmc, data->mrq, 0);
+		} else {
+			phytium_mci_unprepare_data(host, data->mrq);
+		}
+
+		for_each_sg(data->sg, sg, data->sg_count, i) {
+			dma_len = sg_dma_len(sg);
+			virt_addr = sg_virt(data->sg);
+
+			for (i = 0; i < (dma_len / 4); i++) {
+				data_val = readl(host->regf_base + MCI_DATA);
+				memcpy(virt_addr, &data_val, 4);
+				++virt_addr;
+			}
+		}
+
+		if (tmp & MCI_ASYNC_FLAG)
+			phytium_mci_pre_req(host->mmc, data->mrq);
+		else
+			phytium_mci_prepare_data(host, data->mrq);
+
+		spin_unlock_irqrestore(&host->lock, flags);
+	}
+	data->bytes_xfered = length;
+}
+
+static irqreturn_t phytium_mci_irq(int irq, void *dev_id)
+{
+	struct phytium_mci_host *host = (struct phytium_mci_host *) dev_id;
+	u32 rv2ap_event;
+
+	rv2ap_event = readl(host->regf_base + MMC_RV2AP_INT);
+	if (rv2ap_event & MMC_TXRING_HEAD_INT) {
+		rv2ap_event &= ~MMC_TXRING_HEAD_INT;
+		pr_debug("MCIAP %s MMC_TXRING_HEAD_INT %x\n", __func__, rv2ap_event);
+		writel(rv2ap_event, host->regf_base + MMC_RV2AP_INT);
+	}
+	if (rv2ap_event & MMC_RXRING_TAIL_INT) {
+		rv2ap_event &= ~MMC_RXRING_TAIL_INT;
+		pr_debug("MCIAP %s MMC_RXRING_TAIL_INT %x\n", __func__, rv2ap_event);
+		writel(rv2ap_event, host->regf_base + MMC_RV2AP_INT);
+		phytium_check_msg();
+	}
+	return IRQ_HANDLED;
+}
+
+static void phytium_mci_init_adma_table(struct phytium_mci_host *host,
+					 struct phytium_mci_dma *dma)
+{
+	struct phytium_adma2_64_desc *adma_table = dma->adma_table;
+	dma_addr_t dma_addr;
+	int i;
+
+	memset(adma_table, 0, sizeof(struct phytium_adma2_64_desc) * MAX_BD_NUM);
+
+	for (i = 0; i < (MAX_BD_NUM - 1); i++) {
+		dma_addr = dma->adma_addr + sizeof(*adma_table) * (i + 1);
+		adma_table[i].desc_lo = lower_32_bits(dma_addr);
+		adma_table[i].desc_hi = upper_32_bits(dma_addr);
+		adma_table[i].attribute = 0;
+		adma_table[i].NON1 = 0;
+		adma_table[i].len = 0;
+		adma_table[i].NON2 = 0;
+	}
+
+	phytium_mci_adma_reset(host);
+}
+
+static void phytium_mci_ack_sdio_irq(struct mmc_host *mmc)
+{
+	unsigned long flags;
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	spin_lock_irqsave(&host->lock, flags);
+	__phytium_mci_enable_sdio_irq(host, 1);
+	spin_unlock_irqrestore(&host->lock, flags);
+}
+
+#ifdef CONFIG_PM_SLEEP
+int phyt_mci_suspend(struct device *dev)
+{
+	struct mmc_host *mmc = dev_get_drvdata(dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	phyt_mci_deinit_hw(host);
+	return 0;
+}
+EXPORT_SYMBOL(phyt_mci_suspend);
+
+int phyt_mci_resume(struct device *dev)
+{
+	struct mmc_host *mmc = dev_get_drvdata(dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	phytium_mci_set_int_mask(host);
+	phytium_mci_init(host);
+	phytium_mci_init_hw(host);
+	return 0;
+}
+EXPORT_SYMBOL(phyt_mci_resume);
+
+#endif
+
+#ifdef CONFIG_PM
+int phyt_mci_runtime_suspend(struct device *dev)
+{
+	struct mmc_host *mmc = dev_get_drvdata(dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	phyt_mci_deinit_hw(host);
+	return 0;
+}
+EXPORT_SYMBOL(phyt_mci_runtime_suspend);
+
+int phyt_mci_runtime_resume(struct device *dev)
+{
+	struct mmc_host *mmc = dev_get_drvdata(dev);
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	phytium_mci_set_int_mask(host);
+	phytium_mci_init(host);
+	phytium_mci_init_hw(host);
+	return 0;
+}
+EXPORT_SYMBOL(phyt_mci_runtime_resume);
+
+#endif
+
+static int phytium_ap_to_rv(struct phyt_msg_info *msg)
+{
+	int i;
+	int ret = 0;
+	int tx_t, tx_h, p;
+
+	tx_t = readl(shost->regf_base + MMC_TX_TAIL) & 0xffff;
+	tx_h = readl(shost->regf_base + MMC_TX_HEAD) & 0xffff;
+
+	if ((tx_t + 1) % RING_MAX == tx_h) {
+		pr_err("mci ring buff full\n");
+		return -1;
+	}
+
+	p = tx_t;
+
+	tx_t = (tx_t + 1) % RING_MAX;
+
+	shmem[p] = (struct phyt_msg_info *)(*shmem + p);
+	pr_debug("MCIAP shmem[%d] %x\n", p, (unsigned int)(long)shmem[p]);
+	pr_debug("MCIAP MSG CMD:%d SCMD:%d\n", msg->cmd_type, msg->cmd_subid);
+
+	/*write msg to shmem*/
+	memcpy(shmem[p], msg, sizeof(struct phyt_msg_info));
+
+	/*update tx tail pointer*/
+	writel(tx_t | MMC_TX_TAIL_INT, shost->regf_base + MMC_TX_TAIL);
+
+	/*wait and check status*/
+	for (i = 0; i < COMPLETE_TIMEOUT; i++) {
+		dsb(sy);
+		if (shmem[p]->status0 == GOING || shmem[p]->status0 == NOT_READY) {
+			pr_debug("MCIAP [%d] not complete %x\r\n", p, shmem[p]->status0);
+		} else if (shmem[p]->status0 == SUCCESS) {
+			ret = shmem[p]->status1;
+			pr_debug("MCIAP [%d] complete and return %d\r\n", p, ret);
+			/*clear status*/
+			shmem[p]->status0 = 0;
+			shmem[p]->status1 = 0;
+			break;
+		} else if (shmem[p]->status0 >= GENERIC_ERROR) {
+			pr_debug("MCIAP [%d] status error %x\r\n", p, shmem[p]->status0);
+			ret = -1;
+			/*clear status*/
+			shmem[p]->status0 = 0;
+			shmem[p]->status1 = 0;
+			break;
+		}
+		udelay(40);
+	}
+	pr_debug("MCIAP %s end [%d] times:%d\n", __func__, p, i);
+	return ret;
+}
+
+static void phytium_mci_init(struct phytium_mci_host *host)
+{
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_INIT;
+
+	pr_debug("MCIAP host->mmc->caps %x host->clk_rate %ld\n",
+		host->mmc->caps, host->clk_rate);
+
+	init_data = (struct init_data_t *)host->msg.data;
+	init_data->caps = host->mmc->caps;
+	init_data->clk_rate = host->clk_rate;
+
+	phytium_ap_to_rv(&host->msg);
+}
+
+static void phytium_mci_init_hw(struct phytium_mci_host *host)
+{
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_INIT_HW;
+
+	phytium_ap_to_rv(&host->msg);
+	dev_info(host->dev, "init hardware done!");
+}
+
+void phyt_mci_deinit_hw(struct phytium_mci_host *host)
+{
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_DEINIT_HW;
+
+	phytium_ap_to_rv(&host->msg);
+}
+EXPORT_SYMBOL_GPL(phyt_mci_deinit_hw);
+
+static void phytium_mci_start_command(struct phytium_mci_host *host,
+		struct mmc_request *mrq,
+		struct mmc_command *cmd)
+{
+	u32 rawcmd;
+
+	host->cmd = cmd;
+	host->mrq = mrq;
+	rawcmd = phytium_mci_cmd_prepare_raw_cmd(host, mrq, cmd);
+
+	pr_debug("MCIAP arg%x flags%x opcode%d rawcmd%x\n",
+		host->cmd->arg, host->cmd->flags, host->cmd->opcode, rawcmd);
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_START_CMD;
+
+	start_command_data = (struct start_command_data_t *)host->msg.data;
+	start_command_data->cmd_arg = cmd->arg;
+	start_command_data->cmd_flags = cmd->flags;
+	start_command_data->cmd_opcode = cmd->opcode;
+	start_command_data->rawcmd = rawcmd;
+
+	phytium_ap_to_rv(&host->msg);
+}
+
+static void
+phytium_mci_start_data(struct phytium_mci_host *host, struct mmc_request *mrq,
+		struct mmc_command *cmd, struct mmc_data *data)
+{
+	u32 rawcmd;
+
+	host->cmd = cmd;
+	cmd->error = 0;
+	host->mrq = mrq;
+	host->data = data;
+	rawcmd = phytium_mci_cmd_prepare_raw_cmd(host, mrq, cmd);
+	phytium_mci_data_sg_write_2_admc_table(host, data);
+
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_START_DATA;
+
+	start_data_data = (struct start_data_data_t *)host->msg.data;
+	start_data_data->data_flags = data->flags;
+	start_data_data->adtc_type = host->adtc_type;
+	start_data_data->adma_addr = host->dma.adma_addr;
+	start_data_data->mrq_data_blksz = mrq->data->blksz;
+	start_data_data->mrq_data_blocks = mrq->data->blocks;
+	start_data_data->cmd_arg = cmd->arg;
+	start_data_data->rawcmd = rawcmd;
+
+	phytium_ap_to_rv(&host->msg);
+}
+
+static void phytium_mci_ops_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_OPS_SET_IOS;
+
+	set_ios_data = (struct set_ios_data_t *)host->msg.data;
+	set_ios_data->ios_clock = ios->clock;
+	set_ios_data->ios_timing = ios->timing;
+	set_ios_data->ios_bus_width = ios->bus_width;
+	set_ios_data->ios_power_mode = ios->power_mode;
+
+	phytium_ap_to_rv(&host->msg);
+
+	if (ios->power_mode == MMC_POWER_UP)
+		set_bit(MCI_CARD_NEED_INIT, &host->flags);
+}
+
+static void __phytium_mci_enable_sdio_irq(struct phytium_mci_host *host, int enable)
+{
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_SDIO_IRQ_EN;
+
+	host->msg.data[0] = enable & 0xFF;
+
+	phytium_ap_to_rv(&host->msg);
+}
+
+static void phytium_mci_enable_sdio_irq(struct mmc_host *mmc, int enable)
+{
+	struct phytium_mci_host *host  = mmc_priv(mmc);
+
+	__phytium_mci_enable_sdio_irq(host, enable);
+}
+
+static int phytium_mci_ops_switch_volt(struct mmc_host *mmc, struct mmc_ios *ios)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	int ret = 0;
+
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_SET;
+	host->msg.cmd_subid = MCI_OPS_SWITCH_VOLT;
+
+	host->msg.data[0] = ios->signal_voltage & 0xFF;
+
+	ret = phytium_ap_to_rv(&host->msg);
+
+	pr_debug("MCIAP %s %d\n", __func__, ret);
+
+	return ret;
+}
+
+static void phytium_mci_hw_reset(struct mmc_host *mmc)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_DEFAULT;
+	host->msg.cmd_subid = MCI_HW_RESET;
+
+	phytium_ap_to_rv(&host->msg);
+}
+
+static void phytium_mci_adma_reset(struct phytium_mci_host *host)
+{
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_DEFAULT;
+	host->msg.cmd_subid = MCI_ADMA_RESET;
+
+	phytium_ap_to_rv(&host->msg);
+}
+
+static int phytium_mci_get_cd(struct mmc_host *mmc)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	u32 status;
+
+	if (mmc->caps & MMC_CAP_NONREMOVABLE)
+		return 1;
+
+	status = readl(host->regf_base + MCI_CARD_DETECT);
+
+	pr_debug("MCIAP get cd %d\n", status);
+
+	if ((status & 0x1) == 0x1)
+		return 0;
+
+	return 1;
+}
+
+static int phytium_mci_card_busy(struct mmc_host *mmc)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	int ret;
+
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_GET;
+	host->msg.cmd_subid = MCI_GET_CARD_BUSY;
+
+	ret = phytium_ap_to_rv(&host->msg);
+
+	pr_debug("MCIAP card busy %d\n", ret);
+	return ret;
+}
+
+static int phytium_mci_get_ro(struct mmc_host *mmc)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	int ret;
+
+	host->msg.cmd_type = PHYTMMC_MSG_CMD_GET;
+	host->msg.cmd_subid = MCI_GET_RO;
+
+	ret = phytium_ap_to_rv(&host->msg);
+
+	dev_dbg(host->dev, "MCIAP ro %d\n", ret);
+
+	return ret;
+}
+
+static int ap_phytium_mci_cmd_next(struct phyt_msg_info *rxmsg)
+{
+	struct phytium_mci_host *host;
+	u32 events;
+
+	host = shost;
+
+	if (!host->cmd)
+		return 1;
+
+	cmd_next_data = (struct cmd_next_data_t *)rxmsg->data;
+	events = cmd_next_data->events;
+	host->cmd->resp[0] = cmd_next_data->response0;
+	host->cmd->resp[1] = cmd_next_data->response1;
+	host->cmd->resp[2] = cmd_next_data->response2;
+	host->cmd->resp[3] = cmd_next_data->response3;
+
+	if (!(events & (MCI_RAW_INTS_CMD | MCI_INT_MASK_HTO))) {
+		if (!(host->mmc->caps & MMC_CAP_NONREMOVABLE) && (events & MCI_RAW_INTS_RTO)
+		   && readl(host->regf_base + MCI_CARD_DETECT)) {
+			host->cmd->error = -ENOMEDIUM;
+			host->cmd->resp[0] = 0;
+		} else if (events & MCI_RAW_INTS_RTO ||
+		    (host->cmd->opcode != MMC_SEND_TUNING_BLOCK &&
+		     host->cmd->opcode != MMC_SEND_TUNING_BLOCK_HS200)) {
+			host->cmd->error = -ETIMEDOUT;
+		} else if (events & MCI_RAW_INTS_RCRC) {
+			host->cmd->error = -EILSEQ;
+		} else {
+			host->cmd->error = -ETIMEDOUT;
+		}
+	}
+
+	if ((host->cmd->error && !(host->cmd->opcode == MMC_SEND_TUNING_BLOCK ||
+		host->cmd->opcode == MMC_SEND_TUNING_BLOCK_HS200)) ||
+		(host->mrq->sbc && host->mrq->sbc->error)) {
+		phytium_mci_request_done(host, host->mrq);
+	} else if (host->cmd == host->mrq->sbc) {
+		if ((host->mrq->cmd->opcode == MMC_READ_MULTIPLE_BLOCK) ||
+		    (host->mrq->cmd->opcode == MMC_WRITE_MULTIPLE_BLOCK) ||
+		    (host->mrq->cmd->opcode == MMC_READ_SINGLE_BLOCK) ||
+		    (host->mrq->cmd->opcode == MMC_WRITE_BLOCK)) {
+			dev_dbg(host->dev, "%s %d:sbc done and next cmd :%d length:%d\n",
+				__func__, __LINE__, host->mrq->cmd->opcode,
+				host->mrq->data->sg->length);
+			phytium_mci_prepare_data(host, host->mrq);
+			if (host->is_use_dma)
+				host->adtc_type = BLOCK_RW_ADTC;
+			else
+				host->adtc_type = COMMOM_ADTC;
+			phytium_mci_start_data(host, host->mrq, host->mrq->cmd, host->mrq->data);
+		} else {
+			dev_err(host->dev, "%s %d:ERROR: cmd %d followers the SBC\n",
+				__func__, __LINE__, host->cmd->opcode);
+		}
+	} else if (!host->cmd->data) {
+		phytium_mci_request_done(host, host->mrq);
+	}
+	return 1;
+}
+
+static int ap_phytium_mci_data_xfer_next(struct phyt_msg_info *rxmsg)
+{
+	struct phytium_mci_host *host;
+	u32 events;
+	struct mmc_request *mrq;
+	struct mmc_data *data;
+
+	host = shost;
+	mrq = host->mrq;
+	data = host->data;
+
+	events = ((uint32_t *)(rxmsg->data))[0];
+
+	if (events & MCI_RAW_INTS_DTO) {
+		if (host->adtc_type == COMMOM_ADTC &&
+				(mrq->cmd->flags & MMC_CMD_MASK) == MMC_CMD_ADTC)
+			phytium_mci_data_read_without_dma(host, data);
+		else
+			data->bytes_xfered = data->blocks * data->blksz;
+	} else {
+		data->bytes_xfered = 0;
+		if (!(host->mmc->caps & MMC_CAP_NONREMOVABLE)
+				&& readl(host->regf_base + MCI_CARD_DETECT)
+				&& (events & cmd_err_ints_mask)) {
+			data->error = -ENOMEDIUM;
+			data->mrq->cmd->error =  -ENOMEDIUM;
+		} else if (events & (MCI_RAW_INTS_DCRC | MCI_RAW_INTS_EBE |
+					MCI_RAW_INTS_SBE_BCI)) {
+			data->error = -EILSEQ;
+		} else {
+			data->error = -ETIMEDOUT;
+		}
+	}
+
+	if (mmc_op_multi(mrq->cmd->opcode) && mrq->stop &&
+	    (data->error || !mrq->sbc)) {
+		phytium_mci_start_command(host, mrq, mrq->stop);
+	} else {
+		phytium_mci_request_done(host, mrq);
+	}
+	return 1;
+}
+
+static int ap_phytium_mci_card_detect_irq(struct phyt_msg_info *rxmsg)
+{
+	u8 cd;
+	struct phytium_mci_host *host;
+
+	host = shost;
+	cd = rxmsg->data[0];
+
+	pr_debug("MCIAP card_detect_irq %d\n", cd);
+	if (cd) {
+		if (host->mmc->card) {
+			cancel_delayed_work(&host->mmc->detect);
+			mmc_detect_change(host->mmc, msecs_to_jiffies(0));
+		}
+	} else {
+		cancel_delayed_work(&host->mmc->detect);
+		mmc_detect_change(host->mmc, msecs_to_jiffies(200));
+	}
+	return 1;
+}
+
+static int ap_phytium_mci_err_irq(struct phyt_msg_info *rxmsg)
+{
+	u32 raw_ints;
+	u32 dmac_status;
+	u32 ints_mask;
+	u32 dmac_mask;
+	u32 opcode;
+
+	err_irq_data = (struct err_irq_data_t *)rxmsg->data;
+	raw_ints = err_irq_data->raw_ints;
+	ints_mask = err_irq_data->ints_mask;
+	dmac_status = err_irq_data->dmac_status;
+	dmac_mask = err_irq_data->dmac_mask;
+	opcode = err_irq_data->opcode;
+
+	pr_err("MCIAP ERR raw_ints:%x ints_mask:%x dmac_status:%x dmac_mask:%x cmd:%d\n",
+		raw_ints, ints_mask, dmac_status, dmac_mask, opcode);
+
+	return 1;
+}
+
+static int phytium_check_msg(void)
+{
+	int rx_t, rx_h;
+	int complete;
+	struct phyt_msg_info rxmsg;
+	int p = 0;
+
+	rx_t = readl(shost->regf_base + MMC_RX_TAIL) & 0xffff;
+	rx_h = readl(shost->regf_base + MMC_RX_HEAD) & 0xffff;
+
+	while (rx_t != rx_h) {
+		pr_debug("MCIAP %s rx_t:%d rx_h:%d\n", __func__, rx_t, rx_h);
+
+		p = rx_h;
+		rx_h = (rx_h + 1) % RING_MAX_RV;
+
+		writel(rx_h, shost->regf_base + MMC_RX_HEAD);
+		rvshmem[p] = (struct phyt_msg_info *)(*rvshmem + p);
+		pr_debug("MCIAP %s %d %x\n", __func__, p, (unsigned int)(long)rvshmem[p]);
+
+		/*read msg from shmem*/
+		memcpy(&rxmsg, rvshmem[p], sizeof(struct phyt_msg_info));
+		/*read msg from shmem*/
+
+		/*execute cmd*/
+		switch (rxmsg.cmd_type) {
+		case PHYTMMC_MSG_CMD_REPORT:
+			switch (rxmsg.cmd_subid) {
+			case MCI_CMD_NEXT:
+				complete = ap_phytium_mci_cmd_next(&rxmsg);
+				break;
+			case MCI_DATA_NEXT:
+				complete = ap_phytium_mci_data_xfer_next(&rxmsg);
+				break;
+			case MCI_CD_IRQ:
+				complete = ap_phytium_mci_card_detect_irq(&rxmsg);
+				break;
+			case MCI_ERR_IRQ:
+				complete = ap_phytium_mci_err_irq(&rxmsg);
+				break;
+			default:
+				pr_debug("MCIAP invalid sub cmd\r\n");
+				break;
+			}
+			break;
+		default:
+			pr_debug("MCIAP invalid cmd\r\n");
+			break;
+		}
+
+		/*write complete*/
+		rvshmem[p]->status0 = complete;
+	}
+	return 1;
+}
+
+int phytium_mci_set_debug_enable(struct phytium_mci_host *host, bool enable)
+{
+	static bool debug_enable;
+	u32 debug_reg;
+
+	if (enable == debug_enable)
+		return 0;
+
+	debug_enable = enable;
+
+	debug_reg = readl(host->regf_base + MCI_DEBUG);
+	pr_debug("MCIAP %s debug_reg %x\n", __func__, debug_reg);
+
+	if (!debug_enable && (debug_reg & MCI_DEBUG_ENABLE)) {
+		debug_reg &= ~MCI_DEBUG_ENABLE;
+		writel(debug_reg, host->regf_base + MCI_DEBUG);
+	} else if (debug_enable && !(debug_reg & MCI_DEBUG_ENABLE)) {
+		debug_reg |= MCI_DEBUG_ENABLE;
+		writel(debug_reg, host->regf_base + MCI_DEBUG);
+	}
+
+	return 1;
+}
+EXPORT_SYMBOL(phytium_mci_set_debug_enable);
+
+int phytium_mci_set_alive_enable(struct phytium_mci_host *host, bool enable)
+{
+	static bool alive_enable;
+	u32 debug_reg;
+
+	if (enable == alive_enable)
+		return 0;
+
+	alive_enable = enable;
+
+	debug_reg = readl(host->regf_base + MCI_DEBUG);
+	pr_debug("MCIAP %s debug_reg %x\n", __func__, debug_reg);
+
+	if (!alive_enable && (debug_reg & MCI_ALIVE_ENABLE)) {
+		debug_reg &= ~MCI_ALIVE_ENABLE;
+		writel(debug_reg, host->regf_base + MCI_DEBUG);
+		del_timer(&host->alive_timer);
+	} else if (alive_enable && !(debug_reg & MCI_ALIVE_ENABLE)) {
+		debug_reg |= MCI_ALIVE_ENABLE | MCI_ALIVE;
+		writel(debug_reg, host->regf_base + MCI_DEBUG);
+		add_timer(&host->alive_timer);
+	}
+
+	return 1;
+}
+EXPORT_SYMBOL(phytium_mci_set_alive_enable);
+
+static void alive_timer_func(struct timer_list *t)
+{
+	struct phytium_mci_host *host;
+	u32 debug_reg;
+
+	host = from_timer(host, t, alive_timer);
+	if (!host)
+		return;
+
+	debug_reg = readl(host->regf_base + MCI_DEBUG);
+	pr_debug("MCIAP %s debug_reg %x\n", __func__, debug_reg);
+	debug_reg |= MCI_ALIVE;
+	writel(debug_reg, host->regf_base + MCI_DEBUG);
+	mod_timer(&host->alive_timer, jiffies + msecs_to_jiffies(5000));
+}
+
+static struct mmc_host_ops phytium_mci_ops = {
+	.post_req = phytium_mci_post_req,
+	.pre_req = phytium_mci_pre_req,
+	.request = phytium_mci_ops_request,
+	.set_ios = phytium_mci_ops_set_ios,
+	.get_cd = phytium_mci_get_cd,
+	.get_ro = phytium_mci_get_ro,
+	.enable_sdio_irq = phytium_mci_enable_sdio_irq,
+	.ack_sdio_irq = phytium_mci_ack_sdio_irq,
+	.card_busy = phytium_mci_card_busy,
+	.start_signal_voltage_switch = phytium_mci_ops_switch_volt,
+	.card_hw_reset = phytium_mci_hw_reset,
+};
+
+int phyt_mci_common_probe(struct phytium_mci_host *host)
+{
+	struct mmc_host *mmc = host->mmc;
+	struct device *dev = host->dev;
+	int ret;
+
+	shost = host;
+
+	dev_info(host->dev, "phytium_mci_common_probe start\n");
+
+	*shmem = host->base;
+	*rvshmem = (struct phyt_msg_info *)(*shmem + RING_MAX);
+
+	dma_set_mask(dev, DMA_BIT_MASK(64));
+	dma_set_coherent_mask(dev, DMA_BIT_MASK(64));
+
+	host->alive_timer.expires = jiffies + msecs_to_jiffies(5000);
+	timer_setup(&host->alive_timer, alive_timer_func, 0);
+
+	mmc->f_min = MCI_F_MIN;
+	if (!mmc->f_max)
+		mmc->f_max = MCI_F_MAX;
+
+	mmc->ops = &phytium_mci_ops;
+	mmc->ocr_avail_sdio = MMC_VDD_32_33 | MMC_VDD_33_34;
+	mmc->ocr_avail_sd = MMC_VDD_32_33 | MMC_VDD_33_34;
+	mmc->ocr_avail_mmc = MMC_VDD_165_195;
+	mmc->ocr_avail = MMC_VDD_165_195 | MMC_VDD_32_33 | MMC_VDD_33_34;
+	mmc->caps |= host->caps;
+
+	if (mmc->caps & MMC_CAP_SDIO_IRQ) {
+		mmc->caps2 |= MMC_CAP2_SDIO_IRQ_NOTHREAD;
+		dev_dbg(host->dev, "%s %d: MMC_CAP_SDIO_IRQ\n", __func__, __LINE__);
+	}
+	mmc->caps2 |= host->caps2;
+
+	phytium_mci_set_int_mask(host);
+
+	phytium_mci_init(host);
+
+	phytium_mci_init_hw(host);
+
+	if (host->is_use_dma) {
+		/* MMC core transfer sizes tunable parameters */
+		mmc->max_segs = MAX_BD_NUM;
+		mmc->max_seg_size = 4 * 1024;
+		mmc->max_blk_size = 512;
+		mmc->max_req_size = 512 * 1024;
+		mmc->max_blk_count = mmc->max_req_size / 512;
+		host->dma.adma_table = dma_alloc_coherent(host->dev,
+							   MAX_BD_NUM *
+							   sizeof(struct phytium_adma2_64_desc),
+							   &host->dma.adma_addr, GFP_KERNEL);
+		if (!host->dma.adma_table)
+			return MCI_REALEASE_MEM;
+
+		host->dma.desc_sz = ADMA2_64_DESC_SZ;
+		phytium_mci_init_adma_table(host, &host->dma);
+	} else {
+		mmc->max_segs = MAX_BD_NUM;
+		mmc->max_seg_size = 4 * 1024;
+		mmc->max_blk_size = 512;
+		mmc->max_req_size = 4 * 512;
+		mmc->max_blk_count = mmc->max_req_size / 512;
+	}
+
+	spin_lock_init(&host->lock);
+
+	ret = devm_request_irq(host->dev, host->irq, phytium_mci_irq,
+			       host->irq_flags, "phytium-mci", host);
+	if (ret)
+		return ret;
+
+	ret = mmc_add_host(mmc);
+	if (ret) {
+		dev_err(host->dev, "%s %d: mmc add host!\n", __func__, __LINE__);
+		return ret;
+	}
+	return 0;
+}
+EXPORT_SYMBOL(phyt_mci_common_probe);
+
+MODULE_DESCRIPTION("Phytium Multimedia Card Interface driver");
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Lai Xueyu <laixueyu1280@phytium.com.cn>");

--- a/drivers/mmc/host/phytium-mci-v2.h
+++ b/drivers/mmc/host/phytium-mci-v2.h
@@ -1,0 +1,312 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * Driver for Phytium Multimedia Card Interface
+ *
+ * Copyright (C) 2024 Phytium Technology Co., Ltd.
+ */
+
+#ifndef __PHYTIUM_MCI_H
+#define __PHYTIUM_MCI_H
+
+#include <linux/scatterlist.h>
+#include <linux/compiler.h>
+#include <linux/types.h>
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/interrupt.h>
+#include <linux/mmc/host.h>
+
+/*------------------------------------------------------*/
+/* Common Definition					*/
+/*------------------------------------------------------*/
+#define SD_BLOCK_SIZE		512
+#define MAX_BD_NUM		128
+#define MCI_CLK			1200000000
+#define MCI_REALEASE_MEM	0x1
+
+#define MCI_PREPARE_FLAG	(0x1 << 0)
+#define MCI_ASYNC_FLAG		(0x1 << 1)
+#define MCI_MMAP_FLAG		(0x1 << 2)
+
+#define MCI_F_MIN		400000
+#define MCI_F_MAX		50000000
+
+/* MCI_RAW_INTS mask */
+#define MCI_RAW_INTS_CD			(0x1 << 0) /* W1C */
+#define MCI_RAW_INTS_RE			(0x1 << 1) /* W1C */
+#define MCI_RAW_INTS_CMD		(0x1 << 2) /* W1C */
+#define MCI_RAW_INTS_DTO		(0x1 << 3) /* W1C */
+#define MCI_RAW_INTS_TXDR		(0x1 << 4) /* W1C */
+#define MCI_RAW_INTS_RXDR		(0x1 << 5) /* W1C */
+#define MCI_RAW_INTS_RCRC		(0x1 << 6) /* W1C */
+#define MCI_RAW_INTS_DCRC		(0x1 << 7) /* W1C */
+#define MCI_RAW_INTS_RTO		(0x1 << 8) /* W1C */
+#define MCI_RAW_INTS_DRTO		(0x1 << 9) /* W1C */
+#define MCI_RAW_INTS_HTO		(0x1 << 10) /* W1C */
+#define MCI_RAW_INTS_FRUN		(0x1 << 11) /* W1C */
+#define MCI_RAW_INTS_HLE		(0x1 << 12) /* W1C */
+#define MCI_RAW_INTS_SBE_BCI		(0x1 << 13) /* W1C */
+#define MCI_RAW_INTS_ACD		(0x1 << 14) /* W1C */
+#define MCI_RAW_INTS_EBE		(0x1 << 15) /* W1C */
+#define MCI_RAW_INTS_SDIO		(0x1 << 16)  /* W1C */
+
+/* MCI_MASKED_INTS mask */
+#define MCI_MASKED_INTS_CD		(0x1 << 0) /* RO */
+#define MCI_MASKED_INTS_RE		(0x1 << 1) /* RO */
+#define MCI_MASKED_INTS_CMD		(0x1 << 2) /* RO */
+#define MCI_MASKED_INTS_DTO		(0x1 << 3) /* RO */
+#define MCI_MASKED_INTS_TXDR		(0x1 << 4) /* RO */
+#define MCI_MASKED_INTS_RXDR		(0x1 << 5) /* RO */
+#define MCI_MASKED_INTS_RCRC		(0x1 << 6) /* RO */
+#define MCI_MASKED_INTS_DCRC		(0x1 << 7) /* RO */
+#define MCI_MASKED_INTS_RTO		(0x1 << 8) /* RO */
+#define MCI_MASKED_INTS_DRTO		(0x1 << 9) /* RO */
+#define MCI_MASKED_INTS_HTO		(0x1 << 10) /* RO */
+#define MCI_MASKED_INTS_FRUN		(0x1 << 11) /* RO */
+#define MCI_MASKED_INTS_HLE		(0x1 << 12) /* RO */
+#define MCI_MASKED_INTS_SBE_BCI		(0x1 << 13) /* RO */
+#define MCI_MASKED_INTS_ACD		(0x1 << 14) /* RO */
+#define MCI_MASKED_INTS_EBE		(0x1 << 15) /* RO */
+#define MCI_MASKED_INTS_SDIO		(0x1 << 16) /* RO */
+
+/* MCI_INT_MASK mask */
+#define MCI_INT_MASK_CD			(0x1 << 0) /* RW */
+#define MCI_INT_MASK_RE			(0x1 << 1) /* RW */
+#define MCI_INT_MASK_CMD		(0x1 << 2) /* RW */
+#define MCI_INT_MASK_DTO		(0x1 << 3) /* RW */
+#define MCI_INT_MASK_TXDR		(0x1 << 4) /* RW */
+#define MCI_INT_MASK_RXDR		(0x1 << 5) /* RW */
+#define MCI_INT_MASK_RCRC		(0x1 << 6) /* RW */
+#define MCI_INT_MASK_DCRC		(0x1 << 7) /* RW */
+#define MCI_INT_MASK_RTO		(0x1 << 8) /* RW */
+#define MCI_INT_MASK_DRTO		(0x1 << 9) /* RW */
+#define MCI_INT_MASK_HTO		(0x1 << 10) /* RW */
+#define MCI_INT_MASK_FRUN		(0x1 << 11) /* RW */
+#define MCI_INT_MASK_HLE		(0x1 << 12) /* RW */
+#define MCI_INT_MASK_SBE_BCI		(0x1 << 13) /* RW */
+#define MCI_INT_MASK_ACD		(0x1 << 14) /* RW */
+#define MCI_INT_MASK_EBE		(0x1 << 15) /* RW */
+#define MCI_INT_MASK_SDIO		(0x1 << 16) /* RW */
+
+#define MCI_CARD_DETECT			0x30 /* the card detect reg */
+#define MCI_DATA			0x34 /* the data FIFO access */
+
+#define MCI_DEBUG			0x58 /* debug function */
+
+/* MCI_DEBUG mask */
+#define MCI_DEBUG_ENABLE		(0x1 << 0) /* RW */
+#define MCI_ALIVE_ENABLE		(0x1 << 1) /* RW */
+#define MCI_ALIVE			(0x1 << 2) /* RW */
+#define MCI_HAVE_LOG			(0x1 << 3) /* RW */
+#define MCI_SIZE			(0xf << 4) /* RW */
+#define MCI_ADDR			(0x3fffff << 8) /* RW */
+
+#define AP_TO_RV_MAX_DATA		64
+#define MCI_HW_RESET			0x00
+#define MCI_ADMA_RESET			0x01
+#define MCI_INIT			0x00
+#define MCI_INIT_HW			0x01
+#define MCI_DEINIT_HW			0x02
+#define MCI_START_CMD			0x03
+#define MCI_START_DATA			0x04
+#define MCI_OPS_SET_IOS			0x05
+#define MCI_SDIO_IRQ_EN			0x06
+#define MCI_OPS_SWITCH_VOLT		0x07
+#define MCI_GET_CD			0x00
+#define MCI_GET_CARD_BUSY		0x01
+#define MCI_GET_STATUS			0x02
+#define MCI_GET_RO			0x03
+#define MCI_CD_IRQ			0x00
+#define MCI_ERR_IRQ			0x01
+#define MCI_CMD_NEXT			0x02
+#define MCI_DATA_NEXT			0x03
+
+#define RING_MAX			20
+#define RING_MAX_RV			10
+
+#define COMPLETE_TIMEOUT		200
+
+#define MMC_TX_HEAD			0x0
+#define MMC_TX_TAIL			0x4
+#define MMC_RX_HEAD			0x8
+#define MMC_RX_TAIL			0xc
+#define MMC_TX_TAIL_INT			(0x1 << 16) /* RW */
+
+#define MMC_RV2AP_INT_MASK		0x028
+#define MMC_TXRING_HEAD_INT_MASK	0x1 /* RW */
+#define MMC_RXRING_TAIL_INT_MASK	(0x1 << 1) /* RW */
+
+#define MMC_RV2AP_INT			0x02c
+#define MMC_TXRING_HEAD_INT		0x1 /* RW */
+#define MMC_RXRING_TAIL_INT		(0x1 << 1) /* RW */
+/*--------------------------------------*/
+/*		Structure Type		*/
+/*--------------------------------------*/
+/* Maximum segments assuming a 512KiB maximum requisition */
+/* size and a minimum4KiB page size. */
+#define MCI_MAX_SEGS			128
+/* ADMA2 64-bit DMA descriptor size */
+#define ADMA2_64_DESC_SZ		32
+
+/* Each descriptor can transfer up to 4KB of data in chained mode */
+/*ADMA2 64-bit descriptor.*/
+struct phytium_adma2_64_desc {
+	u32 attribute;
+#define IDMAC_DES0_DIC	BIT(1)
+#define IDMAC_DES0_LD	BIT(2)
+#define IDMAC_DES0_FD	BIT(3)
+#define IDMAC_DES0_CH	BIT(4)
+#define IDMAC_DES0_ER	BIT(5)
+#define IDMAC_DES0_CES	BIT(30)
+#define IDMAC_DES0_OWN	BIT(31)
+	u32	NON1;
+	u32	len;
+	u32	NON2;
+	u32	addr_lo; /* Lower 32-bits of Buffer Address Pointer 1*/
+	u32	addr_hi; /* Upper 32-bits of Buffer Address Pointer 1*/
+	u32	desc_lo; /* Lower 32-bits of Next Descriptor Address */
+	u32	desc_hi; /* Upper 32-bits of Next Descriptor Address */
+} __packed __aligned(4);
+
+struct phytium_mci_dma {
+	struct scatterlist *sg;	/* I/O scatter list */
+	/* ADMA descriptor table, pointer to adma_table array */
+	struct phytium_adma2_64_desc *adma_table;
+	/* Mapped ADMA descr. table, the physical address of adma_table array */
+	dma_addr_t adma_addr;
+	unsigned int desc_sz;	/* ADMA descriptor size */
+};
+
+enum adtc_t {
+	COMMOM_ADTC	= 0,
+	BLOCK_RW_ADTC	= 1
+};
+
+enum phytmmc_msg_cmd_id {
+	PHYTMMC_MSG_CMD_DEFAULT = 0,
+	PHYTMMC_MSG_CMD_SET,
+	PHYTMMC_MSG_CMD_GET,
+	PHYTMMC_MSG_CMD_DATA,
+	PHYTMMC_MSG_CMD_REPORT
+};
+
+struct phyt_msg_info {
+	u8 reserved;
+	u8 seq;
+	u8 cmd_type;
+	u8 cmd_subid;
+	u16 len;
+	u8 status1;
+	u8 status0;
+#define NOT_READY		0x0
+#define SUCCESS			0x1
+#define GOING			0x2
+#define GENERIC_ERROR		0x10
+#define TYPE_NOT_SUPPORTED	0x11
+#define CMD_NOT_SUPPORTED	0x12
+#define INVALID_PARAMETERS	0x13
+	u8 data[56];
+};
+
+struct phytium_mci_host {
+	struct device *dev;
+	struct mmc_host *mmc;
+	u32 caps;
+	u32 caps2;
+	spinlock_t lock;
+	struct mmc_request *mrq;
+	struct mmc_command *cmd;
+	struct mmc_data *data;
+	int error;
+	void __iomem *base;		    /* host base address */
+	void __iomem *regf_base;		    /* regfile base address */
+	void *adma_table1;
+	dma_addr_t adma_addr1;
+	struct phytium_mci_dma dma_rx;	/* dma channel */
+	struct phytium_mci_dma dma_tx;	/* dma channel */
+	struct phytium_mci_dma dma;	/* dma channel */
+	u64 dma_mask;
+	bool vqmmc_enabled;
+	u32 *sg_virt_addr;
+	enum adtc_t adtc_type;      /* 0:common adtc cmd; 1:block r/w adtc cmd;*/
+	struct timer_list hotplug_timer;
+	struct delayed_work req_timeout;
+	int irq;		    /* host interrupt */
+	u32 current_rca;    /*the current rca value*/
+	u32 current_ios_clk;
+	u32 is_use_dma;
+	u32 is_device_x100;
+	struct clk *src_clk;	    /* phytium_mci source clock */
+	unsigned long clk_rate;
+	unsigned long clk_div;
+	unsigned long irq_flags;
+	unsigned long flags;
+#define MCI_CARD_NEED_INIT	1
+	bool cmd_cs;	/*volt switch cmd cs status*/
+	bool use_hold;	/*use hold*/
+	bool clk_set;	/*clock set*/
+	s32 clk_smpl_drv_25m;
+	s32 clk_smpl_drv_50m;
+	s32 clk_smpl_drv_66m;
+	s32 clk_smpl_drv_100m;
+	struct phyt_msg_info msg;
+	struct phyt_msg_info rxmsg;
+	bool debug_enable;
+	bool alive_enable;
+	struct timer_list alive_timer;
+};
+
+int phyt_mci_common_probe(struct phytium_mci_host *host);
+void phyt_mci_deinit_hw(struct phytium_mci_host *host);
+int phyt_mci_runtime_suspend(struct device *dev);
+int phyt_mci_runtime_resume(struct device *dev);
+int phyt_mci_resume(struct device *dev);
+int phyt_mci_suspend(struct device *dev);
+int phytium_mci_set_debug_enable(struct phytium_mci_host *host, bool enable);
+int phytium_mci_set_alive_enable(struct phytium_mci_host *host, bool enable);
+
+struct init_data_t {
+	uint32_t caps;
+	uint32_t clk_rate;
+};
+
+struct start_command_data_t {
+	uint32_t cmd_arg;
+	uint32_t cmd_flags;
+	uint32_t cmd_opcode;
+	uint32_t rawcmd;
+};
+
+struct start_data_data_t {
+	uint32_t data_flags;
+	uint32_t adtc_type;
+	uint64_t adma_addr;
+	uint32_t mrq_data_blksz;
+	uint32_t mrq_data_blocks;
+	uint32_t cmd_arg;
+	uint32_t rawcmd;
+};
+
+struct set_ios_data_t {
+	uint32_t ios_clock;
+	uint8_t ios_timing;
+	uint8_t ios_bus_width;
+	uint8_t ios_power_mode;
+};
+
+struct cmd_next_data_t {
+	uint32_t events;
+	uint32_t response0;
+	uint32_t response1;
+	uint32_t response2;
+	uint32_t response3;
+};
+
+struct err_irq_data_t {
+	uint32_t raw_ints;
+	uint32_t ints_mask;
+	uint32_t dmac_status;
+	uint32_t dmac_mask;
+	uint32_t opcode;
+};
+#endif /* __PHYTIUM_MCI_HW_H */

--- a/drivers/mmc/host/phytium-mci.c
+++ b/drivers/mmc/host/phytium-mci.c
@@ -44,7 +44,7 @@ static const u32 data_ints_mask = MCI_INT_MASK_DTO | MCI_INT_MASK_DCRC | MCI_INT
 				  MCI_INT_MASK_SBE_BCI;
 static const u32 cmd_err_ints_mask = MCI_INT_MASK_RTO | MCI_INT_MASK_RCRC | MCI_INT_MASK_RE |
 				     MCI_INT_MASK_DCRC | MCI_INT_MASK_DRTO |
-				     MCI_MASKED_INTS_SBE_BCI;
+				     MCI_MASKED_INTS_SBE_BCI | MCI_MASKED_INTS_EBE;
 
 static const u32 dmac_ints_mask = MCI_DMAC_INT_ENA_FBE | MCI_DMAC_INT_ENA_DU |
 				  MCI_DMAC_INT_ENA_NIS | MCI_DMAC_INT_ENA_AIS;
@@ -62,6 +62,7 @@ static void phytium_mci_init_adma_table(struct phytium_mci_host *host,
 					 struct phytium_mci_dma *dma);
 static void phytium_mci_init_hw(struct phytium_mci_host *host);
 static int phytium_mci_get_cd(struct mmc_host *mmc);
+static int phytium_mci_get_ro(struct mmc_host *mmc);
 static int phytium_mci_err_irq(struct phytium_mci_host *host, u32 dmac_events, u32 events);
 
 static void sdr_set_bits(void __iomem *reg, u32 bs)
@@ -151,10 +152,17 @@ static void phytium_mci_send_cmd(struct phytium_mci_host *host, u32 cmd, u32 arg
 
 static void phytium_mci_update_cmd11(struct phytium_mci_host *host, u32 cmd)
 {
+	int rc;
+	u32 data;
+
 	writel(MCI_CMD_START | cmd, host->base + MCI_CMD);
 
-	while (readl(host->base + MCI_CMD) & MCI_CMD_START)
-		cpu_relax();
+	rc = readl_relaxed_poll_timeout(host->base + MCI_CMD,
+					 data,
+					 !(data & MCI_CMD_START),
+					 0, 100 * 1000);
+	if (rc == -ETIMEDOUT)
+		pr_debug("%s %d, timeout mci_cmd: 0x%08x\n", __func__, __LINE__, data);
 }
 
 static void phytium_mci_set_clk(struct phytium_mci_host *host, struct mmc_ios *ios)
@@ -179,7 +187,7 @@ static void phytium_mci_set_clk(struct phytium_mci_host *host, struct mmc_ios *i
 			host->clk_rate, ios->clock);
 
 		if (ios->clock >= 25000000)
-			tmp_ext_reg = 0x202;
+			tmp_ext_reg = 0x102;
 		else if (ios->clock == 400000)
 			tmp_ext_reg = 0x502;
 		else
@@ -227,8 +235,26 @@ static void phytium_mci_set_clk(struct phytium_mci_host *host, struct mmc_ios *i
 			}
 		}
 
-		dev_dbg(host->dev, "UHS_REG_EXT ext: %x, CLKDIV: %x\n",
-			readl(host->base + MCI_UHS_REG_EXT), readl(host->base + MCI_CLKDIV));
+		if (!(readl(host->base + MCI_CLKDIV) & 0xff00) &&
+			(ios->timing == MMC_TIMING_MMC_DDR52 ||
+			ios->timing == MMC_TIMING_MMC_HS400 ||
+			ios->timing == MMC_TIMING_UHS_DDR50)) {
+			sdr_set_bits(host->base + MCI_CNTRL, MCI_CNTRL_CRC_SERIAL_DATA);
+			sdr_set_bits(host->base + MCI_CNTRL, MCI_CNTRL_DRV_SHIFT_EN);
+		} else {
+			sdr_clr_bits(host->base + MCI_CNTRL, MCI_CNTRL_CRC_SERIAL_DATA);
+			sdr_clr_bits(host->base + MCI_CNTRL, MCI_CNTRL_DRV_SHIFT_EN);
+		}
+
+		if (div >= 2)
+			writel(((2 * (div & 0xff)) & 0xffff), host->base + MCI_CLK_DIVIDER);
+
+		dev_dbg(host->dev, "UHS_REG_EXT ext: %x, CLKDIV: %x MCI_CLK_DIVIDER %x %x\n",
+			readl(host->base + MCI_UHS_REG_EXT), readl(host->base + MCI_CLKDIV),
+			readl(host->base + MCI_CLK_DIVIDER), ((2 * (div & 0xff)) & 0xffff));
+
+		if (cur_cmd_index == SD_SWITCH_VOLTAGE)
+			msleep(40);
 
 		sdr_set_bits(host->base + MCI_CLKENA, MCI_CLKENA_CCLK_ENABLE);
 
@@ -1201,6 +1227,7 @@ static void phytium_mci_init_hw(struct phytium_mci_host *host)
 	sdr_set_bits(host->base + MCI_CLKENA, MCI_CLKENA_CCLK_ENABLE);
 	sdr_set_bits(host->base + MCI_UHS_REG_EXT, MCI_EXT_CLK_ENABLE);
 	sdr_clr_bits(host->base + MCI_UHS_REG, MCI_UHS_REG_VOLT);
+	sdr_clr_bits(host->base + MCI_EMMC_DDR_REG, MCI_EMMC_DDR_CYCLE);
 
 	phytium_mci_reset_hw(host);
 
@@ -1303,8 +1330,13 @@ static void phytium_mci_ops_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
 {
 	struct phytium_mci_host *host = mmc_priv(mmc);
 
-	if (ios->timing == MMC_TIMING_MMC_DDR52 || ios->timing == MMC_TIMING_UHS_DDR50)
+	if (ios->timing == MMC_TIMING_MMC_DDR52 ||
+		ios->timing == MMC_TIMING_MMC_HS400 ||
+		ios->timing == MMC_TIMING_UHS_DDR50) {
 		sdr_set_bits(host->base + MCI_UHS_REG, MCI_UHS_REG_DDR);
+		sdr_set_bits(host->base + MCI_CNTRL, MCI_CNTRL_START_BIT_MODE);
+		sdr_clr_bits(host->base + MCI_EMMC_DDR_REG, MCI_EMMC_DDR_CYCLE);
+	}
 	else
 		sdr_clr_bits(host->base + MCI_UHS_REG, MCI_UHS_REG_DDR);
 
@@ -1353,6 +1385,20 @@ static int phytium_mci_get_cd(struct mmc_host *mmc)
 		return 0;
 
 	return 1;
+}
+
+static int phytium_mci_get_ro(struct mmc_host *mmc)
+{
+	struct phytium_mci_host *host = mmc_priv(mmc);
+	u32 status;
+
+	status = readl(host->base + MCI_CARD_WRTPRT);
+
+	dev_dbg(host->dev, "mci_get_ro status %d\n", status);
+	if ((status & 0x1) == 0x1)
+		return 1;
+
+	return 0;
 }
 
 static int phytium_mci_ops_switch_volt(struct mmc_host *mmc, struct mmc_ios *ios)
@@ -1448,6 +1494,7 @@ static struct mmc_host_ops phytium_mci_ops = {
 	.request = phytium_mci_ops_request,
 	.set_ios = phytium_mci_ops_set_ios,
 	.get_cd = phytium_mci_get_cd,
+	.get_ro = phytium_mci_get_ro,
 	.enable_sdio_irq = phytium_mci_enable_sdio_irq,
 	.ack_sdio_irq = phytium_mci_ack_sdio_irq,
 	.card_busy = phytium_mci_card_busy,

--- a/drivers/mmc/host/phytium-mci.h
+++ b/drivers/mmc/host/phytium-mci.h
@@ -104,6 +104,7 @@
 #define MCI_UHS_REG_EXT	0x108 /* the UHS register extension */
 #define MCI_EMMC_DDR_REG	0x10C /* the EMMC DDR reg */
 #define MCI_ENABLE_SHIFT	0x110 /* the enable phase shift reg */
+#define MCI_CLK_DIVIDER	0x114 /* CLK DIVIDER */
 #define MCI_DATA		0x200 /* the data FIFO access */
 
 /* Command register defines */
@@ -132,12 +133,14 @@
 #define MCI_CNTRL_CONTROLLER_RESET	(0x1 << 0) /* RW */
 #define MCI_CNTRL_FIFO_RESET		(0x1 << 1) /* RW */
 #define MCI_CNTRL_DMA_RESET			(0x1 << 2) /* RW */
-#define MCI_CNTRL_RES				(0x1 << 3) /*  */
+#define MCI_CNTRL_DRV_SHIFT_EN		(0x1 << 3) /*  */
 #define MCI_CNTRL_INT_ENABLE		(0x1 << 4) /* RW */
 #define MCI_CNTRL_DMA_ENABLE		(0x1 << 5) /* RW */
 #define MCI_CNTRL_READ_WAIT			(0x1 << 6) /* RW */
 #define MCI_CNTRL_SEND_IRQ_RESPONSE	(0x1 << 7) /* RW */
 #define MCI_CNTRL_ABORT_READ_DATA	(0x1 << 8) /* RW */
+#define MCI_CNTRL_START_BIT_MODE	(0x1 << 9) /* RW */
+#define MCI_CNTRL_CRC_SERIAL_DATA	(0x1 << 10) /* RW */
 #define MCI_CNTRL_ENDIAN			(0x1 << 11) /* RW */
 //#define MCI_CNTRL_CARD_VOLTAGE_A	(0xF << 16) /* RW */
 //#define MCI_CNTRL_CARD_VOLTAGE_B	(0xF << 20) /* RW */


### PR DESCRIPTION
These patches have added support for phytium MMC.

## Summary by Sourcery

Add support for the Phytium MMC host controller v2.

This introduces a new driver (`phytium-mci-v2`) specifically for the v2 controller hardware, which operates using a shared memory interface for communication. Updates are also made to the existing `phytium-mci` driver.

New Features:
- Introduce the `phytium-mci-v2` driver for the Phytium MMC v2 controller, including platform device support and shared memory communication logic.
- Add sysfs attributes for runtime debug and alive status control for the v2 driver.

Enhancements:
- Implement read-only detection (`get_ro`) for the MMC host.
- Improve clock configuration and DDR/HS400 mode handling.
- Add support for the End-Bit Error (EBE) interrupt.
- Use polling with timeout instead of busy-waiting for command completion.

Build:
- Add Makefile rules for the new `phytium-mci-v2` driver files.

Documentation:
- Add devicetree bindings documentation for the `phytium,mci_2.0` compatible.

Chores:
- Remove the unused `MMC_CAP_WAIT_WHILE_BUSY` capability from the original `phytium-mci-plat` driver.