### PR TITLE
phytium: tacho update to phytium 6.6.0.2 version

### DIFF
--- a/drivers/hwmon/tacho-phytium.c
+++ b/drivers/hwmon/tacho-phytium.c
@@ -57,6 +57,8 @@
 
 #define	TIMER_INT_CLR_MASK	GENMASK(5, 0)
 
+#define TACHO_DRIVER_VERSION "1.1.1"
+
 enum tacho_modes {
 	tacho_mode = 1,
 	capture_mode,
@@ -388,3 +390,4 @@ module_platform_driver(phytium_tacho_driver);
 MODULE_AUTHOR("Zhang Yiqun <zhangyiqun@phytium.com.cn>");
 MODULE_DESCRIPTION("Phytium tachometer driver");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(TACHO_DRIVER_VERSION);

--- a/drivers/hwmon/tacho-phytium.c
+++ b/drivers/hwmon/tacho-phytium.c
@@ -236,41 +236,24 @@ static const struct attribute_group *capture_groups[] = {
 
 static int phytium_tacho_get_work_mode(struct phytium_tacho *tacho)
 {
-	struct device_node *nc = tacho->dev->of_node;
 	struct fwnode_handle *fwn = tacho->dev->fwnode;
 
-	if (of_property_read_bool(nc, "tacho"))
+	if (fwnode_property_read_bool(fwn, "tacho"))
 		return tacho_mode;
-	else if (has_acpi_companion(tacho->dev) && fwnode_property_read_bool(
-				fwn, "tacho"))
-		return tacho_mode;
-	if (of_property_read_bool(nc, "capture"))
-		return capture_mode;
-	else if (has_acpi_companion(tacho->dev) && fwnode_property_read_bool(
-				fwn, "capture"))
+	if (fwnode_property_read_bool(fwn, "capture"))
 		return capture_mode;
 	return tacho_mode;
 }
 
 static int phytium_tacho_get_edge_mode(struct phytium_tacho *tacho)
 {
-	struct device_node *nc = tacho->dev->of_node;
 	struct fwnode_handle *fwn = tacho->dev->fwnode;
 
-	if (of_property_read_bool(nc, "up"))
+	if (fwnode_property_read_bool(fwn, "up"))
 		return rising_edge;
-	else if (has_acpi_companion(tacho->dev) && fwnode_property_read_bool(
-				fwn, "up"))
-		return rising_edge;
-	if (of_property_read_bool(nc, "down"))
+	if (fwnode_property_read_bool(fwn, "down"))
 		return falling_edge;
-	else if (has_acpi_companion(tacho->dev) && fwnode_property_read_bool(
-				fwn, "down"))
-		return falling_edge;
-	if (of_property_read_bool(nc, "double"))
-		return double_edge;
-	else if (has_acpi_companion(tacho->dev) && fwnode_property_read_bool(
-				fwn, "double"))
+	if (fwnode_property_read_bool(fwn, "double"))
 		return double_edge;
 	return rising_edge;
 }
@@ -278,15 +261,10 @@ static int phytium_tacho_get_edge_mode(struct phytium_tacho *tacho)
 static int phytium_tacho_get_debounce(struct phytium_tacho *tacho)
 {
 	u32 value;
-	struct device_node *nc = tacho->dev->of_node;
 	struct fwnode_handle *fwn = tacho->dev->fwnode;
 
-	if (!of_property_read_u32(nc, "debounce-level", &value))
+	if (!fwnode_property_read_u32(fwn, "debounce-level", &value))
 		return value;
-	if (has_acpi_companion(tacho->dev)) {
-		if (!fwnode_property_read_u32(fwn, "debounce-level", &value))
-			return value;
-	}
 	return 0;
 }
 
@@ -303,6 +281,7 @@ static int phytium_tacho_probe(struct platform_device *pdev)
 	struct resource *res;
 	struct phytium_tacho *tacho;
 	int ret;
+	u32 fre;
 
 	tacho = devm_kzalloc(dev, sizeof(*tacho), GFP_KERNEL);
 	if (!tacho)
@@ -320,24 +299,19 @@ static int phytium_tacho_probe(struct platform_device *pdev)
 		return PTR_ERR(tacho->base);
 	}
 
+	tacho->clk = devm_clk_get(&pdev->dev, NULL);
+	if (IS_ERR(tacho->clk))
+		return PTR_ERR(tacho->clk);
+	ret = clk_prepare_enable(tacho->clk);
+	if (ret)
+		return ret;
+
 	if (!has_acpi_companion(tacho->dev)) {
-		tacho->clk = devm_clk_get(&pdev->dev, NULL);
-		if (IS_ERR(tacho->clk))
-			return PTR_ERR(tacho->clk);
-		ret = clk_prepare_enable(tacho->clk);
-		if (ret)
-			return ret;
 		tacho->freq = clk_get_rate(tacho->clk);
 	} else {
-		u32 fre;
-
-		ret = clk_prepare_enable(tacho->clk);
-		if (ret)
-			return ret;
 		fwnode_property_read_u32(tacho->dev->fwnode, "clock-frequency", &fre);
 		tacho->freq = fre;
 	}
-
 	tacho->irq = platform_get_irq(pdev, 0);
 	if (tacho->irq < 0) {
 		dev_err(&pdev->dev, "no irq resource?\n");

--- a/drivers/hwmon/tacho-phytium.c
+++ b/drivers/hwmon/tacho-phytium.c
@@ -56,6 +56,7 @@
 #define	TIMER_START_VALUE_REG	0x38
 
 #define	TIMER_INT_CLR_MASK	GENMASK(5, 0)
+#define TIMER_TACHO_DEFAULT_FREQ	0x2FAF080
 
 #define TACHO_DRIVER_VERSION "1.1.1"
 
@@ -301,18 +302,18 @@ static int phytium_tacho_probe(struct platform_device *pdev)
 		return PTR_ERR(tacho->base);
 	}
 
-	tacho->clk = devm_clk_get(&pdev->dev, NULL);
-	if (IS_ERR(tacho->clk))
-		return PTR_ERR(tacho->clk);
-	ret = clk_prepare_enable(tacho->clk);
-	if (ret)
-		return ret;
-
+	tacho->freq = TIMER_TACHO_DEFAULT_FREQ;
 	if (!has_acpi_companion(tacho->dev)) {
-		tacho->freq = clk_get_rate(tacho->clk);
+		tacho->clk = devm_clk_get(&pdev->dev, NULL);
+		if (IS_ERR(tacho->clk) || clk_prepare_enable(tacho->clk))
+			dev_err(&pdev->dev, "Tacho get clocks failed\n");
+		else
+			tacho->freq = clk_get_rate(tacho->clk);
 	} else {
-		fwnode_property_read_u32(tacho->dev->fwnode, "clock-frequency", &fre);
-		tacho->freq = fre;
+		if (fwnode_property_read_u32(tacho->dev->fwnode, "clock-frequency", &fre))
+			dev_err(&pdev->dev, "Tacho get clock-frequency failed\n");
+		else
+			tacho->freq = fre;
 	}
 	tacho->irq = platform_get_irq(pdev, 0);
 	if (tacho->irq < 0) {


### PR DESCRIPTION
This patch optimizes the method to get resources in tacho driver, adds driver version information, and tacho driver probe failure issue caused by failure to read clock data when using uefi startup.

## Summary by Sourcery

Update the Phytium tacho driver, improving device property access and clock frequency handling during initialization.

Bug Fixes:
- Prevent probe failure due to missing clock data by using a default frequency and logging errors instead of failing initialization.

Enhancements:
- Simplify device property lookups using firmware node helpers.

Chores:
- Add driver version information.