### PR TITLE
thermal: boost: phytium: Automatic enable/disable of BOOST feature

### DIFF
--- a/drivers/cpufreq/cpufreq.c
+++ b/drivers/cpufreq/cpufreq.c
@@ -86,7 +86,7 @@ static void cpufreq_governor_limits(struct cpufreq_policy *policy);
 static int cpufreq_set_policy(struct cpufreq_policy *policy,
 			      struct cpufreq_governor *new_gov,
 			      unsigned int new_pol);
-static bool cpufreq_boost_supported(void);
+bool cpufreq_boost_supported(void);
 
 /*
  * Two notifier lists: the "policy" list is involved in the
@@ -1224,7 +1224,6 @@ static void cpufreq_policy_put_kobj(struct cpufreq_policy *policy)
 	cmp = &policy->kobj_unregister;
 	up_write(&policy->rwsem);
 	kobject_put(kobj);
-
 	/*
 	 * We need to make sure that the underlying kobj is
 	 * actually not referenced anymore by anybody before we
@@ -2794,10 +2793,14 @@ err_reset_state:
 	return ret;
 }
 
-static bool cpufreq_boost_supported(void)
+bool cpufreq_boost_supported(void)
 {
+	if (!cpufreq_driver)
+		return -EINVAL;
+
 	return cpufreq_driver->set_boost;
 }
+EXPORT_SYMBOL_GPL(cpufreq_boost_supported);
 
 static int create_boost_sysfs_file(void)
 {
@@ -2834,6 +2837,9 @@ EXPORT_SYMBOL_GPL(cpufreq_enable_boost_support);
 
 int cpufreq_boost_enabled(void)
 {
+	if (!cpufreq_driver)
+		return -EINVAL;
+
 	return cpufreq_driver->boost_enabled;
 }
 EXPORT_SYMBOL_GPL(cpufreq_boost_enabled);

--- a/drivers/cpufreq/cpufreq.c
+++ b/drivers/cpufreq/cpufreq.c
@@ -1224,6 +1224,7 @@ static void cpufreq_policy_put_kobj(struct cpufreq_policy *policy)
 	cmp = &policy->kobj_unregister;
 	up_write(&policy->rwsem);
 	kobject_put(kobj);
+
 	/*
 	 * We need to make sure that the underlying kobj is
 	 * actually not referenced anymore by anybody before we

--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -18,9 +18,10 @@
 #include <linux/thermal.h>
 #include <linux/reboot.h>
 #include <linux/string.h>
+#include <linux/cpufreq.h>
 #include <linux/of.h>
 #include <linux/suspend.h>
-
+#include <asm/stacktrace.h>
 #define CREATE_TRACE_POINTS
 #include "thermal_trace.h"
 
@@ -341,6 +342,49 @@ static void handle_critical_trips(struct thermal_zone_device *tz,
 		tz->ops->critical(tz);
 }
 
+static int thermal_boost_enable(struct thermal_zone_device *tz)
+{
+	enum thermal_trend trend = get_tz_trend(tz, 0);
+	struct thermal_trip trip;
+
+	if (!tz->overheated)
+		return -EPERM;
+	if (trend == THERMAL_TREND_RAISING)
+		return -EBUSY;
+
+	__thermal_zone_get_trip(tz, 0, &trip);
+
+	if ((tz->temperature + (trip.temperature >> 2)) < trip.temperature) {
+		mutex_lock(&tz->lock);
+		tz->overheated = false;
+		if (tz->boost_polling) {
+			tz->boost_polling = false;
+			thermal_zone_device_set_polling(tz, 0);
+		}
+		mutex_unlock(&tz->lock);
+		cpufreq_boost_trigger_state(1);
+		return 0;
+	}
+	return -EBUSY;
+}
+
+static void thermal_boost_disable(struct thermal_zone_device *tz)
+{
+	cpufreq_boost_trigger_state(0);
+
+	/*
+	 * If no workqueue for monitoring is running - start one with
+	 * 1000 ms monitoring period
+	 * If workqueue already running - do not change its period and only
+	 * test if target CPU has cooled down
+	 */
+	if (tz->mode != THERMAL_DEVICE_ENABLED) {
+		tz->boost_polling = true;
+		thermal_zone_device_set_polling(tz, 1000);
+	}
+	tz->overheated = true;
+}
+
 static void handle_thermal_trip(struct thermal_zone_device *tz, int trip_id)
 {
 	struct thermal_trip trip;
@@ -419,6 +463,11 @@ void __thermal_zone_device_update(struct thermal_zone_device *tz,
 		return;
 
 	update_temperature(tz);
+
+	if (cpufreq_boost_supported() && cpufreq_boost_enabled())
+		if ((tz->temperature + (tz->trips[0].temperature >> 2))
+					>= tz->trips[0].temperature)
+			thermal_boost_disable(tz);
 
 	__thermal_zone_set_trips(tz);
 
@@ -526,6 +575,9 @@ static void thermal_zone_device_check(struct work_struct *work)
 	struct thermal_zone_device *tz = container_of(work, struct
 						      thermal_zone_device,
 						      poll_queue.work);
+	if (cpufreq_boost_supported())
+		if (!thermal_boost_enable(tz))
+			return;
 	thermal_zone_device_update(tz, THERMAL_EVENT_UNSPECIFIED);
 }
 

--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -21,6 +21,7 @@
 #include <linux/cpufreq.h>
 #include <linux/of.h>
 #include <linux/suspend.h>
+
 #include <asm/stacktrace.h>
 #define CREATE_TRACE_POINTS
 #include "thermal_trace.h"

--- a/include/linux/cpufreq.h
+++ b/include/linux/cpufreq.h
@@ -797,6 +797,7 @@ ssize_t cpufreq_show_cpus(const struct cpumask *mask, char *buf);
 #ifdef CONFIG_CPU_FREQ
 int cpufreq_boost_trigger_state(int state);
 int cpufreq_boost_enabled(void);
+bool cpufreq_boost_supported(void);
 int cpufreq_enable_boost_support(void);
 bool policy_has_boost_freq(struct cpufreq_policy *policy);
 

--- a/include/linux/thermal.h
+++ b/include/linux/thermal.h
@@ -176,6 +176,8 @@ struct thermal_zone_device {
 	int prev_low_trip;
 	int prev_high_trip;
 	atomic_t need_update;
+	bool overheated;
+	bool boost_polling;
 	struct thermal_zone_device_ops *ops;
 	struct thermal_zone_params *tzp;
 	struct thermal_governor *governor;


### PR DESCRIPTION
This patch provides auto disable/enable operation for boost. When the device temperature rises above 75% of the smallest trip point, the boost is disabled.
In that moment thermal monitor workqueue will monitors if the device cools down. When the device temperature drops below 75% of the smallest trip point, the boost is enabled again.

Mainline: NA

## Summary by Sourcery

Introduce automatic thermal management for CPU frequency boost. This disables the boost feature when the thermal zone temperature exceeds a threshold relative to the lowest trip point and re-enables it once the temperature drops below that threshold.

New Features:
- Implement automatic enable/disable logic for CPU frequency boost based on thermal zone temperature.
- Add a polling mechanism to monitor temperature drops for re-enabling boost when it has been thermally disabled.