### PR TITLE
add:phytium: usb and xHCI driver patch

### DIFF
--- a/Documentation/devicetree/bindings/usb/phytium,usb2-2.0.yaml
+++ b/Documentation/devicetree/bindings/usb/phytium,usb2-2.0.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/usb/phytium,usb2-2.0.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium USBHS-DRD controller bindings
+
+maintainers:
+  - Chen Zhenhua <chenzhenhua@phytium.com>
+
+properties:
+  compatible:
+    const: phytium,usb2-2.0
+
+  reg:
+    items:
+      - description: USB controller registers
+
+  interrupts:
+    maxItems: 1
+
+required:
+  - compatible
+  - reg
+  - interrupts
+
+additionalProperties: false
+
+examples:
+  - |
+    usb2_0: usb2@26f00000 {
+            compatible = "phytium,usb2-2.0";
+            reg = <0x0 0x26f00000 0x0 0x4000>,
+                <0x0 0x26f04000 0x0 0x4000>,
+                <0x0 0x26f08000 0x0 0x18000>;
+            interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>,  //host & device interrupt
+            <GIC_SPI 148 IRQ_TYPE_LEVEL_HIGH>; //otg interrupt
+    };

--- a/Documentation/devicetree/bindings/usb/phytium.role-sw.yaml
+++ b/Documentation/devicetree/bindings/usb/phytium.role-sw.yaml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+%YAML 1.2
+---
+
+title:Phytium USB Type-C controller
+
+maintainers:
+  - Wu Jinyong <wujinyong1788@phytium.com.cn>
+
+properties:
+  compatible:
+    enum:
+      - phytium,role-sw
+
+  reg:
+    maxItems: 1
+
+  interrupts:
+    maxItems: 1
+
+  connector:
+    type: object
+    $ref: ../connector/usb-connector.yaml
+    unevaluatedProperties: false
+
+    description:
+      Properties for usb c connector.
+
+    properties:
+      compatible:
+        const: usb-c-connector
+
+      power-role: true
+
+      data-role: true
+
+      try-power-role: true
+
+    required:
+      - compatible
+
+required:
+  - compatible
+  - reg
+  - connector
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/interrupt-controller/irq.h>
+    i2c {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        typec@2c {
+            compatible = "phytium,role-sw";
+            reg = <0x2c>;
+            interrupts = <8 IRQ_TYPE_EDGE_FALLING>;
+            interrupt-parent = <&gpio0>;
+
+            typec_con: connector {
+                compatible = "usb-c-connector";
+                power-role = "dual";
+                data-role = "dual";
+                try-power-role = "source";
+
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    port@0 {
+                        reg = <0>;
+                        typec_con_ep: endpoint {
+                            remote-endpoint = <&usbotg_hs_ep>;
+                        };
+                    };
+                };
+            };
+        };
+    };
+...

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17471,6 +17471,8 @@ S:	Maintained
 W:	https://gerrit.b.cpu.ac/c/linux
 F:	Documentation/devicetree/bindings/gpio/phytium,gpio.yaml
 F:	Documentation/devicetree/bindings/usb/phytium,usb2-2.0.yaml
+F:	Documentation/devicetree/bindings/usb/phytium,usb2.yaml
+F:	Documentation/devicetree/bindings/usb/phytium.role-sw.yaml
 F:	drivers/usb/phytium/*
 F:	arch/arm64/boot/dts/phytium/*
 F:	drivers/gpio/gpio-phytium*

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17471,6 +17471,7 @@ S:	Maintained
 W:	https://gerrit.b.cpu.ac/c/linux
 F:	Documentation/devicetree/bindings/gpio/phytium,gpio.yaml
 F:	Documentation/devicetree/bindings/usb/phytium,usb2-2.0.yaml
+F:	drivers/usb/phytium/*
 F:	arch/arm64/boot/dts/phytium/*
 F:	drivers/gpio/gpio-phytium*
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17470,6 +17470,7 @@ M:	Wang Yinfeng <wangyinfeng@phytium.com.cn>
 S:	Maintained
 W:	https://gerrit.b.cpu.ac/c/linux
 F:	Documentation/devicetree/bindings/gpio/phytium,gpio.yaml
+F:	Documentation/devicetree/bindings/usb/phytium,usb2-2.0.yaml
 F:	arch/arm64/boot/dts/phytium/*
 F:	drivers/gpio/gpio-phytium*
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17474,6 +17474,8 @@ F:	Documentation/devicetree/bindings/usb/phytium,usb2-2.0.yaml
 F:	Documentation/devicetree/bindings/usb/phytium,usb2.yaml
 F:	Documentation/devicetree/bindings/usb/phytium.role-sw.yaml
 F:	drivers/usb/phytium/*
+F:	drivers/usb/phytium/phytium_usb_v2*
+F:	drivers/usb/typec/role-switch-phytium.c
 F:	arch/arm64/boot/dts/phytium/*
 F:	drivers/gpio/gpio-phytium*
 

--- a/drivers/dma/phytium/phytium-ddmac.c
+++ b/drivers/dma/phytium/phytium-ddmac.c
@@ -29,6 +29,7 @@
 #include <asm/barrier.h>
 #include "phytium-ddmac.h"
 
+#define DDMA_DRIVER_VERSION "1.1.1"
 
 static inline struct phytium_ddma_device *to_ddma_device
 		(struct dma_chan *chan)
@@ -958,3 +959,4 @@ module_platform_driver(phytium_driver);
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Phytium DDMA Controller platform driver");
 MODULE_AUTHOR("HuangJie <huangjie1663@phytium.com.cn>");
+MODULE_VERSION(DDMA_DRIVER_VERSION);

--- a/drivers/usb/Kconfig
+++ b/drivers/usb/Kconfig
@@ -131,6 +131,8 @@ source "drivers/usb/isp1760/Kconfig"
 
 source "drivers/usb/phytium/Kconfig"
 
+source "drivers/usb/phytium_usb_v2/Kconfig"
+
 comment "USB port drivers"
 
 if USB

--- a/drivers/usb/Makefile
+++ b/drivers/usb/Makefile
@@ -19,6 +19,7 @@ obj-$(CONFIG_USB_CDNSP_PCI)	+= cdns3/
 
 obj-$(CONFIG_USB_FOTG210)	+= fotg210/
 obj-$(CONFIG_USB_PHYTIUM)	+= phytium/
+obj-$(CONFIG_USB_PHYTIUM_V2)	+= phytium_usb_v2/
 
 obj-$(CONFIG_USB_MON)		+= mon/
 obj-$(CONFIG_USB_MTU3)		+= mtu3/

--- a/drivers/usb/host/xhci-plat.c
+++ b/drivers/usb/host/xhci-plat.c
@@ -101,7 +101,7 @@ static int xhci_plat_start(struct usb_hcd *hcd)
 }
 
 static const struct xhci_plat_priv xhci_plat_phytium_pe220x = {
-	.quirks = XHCI_RESET_ON_RESUME,
+	.quirks = XHCI_RESET_ON_RESUME | XHCI_S1_SUSPEND_WAKEUP,
 };
 
 #ifdef CONFIG_OF

--- a/drivers/usb/host/xhci-ring.c
+++ b/drivers/usb/host/xhci-ring.c
@@ -3205,6 +3205,12 @@ irqreturn_t xhci_irq(struct usb_hcd *hcd)
 		goto out;
 	}
 
+	if (status & STS_WAKEUP) {
+		status |= STS_WAKEUP;
+		writel(status, &xhci->op_regs->status);
+		ret = IRQ_HANDLED;
+	}
+
 	if (!(status & STS_EINT))
 		goto out;
 

--- a/drivers/usb/host/xhci.c
+++ b/drivers/usb/host/xhci.c
@@ -937,6 +937,18 @@ int xhci_suspend(struct xhci_hcd *xhci, bool do_wakeup)
 			return -ETIMEDOUT;
 		}
 	}
+
+	if (xhci->quirks & XHCI_S1_SUSPEND_WAKEUP) {
+		if (device_may_wakeup(xhci_to_hcd(xhci)->self.controller) && do_wakeup) {
+			if (enable_irq_wake(hcd->irq))
+				xhci_err(xhci, "failed to enable irq wakes\n");
+
+			set_bit(HCD_FLAG_HW_ACCESSIBLE, &hcd->flags);
+			if (xhci->shared_hcd)
+				set_bit(HCD_FLAG_HW_ACCESSIBLE, &xhci->shared_hcd->flags);
+		}
+	}
+
 	spin_unlock_irq(&xhci->lock);
 
 	/*
@@ -982,6 +994,13 @@ int xhci_resume(struct xhci_hcd *xhci, pm_message_t msg)
 	if (time_before(jiffies, xhci->usb2_rhub.bus_state.next_statechange) ||
 	    time_before(jiffies, xhci->usb3_rhub.bus_state.next_statechange))
 		msleep(100);
+
+	if (xhci->quirks & XHCI_S1_SUSPEND_WAKEUP) {
+		if (device_may_wakeup(xhci_to_hcd(xhci)->self.controller)) {
+			if (disable_irq_wake(hcd->irq))
+				xhci_err(xhci, "failed to disable irq wakes\n");
+		}
+	}
 
 	set_bit(HCD_FLAG_HW_ACCESSIBLE, &hcd->flags);
 	if (xhci->shared_hcd)

--- a/drivers/usb/host/xhci.h
+++ b/drivers/usb/host/xhci.h
@@ -159,6 +159,8 @@ struct xhci_op_regs {
 /* USBSTS - USB status - status bitmasks */
 /* HC not running - set to 1 when run/stop bit is cleared. */
 #define STS_HALT	XHCI_STS_HALT
+/* event wakeup interrupt */
+#define STS_WAKEUP	(1 << 1)
 /* serious error, e.g. PCI parity error.  The HC will clear the run/stop bit. */
 #define STS_FATAL	(1 << 2)
 /* event interrupt - clear this prior to clearing any IP flags in IR set*/
@@ -1663,6 +1665,7 @@ struct xhci_hcd {
 #define XHCI_WRITE_64_HI_LO	BIT_ULL(47)
 #define XHCI_CDNS_SCTX_QUIRK	BIT_ULL(48)
 #define XHCI_ETRON_HOST	BIT_ULL(49)
+#define XHCI_S1_SUSPEND_WAKEUP	BIT_ULL(50)
 
 	unsigned int		num_active_eps;
 	unsigned int		limit_active_eps;

--- a/drivers/usb/phytium/core.c
+++ b/drivers/usb/phytium/core.c
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #include "core.h"
 
 int phytium_core_reset(struct phytium_cusb *config, bool skip_wait)

--- a/drivers/usb/phytium/core.h
+++ b/drivers/usb/phytium/core.h
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #ifndef __PHYTIUM_CORE_H__
 #define __PHYTIUM_CORE_H__
 

--- a/drivers/usb/phytium/dma.c
+++ b/drivers/usb/phytium/dma.c
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #include <linux/errno.h>
 #include <linux/string.h>
 #include "core.h"

--- a/drivers/usb/phytium/dma.h
+++ b/drivers/usb/phytium/dma.h
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #ifndef __PHYTIUM_DMA_H__
 #define __PHYTIUM_DMA_H__
 

--- a/drivers/usb/phytium/gadget.c
+++ b/drivers/usb/phytium/gadget.c
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #include <linux/dma-mapping.h>
 #include "gadget.h"
 #include "dma.h"

--- a/drivers/usb/phytium/gadget.h
+++ b/drivers/usb/phytium/gadget.h
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #ifndef __PHYTIUM_GADGET_H_
 #define __PHYTIUM_GADGET_H_
 

--- a/drivers/usb/phytium/host.c
+++ b/drivers/usb/phytium/host.c
@@ -2058,7 +2058,7 @@ unsigned int get_endpoint_interval(struct usb_endpoint_descriptor desc,
 			interval = 1 << interval;
 			if ((1 << interval) != desc.bInterval)
 				pr_debug("rounding to %d microframes, desc %d microframes\n",
-						1 << interval, desc.bInterval);
+					1 << interval, desc.bInterval);
 			break;
 		}
 
@@ -2067,16 +2067,15 @@ unsigned int get_endpoint_interval(struct usb_endpoint_descriptor desc,
 			interval = 1 << interval;
 			if (interval != desc.bInterval - 1)
 				pr_debug("rounding to %d %sframes\n", 1 << interval,
-						speed == USB_SPEED_FULL ? "" : "micro");
+					speed == USB_SPEED_FULL ? "" : "micro");
 		}
 		break;
 	case USB_SPEED_FULL:
 		if (usb_endpoint_xfer_isoc(&desc)) {
-			interval = clamp_val(desc.bInterval, 1, 16) - 1;
+			interval = clamp_val(desc.bInterval, 1, 16);
 			if (interval != desc.bInterval - 1)
 				pr_debug("rounding to %d %sframes\n", 1 << interval,
-						speed == USB_SPEED_FULL ? "" : "micro");
-			interval += 3;
+					speed == USB_SPEED_FULL ? "" : "micro");
 			break;
 		}
 		fallthrough;
@@ -2086,7 +2085,7 @@ unsigned int get_endpoint_interval(struct usb_endpoint_descriptor desc,
 			interval = clamp_val(interval, 3, 10);
 			if ((1 << interval) != desc.bInterval * 8)
 				pr_debug("rounding to %d microframes, desc %d microframes\n",
-						1 << interval, desc.bInterval);
+					1 << interval, desc.bInterval);
 		}
 	}
 

--- a/drivers/usb/phytium/host.c
+++ b/drivers/usb/phytium/host.c
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #include <linux/dma-mapping.h>
 #include <linux/usb.h>
 #include<linux/usb/hcd.h>

--- a/drivers/usb/phytium/host.c
+++ b/drivers/usb/phytium/host.c
@@ -23,34 +23,35 @@
 
 #define HOST_EP_NUM	16
 
+static void dump_ep_remap_pool(struct HOST_CTRL *priv, bool dirIn)
+{
+	int index, dir = 0;
+
+	if (!dirIn)
+		dir = 1;
+
+	pr_info("%s dir endpoint remap table\n", dir ? "OUT" : "IN");
+
+	for (index = 1; index <= MAX_INSTANCE_EP_NUM; index++)
+		pr_info("ep_remap_pool[%d][%d]->%d\n", dir, index,
+				priv->ep_remap_pool[dir][index]);
+}
+
 static int get_epnum_from_pool(struct HOST_CTRL *priv, int real_epNum, bool dirIn)
 {
 	int index, dir = 0;
 	int ret = 0;
 
-	if (!priv)
+	if (!priv || real_epNum == 0)
 		return 0;
 
 	if (!dirIn)
 		dir = 1;
 
-	if (real_epNum <= MAX_INSTANCE_EP_NUM) {
-		if (!priv->ep_remap_pool[dir][real_epNum]) {
-			priv->ep_remap_pool[dir][real_epNum] = real_epNum;
-			ret = real_epNum;
+	for (index = 1; index <= MAX_INSTANCE_EP_NUM; index++) {
+		if (priv->ep_remap_pool[dir][index] == real_epNum) {
+			ret = index;
 			goto out;
-		}
-
-		if (priv->ep_remap_pool[dir][real_epNum] == real_epNum) {
-			ret = real_epNum;
-			goto out;
-		}
-	} else {
-		for (index = 1; index <= MAX_INSTANCE_EP_NUM; index++) {
-			if (priv->ep_remap_pool[dir][index] == real_epNum) {
-				ret = index;
-				goto out;
-			}
 		}
 	}
 
@@ -62,6 +63,9 @@ static int get_epnum_from_pool(struct HOST_CTRL *priv, int real_epNum, bool dirI
 		}
 	}
 
+	if (index > MAX_INSTANCE_EP_NUM)
+		return index;
+
 out:
 	return ret;
 }
@@ -71,7 +75,7 @@ static int release_epnum_from_pool(struct HOST_CTRL *priv, int real_epNum, bool 
 	int index = 0;
 	int dir = 0;
 
-	if (!priv)
+	if (!priv || real_epNum == 0)
 		return 0;
 
 	if (!dirIn)
@@ -150,7 +154,6 @@ static inline void disconnectHostDetect(struct HOST_CTRL *priv)
 	if (!priv)
 		return;
 
-	memset(priv->ep_remap_pool, 0, sizeof(priv->ep_remap_pool));
 	otgctrl = phytium_read8(&priv->regs->otgctrl);
 	if ((otgctrl & OTGCTRL_ASETBHNPEN) && priv->otgState == HOST_OTG_STATE_A_SUSPEND)
 		pr_info("Device no Response\n");
@@ -286,6 +289,8 @@ static inline void connectHostDetect(struct HOST_CTRL *priv, uint8_t otgState)
 
 	if (!priv)
 		return;
+
+	memset(priv->ep_remap_pool, 0, sizeof(priv->ep_remap_pool));
 	pr_debug("otgState:0x%x pirv->otgState:0x%x\n", otgState, priv->otgState);
 	if (priv->custom_regs) {
 		phytium_write32(&priv->custom_regs->wakeup, 0);
@@ -1308,6 +1313,11 @@ static int hc_urb_enqueue(struct usb_hcd *hcd, struct urb *urb, gfp_t mem_flags)
 	req->isoFramesNumber = urb->number_of_packets;
 	req->epNum = get_epnum_from_pool(config->host_priv, usb_endpoint_num(host_ep_desc),
 			usb_endpoint_dir_in(host_ep_desc));
+	if (req->epNum > MAX_INSTANCE_EP_NUM) {
+		pr_err("Not enough endpoint resource for remap\n");
+		dump_ep_remap_pool(priv, usb_endpoint_num(host_ep_desc));
+		req->epNum = MAX_INSTANCE_EP_NUM;
+	}
 
 	if (usb_endpoint_dir_in(host_ep_desc)) {
 		if (!usbDev->in_ep[req->epNum])
@@ -1407,6 +1417,7 @@ static void hc_endpoint_disable(struct usb_hcd *hcd, struct usb_host_endpoint *l
 	struct HOST_USB_DEVICE *usbDev;
 	int ep_num;
 	struct phytium_cusb *config;
+	struct HOST_CTRL *priv;
 
 	config = *(struct phytium_cusb **)hcd->hcd_priv;
 	if (!config)
@@ -1414,6 +1425,8 @@ static void hc_endpoint_disable(struct usb_hcd *hcd, struct usb_host_endpoint *l
 
 	ep_num = get_epnum_from_pool(config->host_priv, usb_endpoint_num(&ld_ep->desc),
 			usb_endpoint_dir_in(&ld_ep->desc));
+
+	priv = config->host_priv;
 
 	usbDev = (struct HOST_USB_DEVICE *)ld_ep->hcpriv;
 	if (!usbDev)
@@ -1426,6 +1439,7 @@ static void hc_endpoint_disable(struct usb_hcd *hcd, struct usb_host_endpoint *l
 				INIT_LIST_HEAD(&usbDev->in_ep[ep_num]->reqList);
 				kfree(usbDev->in_ep[ep_num]);
 				usbDev->in_ep[ep_num] = NULL;
+				priv->ep_remap_pool[0][ep_num] = 0;
 			}
 		} else {
 			if (usbDev->out_ep[ep_num]) {
@@ -1433,6 +1447,7 @@ static void hc_endpoint_disable(struct usb_hcd *hcd, struct usb_host_endpoint *l
 				INIT_LIST_HEAD(&usbDev->out_ep[ep_num]->reqList);
 				kfree(usbDev->out_ep[ep_num]);
 				usbDev->out_ep[ep_num] = NULL;
+				priv->ep_remap_pool[1][ep_num] = 0;
 			}
 		}
 	}

--- a/drivers/usb/phytium/host.c
+++ b/drivers/usb/phytium/host.c
@@ -2047,6 +2047,12 @@ unsigned int get_endpoint_interval(struct usb_endpoint_descriptor desc,
 		if (usb_endpoint_xfer_control(&desc) || usb_endpoint_xfer_bulk(&desc)) {
 			if (desc.bInterval == 0)
 				return interval;
+
+			if (usb_endpoint_xfer_bulk(&desc)) {
+				interval = 1;
+				return interval;
+			}
+
 			interval = fls(desc.bInterval) - 1;
 			interval = clamp_val(interval, 0, 15);
 			interval = 1 << interval;

--- a/drivers/usb/phytium/host_api.h
+++ b/drivers/usb/phytium/host_api.h
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #ifndef __PHYTIUM_HOST_API_H_
 #define __PHYTIUM_HOST_API_H_
 

--- a/drivers/usb/phytium/hw-regs.h
+++ b/drivers/usb/phytium/hw-regs.h
@@ -1,4 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 */
+
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #ifndef __LINUX_PHYTIUM_HW_REGS
 #define __LINUX_PHYTIUM_HW_REGS
 

--- a/drivers/usb/phytium/pci.c
+++ b/drivers/usb/phytium/pci.c
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/io.h>

--- a/drivers/usb/phytium/platform.c
+++ b/drivers/usb/phytium/platform.c
@@ -10,7 +10,7 @@
 #include "core.h"
 #include "hw-regs.h"
 
-#define PHYTIUM_OTG_V1_VERSION "1.0.0"
+#define PHYTIUM_OTG_V1_VERSION "1.0.1"
 #define PHYTIUM_OTG_USB_LOADED  3
 #define USB2_2_BASE_ADDRESS 0x31800000
 

--- a/drivers/usb/phytium/platform.c
+++ b/drivers/usb/phytium/platform.c
@@ -1,4 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
+
+/*
+ * Copyright (c) 2022, Phytium Technology Co., Ltd.
+ */
+
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/io.h>
@@ -10,7 +15,7 @@
 #include "core.h"
 #include "hw-regs.h"
 
-#define PHYTIUM_OTG_V1_VERSION "1.0.1"
+#define PHYTIUM_OTG_V1_VERSION "1.0.2"
 #define PHYTIUM_OTG_USB_LOADED  3
 #define USB2_2_BASE_ADDRESS 0x31800000
 

--- a/drivers/usb/phytium/platform.c
+++ b/drivers/usb/phytium/platform.c
@@ -10,6 +10,7 @@
 #include "core.h"
 #include "hw-regs.h"
 
+#define PHYTIUM_OTG_V1_VERSION "1.0.0"
 #define PHYTIUM_OTG_USB_LOADED  3
 #define USB2_2_BASE_ADDRESS 0x31800000
 
@@ -214,3 +215,4 @@ module_platform_driver(phytium_otg_driver);
 MODULE_AUTHOR("Chen Zhenhua <chenzhenhua@phytium.com.cn>");
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Phytium usb platform wrapper");
+MODULE_VERSION(PHYTIUM_OTG_V1_VERSION);

--- a/drivers/usb/phytium_usb_v2/Kconfig
+++ b/drivers/usb/phytium_usb_v2/Kconfig
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0
+
+config USB_PHYTIUM_PCI_V2
+	tristate "PHYTIUM USB V2 Support for PCI"
+	depends on USB && USB_GADGET && USB_ROLE_SWITCH
+	help
+	  Say Y or M here if your system has a OTG USB Controller based on PHYTIUM SOC.
+
+	  If you choose to build this driver is a dynamically linked modules, the module will
+          be called phytium-usb-v2-pci.ko
+
+config USB_PHYTIUM_V2
+	tristate "PHYTIUM USB V2 Support for Platform"
+	depends on USB && USB_GADGET && USB_ROLE_SWITCH
+	help
+	  Say Y or M here if your system has a OTG USB Controller based on PHYTIUM SOC.
+
+	  If you choose to build this driver is a dynamically linked modules, the module will
+          be called phytium-usb-v2-platform.ko

--- a/drivers/usb/phytium_usb_v2/Makefile
+++ b/drivers/usb/phytium_usb_v2/Makefile
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0
+
+obj-$(CONFIG_USB_PHYTIUM_PCI_V2)	+= phytium-usb-pci-v2.o
+
+obj-$(CONFIG_USB_PHYTIUM_V2)	+= phytium-usb-platform-v2.o
+
+phytium-usb-pci-v2-y	:= core.o pci.o host.o gadget.o otg.o mem.o ring.o
+
+phytium-usb-platform-v2-y	:= core.o platform.o host.o gadget.o otg.o mem.o ring.o

--- a/drivers/usb/phytium_usb_v2/core.c
+++ b/drivers/usb/phytium_usb_v2/core.c
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/dma-mapping.h>
+#include <linux/module.h>
+
+#include "core.h"
+#include "otg.h"
+#include "host.h"
+#include "gadget.h"
+
+static enum usb_role hw_role_state_machine(struct phytium_usb *phytium_usb)
+{
+	enum usb_role role = USB_ROLE_NONE;
+	int id, vbus;
+
+	if (phytium_usb->dr_mode != USB_DR_MODE_OTG) {
+		if (phytium_usb_otg_is_host(phytium_usb))
+			role = USB_ROLE_HOST;
+
+		if (phytium_usb_otg_is_device(phytium_usb))
+			role = USB_ROLE_DEVICE;
+
+		return role;
+	}
+
+	id = phytium_usb_otg_get_id(phytium_usb);
+	vbus = phytium_usb_otg_get_vbus(phytium_usb);
+
+	role = phytium_usb->role;
+
+	switch (role) {
+	case USB_ROLE_NONE:
+		if (!id)
+			role = USB_ROLE_HOST;
+		else if (vbus)
+			role = USB_ROLE_DEVICE;
+		break;
+	case USB_ROLE_HOST:
+		if (id)
+			role = USB_ROLE_NONE;
+		break;
+	case USB_ROLE_DEVICE:
+		if (!vbus)
+			role = USB_ROLE_NONE;
+		break;
+	}
+
+	dev_info(phytium_usb->dev, "role %d -> %d\n", phytium_usb->role, role);
+
+	return role;
+}
+
+int phytium_usb_role_start(struct phytium_usb *phytium_usb, enum usb_role role)
+{
+	int ret;
+
+	mutex_lock(&phytium_usb->mutex);
+	phytium_usb->role = role;
+	mutex_unlock(&phytium_usb->mutex);
+
+	if (!phytium_usb->roles[role])
+		return -ENXIO;
+
+	if (phytium_usb->roles[role]->state == ROLE_STATE_ACTIVE)
+		return 0;
+
+	mutex_lock(&phytium_usb->mutex);
+	ret = phytium_usb->roles[role]->start((void *)phytium_usb);
+	if (!ret)
+		phytium_usb->roles[role]->state = ROLE_STATE_ACTIVE;
+	mutex_unlock(&phytium_usb->mutex);
+
+	return ret;
+}
+
+void phytium_usb_role_stop(struct phytium_usb *phytium_usb)
+{
+	enum usb_role role;
+
+	if (phytium_usb) {
+		role = phytium_usb->role;
+
+		if (phytium_usb->roles[role]->state == ROLE_STATE_INACTIVE)
+			return;
+
+		mutex_lock(&phytium_usb->mutex);
+		phytium_usb->roles[role]->stop((void *)phytium_usb);
+		phytium_usb->roles[role]->state = ROLE_STATE_INACTIVE;
+		mutex_unlock(&phytium_usb->mutex);
+	}
+}
+
+static enum usb_role role_get(struct usb_role_switch *sw)
+{
+	struct phytium_usb *phytium_usb = usb_role_switch_get_drvdata(sw);
+
+	return phytium_usb->role;
+}
+
+static int role_set(struct usb_role_switch *sw, enum usb_role role)
+{
+	struct phytium_usb *phytium_usb = usb_role_switch_get_drvdata(sw);
+	int ret = 0;
+
+	if (phytium_usb->role == role)
+		return ret;
+
+	if (phytium_usb->dr_mode == USB_DR_MODE_HOST) {
+		switch (role) {
+		case USB_ROLE_NONE:
+		case USB_ROLE_HOST:
+			break;
+		default:
+			return ret;
+		}
+	}
+
+	if (phytium_usb->dr_mode == USB_DR_MODE_PERIPHERAL) {
+		switch (role) {
+		case USB_ROLE_NONE:
+		case USB_ROLE_DEVICE:
+			break;
+		default:
+			return ret;
+		}
+	}
+
+	phytium_usb_role_stop(phytium_usb);
+	ret = phytium_usb_role_start(phytium_usb, role);
+	if (ret)
+		dev_err(phytium_usb->dev, "set role %d has failed\n", role);
+
+	return ret;
+}
+
+int phytium_usb_hw_role_switch(struct phytium_usb *phytium_usb)
+{
+	enum usb_role real_role, current_role;
+	int ret = 0;
+
+	if (phytium_usb) {
+		if (phytium_usb->role_sw)
+			return ret;
+
+		current_role = phytium_usb->role;
+		real_role = hw_role_state_machine(phytium_usb);
+
+		if (current_role == real_role)
+			goto exit;
+
+		if (current_role != 0 && real_role == 0)
+			goto exit;
+
+		phytium_usb_role_stop(phytium_usb);
+
+		dev_info(phytium_usb->dev, "Switching role %d -> %d\n", current_role, real_role);
+
+		ret = phytium_usb_role_start(phytium_usb, real_role);
+		if (ret) {
+			dev_err(phytium_usb->dev, "set %d has failed, back to %d\n",
+					real_role, current_role);
+			ret = phytium_usb_role_start(phytium_usb, current_role);
+			if (ret)
+				dev_err(phytium_usb->dev, "Back to %d failed too\n", current_role);
+		}
+	}
+
+exit:
+	return ret;
+}
+
+
+static int phytium_usb_set_mode(struct phytium_usb *phytium_usb)
+{
+	if (phytium_usb) {
+		if (phytium_usb->dr_mode == USB_DR_MODE_OTG) {
+			phytium_usb_otg_disable_irq((void *)phytium_usb);
+			phytium_usb_otg_clear_irq((void *)phytium_usb);
+		}
+	}
+
+	return 0;
+}
+
+static int phytium_usb_start_mode(struct phytium_usb *phytium_usb)
+{
+	int ret = 0;
+
+	if (phytium_usb) {
+		switch (phytium_usb->dr_mode) {
+		case USB_DR_MODE_HOST:
+			ret = phytium_usb_role_start(phytium_usb, USB_ROLE_HOST);
+			break;
+		case USB_DR_MODE_PERIPHERAL:
+			ret = phytium_usb_role_start(phytium_usb, USB_ROLE_DEVICE);
+			break;
+		case USB_DR_MODE_OTG:
+			ret = phytium_usb_hw_role_switch(phytium_usb);
+			break;
+		default:
+			dev_warn(phytium_usb->dev, "unknown dr_mode:%d\n", phytium_usb->dr_mode);
+			ret = -EINVAL;
+			goto err;
+		}
+	}
+
+	return ret;
+err:
+	phytium_usb_role_stop(phytium_usb);
+	phytium_usb_otg_disable_irq((void *)phytium_usb);
+
+	return ret;
+}
+
+static int idle_role_start(void *data)
+{
+	return 0;
+}
+
+static void idle_role_stop(void *data)
+{
+}
+
+static int phytium_usb_idle_init(struct phytium_usb *phytium_usb)
+{
+	struct phytium_usb_role_driver *rdrv;
+
+	rdrv = devm_kzalloc(phytium_usb->dev, sizeof(*rdrv), GFP_KERNEL);
+	if (!rdrv)
+		return -ENOMEM;
+
+	rdrv->start = idle_role_start;
+	rdrv->stop = idle_role_stop;
+	rdrv->state = ROLE_STATE_INACTIVE;
+	rdrv->suspend = NULL;
+	rdrv->resume = NULL;
+	rdrv->name = "idle";
+
+	phytium_usb->roles[USB_ROLE_NONE] = rdrv;
+
+	return 0;
+}
+
+static int phytium_usb_init_role(struct phytium_usb *phytium_usb)
+{
+	int ret = 0;
+	enum usb_dr_mode dr_mode;
+
+	phytium_usb->role = USB_ROLE_NONE;
+
+	ret = phytium_usb_idle_init(phytium_usb);
+	if (ret)
+		return ret;
+
+	dr_mode = usb_get_dr_mode(phytium_usb->dev);
+	if (dr_mode == USB_DR_MODE_UNKNOWN)
+		dr_mode = USB_DR_MODE_OTG;
+
+	phytium_usb_host_init((void *)phytium_usb);
+
+	phytium_usb_gadget_init((void *)phytium_usb);
+
+
+	phytium_usb_set_mode(phytium_usb);
+
+	phytium_usb->dr_mode = dr_mode;
+
+	ret = phytium_usb_start_mode(phytium_usb);
+
+	return ret;
+}
+
+int phytium_usb_init(struct phytium_usb *phytium_usb)
+{
+	int ret;
+
+	if (!phytium_usb)
+		return 0;
+
+	mutex_init(&phytium_usb->mutex);
+
+	ret = dma_set_mask_and_coherent(phytium_usb->dev, DMA_BIT_MASK(32));
+	if (ret) {
+		dev_warn(phytium_usb->dev, "set dma mask failed with:%d\n", ret);
+		return ret;
+	}
+
+	if (device_property_read_bool(phytium_usb->dev, "usb-role-switch")) {
+		struct usb_role_switch_desc sw_desc = { };
+
+		sw_desc.get = role_get;
+		sw_desc.set = role_set;
+		sw_desc.allow_userspace_control = true;
+		sw_desc.driver_data = phytium_usb;
+		sw_desc.fwnode = phytium_usb->dev->fwnode;
+
+		phytium_usb->role_sw = usb_role_switch_register(phytium_usb->dev, &sw_desc);
+		if (IS_ERR(phytium_usb->role_sw)) {
+			dev_warn(phytium_usb->dev, "Unalbe to register Role Switch\n");
+			return PTR_ERR(phytium_usb->role_sw);
+		}
+	}
+
+	ret = phytium_usb_otg_init((void *)phytium_usb);
+	if (ret)
+		goto init_failed;
+
+	ret = phytium_usb_init_role(phytium_usb);
+	if (ret)
+		goto init_failed;
+
+	spin_lock_init(&phytium_usb->lock);
+
+	return 0;
+
+init_failed:
+	phytium_usb_otg_disable_irq((void *)phytium_usb);
+
+	if (phytium_usb->role_sw)
+		usb_role_switch_unregister(phytium_usb->role_sw);
+
+	return ret;
+}
+
+int phytium_usb_uninit(struct phytium_usb *phytium_usb)
+{
+	if (phytium_usb->role_sw)
+		usb_role_switch_unregister(phytium_usb->role_sw);
+
+	phytium_usb_role_stop(phytium_usb);
+	phytium_usb_otg_uninit((void *)phytium_usb);
+
+	kfree(phytium_usb);
+
+	return 0;
+}
+
+int phytium_usb_resume(struct phytium_usb *phytium_usb, u8 set_active)
+{
+	enum usb_role real_role;
+	bool role_changed = false;
+	int ret = 0;
+
+	if (phytium_usb_otg_power_is_lost((void *)phytium_usb)) {
+		if (phytium_usb->role_sw) {
+			phytium_usb->role = role_get(phytium_usb->role_sw);
+		} else {
+			real_role = hw_role_state_machine(phytium_usb);
+			if (real_role != phytium_usb->role) {
+				ret = phytium_usb_hw_role_switch(phytium_usb);
+				if (ret)
+					return ret;
+
+				role_changed = true;
+			}
+		}
+
+		if (!role_changed) {
+			if (phytium_usb->role == USB_ROLE_HOST)
+				ret = phytium_usb_otg_host_on((void *)phytium_usb);
+			else if (phytium_usb->role == USB_ROLE_DEVICE)
+				ret = phytium_usb_otg_gadget_on((void *)phytium_usb);
+
+			if (ret)
+				return ret;
+		}
+	}
+
+	if (phytium_usb->roles[phytium_usb->role]->resume)
+		phytium_usb->roles[phytium_usb->role]->resume(phytium_usb,
+				phytium_usb_otg_power_is_lost(phytium_usb));
+
+	return 0;
+}
+
+int phytium_usb_suspend(struct phytium_usb *phytium_usb)
+{
+	unsigned long flags;
+
+	if (phytium_usb->roles[phytium_usb->role]->suspend) {
+		spin_lock_irqsave(&phytium_usb->lock, flags);
+		phytium_usb->roles[phytium_usb->role]->suspend(phytium_usb, false);
+		spin_unlock_irqrestore(&phytium_usb->lock, flags);
+	}
+
+	return 0;
+}
+
+MODULE_AUTHOR("Zhenhua Chen <chenzhenhua@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium USB2 DRD Controller Driver");

--- a/drivers/usb/phytium_usb_v2/core.h
+++ b/drivers/usb/phytium_usb_v2/core.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LINUX_PHYTIUM_USB_CORE_H__
+#define __LINUX_PHYTIUM_USB_CORE_H__
+
+#include <linux/usb/otg.h>
+#include <linux/platform_device.h>
+#include <linux/usb/role.h>
+
+#include "otg.h"
+
+#define ROLE_STATE_INACTIVE	0
+#define ROLE_STATE_ACTIVE	1
+#define PHYTIUM_USB_DRIVER_V2_VERSION "1.0.0"
+
+struct phytium_usb_platform_data {
+	int (*platform_suspend)(struct device *dev, bool suspend, bool wakeup);
+	unsigned long quirks;
+};
+
+struct phytium_usb_role_driver {
+	int (*start)(void *data);
+	void (*stop)(void *data);
+	int (*suspend)(void *data, bool do_wakeup);
+	int (*resume)(void *data, bool hibernated);
+	const char *name;
+	int state;
+};
+
+struct phytium_usb {
+	struct device *dev;
+	void __iomem *host_regs;
+	struct resource	host_res[2];
+	struct phytium_usb_platform_data	*platdata;
+	int device_irq;
+	void __iomem *device_regs;
+	int otg_irq;
+	struct resource otg_res;
+	struct phytium_usb_otg_regs __iomem *otg_regs;
+	enum usb_dr_mode dr_mode;
+	enum usb_role  role;
+	struct phytium_usb_role_driver *roles[USB_ROLE_DEVICE + 1];
+	struct platform_device *host_dev;
+	struct xhci_plat_priv *host_plat_data;
+	spinlock_t lock;
+	void *gadget_dev;
+	struct mutex mutex;
+	bool in_lpm;
+	struct usb_role_switch *role_sw;
+};
+
+int phytium_usb_init(struct phytium_usb *phytium_usb);
+int phytium_usb_uninit(struct phytium_usb *phytium_usb);
+int phytium_usb_hw_role_switch(struct phytium_usb *phytium_usb);
+int phytium_usb_resume(struct phytium_usb *phytium_usb, u8 set_active);
+int phytium_usb_suspend(struct phytium_usb *phytium_usb);
+int phytium_usb_role_start(struct phytium_usb *phytium_usb, enum usb_role role);
+void phytium_usb_role_stop(struct phytium_usb *phytium_usb);
+
+#endif

--- a/drivers/usb/phytium_usb_v2/gadget.c
+++ b/drivers/usb/phytium_usb_v2/gadget.c
@@ -1,0 +1,1697 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/dma-mapping.h>
+#include <linux/io-64-nonatomic-lo-hi.h>
+
+#include "gadget.h"
+#include "otg.h"
+#include "core.h"
+#include "mem.h"
+#include "ring.h"
+
+#define GADGET_IF_EP_EXIST(pdev, ep_num, dir) \
+	(readl(&(pdev)->rev_cap->ep_supported) & \
+	 (BIT(ep_num) << ((dir) ? 0 : 16)))
+
+#define STREAM_LOG_STREAMS 4
+#define STREAM_NUM_STREAMS BIT(STREAM_LOG_STREAMS)
+
+#define EP0_SETUP_SIZE 512
+#define RTL_REV_CAP 0xc4
+
+#define CFG_3XPORT_U1_PIPE_CLK_GATE_EN BIT(0)
+
+#define HCC_PARAMS_OFFSET 0x10
+#define HCC_EXT_CAPS(p) (((p) & GENMASK(31, 16)) >> 16)
+#define EXT_CAPS_ID(p) (((p) >> 0) & GENMASK(7, 0))
+#define EXT_CAPS_NEXT(p) (((p) >> 8) & GENMASK(7, 0))
+
+#define MAX_HALT_USEC (16 * 1000) //16ms
+
+#define D_XEC_PER_REGS_CAP 0xC8
+#define REG_CHICKEN_BITS_2_OFFSET 0x48
+#define CHICKEN_XDMA_2_TP_CACHE_DIS BIT(28)
+
+#define XBUF_CAP_ID	0xCB
+#define XBUF_RX_TAG_MASK_0_OFFSET 0x1C
+#define XBUF_RX_TAG_MASK_1_OFFSET 0x24
+#define XBUF_TX_CMD_OFFSET	0x2c
+
+#define HCS_ENDPOINTS_MASK	GENMASK(7, 0)
+#define HCS_ENDPOINTS(p)	(((p) & HCS_ENDPOINTS_MASK) >> 0)
+
+#define to_gadget_ep(ep) (container_of(ep, struct gadget_ep, endpoint))
+#define to_gadget_request(r) (container_of(r, struct gadget_request, request))
+#define gadget_to_device(g)	(container_of(g, struct phytium_device, gadget))
+#define request_to_gadget_request(r) (container_of(r, struct gadget_request, request))
+
+#define IMOD_INTERVAL_MASK		GENMASK(15, 0)
+#define IMOD_COUNTER_MASK		GENMASK(31, 16)
+#define IMOD_DEFAULT_INTERVAL	0
+
+#define CFG_3XPORT_SSP_SUPPORT	BIT(31)
+#define PORT_REG6_FORCE_FS		BIT(0)
+#define PORT_REG6_L1_L0_HW_EN	BIT(1)
+
+#define GADGET_MAX_HALT_USEC (16 * 1000)
+#define GADGET_DEFAULT_BESL	0
+
+unsigned int gadget_port_speed(unsigned int port_status)
+{
+	if (DEV_SUPERSPEEDPLUS(port_status))
+		return USB_SPEED_SUPER_PLUS;
+	else if (DEV_SUPERSPEED(port_status))
+		return USB_SPEED_SUPER;
+	else if (DEV_HIGHSPEED(port_status))
+		return USB_SPEED_HIGH;
+	else if (DEV_FULLSPEED(port_status))
+		return USB_SPEED_FULL;
+
+	return USB_SPEED_UNKNOWN;
+}
+
+
+u32 gadget_port_state_to_neutral(u32 state)
+{
+	return (state & GADGET_PORT_RO) | (state & GADGET_PORT_RWS);
+}
+
+int gadget_alloc_streams(struct phytium_device *pdev, struct gadget_ep *pep)
+{
+	return 0;
+}
+
+static unsigned int
+	gadget_get_endpoint_index(const struct usb_endpoint_descriptor *desc)
+{
+	unsigned int index = (unsigned int)usb_endpoint_num(desc);
+
+	if (usb_endpoint_xfer_control(desc))
+		return index * 2;
+
+	return (index * 2) + (usb_endpoint_dir_in(desc) ? 1 : 0) - 1;
+}
+
+static unsigned int
+	gadget_get_endpoint_flag(const struct usb_endpoint_descriptor *desc)
+{
+	return 1 << (gadget_get_endpoint_index(desc) + 1);
+}
+
+static void gadget_set_chicken_bits_2(struct phytium_device *pdev, u32 bit)
+{
+	__le32 __iomem *reg;
+	void __iomem *base;
+	u32 offset = 0;
+
+	base = &pdev->cap_regs->hc_capbase;
+	offset = phytium_gadget_find_next_ext_cap(base, offset,
+			D_XEC_PER_REGS_CAP);
+	reg = base + offset + REG_CHICKEN_BITS_2_OFFSET;
+
+	bit = readl(reg) | bit;
+	writel(bit, reg);
+}
+
+bool gadget_last_trb_on_seg(struct gadget_segment *seg, union gadget_trb *trb)
+{
+	return trb == &seg->trbs[TRBS_PER_SEGMENT - 1];
+}
+
+bool gadget_last_trb_on_ring(struct gadget_ring *ring, struct gadget_segment *seg,
+		union gadget_trb *trb)
+{
+	return gadget_last_trb_on_seg(seg, trb) && (seg->next == ring->first_seg);
+}
+
+int gadget_wait_for_cmd_compl(struct phytium_device *pdev)
+{
+	struct gadget_segment *event_deq_seg;
+	union gadget_trb *cmd_trb;
+	dma_addr_t cmd_deq_dma;
+	union gadget_trb *event;
+	u32 cycle_state;
+	int ret, val;
+	u64 cmd_dma;
+	u32 flags;
+
+	cmd_trb = pdev->cmd.command_trb;
+	pdev->cmd.status = 0;
+
+	ret = readl_poll_timeout_atomic(&pdev->op_regs->cmd_ring, val,
+		!CMD_RING_BUSY(val), 1, GADGET_CMD_TIMEOUT);
+	if (ret) {
+		dev_err(pdev->dev, "ERR: Timeout while waiting for command\n");
+		pdev->gadget_state = GADGET_STATE_DYING;
+		return -ETIMEDOUT;
+	}
+
+	event = pdev->event_ring->dequeue;
+	event_deq_seg = pdev->event_ring->deq_seg;
+	cycle_state = pdev->event_ring->cycle_state;
+
+	cmd_deq_dma = gadget_trb_virt_to_dma(pdev->cmd_ring->deq_seg, cmd_trb);
+	if (!cmd_deq_dma)
+		return -EINVAL;
+
+	while (1) {
+		flags = le32_to_cpu(event->event_cmd.flags);
+
+		if ((flags & TRB_CYCLE) != cycle_state)
+			return -EINVAL;
+
+		cmd_dma = le64_to_cpu(event->event_cmd.cmd_trb);
+
+		if (TRB_FIELD_TO_TYPE(flags) != TRB_COMPLETION ||
+			cmd_dma != (u64)cmd_deq_dma) {
+			if (!gadget_last_trb_on_seg(event_deq_seg, event)) {
+				event++;
+				continue;
+			}
+
+			if (gadget_last_trb_on_ring(pdev->event_ring, event_deq_seg, event))
+				cycle_state ^= 1;
+
+			event_deq_seg = event_deq_seg->next;
+			event = event_deq_seg->trbs;
+			continue;
+		}
+
+		pdev->cmd.status = GET_COMP_CODE(le32_to_cpu(event->event_cmd.status));
+		if (pdev->cmd.status == COMP_SUCCESS)
+			return 0;
+
+		return pdev->cmd.status;
+	}
+}
+
+static int gadget_configure_endpoint(struct phytium_device *pdev)
+{
+	int ret;
+
+	gadget_queue_configure_endpoint(pdev, pdev->cmd.in_ctx->dma);
+	gadget_ring_cmd_db(pdev);
+
+	ret = gadget_wait_for_cmd_compl(pdev);
+	if (ret) {
+		dev_err(pdev->dev, "ERR: unexpected command completion code\n");
+		return -EINVAL;
+	}
+
+	return ret;
+}
+
+static void gadget_zero_in_ctx(struct phytium_device *pdev)
+{
+	struct gadget_input_control_ctx *ctrl_ctx;
+	struct gadget_slot_ctx *slot_ctx;
+	struct gadget_ep_ctx *ep_ctx;
+	int i;
+
+	ctrl_ctx = gadget_get_input_control_ctx(&pdev->in_ctx);
+
+	ctrl_ctx->drop_flags = 0;
+	ctrl_ctx->add_flags = 0;
+	slot_ctx = gadget_get_slot_ctx(&pdev->in_ctx);
+	slot_ctx->dev_info &= cpu_to_le32(~LAST_CTX_MASK);
+	slot_ctx->dev_info |= cpu_to_le32(LAST_CTX(1));
+
+	for (i = 1; i < GADGET_ENDPOINTS_NUM; ++i) {
+		ep_ctx = gadget_get_ep_ctx(&pdev->in_ctx, i);
+		ep_ctx->ep_info = 0;
+		ep_ctx->ep_info2 = 0;
+		ep_ctx->deq = 0;
+		ep_ctx->tx_info = 0;
+	}
+}
+
+static int gadget_update_eps_configuration(struct phytium_device *pdev,
+		struct gadget_ep *pep)
+{
+	struct gadget_input_control_ctx *ctrl_ctx;
+	struct gadget_slot_ctx *slot_ctx;
+	int ret = 0;
+	int i;
+	u32 ep_sts;
+
+	ctrl_ctx = gadget_get_input_control_ctx(&pdev->in_ctx);
+
+	if (ctrl_ctx->add_flags == 0 && ctrl_ctx->drop_flags == 0)
+		return 0;
+
+	ctrl_ctx->add_flags |= cpu_to_le32(SLOT_FLAG);
+	ctrl_ctx->add_flags &= cpu_to_le32(~EP0_FLAG);
+	ctrl_ctx->drop_flags &= cpu_to_le32(~(SLOT_FLAG | EP0_FLAG));
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->in_ctx);
+	for (i = GADGET_ENDPOINTS_NUM; i >= 1; i--) {
+		__le32 le32 = cpu_to_le32(BIT(i));
+
+		if ((pdev->eps[i - 1].ring && !(ctrl_ctx->drop_flags & le32)) ||
+			(ctrl_ctx->add_flags & le32) || i == 1) {
+			slot_ctx->dev_info &= cpu_to_le32(~LAST_CTX_MASK);
+			slot_ctx->dev_info |= cpu_to_le32(LAST_CTX(i));
+			break;
+		}
+	}
+
+	ep_sts = GET_EP_CTX_STATE(pep->out_ctx);
+
+	if ((ctrl_ctx->add_flags != cpu_to_le32(SLOT_FLAG) &&
+			ep_sts == EP_STATE_DISABLED) ||
+			(ep_sts != EP_STATE_DISABLED && ctrl_ctx->drop_flags))
+		ret = gadget_configure_endpoint(pdev);
+
+	gadget_zero_in_ctx(pdev);
+
+	return ret;
+}
+
+static int gadget_ep_enable(struct usb_ep *ep,
+		const struct usb_endpoint_descriptor *desc)
+{
+	struct gadget_input_control_ctx *ctrl_ctx;
+	struct phytium_device *pdev;
+	struct gadget_ep *pep;
+	unsigned long flags;
+	u32 added_ctxs;
+	int ret;
+
+	if (!ep || !desc || desc->bDescriptorType != USB_DT_ENDPOINT ||
+			!desc->wMaxPacketSize)
+		return -EINVAL;
+
+	pep = to_gadget_ep(ep);
+	pdev = pep->pdev;
+	pep->ep_state &= ~EP_UNCONFIGURED;
+
+	if (pep->ep_state & EP_ENABLED) {
+		dev_warn(pdev->dev, "%s is already enalbed\n", pep->name);
+		return 0;
+	}
+
+	spin_lock_irqsave(&pdev->lock, flags);
+
+	added_ctxs = gadget_get_endpoint_flag(desc);
+	if (added_ctxs == SLOT_FLAG || added_ctxs == EP0_FLAG) {
+		dev_err(pdev->dev, "Bad endpoint number\n");
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	pep->interval = desc->bInterval ? BIT(desc->bInterval - 1) : 0;
+
+	if (pdev->gadget.speed == USB_SPEED_FULL) {
+		if (usb_endpoint_type(desc) == USB_ENDPOINT_XFER_INT)
+			pep->interval = desc->bInterval << 3;
+		if (usb_endpoint_type(desc) == USB_ENDPOINT_XFER_ISOC)
+			pep->interval = BIT(desc->bInterval - 1) << 3;
+	}
+
+	if (usb_endpoint_type(desc) == USB_ENDPOINT_XFER_ISOC) {
+		if (pep->interval > BIT(12)) {
+			dev_err(pdev->dev, "bInterval %d not supported\n",
+					desc->bInterval);
+			ret = -EINVAL;
+			goto unlock;
+		}
+		gadget_set_chicken_bits_2(pdev, CHICKEN_XDMA_2_TP_CACHE_DIS);
+	}
+
+	ret = gadget_endpoint_init(pdev, pep, GFP_ATOMIC);
+	if (ret)
+		goto unlock;
+
+	ctrl_ctx = gadget_get_input_control_ctx(&pdev->in_ctx);
+	ctrl_ctx->add_flags = cpu_to_le32(added_ctxs);
+	ctrl_ctx->drop_flags = 0;
+
+	ret = gadget_update_eps_configuration(pdev, pep);
+	if (ret) {
+		gadget_free_endpoint_rings(pdev, pep);
+		goto unlock;
+	}
+
+	pep->ep_state |= EP_ENABLED;
+	pep->ep_state &= ~EP_STOPPED;
+
+unlock:
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+static struct usb_request *gadget_ep_alloc_request(struct usb_ep *ep, gfp_t gfp_flags)
+{
+	struct gadget_ep *pep = to_gadget_ep(ep);
+	struct gadget_request *preq;
+
+	preq = kzalloc(sizeof(*preq), gfp_flags);
+	if (!preq)
+		return NULL;
+
+	preq->epnum = pep->number;
+	preq->pep = pep;
+
+	return &preq->request;
+}
+
+static void gadget_ep_free_request(struct usb_ep *ep, struct usb_request *request)
+{
+	struct gadget_request *preq = to_gadget_request(request);
+
+	kfree(preq);
+}
+
+
+static void gadget_invalidate_ep_events(struct phytium_device *pdev, struct gadget_ep *pep)
+{
+	struct gadget_segment *segment;
+	union gadget_trb *event;
+	u32 cycle_state;
+	u32 data;
+
+	event = pdev->event_ring->dequeue;
+	segment = pdev->event_ring->deq_seg;
+	cycle_state = pdev->event_ring->cycle_state;
+
+	while (1) {
+		data = le32_to_cpu(event->trans_event.flags);
+		if ((data & TRB_CYCLE) != cycle_state)
+			break;
+
+		if (TRB_FIELD_TO_TYPE(data) == TRB_TRANSFER &&
+			TRB_TO_EP_ID(data) == (pep->idx + 1)) {
+			data |= TRB_EVENT_INVALIDATE;
+			event->trans_event.flags = cpu_to_le32(data);
+		}
+
+		if (gadget_last_trb_on_seg(segment, event)) {
+			cycle_state ^= 1;
+			segment = pdev->event_ring->deq_seg->next;
+			event = segment->trbs;
+		} else {
+			event++;
+		}
+	}
+}
+
+int ep_dequeue(struct gadget_ep *pep, struct gadget_request *preq)
+{
+	struct phytium_device *pdev = pep->pdev;
+	int ret_stop = 0;
+	int ret_rem;
+
+	if (GET_EP_CTX_STATE(pep->out_ctx) == EP_STATE_RUNNING)
+		ret_stop = gadget_cmd_stop_ep(pdev, pep);
+
+	ret_rem = gadget_remove_request(pdev, preq, pep);
+
+	return ret_rem ? ret_rem : ret_stop;
+}
+
+int gadget_ep_enqueue(struct gadget_ep *pep, struct gadget_request *preq)
+{
+	struct phytium_device *pdev = pep->pdev;
+	struct usb_request *request;
+	int ret;
+
+	if (preq->epnum == 0 && !list_empty(&pep->pending_list))
+		return -EBUSY;
+
+	request = &preq->request;
+	request->actual = 0;
+	request->status = -EINPROGRESS;
+	preq->direction = pep->direction;
+	preq->epnum = pep->number;
+	preq->td.drbl = 0;
+
+	ret = usb_gadget_map_request_by_dev(pdev->dev, request, pep->direction);
+	if (ret)
+		return ret;
+
+	list_add_tail(&preq->list, &pep->pending_list);
+
+	switch (usb_endpoint_type(pep->endpoint.desc)) {
+	case USB_ENDPOINT_XFER_CONTROL:
+		ret = gadget_queue_ctrl_tx(pdev, preq);
+		break;
+	case USB_ENDPOINT_XFER_BULK:
+	case USB_ENDPOINT_XFER_INT:
+		ret = gadget_queue_bulk_tx(pdev, preq);
+		break;
+	case USB_ENDPOINT_XFER_ISOC:
+		ret = gadget_queue_isoc_tx_prepare(pdev, preq);
+		break;
+	}
+
+	if (ret)
+		goto unmap;
+
+	return 0;
+
+unmap:
+	usb_gadget_unmap_request_by_dev(pdev->dev, &preq->request, pep->direction);
+
+	list_del(&preq->list);
+
+	return ret;
+}
+
+static int gadget_ep_disable(struct usb_ep *ep)
+{
+	struct gadget_input_control_ctx *ctrl_ctx;
+	struct gadget_request *preq;
+	struct phytium_device *pdev;
+	struct gadget_ep *pep;
+	unsigned long flags;
+	u32 drop_flag;
+	int ret = 0;
+
+	if (!ep)
+		return -EINVAL;
+
+	pep = to_gadget_ep(ep);
+	pdev = pep->pdev;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	if (!(pep->ep_state & EP_ENABLED)) {
+		dev_err(pdev->dev, "%s is already disabled\n", pep->name);
+		ret = -EINVAL;
+		goto finish;
+	}
+
+	pep->ep_state |= EP_DIS_IN_PROGRESS;
+
+	if (!(pep->ep_state & EP_UNCONFIGURED)) {
+		gadget_cmd_stop_ep(pdev, pep);
+		gadget_cmd_flush_ep(pdev, pep);
+	}
+
+	while (!list_empty(&pep->pending_list)) {
+		preq = next_request(&pep->pending_list);
+		ep_dequeue(pep, preq);
+	}
+
+	gadget_invalidate_ep_events(pdev, pep);
+
+	pep->ep_state &= ~EP_DIS_IN_PROGRESS;
+	drop_flag = gadget_get_endpoint_flag(pep->endpoint.desc);
+	ctrl_ctx = gadget_get_input_control_ctx(&pdev->in_ctx);
+	ctrl_ctx->drop_flags = cpu_to_le32(drop_flag);
+	ctrl_ctx->add_flags = 0;
+
+	gadget_endpoint_zero(pdev, pep);
+
+	if (!(pep->ep_state & EP_UNCONFIGURED))
+		ret = gadget_update_eps_configuration(pdev, pep);
+
+	gadget_free_endpoint_rings(pdev, pep);
+
+	pep->ep_state &= ~(EP_ENABLED | EP_UNCONFIGURED);
+	pep->ep_state |= EP_STOPPED;
+
+finish:
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+static int gadget_ep_queue(struct usb_ep *ep, struct usb_request *request, gfp_t gfp_flags)
+{
+	struct gadget_request *preq;
+	struct phytium_device *pdev;
+	struct gadget_ep *pep;
+	unsigned long flags;
+	int ret;
+
+	if (!request || !ep)
+		return -EINVAL;
+
+	pep = to_gadget_ep(ep);
+	pdev = pep->pdev;
+
+	if (!(pep->ep_state & EP_ENABLED)) {
+		dev_err(pdev->dev, "%s: can't queue to disabled endpoint\n", pep->name);
+		return -EINVAL;
+	}
+
+	preq = to_gadget_request(request);
+	spin_lock_irqsave(&pdev->lock, flags);
+	ret = gadget_ep_enqueue(pep, preq);
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+static int gadget_ep_dequeue(struct usb_ep *ep, struct usb_request *request)
+{
+	struct phytium_device *pdev;
+	struct gadget_ep *pep;
+	unsigned long flags;
+	int ret;
+
+	if (!request || !ep)
+		return -EINVAL;
+
+	pep = to_gadget_ep(ep);
+	if (!pep->endpoint.desc) {
+		dev_err(pdev->dev, "%s: can't dequeue to disabled endpoint\n", pep->name);
+		return -ESHUTDOWN;
+	}
+
+	if (!(pep->ep_state & EP_ENABLED))
+		return 0;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	ret = ep_dequeue(pep, to_gadget_request(request));
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+static int gadget_ep_set_halt(struct usb_ep *ep, int value)
+{
+	struct gadget_ep *pep = to_gadget_ep(ep);
+	struct phytium_device *pdev = pep->pdev;
+	struct gadget_request *preq;
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+
+	preq = next_request(&pep->pending_list);
+	if (value) {
+		if (preq) {
+			ret = -EAGAIN;
+			goto done;
+		}
+	}
+
+	ret = gadget_halt_endpoint(pdev, pep, value);
+
+done:
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+static int gadget_ep_set_wedge(struct usb_ep *ep)
+{
+	struct gadget_ep *pep = to_gadget_ep(ep);
+	struct phytium_device *pdev = pep->pdev;
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	pep->ep_state |= EP_WEDGE;
+	ret = gadget_halt_endpoint(pdev, pep, 1);
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+static const struct usb_ep_ops gadget_ep0_ops = {
+	.enable		= gadget_ep_enable,
+	.disable	= gadget_ep_disable,
+	.alloc_request	= gadget_ep_alloc_request,
+	.free_request	= gadget_ep_free_request,
+	.queue		= gadget_ep_queue,
+	.dequeue	= gadget_ep_dequeue,
+	.set_halt	= gadget_ep_set_halt,
+	.set_wedge	= gadget_ep_set_wedge,
+};
+
+static const struct usb_ep_ops gadget_ep_ops = {
+	.enable		= gadget_ep_enable,
+	.disable	= gadget_ep_disable,
+	.alloc_request	= gadget_ep_alloc_request,
+	.free_request	= gadget_ep_free_request,
+	.queue		= gadget_ep_queue,
+	.dequeue	= gadget_ep_dequeue,
+	.set_halt	= gadget_ep_set_halt,
+	.set_wedge	= gadget_ep_set_wedge,
+};
+
+static struct usb_endpoint_descriptor gadget_ep0_desc = {
+	.bLength = USB_DT_ENDPOINT_SIZE,
+	.bDescriptorType = USB_DT_ENDPOINT,
+	.bmAttributes = USB_ENDPOINT_XFER_CONTROL,
+};
+
+void resume_gadget(struct phytium_device *pdev)
+{
+	if (pdev->gadget_driver && pdev->gadget_driver->resume) {
+		spin_unlock(&pdev->lock);
+		pdev->gadget_driver->resume(&pdev->gadget);
+		spin_lock(&pdev->lock);
+	}
+}
+
+void suspend_gadget(struct phytium_device *pdev)
+{
+	if (pdev->gadget_driver && pdev->gadget_driver->suspend) {
+		spin_unlock(&pdev->lock);
+		pdev->gadget_driver->suspend(&pdev->gadget);
+		spin_lock(&pdev->lock);
+	}
+}
+
+static void gadget_clear_chicken_bit_2(struct phytium_device *pdev, u32 bit)
+{
+	__le32 __iomem *reg;
+	void __iomem *base;
+	u32 offset = 0;
+
+	base = &pdev->cap_regs->hc_capbase;
+	offset = phytium_gadget_find_next_ext_cap(base, offset, D_XEC_PER_REGS_CAP);
+	reg = base + offset + REG_CHICKEN_BITS_2_OFFSET;
+
+	bit = readl(reg) & ~bit;
+	writel(bit, reg);
+}
+
+int gadget_setup_device(struct phytium_device *pdev, enum gadget_setup_dev setup)
+{
+	struct gadget_input_control_ctx *ctrl_ctx;
+	struct gadget_slot_ctx *slot_ctx;
+	int dev_state = 0;
+	int ret;
+
+	if (!pdev->slot_id)
+		return -EINVAL;
+
+	if (!pdev->active_port->port_num)
+		return -EINVAL;
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->out_ctx);
+	dev_state = GET_SLOT_STATE(le32_to_cpu(slot_ctx->dev_state));
+
+	if (setup == SETUP_CONTEXT_ONLY && dev_state == SLOT_STATE_DEFAULT)
+		return 0;
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->in_ctx);
+	ctrl_ctx = gadget_get_input_control_ctx(&pdev->in_ctx);
+
+	if (!slot_ctx->dev_info || dev_state == SLOT_STATE_DEFAULT) {
+		ret = gadget_setup_addressable_priv_dev((void *)pdev);
+		if (ret)
+			return ret;
+	}
+
+	gadget_copy_ep0_dequeue_into_input_ctx(pdev);
+
+	ctrl_ctx->add_flags = cpu_to_le32(SLOT_FLAG | EP0_FLAG);
+	ctrl_ctx->drop_flags = 0;
+
+	gadget_queue_address_device(pdev, pdev->in_ctx.dma, setup);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+
+	ctrl_ctx->add_flags = 0;
+	ctrl_ctx->drop_flags = 0;
+
+	return ret;
+}
+
+static int gadget_get_frame(struct usb_gadget *g)
+{
+	struct phytium_device *pdev = gadget_to_device(g);
+
+	return readl(&pdev->run_regs->microframe_index) >> 3;
+}
+
+static void __gadget_wakeup(struct phytium_device *pdev)
+{
+	struct gadget_port_regs __iomem *port_regs;
+	u32 portpm, portsc;
+
+	port_regs = pdev->active_port->regs;
+	portsc = readl(&port_regs->portsc) & PORT_PLS_MASK;
+
+	if (pdev->gadget.speed < USB_SPEED_SUPER && portsc == XDEV_U2) {
+		portpm = readl(&port_regs->portpmsc);
+		if (!(portpm & PORT_RWE))
+			return;
+	}
+
+	if (portsc == XDEV_U3 && !pdev->may_wakeup)
+		return;
+
+	gadget_set_link_state(pdev, &port_regs->portsc, XDEV_U0);
+
+	pdev->gadget_state |= GADGET_WAKEUP_PENDING;
+}
+
+static int gadget_wakeup(struct usb_gadget *g)
+{
+	struct phytium_device *pdev = gadget_to_device(g);
+	unsigned long flags;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	__gadget_wakeup(pdev);
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return 0;
+}
+
+static int gadget_set_selfpowered(struct usb_gadget *g,
+		int is_selfpowered)
+{
+	struct phytium_device *pdev = gadget_to_device(g);
+	unsigned long flags;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	g->is_selfpowered = !!is_selfpowered;
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return 0;
+}
+
+int gadget_halt_endpoint(struct phytium_device *pdev, struct gadget_ep *pep, int value)
+{
+	int ret;
+
+	ret = gadget_cmd_stop_ep(pdev, pep);
+	if (ret)
+		return ret;
+
+	if (value) {
+		if (GET_EP_CTX_STATE(pep->out_ctx) == EP_STATE_STOPPED) {
+			gadget_queue_halt_endpoint(pdev, pep->idx);
+			gadget_ring_cmd_db(pdev);
+			ret = gadget_wait_for_cmd_compl(pdev);
+		}
+		pep->ep_state |= EP_HALTED;
+	} else {
+		gadget_queue_reset_ep(pdev, pep->idx);
+		gadget_ring_cmd_db(pdev);
+		ret = gadget_wait_for_cmd_compl(pdev);
+
+		if (ret)
+			return ret;
+
+		pep->ep_state &= ~EP_HALTED;
+
+		if (pep->idx != 0 && !(pep->ep_state & EP_WEDGE))
+			gadget_ring_doorbell_for_active_rings(pdev, pep);
+
+		pep->ep_state &= ~EP_WEDGE;
+	}
+
+	return 0;
+}
+
+int gadget_reset_device(struct phytium_device *pdev)
+{
+	struct gadget_slot_ctx *slot_ctx;
+	int slot_state;
+	int ret, i;
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->in_ctx);
+	slot_ctx->dev_info = 0;
+	pdev->device_address = 0;
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->out_ctx);
+	slot_state = GET_SLOT_STATE(le32_to_cpu(slot_ctx->dev_state));
+
+	if (slot_state <= SLOT_STATE_DEFAULT && pdev->eps[0].ep_state & EP_HALTED)
+		gadget_halt_endpoint(pdev, &pdev->eps[0], 0);
+
+	pdev->eps[0].ep_state &= ~(EP_STATE_STOPPED | EP_HALTED);
+	pdev->eps[0].ep_state |= EP_ENABLED;
+
+	if (slot_state <= SLOT_STATE_DEFAULT)
+		return 0;
+
+	gadget_queue_reset_device(pdev);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+
+	for (i = 1; i < GADGET_ENDPOINTS_NUM; i++)
+		pdev->eps[i].ep_state |= EP_STATE_STOPPED | EP_UNCONFIGURED;
+
+	if (ret)
+		dev_err(pdev->dev, "Reset device failed with %d\n", ret);
+
+	return ret;
+}
+
+void gadget_irq_reset(struct phytium_device *pdev)
+{
+	struct gadget_port_regs __iomem *port_regs;
+
+	gadget_reset_device(pdev);
+
+	port_regs = pdev->active_port->regs;
+	pdev->gadget.speed = gadget_port_speed(readl(port_regs));
+
+	spin_unlock(&pdev->lock);
+	usb_gadget_udc_reset(&pdev->gadget, pdev->gadget_driver);
+	spin_lock(&pdev->lock);
+
+	switch (pdev->gadget.speed) {
+	case USB_SPEED_SUPER_PLUS:
+	case USB_SPEED_SUPER:
+		gadget_ep0_desc.wMaxPacketSize = cpu_to_le16(512);
+		pdev->gadget.ep0->maxpacket = 512;
+		break;
+	case USB_SPEED_HIGH:
+	case USB_SPEED_FULL:
+		gadget_ep0_desc.wMaxPacketSize = cpu_to_le16(64);
+		pdev->gadget.ep0->maxpacket = 64;
+		break;
+	default:
+		dev_err(pdev->dev, "Unknown device speed\n");
+		break;
+	}
+
+	gadget_clear_chicken_bit_2(pdev, CHICKEN_XDMA_2_TP_CACHE_DIS);
+	gadget_setup_device(pdev, SETUP_CONTEXT_ONLY);
+	usb_gadget_set_state(&pdev->gadget, USB_STATE_DEFAULT);
+}
+
+static int gadget_pullup(struct usb_gadget *g, int is_on)
+{
+	struct phytium_device *pdev = gadget_to_device(g);
+	struct phytium_usb *phytium_usb = dev_get_drvdata(pdev->dev);
+	unsigned long flags;
+
+	disable_irq(phytium_usb->device_irq);
+	spin_lock_irqsave(&pdev->lock, flags);
+
+	if (!is_on)
+		gadget_reset_device(pdev);
+
+	spin_unlock_irqrestore(&pdev->lock, flags);
+	enable_irq(phytium_usb->device_irq);
+
+	return 0;
+}
+
+static void gadget_disable_port(struct phytium_device *pdev, __le32 __iomem *port_regs)
+{
+	u32 temp = gadget_port_state_to_neutral(readl(port_regs));
+
+	writel(temp | PORT_PED, port_regs);
+}
+
+static int start(struct phytium_device *pdev)
+{
+	u32 temp;
+	int ret;
+
+	temp = readl(&pdev->op_regs->command);
+	temp |= (CMD_R_S | CMD_DEVEN);
+	writel(temp, &pdev->op_regs->command);
+
+	pdev->gadget_state = 0;
+
+	ret = readl_poll_timeout_atomic(&pdev->op_regs->status, temp,
+			!(temp & STS_HALT), 1, GADGET_MAX_HALT_USEC);
+	if (ret) {
+		pdev->gadget_state = GADGET_STATE_DYING;
+		dev_err(pdev->dev, "Error: Controller run failed\n");
+	}
+
+	return ret;
+}
+
+static int gadget_run(struct phytium_device *pdev, enum usb_device_speed speed)
+{
+	u32 fs_speed = 0;
+	u32 temp;
+	int ret;
+
+	temp = readl(&pdev->ir_set->irq_control);
+	temp &= ~IMOD_INTERVAL_MASK;
+	temp |= ((IMOD_DEFAULT_INTERVAL / 250) & IMOD_INTERVAL_MASK);
+	writel(temp, &pdev->ir_set->irq_control);
+
+	temp = readl(&pdev->port3x_regs->mode_addr);
+
+	switch (speed) {
+	case USB_SPEED_SUPER_PLUS:
+		temp |= CFG_3XPORT_SSP_SUPPORT;
+		break;
+	case USB_SPEED_SUPER:
+		temp &= ~CFG_3XPORT_SSP_SUPPORT;
+		break;
+	case USB_SPEED_HIGH:
+		break;
+	case USB_SPEED_FULL:
+		fs_speed = PORT_REG6_FORCE_FS;
+		break;
+	default:
+		dev_err(pdev->dev, "Invalid max_speed parameter %d\n", speed);
+		fallthrough;
+	case USB_SPEED_UNKNOWN:
+		speed = USB_SPEED_SUPER;
+		break;
+	}
+
+	if (speed >= USB_SPEED_SUPER) {
+		writel(temp, &pdev->port3x_regs->mode_addr);
+		gadget_set_link_state(pdev, &pdev->usb3_port.regs->portsc, XDEV_RXDETECT);
+	} else {
+		gadget_disable_port(pdev, &pdev->usb3_port.regs->portsc);
+	}
+
+	gadget_set_link_state(pdev, &pdev->usb2_port.regs->portsc, XDEV_RXDETECT);
+
+	gadget_ep0_desc.wMaxPacketSize = cpu_to_le16(512);
+
+	writel(PORT_REG6_L1_L0_HW_EN | fs_speed, &pdev->port20_regs->port_regs6);
+
+	ret = start(pdev);
+	if (ret) {
+		ret = -ENODEV;
+		goto err;
+	}
+
+	temp = readl(&pdev->op_regs->command);
+	temp |= CMD_INTE;
+	writel(temp, &pdev->op_regs->command);
+
+	temp = readl(&pdev->ir_set->irq_pending);
+	writel(IMAN_IE_SET(temp), &pdev->ir_set->irq_pending);
+
+	return 0;
+
+err:
+	gadget_halt(pdev);
+
+	return ret;
+}
+
+static int gadget_udc_start(struct usb_gadget *g,
+		struct usb_gadget_driver *driver)
+{
+	enum usb_device_speed max_speed = driver->max_speed;
+	struct phytium_device *pdev = gadget_to_device(g);
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	pdev->gadget_driver = driver;
+
+	max_speed = min(driver->max_speed, g->max_speed);
+	ret = gadget_run(pdev, max_speed);
+
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+void gadget_set_usb2_hardware_lpm(struct phytium_device *pdev,
+		struct usb_request *req, int enable)
+{
+	if (pdev->active_port != &pdev->usb2_port || !pdev->gadget.lpm_capable)
+		return;
+
+	if (enable)
+		writel(PORT_BESL(GADGET_DEFAULT_BESL) | PORT_L1S_NYET | PORT_HLE,
+				&pdev->active_port->regs->portpmsc);
+	else
+		writel(PORT_L1S_NYET, &pdev->active_port->regs->portpmsc);
+}
+
+int gadget_disable_slot(struct phytium_device *pdev)
+{
+	int ret;
+
+	gadget_queue_slot_control(pdev, TRB_DISABLE_SLOT);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+
+	pdev->slot_id = 0;
+	pdev->active_port = NULL;
+
+	memset(pdev->in_ctx.bytes, 0, GADGET_CTX_SIZE);
+	memset(pdev->out_ctx.bytes, 0, GADGET_CTX_SIZE);
+
+	return ret;
+}
+
+int gadget_enable_slot(struct phytium_device *pdev)
+{
+	struct gadget_slot_ctx *slot_ctx;
+	int slot_state, ret;
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->out_ctx);
+	slot_state = GET_SLOT_STATE(le32_to_cpu(slot_ctx->dev_state));
+
+	if (slot_state != SLOT_STATE_DISABLED)
+		return 0;
+
+	gadget_queue_slot_control(pdev, TRB_ENABLE_SLOT);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+	if (ret)
+		return ret;
+
+	pdev->slot_id = 1;
+
+	return ret;
+}
+
+static void gadget_clear_port_change_bit(struct phytium_device *pdev, __le32 __iomem *port_regs)
+{
+	u32 portsc = readl(port_regs);
+
+	writel(gadget_port_state_to_neutral(portsc) | (portsc & PORT_CHANGE_BITS), port_regs);
+}
+
+void gadget_update_erst_dequeue(struct phytium_device *pdev, union gadget_trb *event_ring_deq,
+		u8 clear_ehb)
+{
+	u64 temp_64;
+	dma_addr_t deq;
+
+	temp_64 = lo_hi_readq(&pdev->ir_set->erst_dequeue);
+
+	if (event_ring_deq != pdev->event_ring->dequeue) {
+		deq = gadget_trb_virt_to_dma(pdev->event_ring->deq_seg, pdev->event_ring->dequeue);
+		temp_64 &= ERST_PTR_MASK;
+		temp_64 |= ((u64)deq & (u64)~ERST_PTR_MASK);
+	}
+
+	if (clear_ehb)
+		temp_64 |= ERST_EHB;
+	else
+		temp_64 &= ~ERST_EHB;
+
+	lo_hi_writeq(temp_64, &pdev->ir_set->erst_dequeue);
+}
+
+static void gadget_consume_all_events(struct phytium_device *pdev)
+{
+	struct gadget_segment *event_deq_seg;
+	union gadget_trb *event_ring_deq;
+	union gadget_trb *event;
+	u32 cycle_bit;
+
+	event_ring_deq = pdev->event_ring->dequeue;
+	event_deq_seg = pdev->event_ring->deq_seg;
+	event = pdev->event_ring->dequeue;
+
+	while (1) {
+		cycle_bit = (le32_to_cpu(event->event_cmd.flags) & TRB_CYCLE);
+
+		if (cycle_bit != pdev->event_ring->cycle_state)
+			break;
+
+		gadget_inc_deq(pdev, pdev->event_ring);
+
+		if (!gadget_last_trb_on_seg(event_deq_seg, event)) {
+			event++;
+			continue;
+		}
+
+		if (gadget_last_trb_on_ring(pdev->event_ring, event_deq_seg, event))
+			cycle_bit ^= 1;
+
+		event_deq_seg = event_deq_seg->next;
+		event = event_deq_seg->trbs;
+	}
+
+	gadget_update_erst_dequeue(pdev, event_ring_deq, 1);
+}
+
+static void gadget_clear_cmd_ring(struct phytium_device *pdev)
+{
+	struct gadget_segment *seg;
+	u64 val_64;
+	int i;
+
+	gadget_initialize_ring_info(pdev->cmd_ring);
+
+	seg = pdev->cmd_ring->first_seg;
+	for (i = 0; i < pdev->cmd_ring->num_segs; i++) {
+		memset(seg->trbs, 0, sizeof(union gadget_trb) * (TRBS_PER_SEGMENT - 1));
+		seg = seg->next;
+	}
+
+	val_64 = lo_hi_readq(&pdev->op_regs->cmd_ring);
+	val_64 = (val_64 & (u64)CMD_RING_RSVD_BITS) |
+		(pdev->cmd_ring->first_seg->dma & (u64)~CMD_RING_RSVD_BITS)
+		| pdev->cmd_ring->cycle_state;
+	lo_hi_writeq(val_64, &pdev->op_regs->cmd_ring);
+}
+
+static void stop(struct phytium_device *pdev)
+{
+	u32 temp;
+
+	gadget_cmd_flush_ep(pdev, &pdev->eps[0]);
+
+	if (!list_empty(&pdev->eps[0].pending_list)) {
+		struct gadget_request *req;
+
+		req = next_request(&pdev->eps[0].pending_list);
+		if (req == &pdev->ep0_preq)
+			ep_dequeue(&pdev->eps[0], req);
+	}
+
+	gadget_disable_port(pdev, &pdev->usb2_port.regs->portsc);
+	gadget_disable_port(pdev, &pdev->usb3_port.regs->portsc);
+	gadget_disable_slot(pdev);
+	gadget_halt(pdev);
+
+	temp = readl(&pdev->op_regs->status);
+	writel((temp & ~0x1fff) | STS_EINT, &pdev->op_regs->status);
+
+	temp = readl(&pdev->ir_set->irq_pending);
+	writel(IMAN_IE_CLEAR(temp), &pdev->ir_set->irq_pending);
+
+	gadget_clear_port_change_bit(pdev, &pdev->usb2_port.regs->portsc);
+	gadget_clear_port_change_bit(pdev, &pdev->usb3_port.regs->portsc);
+
+	temp = readl(&pdev->ir_set->irq_pending);
+	temp |= IMAN_IP;
+	writel(temp, &pdev->ir_set->irq_pending);
+
+	gadget_consume_all_events(pdev);
+	gadget_clear_cmd_ring(pdev);
+}
+
+static int gadget_udc_stop(struct usb_gadget *g)
+{
+	struct phytium_device *pdev = gadget_to_device(g);
+	unsigned long flags;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	stop(pdev);
+	pdev->gadget_driver = NULL;
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return 0;
+}
+
+static const struct usb_gadget_ops phytium_usb_gadget_ops = {
+	.get_frame		= gadget_get_frame,
+	.wakeup			= gadget_wakeup,
+	.set_selfpowered	= gadget_set_selfpowered,
+	.pullup			= gadget_pullup,
+	.udc_start		= gadget_udc_start,
+	.udc_stop		= gadget_udc_stop,
+};
+
+void gadget_died(struct phytium_device *pdev)
+{
+	dev_err(pdev->dev, "Error: controller not responding\n");
+	pdev->gadget_state |= GADGET_STATE_DYING;
+	gadget_halt(pdev);
+}
+
+static void gadget_quiesce(struct phytium_device *pdev)
+{
+	u32 halted, mask, cmd;
+
+	mask = ~(u32)(GADGET_IRQS);
+
+	halted = readl(&pdev->op_regs->status) & STS_HALT;
+	if (!halted)
+		mask &= ~(CMD_R_S | CMD_DEVEN);
+
+	cmd = readl(&pdev->op_regs->command);
+	cmd &= mask;
+	writel(cmd, &pdev->op_regs->command);
+}
+
+int gadget_halt(struct phytium_device *pdev)
+{
+	int ret;
+	u32 val;
+
+	gadget_quiesce(pdev);
+
+	ret = readl_poll_timeout_atomic(&pdev->op_regs->status, val,
+			val & STS_HALT, 1, MAX_HALT_USEC);
+	if (ret) {
+		dev_err(pdev->dev, "gadget halt failed\n");
+		return ret;
+	}
+
+	pdev->gadget_state |= GADGET_STATE_HALTED;
+
+	return 0;
+}
+
+int gadget_reset(struct phytium_device *pdev)
+{
+	u32 cmd, temp;
+	int ret;
+
+	temp = readl(&pdev->op_regs->status);
+	if (temp == ~(u32)0) {
+		dev_err(pdev->dev, "Controller not accessible\n");
+		return -ENODEV;
+	}
+
+	if ((temp & STS_HALT) == 0) {
+		dev_err(pdev->dev, "controller not halted, abort reset\n");
+		return -EINVAL;
+	}
+
+	cmd = readl(&pdev->op_regs->command);
+	cmd |= CMD_RESET;
+	writel(cmd, &pdev->op_regs->command);
+
+	ret = readl_poll_timeout_atomic(&pdev->op_regs->command, temp,
+			!(temp & CMD_RESET), 1, 10 * 1000);
+	if (ret) {
+		dev_err(pdev->dev, "controller reset failed\n");
+		return ret;
+	}
+
+	ret = readl_poll_timeout_atomic(&pdev->op_regs->status, temp,
+			!(temp & STS_CNR), 1, 10 * 1000);
+	if (ret) {
+		dev_err(pdev->dev, "controller not ready to work\n");
+		return ret;
+	}
+
+	dev_info(pdev->dev, "controller ready to work\n");
+
+	return ret;
+}
+
+int phytium_gadget_find_next_ext_cap(void __iomem *base, u32 start, int id)
+{
+	u32 offset = start;
+	u32 next;
+	u32 val;
+
+	if (!start || start == HCC_PARAMS_OFFSET) {
+		val = readl(base + HCC_PARAMS_OFFSET);
+		if (val == ~0)
+			return 0;
+
+		offset = HCC_EXT_CAPS(val) << 2;
+		if (!offset)
+			return 0;
+	}
+
+	do {
+		val = readl(base + offset);
+		if (val == ~0)
+			return 0;
+
+		if (EXT_CAPS_ID(val) == id && offset != start)
+			return offset;
+
+		next = EXT_CAPS_NEXT(val);
+		offset += next << 2;
+	} while (next);
+
+	return 0;
+}
+
+static void phytium_gadget_get_rev_cap(struct phytium_device *pdev)
+{
+	void __iomem *reg;
+
+	if (!pdev)
+		return;
+
+	reg = &pdev->cap_regs->hc_capbase;
+	reg += phytium_gadget_find_next_ext_cap(reg, 0, RTL_REV_CAP);
+	pdev->rev_cap = reg;
+
+	dev_info(pdev->dev, "Rev: %08x/%08x, eps: %08x, buff: %08x/%08x\n",
+			readl(&pdev->rev_cap->ctrl_revision),
+			readl(&pdev->rev_cap->rtl_revision),
+			readl(&pdev->rev_cap->ep_supported),
+			readl(&pdev->rev_cap->rx_buff_size),
+			readl(&pdev->rev_cap->tx_buff_size));
+}
+
+static int gadget_gen_setup(struct phytium_device *pdev)
+{
+	int ret;
+	u32 reg;
+
+	if (!pdev)
+		return 0;
+
+	pdev->cap_regs = pdev->regs;
+	pdev->op_regs = pdev->regs +
+		HC_LENGTH(readl(&pdev->cap_regs->hc_capbase));
+	pdev->run_regs = pdev->regs +
+		(readl(&pdev->cap_regs->run_regs_off) & RTSOFF_MASK);
+	pdev->hcs_params1 = readl(&pdev->cap_regs->hcs_params1);
+	pdev->hcc_params = readl(&pdev->cap_regs->hc_capbase);
+	pdev->hci_version = HC_VERSION(pdev->hcc_params);
+	pdev->hcc_params = readl(&pdev->cap_regs->hcc_params);
+
+	phytium_gadget_get_rev_cap(pdev);
+
+	ret = gadget_halt(pdev);
+	if (ret)
+		return ret;
+
+	ret = gadget_reset(pdev);
+	if (ret)
+		return ret;
+
+	if (HCC_64BIT_ADDR(pdev->hcc_params) &&
+		!dma_set_mask(pdev->dev, DMA_BIT_MASK(64))) {
+		dev_info(pdev->dev, "Enableing 64 bit DMA addr\n");
+		dma_set_coherent_mask(pdev->dev, DMA_BIT_MASK(64));
+	} else {
+		ret = dma_set_mask(pdev->dev, DMA_BIT_MASK(32));
+		if (ret)
+			return ret;
+
+		dev_info(pdev->dev, "Enableing 32 bit DMA addr\n");
+		dma_set_coherent_mask(pdev->dev, DMA_BIT_MASK(32));
+	}
+
+	spin_lock_init(&pdev->lock);
+
+	ret = gadget_mem_init((void *)pdev);
+	if (ret)
+		return ret;
+
+	reg = readl(&pdev->port3x_regs->mode_2);
+	reg &= ~CFG_3XPORT_U1_PIPE_CLK_GATE_EN;
+	writel(reg, &pdev->port3x_regs->mode_2);
+
+	return 0;
+}
+
+static void gadget_get_ep_buffering(struct phytium_device *pdev, struct gadget_ep *pep)
+{
+	void __iomem *reg = &pdev->cap_regs->hc_capbase;
+	int endpoints;
+
+	reg += phytium_gadget_find_next_ext_cap(reg, 0, XBUF_CAP_ID);
+
+	if (!pep->direction) {
+		pep->buffering = readl(reg + XBUF_RX_TAG_MASK_0_OFFSET);
+		pep->buffering_period = readl(reg + XBUF_RX_TAG_MASK_1_OFFSET);
+		pep->buffering = (pep->buffering + 1) / 2;
+		pep->buffering_period = (pep->buffering_period + 1) / 2;
+
+		return;
+	}
+
+	endpoints = HCS_ENDPOINTS(pdev->hcs_params1) / 2;
+
+	reg += XBUF_TX_CMD_OFFSET + (endpoints * 2 + 2) * sizeof(u32);
+	reg += pep->number * sizeof(u32) * 2;
+	pep->buffering = (readl(reg) + 1) / 2;
+	pep->buffering_period = pep->buffering;
+}
+
+static int gadget_init_endpoints(struct phytium_device *pdev)
+{
+	int max_streams = HCC_MAX_PSA(pdev->hcc_params);
+	struct gadget_ep *pep;
+	int i;
+
+	INIT_LIST_HEAD(&pdev->gadget.ep_list);
+
+	if (max_streams < STREAM_LOG_STREAMS) {
+		dev_err(pdev->dev, "Stream size %d not supported\n",
+				max_streams);
+		return -EINVAL;
+	}
+
+	max_streams = STREAM_LOG_STREAMS;
+
+	for (i = 0; i < GADGET_ENDPOINTS_NUM; i++) {
+		bool direction = !(i & 1);
+		u8 epnum = ((i + 1) >> 1);
+
+		if (!GADGET_IF_EP_EXIST(pdev, epnum, direction))
+			continue;
+
+		pep = &pdev->eps[i];
+		pep->pdev = pdev;
+		pep->number = epnum;
+		pep->direction = direction;
+
+		if (epnum == 0) {
+			snprintf(pep->name, sizeof(pep->name), "ep%d%s",
+					epnum, "BiDir");
+
+			pep->idx = 0;
+			usb_ep_set_maxpacket_limit(&pep->endpoint, 512);
+			pep->endpoint.maxburst = 1;
+			pep->endpoint.ops = &gadget_ep0_ops;
+			pep->endpoint.desc = &gadget_ep0_desc;
+			pep->endpoint.comp_desc = NULL;
+			pep->endpoint.caps.type_control = true;
+			pep->endpoint.caps.dir_in = true;
+			pep->endpoint.caps.dir_out = true;
+
+			pdev->ep0_preq.epnum = pep->number;
+			pdev->ep0_preq.pep = pep;
+			pdev->gadget.ep0 = &pep->endpoint;
+		} else {
+			snprintf(pep->name, sizeof(pep->name), "ep%d%s", epnum,
+				(pep->direction) ? "in" : "out");
+
+				pep->idx = (epnum * 2 + (direction ? 1 : 0)) - 1;
+				usb_ep_set_maxpacket_limit(&pep->endpoint, 1024);
+
+				pep->endpoint.max_streams = max_streams;
+				pep->endpoint.ops = &gadget_ep_ops;
+				list_add_tail(&pep->endpoint.ep_list, &pdev->gadget.ep_list);
+
+				pep->endpoint.caps.type_iso = true;
+				pep->endpoint.caps.type_bulk = true;
+				pep->endpoint.caps.type_int = true;
+				pep->endpoint.caps.dir_in = direction;
+				pep->endpoint.caps.dir_out = !direction;
+		}
+
+		pep->endpoint.name = pep->name;
+		pep->in_ctx = gadget_get_ep_ctx(&pdev->in_ctx, pep->idx);
+		pep->out_ctx = gadget_get_ep_ctx(&pdev->out_ctx, pep->idx);
+		gadget_get_ep_buffering(pdev, pep);
+
+		INIT_LIST_HEAD(&pep->pending_list);
+	}
+
+	return 0;
+}
+
+static void gadget_free_endpoints(struct phytium_device *pdev)
+{
+}
+
+static int gadget_restart(void *data, struct phytium_device *pdev)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	int ret;
+	u32 reg;
+
+	if (!phytium_usb)
+		return 0;
+
+	ret = gadget_mem_init((void *)pdev);
+	if (ret)
+		return ret;
+
+	reg = readl(&pdev->port3x_regs->mode_2);
+	reg &= ~CFG_3XPORT_U1_PIPE_CLK_GATE_EN;
+	writel(reg, &pdev->port3x_regs->mode_2);
+
+	ret = gadget_init_endpoints(pdev);
+	if (ret) {
+		dev_err(pdev->dev, "gadget_init_endpoints failed\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+static int gadget_start(void *data)
+{
+	struct phytium_device *pdev;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	u32 max_speed;
+	int ret;
+
+	if (!phytium_usb)
+		return 0;
+
+	phytium_usb_otg_gadget_on((void *)phytium_usb);
+
+	pdev = kzalloc(sizeof(*pdev), GFP_KERNEL);
+	if (!pdev)
+		return -ENOMEM;
+
+	phytium_usb->gadget_dev = pdev;
+	pdev->dev = phytium_usb->dev;
+	pdev->regs = phytium_usb->device_regs;
+	max_speed = usb_get_maximum_speed(pdev->dev);
+
+	switch (max_speed) {
+	case USB_SPEED_FULL:
+	case USB_SPEED_HIGH:
+	case USB_SPEED_SUPER:
+	case USB_SPEED_SUPER_PLUS:
+		break;
+	case USB_SPEED_UNKNOWN:
+		max_speed = USB_SPEED_SUPER_PLUS;
+		break;
+	default:
+		dev_err(pdev->dev, "invalid max speed %d\n", max_speed);
+	}
+
+	pdev->gadget.ops = &phytium_usb_gadget_ops;
+	pdev->gadget.name = "phytium_usb_gadget";
+	pdev->gadget.speed = USB_SPEED_UNKNOWN;
+	pdev->gadget.sg_supported = 0;
+	pdev->gadget.max_speed = max_speed;
+	pdev->gadget.lpm_capable = 0;
+	pdev->gadget.quirk_ep_out_aligned_size = true;
+
+	pdev->setup_buf = kzalloc(EP0_SETUP_SIZE, GFP_KERNEL);
+	if (!pdev->setup_buf)
+		goto free_pdev;
+
+	ret = gadget_gen_setup(pdev);
+	if (ret) {
+		dev_err(pdev->dev, "gadget_gen_setup failed\n");
+		goto free_setup;
+	}
+
+	ret = gadget_init_endpoints(pdev);
+	if (ret) {
+		dev_err(pdev->dev, "gadget_init_endpoints failed\n");
+		goto free_pdev;
+	}
+
+	ret = usb_add_gadget_udc(pdev->dev, &pdev->gadget);
+	if (ret) {
+		dev_err(pdev->dev, "usb_add_gadget_udc failed\n");
+		goto free_endpoints;
+	}
+
+	ret = devm_request_irq(pdev->dev, phytium_usb->device_irq, gadget_irq_handler,
+			IRQF_SHARED, "phytium_usb_gadget", pdev);
+	if (ret)
+		goto del_gadget;
+
+	return 0;
+
+del_gadget:
+	usb_del_gadget_udc(&pdev->gadget);
+free_endpoints:
+	gadget_free_endpoints(pdev);
+free_setup:
+	kfree(pdev->setup_buf);
+free_pdev:
+	kfree(pdev);
+
+	return ret;
+}
+
+static void gadget_stop(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	struct phytium_device *pdev = phytium_usb->gadget_dev;
+
+	devm_free_irq(pdev->dev, phytium_usb->device_irq, pdev);
+	usb_del_gadget_udc(&pdev->gadget);
+	gadget_free_endpoints(pdev);
+	gadget_mem_cleanup((void *)pdev);
+	kfree(pdev);
+	phytium_usb->gadget_dev = NULL;
+	phytium_usb_otg_gadget_off((void *)phytium_usb);
+}
+
+void disconnect_gadget(struct phytium_device *pdev)
+{
+	pdev->gadget_state |= GADGET_STATE_DISCONNECT_PENDING;
+
+	if (pdev->gadget_driver && pdev->gadget_driver->disconnect) {
+		spin_unlock(&pdev->lock);
+		pdev->gadget_driver->disconnect(&pdev->gadget);
+		spin_lock(&pdev->lock);
+	}
+
+	pdev->gadget.speed = USB_SPEED_UNKNOWN;
+	usb_gadget_set_state(&pdev->gadget, USB_STATE_NOTATTACHED);
+
+	pdev->gadget_state &= ~GADGET_STATE_DISCONNECT_PENDING;
+}
+
+static int gadget_suspend(void *data, bool do_wakeup)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	struct phytium_device *pdev = phytium_usb->gadget_dev;
+	unsigned long flags;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	disconnect_gadget(pdev);
+	stop(pdev);
+	gadget_mem_cleanup((void *)pdev);
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return 0;
+}
+
+static int gadget_resume(void *data, bool hibernated)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	struct phytium_device *pdev = phytium_usb->gadget_dev;
+	unsigned long flags;
+	enum usb_device_speed max_speed;
+	int ret;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	gadget_restart(phytium_usb, pdev);
+
+	if (!pdev->gadget_driver) {
+		spin_unlock_irqrestore(&pdev->lock, flags);
+		return 0;
+	}
+
+	max_speed = pdev->gadget_driver->max_speed;
+	max_speed = min(max_speed, pdev->gadget.max_speed);
+
+	ret = gadget_run(pdev, max_speed);
+	phytium_usb_otg_gadget_on((void *)phytium_usb);
+
+	if (pdev->link_state == XDEV_U3)
+		__gadget_wakeup(pdev);
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return ret;
+}
+
+int phytium_usb_gadget_init(void *data)
+{
+	struct phytium_usb_role_driver *role_driver;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		role_driver = devm_kzalloc(phytium_usb->dev, sizeof(*phytium_usb), GFP_KERNEL);
+		if (!role_driver)
+			return -ENOMEM;
+
+		role_driver->start = gadget_start;
+		role_driver->stop = gadget_stop;
+		role_driver->suspend = gadget_suspend;
+		role_driver->resume = gadget_resume;
+		role_driver->state = ROLE_STATE_INACTIVE;
+		role_driver->name = "gadget";
+		phytium_usb->roles[USB_ROLE_DEVICE] = role_driver;
+	}
+
+	return 0;
+}

--- a/drivers/usb/phytium_usb_v2/gadget.h
+++ b/drivers/usb/phytium_usb_v2/gadget.h
@@ -1,0 +1,712 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LINUX_PHYTIUM_USB_GADGET_H__
+#define __LINUX_PHYTIUM_USB_GADGET_H__
+
+#include <linux/usb/gadget.h>
+
+#define SCT_SEC_TR	0
+#define SCT_PRI_TR	1
+#define SCT_FOR_TRB(p)		(((p) << 1) & 0x7)
+#define SCT_FOR_CTX(p) (((p) << 1) & GENMASK(3, 1))
+
+
+#define TRB_EVENT_INVALIDATE 8
+
+#define COMP_CODE_MASK		(0xff << 24)
+#define GET_COMP_CODE(p)	(((p) & COMP_CODE_MASK) >> 24)
+#define COMP_INVALID				0
+#define COMP_SUCCESS				1
+#define COMP_DATA_BUFFER_ERROR			2
+#define COMP_BABBLE_DETECTED_ERROR		3
+#define COMP_TRB_ERROR				5
+#define COMP_RESOURCE_ERROR			7
+#define COMP_NO_SLOTS_AVAILABLE_ERROR		9
+#define COMP_INVALID_STREAM_TYPE_ERROR		10
+#define COMP_SLOT_NOT_ENABLED_ERROR		11
+#define COMP_ENDPOINT_NOT_ENABLED_ERROR		12
+#define COMP_SHORT_PACKET			13
+#define COMP_RING_UNDERRUN			14
+#define COMP_RING_OVERRUN			15
+#define COMP_VF_EVENT_RING_FULL_ERROR		16
+#define COMP_PARAMETER_ERROR			17
+#define COMP_CONTEXT_STATE_ERROR		19
+#define COMP_EVENT_RING_FULL_ERROR		21
+#define COMP_INCOMPATIBLE_DEVICE_ERROR		22
+#define COMP_MISSED_SERVICE_ERROR		23
+#define COMP_COMMAND_RING_STOPPED		24
+#define COMP_COMMAND_ABORTED			25
+#define COMP_STOPPED				26
+#define COMP_STOPPED_LENGTH_INVALID		27
+#define COMP_STOPPED_SHORT_PACKET		28
+#define COMP_MAX_EXIT_LATENCY_TOO_LARGE_ERROR	29
+#define COMP_ISOCH_BUFFER_OVERRUN		31
+#define COMP_EVENT_LOST_ERROR			32
+#define COMP_UNDEFINED_ERROR			33
+#define COMP_INVALID_STREAM_ID_ERROR		34
+
+
+#define GADGET_DEV_MAX_SLOTS 1
+#define GADGET_CTX_SIZE 2112
+
+#define GADGET_ENDPOINTS_NUM 31
+
+#define RTSOFF_MASK GENMASK(31, 5)
+
+#define HC_LENGTH(p)	(((p) >> 00) & GENMASK(7, 0))
+#define HC_VERSION(p)	(((p) >> 16) & GENMASK(15, 1))
+
+#define HCC_64BIT_ADDR(p)	((p) & BIT(0))
+#define HCC_MAX_PSA(p)		((((p) >> 12) & 0xf) + 1)
+
+#define GADGET_STATE_HALTED	BIT(1)
+#define GADGET_STATE_DYING	BIT(2)
+#define GADGET_STATE_DISCONNECT_PENDING	BIT(3)
+#define GADGET_WAKEUP_PENDING	BIT(4)
+
+#define LINK_TOGGLE BIT(1)
+
+#define XDEV_U0		(0x0 << 5)
+#define XDEV_U1		(0x1 << 5)
+#define XDEV_U2		(0x2 << 5)
+#define XDEV_U3		(0x3 << 5)
+#define XDEV_DISABLED	(0x4 << 5)
+#define XDEV_RXDETECT	(0x5 << 5)
+#define XDEV_INACTIVE	(0x6 << 5)
+#define XDEV_POLLING	(0x7 << 5)
+#define XDEV_RECOVERY	(0x8 << 5)
+#define XDEV_HOT_RESET	(0x9 << 5)
+#define XDEV_COMP_MODE	(0xa << 5)
+#define XDEV_TEST_MODE	(0xb << 5)
+#define XDEV_RESUME	(0xf << 5)
+
+#define PORT_CONNECT	BIT(0)
+#define	PORT_PED	BIT(1)
+#define	PORT_RESET	BIT(4)
+#define PORT_LINK_STROBE	BIT(16)
+#define PORT_CSC	BIT(17)
+#define PORT_WRC	BIT(19)
+#define PORT_RC		BIT(21)
+#define PORT_PLC	BIT(22)
+#define PORT_CEC	BIT(23)
+#define PORT_WKCONN_E	BIT(25)
+#define PORT_WKDISC_E	BIT(26)
+#define PORT_WR		BIT(31)
+#define PORT_CHANGE_BITS (PORT_CSC | PORT_WRC | PORT_RC | PORT_PLC | PORT_CEC)
+#define PORT_PLS_MASK	GENMASK(8, 5)
+#define DEV_SPEED_MASK	GENMASK(13, 10)
+#define XDEV_FS		(0x1 << 10)
+#define XDEV_HS		(0x3 << 10)
+#define XDEV_SS		(0x4 << 10)
+#define XDEV_SSP	(0x5 << 10)
+#define DEV_UNDEFSPEED(p)	(((p) & DEV_SPEED_MASK) == (0x0 << 10))
+#define DEV_FULLSPEED(p)	(((p) & DEV_SPEED_MASK) == XDEV_FS)
+#define DEV_HIGHSPEED(p)	(((p) & DEV_SPEED_MASK) == XDEV_HS)
+#define DEV_SUPERSPEED(p)	(((p) & DEV_SPEED_MASK) == XDEV_SS)
+#define DEV_SUPERSPEEDPLUS(p)	(((p) & DEV_SPEED_MASK) == XDEV_SSP)
+#define DEV_SUPERSPEED_ANY(p)	(((p) & DEV_SPEED_MASK) >= XDEV_SS)
+#define DEV_PORT_SPEED(p)	(((p) >> 10) & 0xf)
+#define DEV_PORT(p)		(((p) & 0xff) << 16)
+#define DEV_ADDR_MASK		GENMASK(7, 0)
+
+#define GADGET_PORT_RO (PORT_CONNECT | DEV_SPEED_MASK)
+#define GADGET_PORT_RWS (PORT_PLS_MASK | PORT_WKCONN_E | PORT_WKDISC_E)
+#define PORT_RWE	BIT(3)
+#define PORT_BESL(p)	(((p) << 4) & GENMASK(7, 4))
+#define PORT_HLE	BIT(16)
+#define RRBESL(p)	(((p) & GENMASK(20, 17)) >> 17)
+#define PORT_L1S_MASK	GENMASK(2, 0)
+#define PORT_L1S(p)		((p) & PORT_L1S_MASK)
+#define PORT_L1S_ACK		PORT_L1S(1)
+#define PORT_L1S_NYET		PORT_L1S(2)
+#define PORT_L1S_STALL		PORT_L1S(3)
+#define PORT_L1S_TIMEOUT	PORT_L1S(4)
+#define PORT_U1_TIMEOUT_MASK	GENMASK(7, 0)
+#define PORT_U1_TIMEOUT(p)	((p) & PORT_U1_TIMEOUT_MASK)
+#define PORT_U2_TIMEOUT_MASK	GENMASK(14, 8)
+#define PORT_U2_TIMEOUT(p)	((p) & PORT_U2_TIMEOUT_MASK)
+
+#define PORT_TEST_MODE_MASK	GENMASK(31, 28)
+#define PORT_TEST_MODE(p)	(((p) << 28) & PORT_TEST_MODE_MASK)
+
+#define IMAN_IP		BIT(0)
+#define IMAN_IE		BIT(1)
+#define IMAN_IE_SET(p)		((p) | IMAN_IE)
+#define IMAN_IE_CLEAR(p)	((p) & ~IMAN_IE)
+
+#define CMD_R_S		BIT(0)
+#define	CMD_RESET	BIT(1)
+#define CMD_INTE	BIT(2)
+#define CMD_DSEIE	BIT(3)
+#define CMD_EWE		BIT(10)
+#define CMD_DEVEN	BIT(17)
+#define GADGET_IRQS	(CMD_INTE | CMD_DSEIE | CMD_EWE)
+
+
+#define STS_HALT	BIT(0)
+#define STS_FATAL	BIT(2)
+#define STS_EINT	BIT(3)
+#define STS_PCD		BIT(4)
+#define STS_SSS		BIT(8)
+#define STS_RSS		BIT(9)
+#define STS_SRE		BIT(10)
+#define STS_CNR		BIT(11)
+#define STS_HCE		BIT(12)
+
+#define CMD_RING_RSVD_BITS GENMASK(5, 0)
+#define DBOFF_MASK GENMASK(31, 2)
+
+
+#define TRB_TO_STREAM_ID(p)	((((p) & GENMASK(31, 16)) >> 16))
+#define STREAM_ID_FOR_TRB(p)	((((p)) << 16) & GENMASK(31, 16))
+#define TRB_TO_SLOT_ID(p)	(((p) & GENMASK(31, 24)) >> 24)
+#define SLOT_ID_FOR_TRB(p)	(((p) << 24) & GENMASK(31, 24))
+#define TRB_TO_EP_INDEX(p)	(((p) >> 16) & 0x1f)
+#define EP_ID_FOR_TRB(p)	((((p) + 1) << 16) & GENMASK(20, 16))
+
+#define TRB_TYPE_BITMASK GENMASK(15, 10)
+#define TRB_TYPE(p) ((p) << 10)
+#define TRB_FIELD_TO_TYPE(p)	(((p) & TRB_TYPE_BITMASK) >> 10)
+
+#define TRB_NORMAL		1
+#define TRB_SETUP		2
+#define TRB_DATA		3
+#define TRB_STATUS		4
+#define TRB_ISOC		5
+#define TRB_LINK		6
+#define TRB_EVENT_DATA		7
+#define TRB_TR_NOOP		8
+#define TRB_ENABLE_SLOT		9
+#define TRB_DISABLE_SLOT	10
+#define TRB_ADDR_DEV		11
+#define TRB_CONFIG_EP		12
+#define TRB_EVAL_CONTEXT	13
+#define TRB_RESET_EP		14
+#define TRB_STOP_RING		15
+#define TRB_SET_DEQ		16
+#define TRB_RESET_DEV		17
+#define TRB_FORCE_EVENT		18
+#define TRB_FORCE_HEADER	22
+#define TRB_CMD_NOOP		23
+#define TRB_TRANSFER		32
+#define TRB_COMPLETION		33
+#define TRB_PORT_STATUS		34
+#define TRB_HC_EVENT		37
+#define TRB_MFINDEX_WRAP	39
+#define TRB_ENDPOINT_NRDY	48
+#define TRB_HALT_ENDPOINT	54
+#define TRB_HALT_OVERFLOW	57
+#define TRB_FLUSH_ENDPOINT	58
+
+#define TRB_TD_SIZE(p)		(min((p), (u32)31) << 17)
+#define GET_TD_SIZE(p)		(((p) & GENMASK(21, 17)) >> 17)
+#define TRB_TD_SIZE_TBC(p)	(min((p), (u32)31) << 17)
+#define TRB_INTR_TARGET(p)	(((p) << 22) & GENMASK(31, 22))
+#define GET_INTR_TARGET(p)	(((p) & GENMASK(31, 22)) >> 22)
+#define TRB_TBC(p)		(((p) & 0x3) << 7)
+#define TRB_TLBPC(p)		(((p) & 0xf) << 16)
+
+#define TRB_LEN(p)	((p) & GENMASK(16, 0))
+#define TRB_CYCLE	BIT(0)
+#define TRB_ENT		BIT(1)
+#define TRB_ISP		BIT(2)
+#define TRB_NO_SNOOP	BIT(3)
+#define TRB_CHAIN	BIT(4)
+#define TRB_IOC		BIT(5)
+#define TRB_IDT		BIT(6)
+#define TRB_STAT	BIT(7)
+#define TRB_BEI		BIT(9)
+#define TRB_DIR_IN	BIT(16)
+
+#define TRB_CONFIG_EP 12
+
+#define TRBS_PER_SEGMENT 256
+#define TRBS_PER_EV_DEQ_UPDATE 100
+#define TRBS_PER_EVENT_SEGMENT 256
+#define TRB_MAX_BUFF_SHIFT	16
+#define TRB_MAX_BUFF_SIZE	BIT(TRB_MAX_BUFF_SHIFT)
+#define TRB_BUFF_LEN_UP_TO_BOUNDARY(addr)	(TRB_MAX_BUFF_SIZE - \
+			((addr) & (TRB_MAX_BUFF_SIZE - 1)))
+
+#define TRB_TYPE_LINK(x)	(((x) & TRB_TYPE_BITMASK) == TRB_TYPE(TRB_LINK))
+#define TRB_TYPE_LINK_LE32(x)	(((x) & cpu_to_le32(TRB_TYPE_BITMASK)) == \
+					cpu_to_le32(TRB_TYPE(TRB_LINK)))
+#define TRB_TYPE_NOOP_LE32(x)	(((x) & cpu_to_le32(TRB_TYPE_BITMASK)) == \
+					cpu_to_le32(TRB_TYPE(TRB_TR_NOOP)))
+
+#define TRB_TO_EP_ID(p)	(((p) & GENMASK(20, 16)) >> 16)
+
+#define ERST_EHB BIT(3)
+#define ERST_PTR_MASK GENMASK(3, 0)
+
+#define LAST_CTX_MASK	((unsigned int)GENMASK(31, 27))
+#define LAST_CTX(p)	((p) << 27)
+#define SLOT_FLAG	BIT(0)
+#define EP0_FLAG	BIT(1)
+
+#define EP_TYPE(p)	((p) << 3)
+
+#define ISOC_OUT_EP     1
+#define BULK_OUT_EP     2
+#define INT_OUT_EP      3
+#define CTRL_EP         4
+#define ISOC_IN_EP      5
+#define BULK_IN_EP      6
+#define INT_IN_EP	7
+
+#define EP_ENABLED		BIT(0)
+#define EP_DIS_IN_PROGRESS	BIT(1)
+#define EP_HALTED		BIT(2)
+#define EP_STOPPED		BIT(3)
+#define EP_WEDGE		BIT(4)
+#define EP_HALTED_STATUS	BIT(5)
+#define EP_HAS_STREAMS		BIT(6)
+#define EP_UNCONFIGURED		BIT(7)
+
+#define EP_STATE_MASK	GENMASK(3, 0)
+#define EP_STATE_DISABLED	0
+#define EP_STATE_RUNNING	1
+#define EP_STATE_HALTED		2
+#define EP_STATE_STOPPED	3
+#define EP_STATE_ERROR		4
+#define GET_EP_CTX_STATE(ctx)	(le32_to_cpu((ctx)->ep_info) & EP_STATE_MASK)
+
+
+#define GADGET_CMD_TIMEOUT (15 * 1000)
+
+#define CMD_RING_BUSY(p)	((p) & BIT(4))
+#define CMD_RING_RUNNING	BIT(3)
+#define CMD_RING_RSVD_BITS	GENMASK(5, 0)
+
+#define SLOT_STATE		GENMASK(31, 27)
+#define GET_SLOT_STATE(p)	(((p) & SLOT_STATE) >> 27)
+#define SLOT_STATE_DISABLED		0
+#define SLOT_STATE_ENABLED		0 //czh test
+#define SLOT_STATE_DEFAULT		1
+#define SLOT_STATE_ADDRESSED	2
+#define SLOT_STATE_CONFIGURED	3
+
+#define EP0_HALTED_STATUS	BIT(5)
+
+enum gadget_setup_dev {
+	SETUP_CONTEXT_ONLY,
+	SETUP_CONTEXT_ADDRESS,
+};
+
+enum gadget_ep0_stage {
+	GADGET_SETUP_STAGE,
+	GADGET_DATA_STAGE,
+	GADGET_STATUS_STAGE,
+};
+
+struct gadget_slot_ctx {
+	__le32 dev_info;
+	__le32 dev_port;
+	__le32 int_target;
+	__le32 dev_state;
+	__le32 reserved[4];
+};
+
+struct gadget_input_control_ctx {
+	__le32 drop_flags;
+	__le32 add_flags;
+	__le32 rsvd2[6];
+};
+
+struct gadget_link_trb {
+	__le64 segment_ptr;
+	__le32 intr_target;
+	__le32 control;
+};
+
+struct gadget_event_cmd {
+	__le64 cmd_trb;
+	__le32 status;
+	__le32 flags;
+};
+
+struct gadget_transfer_event {
+	__le64 buffer;
+	__le32 transfer_len;
+	__le32 flags;
+};
+
+struct gadget_generic_trb {
+	__le32 field[4];
+};
+
+enum gadget_ring_type {
+	TYPE_CTRL = 0,
+	TYPE_ISOC,
+	TYPE_BULK,
+	TYPE_INTR,
+	TYPE_STREAM,
+	TYPE_COMMAND,
+	TYPE_EVENT,
+};
+
+struct phytium_device_intr_reg {
+	__le32 irq_pending;
+	__le32 irq_control;
+	__le32 erst_size;
+	__le32 rsvd;
+	__le64 erst_base;
+	__le64 erst_dequeue;
+};
+
+struct phytium_device_cap_regs {
+	__le32	hc_capbase;
+	__le32	hcs_params1;
+	__le32	hcs_params2;
+	__le32	hcs_params3;
+	__le32	hcc_params;
+	__le32	db_off;
+	__le32	run_regs_off;
+	__le32	hcc_params2;
+};
+
+struct phytium_device_op_regs {
+	__le32 command;
+	__le32 status;
+	__le32 page_size;
+	__le32 reserved1;
+	__le32 reserved2;
+	__le32 dnctrl;
+	__le64 cmd_ring;
+	__le32 reserved3[4];
+	__le64 dcbaa_ptr;
+	__le32 config_reg;
+	__le32 reserved4[241];
+	__le32 port_reg_base;
+};
+
+struct phytium_device_run_regs {
+	__le32 microframe_index;
+	__le32 rsvd[7];
+	struct phytium_device_intr_reg ir_set[128];
+};
+
+struct phytium_device_rev_cap {
+	__le32 ext_cap;
+	__le32 rtl_revision;
+	__le32 rx_buff_size;
+	__le32 tx_buff_size;
+	__le32 ep_supported;
+	__le32 ctrl_revision;
+};
+
+struct gadget_context_array {
+	__le64 dev_context_ptrs[GADGET_DEV_MAX_SLOTS + 1];
+	dma_addr_t dma;
+};
+
+union gadget_trb {
+	struct gadget_link_trb link;
+	struct gadget_transfer_event trans_event;
+	struct gadget_event_cmd event_cmd;
+	struct gadget_generic_trb generic;
+};
+
+struct gadget_segment {
+	union gadget_trb *trbs;
+	struct gadget_segment *next;
+	dma_addr_t dma;
+	dma_addr_t bounce_dma;
+	void *bounce_buf;
+	unsigned int bounce_offs;
+	unsigned int bounce_len;
+};
+
+struct gadget_ring {
+	struct gadget_segment *first_seg;
+	struct gadget_segment *last_seg;
+	union gadget_trb *enqueue;
+	struct gadget_segment *enq_seg;
+	union gadget_trb *dequeue;
+	struct gadget_segment *deq_seg;
+	struct list_head td_list;
+	u32 cycle_state;
+	unsigned int steam_id;
+	unsigned int stream_active;
+	unsigned int stream_rejected;
+	int num_tds;
+	unsigned int num_segs;
+	unsigned int num_trbs_free;
+	unsigned int bounce_buf_len;
+	enum gadget_ring_type type;
+	bool last_td_was_short;
+	struct radix_tree_root *trb_address_map;
+};
+
+struct phytium_device_doorbell_array {
+	__le32 cmd_db;
+	__le32 ep_db;
+};
+
+struct gadget_erst_entry {
+	__le64 seg_addr;
+	__le32 seg_size;
+	__le32 rsvd;
+};
+
+struct gadget_erst {
+	struct gadget_erst_entry *entries;
+	unsigned int num_entries;
+	dma_addr_t erst_dma_addr;
+};
+
+struct phytium_device_20port_cap {
+	__le32 ext_cap;
+	__le32 port_regs1;
+	__le32 port_regs2;
+	__le32 port_regs3;
+	__le32 port_regs4;
+	__le32 port_regs5;
+	__le32 port_regs6;
+};
+
+struct phytium_device_3xport_cap {
+	__le32 ext_cap;
+	__le32 mode_addr;
+	__le32 reserved[52];
+	__le32 mode_2;
+};
+
+struct gadget_port_regs {
+	__le32 portsc;
+	__le32 portpmsc;
+	__le32 portli;
+	__le32 reserved;
+};
+
+struct gadget_port {
+	struct gadget_port_regs __iomem *regs;
+	u8 port_num;
+	u8 exist;
+	u8 maj_rev;
+	u8 min_rev;
+};
+
+struct gadget_container_ctx {
+	unsigned int type;
+	int size;
+	int ctx_size;
+	dma_addr_t dma;
+	u8 *bytes;
+};
+
+struct gadget_ep_ctx {
+	__le32 ep_info;
+	__le32 ep_info2;
+	__le64 deq;
+	__le32 tx_info;
+	__le32 reserved[3];
+};
+
+struct gadget_stream_ctx {
+	__le64 stream_ring;
+	__le32 reserved[2];
+};
+
+struct gadget_stream_info {
+	struct gadget_ring **stream_rings;
+	unsigned int num_streams;
+	struct gadget_stream_ctx *stream_ctx_array;
+	unsigned int num_stream_ctxs;
+	dma_addr_t ctx_array_dma;
+	struct radix_tree_root trb_address_map;
+	int td_count;
+	u8 first_prime_det;
+	u8 drbls_count;
+};
+
+struct gadget_ep {
+	struct usb_ep endpoint;
+	struct list_head pending_list;
+	struct phytium_device *pdev;
+	u8 number;
+	u8 idx;
+	u32 interval;
+	char name[20];
+	u8 direction;
+	u8 buffering;
+	u8 buffering_period;
+	struct gadget_ep_ctx *in_ctx;
+	struct gadget_ep_ctx *out_ctx;
+	struct gadget_ring *ring;
+	struct gadget_stream_info stream_info;
+	unsigned int ep_state;
+	bool skip;
+};
+
+struct gadget_command {
+	struct gadget_container_ctx *in_ctx;
+	u32 status;
+	union gadget_trb *command_trb;
+};
+
+struct gadget_td {
+	struct list_head td_list;
+	struct gadget_request *preq;
+	struct gadget_segment *start_seg;
+	union gadget_trb *first_trb;
+	union gadget_trb *last_trb;
+	struct gadget_segment *bounce_seg;
+	bool request_length_set;
+	bool drbl;
+};
+
+struct gadget_dequeue_state {
+	struct gadget_segment *new_deq_seg;
+	union gadget_trb *new_deq_ptr;
+	int new_cycle_state;
+	unsigned int stream_id;
+};
+
+struct gadget_request {
+	struct gadget_td td;
+	struct usb_request request;
+	struct list_head list;
+	struct gadget_ep *pep;
+	u8 epnum;
+	unsigned direction:1;
+};
+
+struct phytium_device {
+	struct device *dev;
+	struct usb_gadget gadget;
+	struct usb_gadget_driver *gadget_driver;
+	void __iomem *regs;
+	void *setup_buf;
+	u8 setup_id;
+	u8 setup_speed;
+	struct usb_ctrlrequest setup;
+
+	struct phytium_device_cap_regs __iomem *cap_regs;
+	struct phytium_device_op_regs __iomem *op_regs;
+	struct phytium_device_run_regs __iomem *run_regs;
+	struct phytium_device_rev_cap __iomem *rev_cap;
+	struct phytium_device_doorbell_array __iomem *dba;
+	struct phytium_device_intr_reg __iomem *ir_set;
+	struct phytium_device_20port_cap __iomem *port20_regs;
+	struct phytium_device_3xport_cap __iomem *port3x_regs;
+
+	__u32 hcs_params1;
+	__u32 hcs_params3;
+	__u32 hcc_params;
+
+	u8 ep0_expect_in;
+	u8 device_address;
+
+	int may_wakeup;
+	u16 hci_version;
+	unsigned int gadget_state;
+	unsigned int link_state;
+
+	spinlock_t lock;
+
+	struct gadget_context_array *dcbaa;
+	struct gadget_ring *cmd_ring;
+	struct gadget_command cmd;
+	struct gadget_ring *event_ring;
+	struct gadget_erst erst;
+	int slot_id;
+
+	struct gadget_container_ctx out_ctx;
+	struct gadget_container_ctx in_ctx;
+	struct gadget_ep eps[GADGET_ENDPOINTS_NUM];
+
+	struct dma_pool *device_pool;
+	struct dma_pool *segment_pool;
+
+	struct gadget_port usb2_port;
+	struct gadget_port usb3_port;
+	struct gadget_port *active_port;
+	u16 test_mode;
+
+	struct gadget_request ep0_preq;
+	enum gadget_ep0_stage ep0_stage;
+	u8 three_stage_setup;
+
+	u8 u1_allowed:1;
+	u8 u2_allowed:1;
+	u8 usb2_hw_lpm_capable:1;
+};
+
+static inline struct gadget_request *next_request(struct list_head *list)
+{
+	return list_first_entry_or_null(list, struct gadget_request, list);
+}
+
+
+int phytium_usb_gadget_init(void *data);
+
+int phytium_gadget_find_next_ext_cap(void __iomem *base, u32 start, int id);
+
+int gadget_reset(struct phytium_device *pdev);
+
+int gadget_endpoint_init(struct phytium_device *pdev,
+		struct gadget_ep *pep, gfp_t mem_flags);
+
+int gadget_alloc_streams(struct phytium_device *pdev, struct gadget_ep *pep);
+
+struct gadget_input_control_ctx
+	*gadget_get_input_control_ctx(struct gadget_container_ctx *ctx);
+
+void gadget_free_endpoint_rings(struct phytium_device *pdev,
+		struct gadget_ep *pep);
+
+struct gadget_slot_ctx *gadget_get_slot_ctx(struct gadget_container_ctx *ctx);
+
+//gadget
+u32 gadget_port_state_to_neutral(u32 state);
+int gadget_wait_for_cmd_compl(struct phytium_device *pdev);
+void disconnect_gadget(struct phytium_device *pdev);
+bool gadget_last_trb_on_seg(struct gadget_segment *seg, union gadget_trb *trb);
+bool gadget_last_trb_on_ring(struct gadget_ring *ring, struct gadget_segment *seg,
+		union gadget_trb *trb);
+int gadget_halt(struct phytium_device *pdev);
+int gadget_disable_slot(struct phytium_device *pdev);
+int gadget_enable_slot(struct phytium_device *pdev);
+void gadget_set_usb2_hardware_lpm(struct phytium_device *pdev,
+		struct usb_request *req, int enable);
+unsigned int gadget_port_speed(unsigned int port_status);
+void resume_gadget(struct phytium_device *pdev);
+void suspend_gadget(struct phytium_device *pdev);
+void gadget_irq_reset(struct phytium_device *pdev);
+int gadget_ep_enqueue(struct gadget_ep *pep, struct gadget_request *preq);
+void gadget_died(struct phytium_device *pdev);
+int gadget_halt_endpoint(struct phytium_device *pdev, struct gadget_ep *pep, int value);
+int gadget_reset_device(struct phytium_device *pdev);
+int gadget_setup_device(struct phytium_device *pdev, enum gadget_setup_dev setup);
+int ep_dequeue(struct gadget_ep *pep, struct gadget_request *preq);
+void gadget_update_erst_dequeue(struct phytium_device *pdev, union gadget_trb *event_ring_deq,
+		u8 clear_ehb);
+
+//mem
+int gadget_ring_expansion(struct phytium_device *pdev, struct gadget_ring *ring,
+		unsigned int num_trbs, gfp_t flags);
+
+struct gadget_ep_ctx *gadget_get_ep_ctx(struct gadget_container_ctx *ctx,
+		unsigned int ep_index);
+
+void gadget_endpoint_zero(struct phytium_device *pdev, struct gadget_ep *pep);
+struct gadget_ring *gadget_dma_to_transfer_ring(struct gadget_ep *pep, u64 address);
+
+
+
+//ring
+void gadget_ring_cmd_db(struct phytium_device *pdev);
+int gadget_cmd_stop_ep(struct phytium_device *pdev, struct gadget_ep *pep);
+int gadget_cmd_flush_ep(struct phytium_device *pdev, struct gadget_ep *pep);
+int gadget_remove_request(struct phytium_device *pdev, struct gadget_request *preq,
+			struct gadget_ep *pep);
+void gadget_queue_slot_control(struct phytium_device *pdev, u32 trb_type);
+void gadget_inc_deq(struct phytium_device *pdev, struct gadget_ring *ring);
+void gadget_queue_reset_ep(struct phytium_device *pdev, unsigned int ep_index);
+void gadget_queue_halt_endpoint(struct phytium_device *pdev, unsigned int ep_index);
+void gadget_queue_reset_device(struct phytium_device *pdev);
+void gadget_set_link_state(struct phytium_device *pdev,
+		__le32 __iomem *port_regs, u32 link_state);
+
+#endif

--- a/drivers/usb/phytium_usb_v2/host.c
+++ b/drivers/usb/phytium_usb_v2/host.c
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/module.h>
+
+#include "host.h"
+#include "core.h"
+#include "otg.h"
+#include "../host/xhci.h"
+#include "../host/xhci-plat.h"
+
+#define HOST_RESOURCE_NUM 2
+#define XECP_AUX_CTRL_REG1	0x8120
+#define XECP_PORT_CAP_REG	0x8000
+#define CFG_RXDET_P3_EN		BIT(15)
+#define LPM_2_STB_SWITCH_EN	BIT(25)
+#define PM_RUNTIME_ALLOW	BIT(0)
+
+static void plat_phytium_start(struct usb_hcd *hcd)
+{
+	struct xhci_hcd *host = hcd_to_xhci(hcd);
+	u32 value;
+
+	if (host) {
+		value = readl(&host->op_regs->command);
+		value |= CMD_PM_INDEX;
+		writel(value, &host->op_regs->command);
+	}
+}
+
+static int plat_phytium_resume_quirk(struct usb_hcd *hcd)
+{
+	plat_phytium_start(hcd);
+
+	return 0;
+}
+
+static const struct xhci_plat_priv plat_phytium_usb = {
+	.plat_start = plat_phytium_start,
+	.resume_quirk = plat_phytium_resume_quirk,
+};
+
+static int host_start(void *data)
+{
+	struct phytium_usb *phytium_usb;
+	struct platform_device *host;
+	struct usb_hcd *hcd;
+	int ret;
+
+	phytium_usb = (struct phytium_usb *)data;
+	if (!phytium_usb)
+		return 0;
+
+	phytium_usb_otg_host_on((void *)phytium_usb);
+
+	host = platform_device_alloc("xhci-hcd", PLATFORM_DEVID_AUTO);
+	if (!host) {
+		dev_err(phytium_usb->dev, "platform_device_alloc failed\n");
+		return -ENOMEM;
+	}
+
+	host->dev.parent = phytium_usb->dev;
+	phytium_usb->host_dev = host;
+
+	ret = platform_device_add_resources(host, phytium_usb->host_res,
+			HOST_RESOURCE_NUM);
+	if (ret) {
+		dev_err(phytium_usb->dev, "platform_device_add_resources failed\n");
+		goto err;
+	}
+
+	phytium_usb->host_plat_data = kmemdup(&plat_phytium_usb,
+			sizeof(struct xhci_plat_priv), GFP_KERNEL);
+	if (!phytium_usb->host_plat_data) {
+		ret = -ENOMEM;
+		goto err;
+	}
+
+
+	phytium_usb->host_plat_data->quirks |= XHCI_RESET_ON_RESUME;
+	ret = platform_device_add_data(host, phytium_usb->host_plat_data,
+			sizeof(struct xhci_plat_priv));
+	if (ret)
+		goto free_memory;
+
+	ret = platform_device_add(host);
+	if (ret) {
+		dev_err(phytium_usb->dev, "register host failed\n");
+		goto free_memory;
+	}
+
+	hcd = platform_get_drvdata(host);
+	if (hcd)
+		phytium_usb->host_regs = hcd->regs;
+
+	return 0;
+
+free_memory:
+	kfree(phytium_usb->host_plat_data);
+
+err:
+	platform_device_put(host);
+
+	return ret;
+}
+
+static void host_stop(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		phytium_usb_otg_host_off((void *)phytium_usb);
+		kfree(phytium_usb->host_plat_data);
+		platform_device_unregister(phytium_usb->host_dev);
+		phytium_usb->host_dev = NULL;
+	}
+}
+
+int phytium_usb_host_init(void *data)
+{
+	struct phytium_usb_role_driver *role_driver;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		role_driver = devm_kzalloc(phytium_usb->dev, sizeof(*phytium_usb), GFP_KERNEL);
+		if (!role_driver)
+			return -ENOMEM;
+
+		role_driver->start = host_start;
+		role_driver->stop = host_stop;
+		role_driver->state = ROLE_STATE_INACTIVE;
+		role_driver->name = "host";
+		phytium_usb->roles[USB_ROLE_HOST] = role_driver;
+	}
+	return 0;
+}
+
+MODULE_AUTHOR("Zhenhua Chen <chenzhenhua@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium USB2 DRD Controller Driver");

--- a/drivers/usb/phytium_usb_v2/host.h
+++ b/drivers/usb/phytium_usb_v2/host.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LINUX_PHYTIUM_USB_HOST_H__
+#define __LINUX_PHYTIUM_USB_HOST_H__
+
+int phytium_usb_host_init(void *data);
+#endif

--- a/drivers/usb/phytium_usb_v2/mem.c
+++ b/drivers/usb/phytium_usb_v2/mem.c
@@ -1,0 +1,1039 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/dma-mapping.h>
+#include <linux/dmapool.h>
+#include <linux/io-64-nonatomic-lo-hi.h>
+#include "mem.h"
+#include "gadget.h"
+#include "ring.h"
+
+#define NUM_PORT_REGS	4
+
+#define GADGET_EXT_PORT_MAJOR(x)	(((x) >> 24) & 0xff)
+#define GADGET_EXT_PORT_MINOR(x)	(((x) >> 16) & 0xff)
+#define GADGET_EXT_PORT_OFF(x)		((x) & 0xff)
+#define GADGET_EXT_PORT_COUNT(x)	(((x) >> 8) & 0xff)
+
+#define HCC_64BYTE_CONTEXT(p) ((p) & BIT(2))
+#define CTX_SIZE(hcc) (HCC_64BYTE_CONTEXT(hcc) ? 64 : 32)
+
+#define GADGET_CTX_TYPE_DEVICE 0x1
+#define GADGET_CTX_TYPE_INPUT 0x2
+
+#define EXT_CAPS_PROTOCOL 2
+#define EXT_CAP_CFG_DEV_20PORT_CAP_ID 0xC1
+#define D_XEC_CFG_3XPORT_CAP 0xC0
+
+#define MAX_DEVS GENMASK(7, 0)
+#define CONFIG_U3E BIT(8)
+
+#define ERST_SIZE_MASK GENMASK(31, 16)
+#define ERST_NUM_SEGS 1
+#define TRB_SEGMENT_SIZE (TRBS_PER_SEGMENT * 16)
+#define TRB_SEGMENT_SHIFT (ilog2(TRB_SEGMENT_SIZE))
+
+
+#define ERROR_COUNT(p)	(((p) & 0x3) << 1)
+
+#define MAX_BURST(p)	(((p) << 8) & GENMASK(15, 8))
+#define MAX_PACKET(p)	(((p) << 16) & GENMASK(31, 16))
+
+#define EP_INTERVAL(p)	(((p) << 16) & GENMASK(23, 16))
+#define EP_MULT(p)	(((p) << 8) & GENMASK(9, 8))
+
+#define EP_AVG_TRB_LENGTH(p)	((p) & GENMASK(15, 0))
+
+#define EP_MAX_ESIT_PAYLOAD_LO(p)	(((p) << 16) & GENMASK(31, 16))
+#define EP_MAX_ESIT_PAYLOAD_HI(p)	((((p) & GENMASK(23, 16)) >> 16) << 24)
+
+#define GADGET_CTX_TYPE_DEVICE	0x1
+#define GADGET_CTX_TYPE_INPTU	0x2
+
+#define SLOT_SPEED_FS	(XDEV_FS << 10)
+#define SLOT_SPEED_HS	(XDEV_HS << 10)
+#define SLOT_SPEED_SS	(XDEV_SS << 10)
+#define SLOT_SPEED_SSP	(XDEV_SSP << 10)
+
+struct gadget_ep_ctx *gadget_get_ep_ctx(struct gadget_container_ctx *ctx,
+		unsigned int ep_index)
+{
+	ep_index++;
+	if (ctx->type == GADGET_CTX_TYPE_INPUT)
+		ep_index++;
+
+	return (struct gadget_ep_ctx *)(ctx->bytes + (ep_index * ctx->ctx_size));
+}
+
+struct gadget_slot_ctx *gadget_get_slot_ctx(struct gadget_container_ctx *ctx)
+{
+	if (ctx->type == GADGET_CTX_TYPE_DEVICE)
+		return (struct gadget_slot_ctx *)ctx->bytes;
+
+	return (struct gadget_slot_ctx *)(ctx->bytes + ctx->ctx_size);
+}
+
+	struct gadget_input_control_ctx
+	*gadget_get_input_control_ctx(struct gadget_container_ctx *ctx)
+{
+	if (ctx->type != GADGET_CTX_TYPE_INPUT)
+		return NULL;
+
+	return (struct gadget_input_control_ctx *)ctx->bytes;
+}
+
+static void gadget_link_segments(struct phytium_device *pdev,
+		struct gadget_segment *prev, struct gadget_segment *next,
+		enum gadget_ring_type type)
+{
+	struct gadget_link_trb *link;
+	u32 val;
+
+	if (!prev || !next)
+		return;
+
+	prev->next = next;
+	if (type != TYPE_EVENT) {
+		link = &prev->trbs[TRBS_PER_SEGMENT - 1].link;
+		link->segment_ptr = cpu_to_le64(next->dma);
+
+		val = le32_to_cpu(link->control);
+		val &= ~TRB_TYPE_BITMASK;
+		val |= TRB_TYPE(TRB_LINK);
+		link->control = cpu_to_le32(val);
+	}
+}
+
+static void gadget_segment_free(struct phytium_device *pdev,
+		struct gadget_segment *seg)
+{
+	if (seg->trbs)
+		dma_pool_free(pdev->segment_pool, seg->trbs, seg->dma);
+
+	kfree(seg->bounce_buf);
+	kfree(seg);
+}
+
+static void gadget_free_segments_for_ring(struct phytium_device *pdev,
+		struct gadget_segment *first)
+{
+	struct gadget_segment *seg;
+
+	seg = first->next;
+
+	while (seg != first) {
+		struct gadget_segment *next = seg->next;
+
+		gadget_segment_free(pdev, seg);
+		seg = next;
+	}
+
+	gadget_segment_free(pdev, first);
+}
+
+static struct gadget_segment *gadget_segment_alloc(struct phytium_device *pdev,
+		unsigned int cycle_state, unsigned int max_packet, gfp_t flags)
+{
+	struct gadget_segment *seg;
+	dma_addr_t dma;
+	int i;
+
+	seg = kzalloc(sizeof(struct gadget_segment), flags);
+	if (!seg)
+		return NULL;
+
+	seg->trbs = dma_pool_zalloc(pdev->segment_pool, flags, &dma);
+	if (!seg->trbs) {
+		kfree(seg);
+		return NULL;
+	}
+
+	if (max_packet) {
+		seg->bounce_buf = kzalloc(max_packet, flags | GFP_DMA);
+		if (!seg->bounce_buf)
+			goto free_dma;
+	}
+
+	if (cycle_state == 0) {
+		for (i = 0; i < TRBS_PER_SEGMENT; i++)
+			seg->trbs[i].link.control |= cpu_to_le32(TRB_CYCLE);
+	}
+
+	seg->dma = dma;
+	seg->next = NULL;
+
+	return seg;
+
+free_dma:
+	dma_pool_free(pdev->segment_pool, seg->trbs, dma);
+	kfree(seg);
+
+	return NULL;
+}
+
+static int gadget_alloc_segments_for_ring(struct phytium_device *pdev,
+		struct gadget_segment **first, struct gadget_segment **last,
+		unsigned int num_segs, unsigned int cycle_state,
+		enum gadget_ring_type type, unsigned int max_packet,
+		gfp_t flags)
+{
+	struct gadget_segment *prev;
+
+	prev = gadget_segment_alloc(pdev, cycle_state, max_packet, flags);
+	if (!prev)
+		return -ENOMEM;
+
+	num_segs--;
+	*first = prev;
+
+	while (num_segs > 0) {
+		struct gadget_segment *next;
+
+		next = gadget_segment_alloc(pdev, cycle_state,
+				max_packet, flags);
+		if (!next) {
+			gadget_free_segments_for_ring(pdev, *first);
+			return -ENOMEM;
+		}
+
+		gadget_link_segments(pdev, prev, next, type);
+
+		prev = next;
+		num_segs--;
+	}
+
+	gadget_link_segments(pdev, prev, *first, type);
+	*last = prev;
+
+	return 0;
+}
+
+void gadget_initialize_ring_info(struct gadget_ring *ring)
+{
+	ring->enqueue = ring->first_seg->trbs;
+	ring->enq_seg = ring->first_seg;
+	ring->dequeue = ring->enqueue;
+	ring->deq_seg = ring->first_seg;
+
+	ring->cycle_state = 1;
+	ring->num_trbs_free = ring->num_segs * (TRBS_PER_SEGMENT - 1) - 1;
+}
+
+static struct gadget_ring *gadget_ring_alloc(struct phytium_device *pdev,
+		unsigned int num_segs, enum gadget_ring_type type,
+		unsigned int max_packet, gfp_t flags)
+{
+	struct gadget_ring *ring;
+	int ret;
+
+	ring = kzalloc(sizeof(struct gadget_ring), flags);
+	if (!ring)
+		return NULL;
+
+	ring->num_segs = num_segs;
+	ring->bounce_buf_len = max_packet;
+	INIT_LIST_HEAD(&ring->td_list);
+	ring->type = type;
+
+	if (num_segs == 0)
+		return ring;
+
+	ret = gadget_alloc_segments_for_ring(pdev, &ring->first_seg,
+			&ring->last_seg, num_segs, 1, type,
+			max_packet, flags);
+	if (ret)
+		goto fail;
+
+	if (type != TYPE_EVENT)
+		ring->last_seg->trbs[TRBS_PER_SEGMENT - 1].link.control |=
+			cpu_to_le32(LINK_TOGGLE);
+
+	gadget_initialize_ring_info(ring);
+
+	return ring;
+
+fail:
+	kfree(ring);
+
+	return NULL;
+}
+
+static int gadget_insert_segment_mapping(struct radix_tree_root *addr_map,
+		struct gadget_ring *ring, struct gadget_segment *seg, gfp_t mem_flags)
+{
+	unsigned long key;
+	int ret;
+
+	key = (unsigned long)(seg->dma >> TRB_SEGMENT_SHIFT);
+
+	if (radix_tree_lookup(addr_map, key))
+		return 0;
+
+	ret = radix_tree_maybe_preload(mem_flags);
+	if (ret)
+		return ret;
+
+	ret = radix_tree_insert(addr_map, key, ring);
+	radix_tree_preload_end();
+
+	return ret;
+}
+
+static void gadget_remove_segment_mapping(struct radix_tree_root *addr_map,
+		struct gadget_segment *seg)
+{
+	unsigned long key;
+
+	key = (unsigned long)(seg->dma >> TRB_SEGMENT_SHIFT);
+	if (radix_tree_lookup(addr_map, key))
+		radix_tree_delete(addr_map, key);
+}
+
+static void gadget_remove_stream_mapping(struct gadget_ring *ring)
+{
+	struct gadget_segment *seg;
+
+	seg = ring->first_seg;
+	do {
+		gadget_remove_segment_mapping(ring->trb_address_map, seg);
+		seg = seg->next;
+	} while (seg != ring->first_seg);
+}
+
+static void gadget_ring_free(struct phytium_device *pdev,
+		struct gadget_ring *ring)
+{
+	if (!ring)
+		return;
+
+	if (ring->first_seg) {
+		if (ring->type == TYPE_STREAM)
+			gadget_remove_stream_mapping(ring);
+
+		gadget_free_segments_for_ring(pdev, ring->first_seg);
+	}
+
+	kfree(ring);
+}
+
+static void gadget_free_stream_ctx(struct phytium_device *pdev,
+		struct gadget_ep *pep)
+{
+	dma_pool_free(pdev->device_pool, pep->stream_info.stream_ctx_array,
+			pep->stream_info.ctx_array_dma);
+}
+
+static void gadget_free_stream_info(struct phytium_device *pdev,
+		struct gadget_ep *pep)
+{
+	struct gadget_stream_info *stream_info = &pep->stream_info;
+	struct gadget_ring *cur_ring;
+	int cur_stream;
+
+	if (!(pep->ep_state & EP_HAS_STREAMS))
+		return;
+
+	for (cur_stream = 1; cur_stream < stream_info->num_streams;
+			cur_stream++) {
+		cur_ring = stream_info->stream_rings[cur_stream];
+		if (cur_ring) {
+			gadget_ring_free(pdev, cur_ring);
+			stream_info->stream_rings[cur_stream] = NULL;
+		}
+	}
+
+	if (stream_info->stream_ctx_array)
+		gadget_free_stream_ctx(pdev, pep);
+
+	kfree(stream_info->stream_rings);
+	pep->ep_state &= ~EP_HAS_STREAMS;
+}
+
+void gadget_free_endpoint_rings(struct phytium_device *pdev,
+		struct gadget_ep *pep)
+{
+	gadget_ring_free(pdev, pep->ring);
+	pep->ring = NULL;
+	gadget_free_stream_info(pdev, pep);
+}
+
+static int gadget_alloc_erst(struct phytium_device *pdev,
+		struct gadget_ring *evt_ring,
+		struct gadget_erst *erst)
+{
+	struct gadget_erst_entry *entry;
+	struct gadget_segment *seg;
+	unsigned int val;
+	size_t size;
+
+	size = sizeof(struct gadget_erst_entry) * evt_ring->num_segs;
+	erst->entries = dma_alloc_coherent(pdev->dev, size,
+			&erst->erst_dma_addr, GFP_KERNEL);
+	if (!erst->entries)
+		return -ENOMEM;
+
+	erst->num_entries = evt_ring->num_segs;
+	seg = evt_ring->first_seg;
+	for (val = 0; val < evt_ring->num_segs; val++) {
+		entry = &erst->entries[val];
+		entry->seg_addr = cpu_to_le64(seg->dma);
+		entry->seg_size = cpu_to_le32(TRBS_PER_SEGMENT);
+		entry->rsvd = 0;
+		seg = seg->next;
+	}
+
+	return 0;
+}
+
+static void gadget_free_erst(struct phytium_device *pdev,
+		struct gadget_erst *erst)
+{
+	size_t size = sizeof(struct gadget_erst_entry) * (erst->num_entries);
+	struct device *dev = pdev->dev;
+
+	if (erst->entries)
+		dma_free_coherent(dev, size, erst->entries,
+				erst->erst_dma_addr);
+
+	erst->entries = NULL;
+}
+
+static void gadget_set_event_deq(struct phytium_device *pdev)
+{
+	dma_addr_t deq;
+	u64 temp;
+
+	deq = gadget_trb_virt_to_dma(pdev->event_ring->deq_seg,
+			pdev->event_ring->dequeue);
+
+	temp = lo_hi_readq(&pdev->ir_set->erst_dequeue);
+	temp &= ERST_PTR_MASK;
+	temp &= ~ERST_EHB;
+	lo_hi_writeq(((u64)deq & (u64)~ERST_PTR_MASK) | temp,
+			&pdev->ir_set->erst_dequeue);
+}
+
+static void gadget_add_in_port(struct phytium_device *pdev,
+		struct gadget_port *port, __le32 __iomem *addr)
+{
+	u32 temp, port_offset, port_count;
+
+	temp = readl(addr);
+	port->maj_rev = GADGET_EXT_PORT_MAJOR(temp);
+	port->min_rev = GADGET_EXT_PORT_MINOR(temp);
+
+	temp = readl(addr + 2);
+	port_offset = GADGET_EXT_PORT_OFF(temp);
+	port_count = GADGET_EXT_PORT_COUNT(temp);
+
+	port->port_num = port_offset;
+	port->exist = 1;
+}
+
+static int gadget_setup_port_arrays(struct phytium_device *pdev)
+{
+	void __iomem *base;
+	u32 offset;
+	int i;
+
+	base = &pdev->cap_regs->hc_capbase;
+	offset = phytium_gadget_find_next_ext_cap(base, 0,
+			EXT_CAP_CFG_DEV_20PORT_CAP_ID);
+	pdev->port20_regs = base + offset;
+
+	offset = phytium_gadget_find_next_ext_cap(base, 0,
+			D_XEC_CFG_3XPORT_CAP);
+	pdev->port3x_regs = base + offset;
+
+	offset = 0;
+	base = &pdev->cap_regs->hc_capbase;
+
+	for (i = 0; i < 2; i++) {
+		u32 temp;
+
+		offset = phytium_gadget_find_next_ext_cap(base, offset,
+				EXT_CAPS_PROTOCOL);
+		temp = readl(base + offset);
+
+		if (GADGET_EXT_PORT_MAJOR(temp) == 0x03 &&
+				!pdev->usb3_port.port_num)
+			gadget_add_in_port(pdev, &pdev->usb3_port,
+					base + offset);
+
+		if (GADGET_EXT_PORT_MAJOR(temp) == 0x02 &&
+				!pdev->usb2_port.port_num)
+			gadget_add_in_port(pdev, &pdev->usb2_port,
+					base + offset);
+	}
+
+	pdev->usb2_port.regs = (struct gadget_port_regs __iomem *)
+		(&pdev->op_regs->port_reg_base + NUM_PORT_REGS * (pdev->usb2_port.port_num - 1));
+
+	pdev->usb3_port.regs = (struct gadget_port_regs __iomem *)
+		(&pdev->op_regs->port_reg_base + NUM_PORT_REGS * (pdev->usb3_port.port_num - 1));
+
+	return 0;
+}
+
+static int gadget_init_device_ctx(struct phytium_device *pdev)
+{
+	int size = HCC_64BYTE_CONTEXT(pdev->hcc_params) ? 2048 : 1024;
+
+	pdev->out_ctx.type = GADGET_CTX_TYPE_DEVICE;
+	pdev->out_ctx.size = size;
+	pdev->out_ctx.ctx_size = CTX_SIZE(pdev->hcc_params);
+	pdev->out_ctx.bytes = dma_pool_zalloc(pdev->device_pool, GFP_ATOMIC,
+			&pdev->out_ctx.dma);
+	if (!pdev->out_ctx.bytes)
+		return -ENOMEM;
+
+	pdev->in_ctx.type = GADGET_CTX_TYPE_INPUT;
+	pdev->in_ctx.ctx_size = pdev->out_ctx.ctx_size;
+	pdev->in_ctx.size = size + pdev->out_ctx.ctx_size;
+	pdev->in_ctx.bytes = dma_pool_zalloc(pdev->device_pool, GFP_ATOMIC,
+			&pdev->in_ctx.dma);
+
+	if (!pdev->in_ctx.bytes) {
+		dma_pool_free(pdev->device_pool, pdev->out_ctx.bytes,
+				pdev->out_ctx.dma);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static int gadget_alloc_priv_device(struct phytium_device *pdev)
+{
+	int ret;
+
+	ret = gadget_init_device_ctx(pdev);
+	if (ret)
+		return ret;
+
+	pdev->eps[0].ring = gadget_ring_alloc(pdev, 2, TYPE_CTRL, 0,
+			GFP_ATOMIC);
+	if (!pdev->eps[0].ring)
+		goto fail;
+
+	pdev->dcbaa->dev_context_ptrs[1] = cpu_to_le64(pdev->out_ctx.dma);
+	pdev->cmd.in_ctx = &pdev->in_ctx;
+
+	return 0;
+
+fail:
+	dma_pool_free(pdev->device_pool, pdev->out_ctx.bytes,
+			pdev->out_ctx.dma);
+	dma_pool_free(pdev->device_pool, pdev->in_ctx.bytes,
+			pdev->in_ctx.dma);
+
+	return ret;
+}
+
+int gadget_mem_init(void *data)
+{
+	unsigned int val;
+	u32 page_size;
+	dma_addr_t dma;
+	int ret = -ENOMEM;
+	u64 val_64;
+	struct phytium_device *pdev = (struct phytium_device *)data;
+
+	if (!pdev)
+		return 0;
+
+	page_size = 1 << 12;
+
+	val = readl(&pdev->op_regs->config_reg);
+	val |= ((val & ~MAX_DEVS) | GADGET_DEV_MAX_SLOTS) | CONFIG_U3E;
+	writel(val, &pdev->op_regs->config_reg);
+
+	pdev->dcbaa = dma_alloc_coherent(pdev->dev, sizeof(*pdev->dcbaa),
+			&dma, GFP_KERNEL);
+	if (!pdev->dcbaa)
+		return -ENOMEM;
+
+	pdev->dcbaa->dma = dma;
+	lo_hi_writeq(dma, &pdev->op_regs->dcbaa_ptr);
+
+	pdev->segment_pool = dma_pool_create("gadget input/output contexts",
+				pdev->dev, TRB_SEGMENT_SIZE, TRB_SEGMENT_SIZE,
+				page_size);
+	if (!pdev->segment_pool)
+		goto release_dcbaa;
+
+	pdev->device_pool = dma_pool_create("gadget input/output contexts",
+				pdev->dev, GADGET_CTX_SIZE, 64, page_size);
+	if (!pdev->device_pool)
+		goto destroy_segment_pool;
+
+	pdev->cmd_ring = gadget_ring_alloc(pdev, 1, TYPE_COMMAND, 0,
+			GFP_KERNEL);
+	if (!pdev->cmd_ring)
+		goto destroy_device_pool;
+
+	val_64 = lo_hi_readq(&pdev->op_regs->cmd_ring);
+	val_64 = (val_64 & (u64)CMD_RING_RSVD_BITS) |
+		(pdev->cmd_ring->first_seg->dma & (u64)~CMD_RING_RSVD_BITS) |
+		pdev->cmd_ring->cycle_state;
+	lo_hi_writeq(val_64, &pdev->op_regs->cmd_ring);
+
+	val = readl(&pdev->cap_regs->db_off);
+	val &= DBOFF_MASK;
+	pdev->dba = (void __iomem *)pdev->cap_regs + val;
+	pdev->ir_set = &pdev->run_regs->ir_set[0];
+
+	pdev->event_ring = gadget_ring_alloc(pdev, ERST_NUM_SEGS, TYPE_EVENT,
+				0, GFP_KERNEL);
+	if (!pdev->event_ring)
+		goto free_cmd_ring;
+
+	ret = gadget_alloc_erst(pdev, pdev->event_ring, &pdev->erst);
+	if (ret)
+		goto free_event_ring;
+
+	val = readl(&pdev->ir_set->erst_size);
+	val &= ERST_SIZE_MASK;
+	val |= ERST_NUM_SEGS;
+	writel(val, &pdev->ir_set->erst_size);
+
+	val_64 = lo_hi_readq(&pdev->ir_set->erst_base);
+	val_64 &= ERST_PTR_MASK;
+	val_64 |= (pdev->erst.erst_dma_addr & (u64)~ERST_PTR_MASK);
+	lo_hi_writeq(val_64, &pdev->ir_set->erst_base);
+
+	gadget_set_event_deq(pdev);
+
+	ret = gadget_setup_port_arrays(pdev);
+	if (ret)
+		goto free_erst;
+
+	ret = gadget_alloc_priv_device(pdev);
+	if (ret) {
+		dev_err(pdev->dev, "gadget_alloc_priv_device failed\n");
+		goto free_erst;
+	}
+
+	return 0;
+free_erst:
+	gadget_free_erst(pdev, &pdev->erst);
+free_event_ring:
+	gadget_ring_free(pdev, pdev->event_ring);
+free_cmd_ring:
+	gadget_ring_free(pdev, pdev->cmd_ring);
+destroy_device_pool:
+	dma_pool_destroy(pdev->device_pool);
+destroy_segment_pool:
+	dma_pool_destroy(pdev->segment_pool);
+
+release_dcbaa:
+	dma_free_coherent(pdev->dev, sizeof(*pdev->dcbaa), pdev->dcbaa,
+			pdev->dcbaa->dma);
+
+	gadget_reset(pdev);
+
+	return ret;
+}
+
+static u32 gadget_get_endpoint_type(const struct usb_endpoint_descriptor *desc)
+{
+	int in;
+
+	in = usb_endpoint_dir_in(desc);
+
+	switch (usb_endpoint_type(desc)) {
+	case USB_ENDPOINT_XFER_CONTROL:
+		return CTRL_EP;
+	case USB_ENDPOINT_XFER_BULK:
+		return in ? BULK_IN_EP : BULK_OUT_EP;
+	case USB_ENDPOINT_XFER_ISOC:
+		return in ? ISOC_IN_EP : ISOC_OUT_EP;
+	case USB_ENDPOINT_XFER_INT:
+		return in ? INT_IN_EP : INT_OUT_EP;
+	}
+
+	return 0;
+}
+
+static unsigned int gadget_parse_exponent_interval(struct usb_gadget *g,
+		struct gadget_ep *pep)
+{
+	unsigned int interval;
+
+	interval = clamp_val(pep->endpoint.desc->bInterval, 1, 16) - 1;
+	if (interval != pep->endpoint.desc->bInterval - 1)
+		dev_warn(&g->dev, "ep %s -rounding interval to %d %s frames\n",
+			pep->name, 1 << interval,
+			g->speed == USB_SPEED_FULL ? "" : "micro");
+
+	if (g->speed == USB_SPEED_FULL)
+		interval += 3;
+
+	if (interval > 12)
+		interval = 12;
+
+	return interval;
+}
+
+static unsigned int gadget_microframes_to_exponent(struct usb_gadget *g,
+		struct gadget_ep *pep, unsigned int desc_interval,
+		unsigned int min_exponent, unsigned int max_exponent)
+{
+	unsigned int interval;
+
+	interval = fls(desc_interval) - 1;
+
+	return clamp_val(interval, min_exponent, max_exponent);
+}
+
+static u32 gadget_get_max_esit_payload(struct usb_gadget *g,
+		struct gadget_ep *pep)
+{
+	int max_packet;
+	int max_burst;
+
+	if (usb_endpoint_xfer_control(pep->endpoint.desc) ||
+	    usb_endpoint_xfer_bulk(pep->endpoint.desc))
+		return 0;
+
+	if (g->speed >= USB_SPEED_SUPER_PLUS &&
+			USB_SS_SSP_ISOC_COMP(pep->endpoint.desc->bmAttributes))
+		return le16_to_cpu(pep->endpoint.comp_desc->wBytesPerInterval);
+	else if (g->speed >= USB_SPEED_SUPER)
+		return le16_to_cpu(pep->endpoint.comp_desc->wBytesPerInterval);
+
+	max_packet = usb_endpoint_maxp(pep->endpoint.desc);
+	max_burst = usb_endpoint_maxp_mult(pep->endpoint.desc);
+
+	return max_packet * max_burst;
+}
+
+static unsigned int gadget_get_endpoint_interval(struct usb_gadget *g,
+		struct gadget_ep *pep)
+{
+	unsigned int interval = 0;
+
+	switch (g->speed) {
+	case USB_SPEED_HIGH:
+	case USB_SPEED_SUPER:
+	case USB_SPEED_SUPER_PLUS:
+		if (usb_endpoint_xfer_int(pep->endpoint.desc) ||
+		    usb_endpoint_xfer_isoc(pep->endpoint.desc))
+			interval = gadget_parse_exponent_interval(g, pep);
+		break;
+	case USB_SPEED_FULL:
+		if (usb_endpoint_xfer_isoc(pep->endpoint.desc))
+			interval = gadget_parse_exponent_interval(g, pep);
+		else if (usb_endpoint_xfer_int(pep->endpoint.desc)) {
+			interval = pep->endpoint.desc->bInterval << 3;
+			interval = gadget_microframes_to_exponent(g, pep,
+					interval, 3, 10);
+		}
+		break;
+	default:
+		break;
+	}
+
+	return interval;
+}
+
+static u32 gadget_get_endpoint_mult(struct usb_gadget *g, struct gadget_ep *pep)
+{
+	if (g->speed < USB_SPEED_SUPER ||
+		!usb_endpoint_xfer_isoc(pep->endpoint.desc))
+		return 0;
+
+	return pep->endpoint.comp_desc->bmAttributes;
+}
+
+static u32 gadget_get_endpoint_max_burst(struct usb_gadget *g,
+		struct gadget_ep *pep)
+{
+	if (g->speed >= USB_SPEED_SUPER)
+		return pep->endpoint.comp_desc->bMaxBurst;
+
+	if (g->speed == USB_SPEED_HIGH &&
+		(usb_endpoint_xfer_isoc(pep->endpoint.desc) ||
+		 usb_endpoint_xfer_int(pep->endpoint.desc)))
+		return usb_endpoint_maxp_mult(pep->endpoint.desc) - 1;
+
+	return 0;
+}
+
+int gadget_endpoint_init(struct phytium_device *pdev,
+		struct gadget_ep *pep, gfp_t mem_flags)
+{
+	enum gadget_ring_type ring_type;
+	struct gadget_ep_ctx *ep_ctx;
+	unsigned int err_count = 0;
+	unsigned int avg_trb_len, max_packet, max_burst, interval, mult;
+	u32 max_esit_payload, endpoint_type;
+	int ret;
+
+	ep_ctx = pep->in_ctx;
+
+	endpoint_type = gadget_get_endpoint_type(pep->endpoint.desc);
+	if (!endpoint_type)
+		return -EINVAL;
+
+	ring_type = usb_endpoint_type(pep->endpoint.desc);
+
+	max_esit_payload = gadget_get_max_esit_payload(&pdev->gadget, pep);
+	interval = gadget_get_endpoint_interval(&pdev->gadget, pep);
+	mult = gadget_get_endpoint_mult(&pdev->gadget, pep);
+	max_packet = usb_endpoint_maxp(pep->endpoint.desc);
+	max_burst = gadget_get_endpoint_max_burst(&pdev->gadget, pep);
+	avg_trb_len = max_esit_payload;
+
+	if (!usb_endpoint_xfer_isoc(pep->endpoint.desc))
+		err_count = 3;
+
+	if (usb_endpoint_xfer_bulk(pep->endpoint.desc) &&
+		pdev->gadget.speed == USB_SPEED_HIGH)
+		max_packet = 512;
+
+	if (usb_endpoint_xfer_control(pep->endpoint.desc))
+		avg_trb_len = 8;
+
+	pep->ring = gadget_ring_alloc(pdev, 2, ring_type, max_packet,
+					mem_flags);
+	if (!pep->ring)
+		return -ENOMEM;
+
+	pep->skip = false;
+
+	ep_ctx->ep_info = cpu_to_le32(EP_INTERVAL(interval) | EP_MULT(mult) |
+		EP_MAX_ESIT_PAYLOAD_HI(max_esit_payload));
+
+	ep_ctx->ep_info2 = cpu_to_le32(EP_TYPE(endpoint_type) |
+			MAX_PACKET(max_packet) | MAX_BURST(max_burst) |
+			ERROR_COUNT(err_count));
+
+	ep_ctx->deq = cpu_to_le64(pep->ring->first_seg->dma |
+			pep->ring->cycle_state);
+
+	ep_ctx->tx_info = cpu_to_le32(EP_MAX_ESIT_PAYLOAD_LO(max_esit_payload) |
+			EP_AVG_TRB_LENGTH(avg_trb_len));
+
+	if (usb_endpoint_xfer_bulk(pep->endpoint.desc) &&
+		pdev->gadget.speed > USB_SPEED_HIGH) {
+		ret = gadget_alloc_streams(pdev, pep);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int gadget_update_stream_segment_mapping(struct radix_tree_root *trb_address_map,
+			struct gadget_ring *ring, struct gadget_segment *first_seg,
+			struct gadget_segment *last_seg, gfp_t mem_flags)
+{
+	struct gadget_segment *failed_seg;
+	struct gadget_segment *seg;
+	int ret;
+
+	seg = first_seg;
+	do {
+		ret = gadget_insert_segment_mapping(trb_address_map, ring, seg, mem_flags);
+		if (ret)
+			goto remove_streams;
+
+		if (seg == last_seg)
+			return 0;
+
+		seg = seg->next;
+	} while (seg != first_seg);
+
+	return 0;
+
+remove_streams:
+	failed_seg = seg;
+	seg = first_seg;
+	do {
+		gadget_remove_segment_mapping(trb_address_map, seg);
+		if (seg == failed_seg)
+			return ret;
+		seg = seg->next;
+	} while (seg != first_seg);
+
+	return ret;
+}
+
+static void gadget_link_rings(struct phytium_device *pdev, struct gadget_ring *ring,
+		struct gadget_segment *first, struct gadget_segment *last, unsigned int num_segs)
+{
+	struct gadget_segment *next;
+
+	if (!ring || !first || !last)
+		return;
+
+	next = ring->enq_seg->next;
+	gadget_link_segments(pdev, ring->enq_seg, first, ring->type);
+	gadget_link_segments(pdev, last, next, ring->type);
+	ring->num_segs += num_segs;
+	ring->num_trbs_free = (TRBS_PER_SEGMENT - 1) * num_segs;
+
+	if (ring->type != TYPE_EVENT && ring->enq_seg == ring->last_seg) {
+		ring->last_seg->trbs[TRBS_PER_SEGMENT - 1].link.control &=
+			~cpu_to_le32(LINK_TOGGLE);
+		last->trbs[TRBS_PER_SEGMENT - 1].link.control |= cpu_to_le32(LINK_TOGGLE);
+		ring->last_seg = last;
+	}
+}
+
+int gadget_ring_expansion(struct phytium_device *pdev, struct gadget_ring *ring,
+		unsigned int num_trbs, gfp_t flags)
+{
+	unsigned int num_segs_needed;
+	struct gadget_segment *first;
+	struct gadget_segment *last;
+	unsigned int num_segs;
+	int ret;
+
+	num_segs_needed = (num_trbs + (TRBS_PER_SEGMENT - 1) - 1)/
+		(TRBS_PER_SEGMENT - 1);
+
+	num_segs = max(ring->num_segs, num_segs_needed);
+
+	ret = gadget_alloc_segments_for_ring(pdev, &first, &last, num_segs,
+			ring->cycle_state, ring->type, ring->bounce_buf_len, flags);
+	if (ret)
+		return -ENOMEM;
+
+	if (ring->type == TYPE_STREAM)
+		ret = gadget_update_stream_segment_mapping(ring->trb_address_map, ring,
+				first, last, flags);
+	if (ret) {
+		gadget_free_segments_for_ring(pdev, first);
+		return ret;
+	}
+
+	gadget_link_rings(pdev, ring, first, last, num_segs);
+
+	return 0;
+}
+
+void gadget_endpoint_zero(struct phytium_device *pdev, struct gadget_ep *pep)
+{
+	pep->in_ctx->ep_info = 0;
+	pep->in_ctx->ep_info2 = 0;
+	pep->in_ctx->deq = 0;
+	pep->in_ctx->tx_info = 0;
+}
+
+static void gadget_free_priv_device(struct phytium_device *pdev)
+{
+	pdev->dcbaa->dev_context_ptrs[1] = 0;
+
+	gadget_free_endpoint_rings(pdev, &pdev->eps[0]);
+
+	if (pdev->in_ctx.bytes)
+		dma_pool_free(pdev->device_pool, pdev->in_ctx.bytes, pdev->in_ctx.dma);
+
+	if (pdev->out_ctx.bytes)
+		dma_pool_free(pdev->device_pool, pdev->out_ctx.bytes, pdev->out_ctx.dma);
+
+	pdev->in_ctx.bytes = NULL;
+	pdev->out_ctx.bytes = NULL;
+}
+
+void gadget_mem_cleanup(void *data)
+{
+	struct phytium_device *pdev = (struct phytium_device *)data;
+	struct device *dev = pdev->dev;
+
+	gadget_free_priv_device(pdev);
+	gadget_free_erst(pdev, &pdev->erst);
+
+	if (pdev->event_ring)
+		gadget_ring_free(pdev, pdev->event_ring);
+	pdev->event_ring = NULL;
+
+	if (pdev->cmd_ring)
+		gadget_ring_free(pdev, pdev->cmd_ring);
+	pdev->cmd_ring = NULL;
+
+	dma_pool_destroy(pdev->segment_pool);
+	pdev->segment_pool = NULL;
+
+	dma_pool_destroy(pdev->device_pool);
+	pdev->device_pool = NULL;
+
+	dma_free_coherent(dev, sizeof(*pdev->dcbaa), pdev->dcbaa, pdev->dcbaa->dma);
+	pdev->dcbaa = NULL;
+
+	pdev->usb2_port.exist = 0;
+	pdev->usb3_port.exist = 0;
+	pdev->usb2_port.port_num = 0;
+	pdev->usb3_port.port_num = 0;
+	pdev->active_port = NULL;
+}
+
+int gadget_setup_addressable_priv_dev(void *data)
+{
+	struct phytium_device *pdev = (struct phytium_device *)data;
+	struct gadget_slot_ctx *slot_ctx;
+	struct gadget_ep_ctx *ep0_ctx;
+	u32 max_packets, port;
+
+	ep0_ctx = gadget_get_ep_ctx(&pdev->in_ctx, 0);
+	slot_ctx = gadget_get_slot_ctx(&pdev->in_ctx);
+
+	slot_ctx->dev_info |= cpu_to_le32(LAST_CTX(1));
+
+	switch (pdev->gadget.speed) {
+	case USB_SPEED_SUPER_PLUS:
+		slot_ctx->dev_info |= cpu_to_le32(SLOT_SPEED_SSP);
+		max_packets = MAX_PACKET(512);
+		break;
+	case USB_SPEED_SUPER:
+		slot_ctx->dev_info |= cpu_to_le32(SLOT_SPEED_SS);
+		max_packets = MAX_PACKET(512);
+		break;
+	case USB_SPEED_HIGH:
+		slot_ctx->dev_info |= cpu_to_le32(SLOT_SPEED_HS);
+		max_packets = MAX_PACKET(64);
+		break;
+	case USB_SPEED_FULL:
+		slot_ctx->dev_info |= cpu_to_le32(SLOT_SPEED_FS);
+		max_packets = MAX_PACKET(64);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	port = DEV_PORT(pdev->active_port->port_num);
+	slot_ctx->dev_port |= cpu_to_le32(port);
+	slot_ctx->dev_state = cpu_to_le32((pdev->device_address & DEV_ADDR_MASK));
+	ep0_ctx->tx_info = cpu_to_le32(EP_AVG_TRB_LENGTH(0x8));
+	ep0_ctx->ep_info2 = cpu_to_le32(EP_TYPE(CTRL_EP));
+	ep0_ctx->ep_info2 |= cpu_to_le32(MAX_BURST(0) | ERROR_COUNT(3) | max_packets);
+	ep0_ctx->deq = cpu_to_le64(pdev->eps[0].ring->first_seg->dma |
+			pdev->eps[0].ring->cycle_state);
+
+	return 0;
+}
+
+void gadget_copy_ep0_dequeue_into_input_ctx(void *data)
+{
+	struct phytium_device *pdev = (struct phytium_device *)data;
+	struct gadget_ring *ep_ring = pdev->eps[0].ring;
+	struct gadget_ep_ctx *ep0_ctx = pdev->eps[0].in_ctx;
+	dma_addr_t dma;
+
+	dma = gadget_trb_virt_to_dma(ep_ring->enq_seg, ep_ring->enqueue);
+	ep0_ctx->deq = cpu_to_le64(dma | ep_ring->cycle_state);
+}
+
+struct gadget_ring *gadget_dma_to_transfer_ring(struct gadget_ep *pep, u64 address)
+{
+	if (pep->ep_state & EP_HAS_STREAMS)
+		return radix_tree_lookup(&pep->stream_info.trb_address_map,
+				address >> TRB_SEGMENT_SHIFT);
+
+	return pep->ring;
+}

--- a/drivers/usb/phytium_usb_v2/mem.h
+++ b/drivers/usb/phytium_usb_v2/mem.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LINUX_PHYTIUM_USB_MEM_H__
+#define __LINUX_PHYTIUM_USB_MEM_H__
+
+int gadget_mem_init(void *data);
+void gadget_mem_cleanup(void *data);
+int gadget_setup_addressable_priv_dev(void *data);
+void gadget_copy_ep0_dequeue_into_input_ctx(void *data);
+
+#endif

--- a/drivers/usb/phytium_usb_v2/otg.c
+++ b/drivers/usb/phytium_usb_v2/otg.c
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/delay.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+
+#include "core.h"
+#include "otg.h"
+
+#define OTG_NRDY	BIT(11)
+#define OTG_HOST_MODE	BIT(12)
+#define OTG_DEVICE_MODE	BIT(13)
+
+#define OVERRIDE_IDPULLUP  BIT(0)
+#define OVERRIDE_SESS_VLD_SEL	BIT(10)
+
+#define OTGIEN_ID_CHANGE	BIT(0)
+#define OTGIEN_VBUSVALID_RISE	BIT(4)
+#define OTGIEN_VBUSVALID_FALL	BIT(5)
+
+#define OTGIEN_ID_CHANGE_INT		BIT(0)
+#define OTGIEN_VBUSVALID_RISE_INT	BIT(4)
+#define OTGIEN_VBUSVALID_FALL_INT	BIT(5)
+
+#define OTGCMD_DEV_BUS_REQ	BIT(0)
+#define OTGCMD_HOST_BUS_REQ	BIT(1)
+#define OTGCMD_OTG_DIS		BIT(3)
+#define OTGCMD_DEV_BUS_DROP	BIT(8)
+#define OTGCMD_HOST_BUS_DROP	BIT(9)
+
+#define OTGSTS_HOST_READY	BIT(27)
+#define OTGSTS_DEV_READY	BIT(26)
+#define OTGSTS_VBUS_VALID	BIT(1)
+#define OTGSTS_ID_VALUE		BIT(0)
+
+#define OTGSTATE_HOST_STATE_MASK	GENMASK(5, 3)
+#define OTGSTATE_DEV_STATE_MASK		GENMASK(2, 0)
+
+#define ID_HOST			0
+#define ID_PERIPHERAL	1
+//0 NONE  1:HOST 2:DEVICE
+
+static int switch_role(struct phytium_usb *phytium_usb, enum usb_role role)
+{
+	int ret = 0;
+
+	if (phytium_usb->dr_mode == USB_DR_MODE_HOST) {
+		switch (role) {
+		case USB_ROLE_NONE:
+		case USB_ROLE_HOST:
+			break;
+		default:
+			return ret;
+		}
+	}
+
+	if (phytium_usb->dr_mode == USB_DR_MODE_PERIPHERAL) {
+		switch (role) {
+		case USB_ROLE_NONE:
+		case USB_ROLE_DEVICE:
+			break;
+		default:
+			return ret;
+		}
+	}
+
+	phytium_usb_role_stop(phytium_usb);
+	ret = phytium_usb_role_start(phytium_usb, role);
+	if (ret)
+		dev_err(phytium_usb->dev, "set role %d has failed\n", role);
+
+	return ret;
+}
+
+static ssize_t role_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct phytium_usb *phytium_usb = dev_get_drvdata(dev);
+
+	return sprintf(buf, "%u\n", phytium_usb->role);
+}
+
+static ssize_t role_store(struct device *dev, struct device_attribute *attr,
+		const char *buf, size_t count)
+{
+	struct phytium_usb *phytium_usb = dev_get_drvdata(dev);
+	unsigned int role;
+	int ret;
+
+	ret = kstrtouint(buf, 10, &role);
+	if (ret)
+		return ret;
+
+	if (role != phytium_usb->role) {
+		dev_err(phytium_usb->dev, "role switch %d -> %d\n", phytium_usb->role, role);
+		switch_role(phytium_usb, (enum usb_role)role);
+	}
+
+	return count;
+}
+
+static DEVICE_ATTR_RW(role);
+
+static struct attribute *phytium_attributes[] = {
+	&dev_attr_role.attr,
+	NULL
+};
+
+static const struct attribute_group phytium_attr_group = {
+	.attrs = phytium_attributes,
+};
+
+bool phytium_usb_otg_power_is_lost(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		if (!(readl(&phytium_usb->otg_regs->simulate) & BIT(0)))
+			return true;
+	}
+
+	return false;
+}
+
+int phytium_usb_otg_is_host(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		if (phytium_usb->dr_mode == USB_DR_MODE_HOST)
+			return true;
+		else if (phytium_usb_otg_get_id(data) == ID_HOST)
+			return true;
+	}
+
+	return false;
+}
+
+int phytium_usb_otg_is_device(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		if (phytium_usb->dr_mode == USB_DR_MODE_PERIPHERAL)
+			return true;
+		else if (phytium_usb->dr_mode == USB_DR_MODE_OTG)
+			if (phytium_usb_otg_get_id(data) == ID_PERIPHERAL)
+				return true;
+	}
+
+	return false;
+}
+
+int phytium_usb_otg_get_id(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	int id = 0;
+
+	if (phytium_usb)
+		id = !!(readl(&phytium_usb->otg_regs->sts) & OTGSTS_ID_VALUE);
+
+	dev_err(phytium_usb->dev, "OTG ID: %d\n", id);
+
+	return id;
+}
+
+int phytium_usb_otg_get_vbus(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	int vbus = 0;
+
+	if (phytium_usb)
+		vbus = !!(readl(&phytium_usb->otg_regs->sts) & OTGSTS_VBUS_VALID);
+
+	dev_err(phytium_usb->dev, "OTG VBUS: %d\n", vbus);
+
+	return vbus;
+}
+
+static irqreturn_t phytium_usb_otg_thread_irq(int irq, void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb)
+		phytium_usb_hw_role_switch(phytium_usb);
+
+	return IRQ_HANDLED;
+}
+
+static irqreturn_t phytium_usb_otg_irq(int irq, void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+	irqreturn_t ret = IRQ_NONE;
+	u32 reg;
+
+	if (phytium_usb) {
+		if (phytium_usb->dr_mode != USB_DR_MODE_OTG)
+			return IRQ_NONE;
+
+		if (phytium_usb->in_lpm)
+			return ret;
+
+		reg = readl(&phytium_usb->otg_regs->ivect);
+		if (!reg)
+			return ret;
+
+		if (reg & OTGIEN_ID_CHANGE_INT) {
+			dev_err(phytium_usb->dev, "OTG IRQ: new ID:%d\n",
+					phytium_usb_otg_get_id(phytium_usb));
+			ret = IRQ_WAKE_THREAD;
+		}
+
+		if (reg & (OTGIEN_VBUSVALID_RISE_INT | OTGIEN_VBUSVALID_FALL_INT)) {
+			dev_err(phytium_usb->dev, "OTG IRQ: new VBUS: %d\n",
+					phytium_usb_otg_get_vbus(phytium_usb));
+			ret = IRQ_WAKE_THREAD;
+		}
+
+		writel(~0, &phytium_usb->otg_regs->ivect);
+	}
+
+	return ret;
+}
+
+int phytium_usb_otg_init(void *data)
+{
+	u32 state;
+	int ret;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		phytium_usb->otg_regs = devm_ioremap_resource(phytium_usb->dev,
+				&phytium_usb->otg_res);
+		if (IS_ERR(phytium_usb->otg_regs))
+			return PTR_ERR(phytium_usb->otg_regs);
+
+		state = readl(&phytium_usb->otg_regs->sts);
+		if (state & OTG_NRDY) {
+			dev_warn(phytium_usb->dev, "controller is not ready yet\n");
+			return -ENODEV;
+		}
+
+		phytium_usb->dr_mode = USB_DR_MODE_OTG;//USB_DR_MODE_PERIPHERAL;
+		if (OTG_HOST_MODE & state)
+			phytium_usb->dr_mode = USB_DR_MODE_HOST;
+		else if (OTG_DEVICE_MODE & state)
+			phytium_usb->dr_mode = USB_DR_MODE_PERIPHERAL;
+
+		ret = devm_request_threaded_irq(phytium_usb->dev, phytium_usb->otg_irq,
+			phytium_usb_otg_irq, phytium_usb_otg_thread_irq,
+			IRQF_SHARED, "phytium_usb_otg", phytium_usb);
+		if (ret) {
+			dev_warn(phytium_usb->dev, "request otg irq failed with:%d\n", ret);
+			return ret;
+		}
+
+		ret = devm_device_add_group(phytium_usb->dev, &phytium_attr_group);
+		if (ret)
+			dev_err(phytium_usb->dev, "Create sysfs attributes, err: %d\n", ret);
+	}
+
+	return 0;
+}
+
+int phytium_usb_otg_enable_iddig(void *data)
+{
+	u32 reg;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		reg = readl(&phytium_usb->otg_regs->override);
+		reg |= OVERRIDE_IDPULLUP;
+		writel(reg, &phytium_usb->otg_regs->override);
+		usleep_range(50000, 70000);
+	}
+
+	return 0;
+}
+
+int phytium_usb_otg_disable_irq(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb)
+		writel(0, &phytium_usb->otg_regs->ien);
+
+	return 0;
+}
+
+int phytium_usb_otg_clear_irq(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb)
+		writel(~0, &phytium_usb->otg_regs->ivect);
+
+	return 0;
+}
+
+int phytium_usb_otg_enable_irq(void *data)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb)
+		writel(OTGIEN_ID_CHANGE | OTGIEN_VBUSVALID_RISE |
+				OTGIEN_VBUSVALID_FALL,
+				&phytium_usb->otg_regs->ien);
+
+	return 0;
+}
+
+int phytium_usb_otg_host_on(void *data)
+{
+	int ret = 0;
+	u32 val;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		writel(OTGCMD_HOST_BUS_REQ | OTGCMD_OTG_DIS,
+				&phytium_usb->otg_regs->cmd);
+		ret = readl_poll_timeout_atomic(&phytium_usb->otg_regs->sts,
+				val, val & OTGSTS_HOST_READY, 1, 100000);
+		if (ret)
+			dev_err(phytium_usb->dev, "wait for host_ready fail\n");
+		phytium_usb->dr_mode = USB_DR_MODE_HOST;
+	}
+
+	return ret;
+}
+
+int phytium_usb_otg_host_off(void *data)
+{
+	u32 val;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		writel(OTGCMD_HOST_BUS_DROP | OTGCMD_DEV_BUS_DROP,
+			&phytium_usb->otg_regs->cmd);
+
+		readl_poll_timeout_atomic(&phytium_usb->otg_regs->state, val,
+				!(val & OTGSTATE_HOST_STATE_MASK), 1, 2000000);
+		phytium_usb->dr_mode = USB_DR_MODE_OTG;
+	}
+
+	return 0;
+}
+
+int phytium_usb_otg_gadget_on(void *data)
+{
+	int ret = 0;
+	u32 val;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		writel(OTGCMD_DEV_BUS_REQ | OTGCMD_OTG_DIS,
+				&phytium_usb->otg_regs->cmd);
+		ret = readl_poll_timeout_atomic(&phytium_usb->otg_regs->sts,
+				val, val & OTGSTS_DEV_READY, 1, 100000);
+		if (ret)
+			dev_err(phytium_usb->dev, "wait for host_ready fail\n");
+		phytium_usb->dr_mode = USB_DR_MODE_PERIPHERAL;
+	}
+
+	return ret;
+}
+
+int phytium_usb_otg_gadget_off(void *data)
+{
+	u32 val;
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)data;
+
+	if (phytium_usb) {
+		writel(OTGCMD_HOST_BUS_DROP | OTGCMD_DEV_BUS_DROP,
+			&phytium_usb->otg_regs->cmd);
+
+		readl_poll_timeout_atomic(&phytium_usb->otg_regs->state, val,
+				!(val & OTGSTATE_DEV_STATE_MASK), 1, 2000000);
+		phytium_usb->dr_mode = USB_DR_MODE_OTG;
+	}
+
+	return 0;
+}
+
+void phytium_usb_otg_uninit(void *data)
+{
+	phytium_usb_otg_host_off(data);
+	phytium_usb_otg_disable_irq(data);
+}
+
+MODULE_AUTHOR("Zhenhua Chen <chenzhenhua@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium USB2 DRD Controller Driver");

--- a/drivers/usb/phytium_usb_v2/otg.h
+++ b/drivers/usb/phytium_usb_v2/otg.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LINUX_PHYTIUM_USB_OTG_H__
+#define __LINUX_PHYTIUM_USB_OTG_H__
+
+
+struct phytium_usb_otg_regs {
+	__le32	did;			/*0x0*/
+	__le32	rid;			/*0x4*/
+	__le32	cfgs1;			/*0x8*/
+	__le32	cfgs2;			/*0xC*/
+	__le32	cmd;			/*0x10*/
+	__le32	sts;			/*0x14*/
+	__le32	state;			/*0x18*/
+	__le32	ien;			/*0x1C*/
+	__le32	ivect;			/*0x20*/
+	__le32	tmr;			/*0x24*/
+	__le32	simulate;		/*0x28*/
+	__le32	adpbc_sts;		/*0x2c*/
+	__le32	adp_ramp_time;		/*0x30*/
+	__le32	adpbc_ctrl1;		/*0x34*/
+	__le32	adpbc_ctrl2;		/*0x38*/
+	__le32	override;		/*0x3C*/
+	__le32	vbusvalid_dbnc_cfg;	/*0x40*/
+	__le32	sessvalid_dbnc_cfg;	/*0x44*/
+	__le32	susp_timing_ctrl;	/*0x48*/
+};
+
+int phytium_usb_otg_init(void *data);
+void phytium_usb_otg_uninit(void *data);
+int phytium_usb_otg_enable_iddig(void *data);
+int phytium_usb_otg_disable_irq(void *data);
+int phytium_usb_otg_clear_irq(void *data);
+int phytium_usb_otg_enable_irq(void *data);
+int phytium_usb_otg_host_on(void *data);
+int phytium_usb_otg_host_off(void *data);
+int phytium_usb_otg_gadget_on(void *data);
+int phytium_usb_otg_gadget_off(void *data);
+int phytium_usb_otg_get_id(void *data);
+int phytium_usb_otg_get_vbus(void *data);
+int phytium_usb_otg_is_host(void *data);
+int phytium_usb_otg_is_device(void *data);
+bool phytium_usb_otg_power_is_lost(void *data);
+
+#endif

--- a/drivers/usb/phytium_usb_v2/pci.c
+++ b/drivers/usb/phytium_usb_v2/pci.c
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/pci.h>
+
+#include "core.h"
+
+#define BAR_HOST_OFFSET		0x8000
+#define BAR_DEVICE_OFFSET	0x4000
+#define BAR_DEVICE_SIZE		0x4000
+#define BAR_OTG_SIZE		0x4000
+
+static int phytium_pci_probe(struct pci_dev *pdev,
+		const struct pci_device_id *id)
+{
+	int ret;
+
+	struct phytium_usb *phytium_usb;
+
+	ret = pcim_enable_device(pdev);
+	if (ret) {
+		dev_err(&pdev->dev, "pcim_enable_device failed\n");
+		goto put_pci;
+	}
+
+	pci_set_master(pdev);
+	if (pci_is_enabled(pdev)) {
+		phytium_usb = pci_get_drvdata(pdev);
+		if (!phytium_usb) {
+			phytium_usb = kzalloc(sizeof(*phytium_usb), GFP_KERNEL);
+			if (!phytium_usb) {
+				ret = -ENOMEM;
+				goto disabled_pci;
+			}
+		}
+	}
+
+	//otg resource init
+	phytium_usb->otg_res.start = pci_resource_start(pdev, 0);
+	phytium_usb->otg_res.end = phytium_usb->otg_res.start + BAR_OTG_SIZE;
+	phytium_usb->otg_res.name = "otg";
+	phytium_usb->otg_res.flags = IORESOURCE_MEM;
+	phytium_usb->otg_irq = pdev->irq;
+
+	//gadget resource init
+	phytium_usb->device_irq = pdev->irq;
+	phytium_usb->device_regs = devm_ioremap(&pdev->dev, pci_resource_start(pdev, 0)
+			+ BAR_DEVICE_OFFSET, BAR_DEVICE_SIZE);
+	if (IS_ERR(phytium_usb->device_regs)) {
+		dev_warn(&pdev->dev, "gadget ioremap failed\n");
+		return PTR_ERR(phytium_usb->device_regs);
+	}
+
+	//host resource init
+	dev_warn(&pdev->dev, "host resource init\n");
+	phytium_usb->host_res[0].start = pdev->irq;
+	phytium_usb->host_res[0].name = "host";
+	phytium_usb->host_res[0].flags = IORESOURCE_IRQ;
+
+	phytium_usb->host_res[1].start = pci_resource_start(pdev, 0) + BAR_HOST_OFFSET;
+	phytium_usb->host_res[1].end = pci_resource_end(pdev, 0) - BAR_HOST_OFFSET;
+	phytium_usb->host_res[1].name = "host";
+	phytium_usb->host_res[1].flags = IORESOURCE_MEM;
+
+	if (pci_is_enabled(pdev)) {
+		phytium_usb->dev = &pdev->dev;
+		pci_set_drvdata(pdev, phytium_usb);
+
+		ret = phytium_usb_init(phytium_usb);
+		if (ret) {
+			dev_err(&pdev->dev, "phytium_usb_init failed\n");
+			goto free_phytium_usb;
+		}
+	}
+
+	return 0;
+free_phytium_usb:
+	kfree(phytium_usb);
+
+disabled_pci:
+	pci_disable_device(pdev);
+
+put_pci:
+	pci_dev_put(pdev);
+
+	return 0;
+}
+
+static void phytium_pci_remove(struct pci_dev *pdev)
+{
+	struct phytium_usb *phytium_usb = (struct phytium_usb *)pci_get_drvdata(pdev);
+
+	if (!pci_is_enabled(pdev)) {
+		kfree(phytium_usb);
+		goto pci_put;
+	}
+
+	phytium_usb_uninit(phytium_usb);
+
+pci_put:
+	pci_dev_put(pdev);
+	pci_set_drvdata(pdev, NULL);
+}
+
+static int __maybe_unused phytium_pci_suspend(struct device *dev)
+{
+	struct phytium_usb *phytium_usb = dev_get_drvdata(dev);
+
+	return phytium_usb_suspend(phytium_usb);
+}
+
+static int __maybe_unused phytium_pci_resume(struct device *dev)
+{
+	struct phytium_usb *phytium_usb = dev_get_drvdata(dev);
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&phytium_usb->lock, flags);
+	ret = phytium_usb_resume(phytium_usb, 1);
+	spin_unlock_irqrestore(&phytium_usb->lock, flags);
+
+	return ret;
+}
+
+static const struct dev_pm_ops phytium_pci_pm_ops = {
+	SET_SYSTEM_SLEEP_PM_OPS(phytium_pci_suspend, phytium_pci_resume)
+};
+
+static const struct pci_device_id phytium_pci_ids[] = {
+	{ 0x10ee, 0x8012, PCI_ANY_ID, PCI_ANY_ID, 0, 0, 0 },
+	{ 0, }
+};
+
+static struct pci_driver phytium_pci_driver = {
+	.name = "phytium-pci",
+	.id_table = &phytium_pci_ids[0],
+	.probe = phytium_pci_probe,
+	.remove = phytium_pci_remove,
+	.driver = {
+		.pm = &phytium_pci_pm_ops,
+	}
+};
+
+module_pci_driver(phytium_pci_driver);
+MODULE_DEVICE_TABLE(pci, phytium_pci_ids);
+
+MODULE_ALIAS("pci:phytium");
+MODULE_AUTHOR("Chen Zhenhua <chenzhenhua@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium USB PCI driver");
+MODULE_VERSION(PHYTIUM_USB_DRIVER_V2_VERSION);

--- a/drivers/usb/phytium_usb_v2/platform.c
+++ b/drivers/usb/phytium_usb_v2/platform.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/platform_device.h>
+#include <linux/of_platform.h>
+#include <linux/pm_runtime.h>
+#include <linux/irq.h>
+#include <linux/acpi.h>
+
+#include "core.h"
+
+static int phytium_usbplat_probe(struct platform_device *pdev)
+{
+	struct phytium_usb *phytium_usb;
+	struct device *dev = &pdev->dev;
+	int irq;
+	struct resource *res;
+	int ret;
+
+	phytium_usb = devm_kzalloc(dev, sizeof(*phytium_usb), GFP_KERNEL);
+	if (!phytium_usb)
+		return -ENOMEM;
+
+	phytium_usb->dev = dev;
+	phytium_usb->platdata = dev_get_platdata(dev);
+
+	irq = platform_get_irq(pdev, 1);
+	if (irq < 0)
+		return -EINVAL;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (!res) {
+		dev_warn(dev, "get otg resource failed\n");
+		return -ENXIO;
+	}
+	phytium_usb->otg_res = *res;
+	phytium_usb->otg_irq = irq;
+
+	irq = platform_get_irq(pdev, 0);
+	if (irq < 0)
+		return -EINVAL;
+
+	phytium_usb->host_res[0].start = irq;
+	phytium_usb->host_res[0].end = irq;
+	phytium_usb->host_res[0].flags = IORESOURCE_IRQ | irq_get_trigger_type(irq);
+	phytium_usb->host_res[0].name = "host";
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 2);
+	if (!res) {
+		dev_warn(dev, "get host resource failed\n");
+		return -ENXIO;
+	}
+
+	phytium_usb->host_res[1] = *res;
+	phytium_usb->device_irq = irq;
+	phytium_usb->device_regs = devm_platform_ioremap_resource(pdev, 1);
+	if (IS_ERR(phytium_usb->device_regs))
+		return PTR_ERR(phytium_usb->device_regs);
+
+	ret = phytium_usb_init(phytium_usb);
+	if (ret)
+		return ret;
+
+	platform_set_drvdata(pdev, phytium_usb);
+
+	return 0;
+}
+
+static int phytium_usbplat_remove(struct platform_device *pdev)
+{
+	struct phytium_usb *phytium_usb = platform_get_drvdata(pdev);
+
+	if (phytium_usb)
+		phytium_usb_uninit(phytium_usb);
+
+	platform_set_drvdata(pdev, NULL);
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_SLEEP
+static int phytium_usbplat_suspend(struct device *dev)
+{
+	struct phytium_usb *phytium_usb = dev_get_drvdata(dev);
+
+	return  phytium_usb_suspend(phytium_usb);
+}
+
+static int phytium_usbplat_resume(struct device *dev)
+{
+	struct phytium_usb *phytium_usb = dev_get_drvdata(dev);
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&phytium_usb->lock, flags);
+	ret = phytium_usb_resume(phytium_usb, 1);
+	spin_unlock_irqrestore(&phytium_usb->lock, flags);
+
+	return ret;
+}
+#endif
+
+static const struct dev_pm_ops phytium_usbpm_ops = {
+	SET_SYSTEM_SLEEP_PM_OPS(phytium_usbplat_suspend, phytium_usbplat_resume)
+};
+
+#ifdef CONFIG_OF
+static const struct of_device_id of_phytium_usbmatch[] = {
+	{ .compatible = "phytium,usb2-2.0" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, of_phytium_usbmatch);
+#endif
+
+static const struct acpi_device_id acpi_phytium_usbmatch[] = {
+	{ "PHYT0064", },
+	{ }
+};
+MODULE_DEVICE_TABLE(acpi, acpi_phytium_usbmatch);
+
+static struct platform_driver phytium_usbdriver = {
+	.probe	= phytium_usbplat_probe,
+	.remove	= phytium_usbplat_remove,
+	.driver	= {
+		.name	= "phytium-usb2-2.0",
+		.of_match_table	= of_match_ptr(of_phytium_usbmatch),
+		.acpi_match_table = ACPI_PTR(acpi_phytium_usbmatch),
+		.pm	= &phytium_usbpm_ops,
+	},
+};
+
+module_platform_driver(phytium_usbdriver);
+
+MODULE_AUTHOR("Zhenhua Chen <chenzhenhua@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Phytium USB2 DRD Controller Driver");
+MODULE_VERSION(PHYTIUM_USB_DRIVER_V2_VERSION);

--- a/drivers/usb/phytium_usb_v2/ring.c
+++ b/drivers/usb/phytium_usb_v2/ring.c
@@ -1,0 +1,2293 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium USB DRD Driver.
+ *
+ * Copyright (C) 2023 - 2024 Phytium.
+ */
+#include <linux/dma-mapping.h>
+#include <linux/usb/composite.h>
+#include <linux/usb/gadget.h>
+#include <linux/list.h>
+#include "gadget.h"
+#include "ring.h"
+
+#define DB_VALUE(ep, stream)	((((ep) + 1) & 0xff) | ((stream) << 16))
+#define DB_VALUE_EP0_OUT(ep, stream) ((ep) & 0xff)
+#define DB_VALUE_CMD 0x0
+
+#define TRB_BSR	BIT(9)
+#define TRB_DC	BIT(9)
+
+#define TRB_SETUPID_BITMASK		GENMASK(9, 8)
+#define TRB_SETUPID(p)			((p) << 8)
+#define TRB_SETUPID_TO_TYPE(p)	(((p) & TRB_SETUPID_BITMASK) >> 8)
+
+#define TRB_SETUP_SPEED_USB3	0x1
+#define TRB_SETUP_SPEED_USB2	0x1
+
+#define TRB_FH_TO_PACKET_TYPE(p)	((p) & GENMASK(4, 0))
+#define TRB_FH_TO_DEVICE_ADDRESS(p)	(((p) << 25) & GENMASK(31, 25))
+#define TRB_FH_TO_NOT_TYPE(p)		(((p) << 4) & GENMASK(7, 4))
+#define TRB_FH_TO_INTERFACE(p)		(((p) << 8) & GENMASK(15, 8))
+#define TRB_FH_TR_PACKET	0x4
+#define TRB_FH_TR_PACKET_DEV_NOT 0x6
+#define TRB_FH_TR_PACKET_FUNCTION_WAKE 0x1
+
+#define TRB_SETUPSTAT_STALL	0x0
+#define TRB_SETUPSTAT_ACK	0x1
+#define TRB_SETUPSTAT(p)	((p) << 6)
+
+#define TRB_SIA				BIT(31)
+
+#define TRB_SETUP_SPEEDID(p)	((p) & (1 << 7))
+#define GET_PORT_ID(p)		(((p) & GENMASK(31, 24)) >> 24)
+#define SET_PORT_ID(p)		(((p) << 24) & GENMASK(31, 24))
+
+#define EVENT_TRB_LEN(p)	((p) & GENMASK(23, 0))
+
+#define TRB_TO_DEV_STREAM(p)	((p) & GENMASK(16, 0))
+#define TRB_TO_HOST_STREAM(p)	((p) & GENMASK(16, 0))
+#define STREAM_PRIME_ACK		0xFFFE
+#define STREAM_REJECTED			0xFFFF
+
+dma_addr_t gadget_trb_virt_to_dma(struct gadget_segment *seg,
+		union gadget_trb *trb)
+{
+	unsigned long segment_offset = trb - seg->trbs;
+
+	if (trb < seg->trbs || segment_offset >= TRBS_PER_SEGMENT)
+		return 0;
+
+	return seg->dma + (segment_offset * sizeof(*trb));
+}
+
+static bool gadget_room_on_ring(struct phytium_device *pdev,
+			struct gadget_ring *ring, unsigned int num_trbs)
+{
+	int num_trbs_in_deq_seg;
+
+	if (ring->num_trbs_free < num_trbs)
+		return false;
+
+	if (ring->type != TYPE_COMMAND && ring->type != TYPE_EVENT) {
+		num_trbs_in_deq_seg = ring->dequeue - ring->deq_seg->trbs;
+
+		if (ring->num_trbs_free < num_trbs + num_trbs_in_deq_seg)
+			return false;
+	}
+
+	return true;
+}
+
+static bool gadget_trb_is_noop(union gadget_trb *trb)
+{
+	return TRB_TYPE_NOOP_LE32(trb->generic.field[3]);
+}
+
+static bool gadget_trb_is_link(union gadget_trb *trb)
+{
+	return TRB_TYPE_LINK_LE32(trb->link.control);
+}
+
+static bool gadget_link_trb_toggles_cycle(union gadget_trb *trb)
+{
+	return le32_to_cpu(trb->link.control) & LINK_TOGGLE;
+}
+
+static int gadget_prepare_ring(struct phytium_device *pdev,
+		struct gadget_ring *ep_ring, u32 ep_state, unsigned int num_trbs,
+		gfp_t mem_flags)
+{
+	unsigned int num_trbs_needed;
+
+	switch (ep_state) {
+	case EP_STATE_STOPPED:
+	case EP_STATE_RUNNING:
+	case EP_STATE_HALTED:
+		break;
+	default:
+		dev_err(pdev->dev, "Error: incorrect endpoint state\n");
+		return -EINVAL;
+	}
+
+	while (1) {
+		if (gadget_room_on_ring(pdev, ep_ring, num_trbs))
+			break;
+
+		num_trbs_needed = num_trbs - ep_ring->num_trbs_free;
+		if (gadget_ring_expansion(pdev, ep_ring, num_trbs_needed, mem_flags)) {
+			dev_err(pdev->dev, "Ring expansion failed\n");
+			return -ENOMEM;
+		}
+	}
+
+	while (gadget_trb_is_link(ep_ring->enqueue)) {
+		ep_ring->enqueue->link.control |= cpu_to_le32(TRB_CHAIN);
+		/* The cycle bit must be set as the last operation. */
+		wmb();
+		ep_ring->enqueue->link.control ^= cpu_to_le32(TRB_CYCLE);
+
+		if (gadget_link_trb_toggles_cycle(ep_ring->enqueue))
+			ep_ring->cycle_state ^= 1;
+
+		ep_ring->enq_seg = ep_ring->enq_seg->next;
+		ep_ring->enqueue = ep_ring->enq_seg->trbs;
+	}
+
+	return 0;
+}
+
+static void gadget_inc_enq(struct phytium_device *pdev, struct gadget_ring *ring,
+			bool more_trbs_coming)
+{
+	union gadget_trb *next;
+	u32 chain;
+
+	chain = le32_to_cpu(ring->enqueue->generic.field[3]) & TRB_CHAIN;
+
+	if (!gadget_trb_is_link(ring->enqueue))
+		ring->num_trbs_free--;
+	next = ++(ring->enqueue);
+
+	while (gadget_trb_is_link(next)) {
+		if (!chain && !more_trbs_coming)
+			break;
+
+		next->link.control &= cpu_to_le32(~TRB_CHAIN);
+		next->link.control |= cpu_to_le32(chain);
+
+		/* Give this link TRB to the hardware */
+		wmb();
+		next->link.control ^= cpu_to_le32(TRB_CYCLE);
+
+		if (gadget_link_trb_toggles_cycle(next))
+			ring->cycle_state ^= 1;
+
+		ring->enq_seg = ring->enq_seg->next;
+		ring->enqueue = ring->enq_seg->trbs;
+		next = ring->enqueue;
+	}
+}
+
+static void gadget_queue_trb(struct phytium_device *pdev, struct gadget_ring *ring,
+	bool more_trbs_coming, u32 field1, u32 field2, u32 field3, u32 field4)
+{
+	struct gadget_generic_trb *trb;
+
+	trb = &ring->enqueue->generic;
+
+	trb->field[0] = cpu_to_le32(field1);
+	trb->field[1] = cpu_to_le32(field2);
+	trb->field[2] = cpu_to_le32(field3);
+	trb->field[3] = cpu_to_le32(field4);
+
+	gadget_inc_enq(pdev, ring, more_trbs_coming);
+}
+
+static void gadget_queue_command(struct phytium_device *pdev,
+				u32 field1, u32 field2, u32 field3, u32 field4)
+{
+	gadget_prepare_ring(pdev, pdev->cmd_ring, EP_STATE_RUNNING, 1, GFP_ATOMIC);
+
+	pdev->cmd.command_trb = pdev->cmd_ring->enqueue;
+
+	gadget_queue_trb(pdev, pdev->cmd_ring, false, field1, field2, field3,
+		field4 | pdev->cmd_ring->cycle_state);
+}
+
+void gadget_queue_configure_endpoint(struct phytium_device *pdev,
+		dma_addr_t in_ctx_ptr)
+{
+	gadget_queue_command(pdev, lower_32_bits(in_ctx_ptr),
+			upper_32_bits(in_ctx_ptr), 0,
+			TRB_TYPE(TRB_CONFIG_EP) |
+			SLOT_ID_FOR_TRB(pdev->slot_id));
+}
+
+void gadget_ring_cmd_db(struct phytium_device *pdev)
+{
+	writel(DB_VALUE_CMD, &pdev->dba->cmd_db);
+}
+
+void gadget_queue_stop_endpoint(struct phytium_device *pdev, unsigned int ep_indx)
+{
+	gadget_queue_command(pdev, 0, 0, 0, SLOT_ID_FOR_TRB(pdev->slot_id) |
+		EP_ID_FOR_TRB(ep_indx) | TRB_TYPE(TRB_STOP_RING));
+}
+
+int gadget_cmd_stop_ep(struct phytium_device *pdev, struct gadget_ep *pep)
+{
+	u32 ep_state = GET_EP_CTX_STATE(pep->out_ctx);
+	int ret = 0;
+
+	if (ep_state == EP_STATE_STOPPED || ep_state == EP_STATE_DISABLED ||
+		ep_state == EP_STATE_HALTED)
+		goto ep_stopped;
+
+	gadget_queue_stop_endpoint(pdev, pep->idx);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+
+ep_stopped:
+	pep->ep_state |= EP_STOPPED;
+
+	return ret;
+}
+
+void gadget_queue_flush_endpoint(struct phytium_device *pdev, unsigned int ep_index)
+{
+	gadget_queue_command(pdev, 0, 0, 0, TRB_TYPE(TRB_FLUSH_ENDPOINT) |
+			SLOT_ID_FOR_TRB(pdev->slot_id) | EP_ID_FOR_TRB(ep_index));
+}
+
+int gadget_cmd_flush_ep(struct phytium_device *pdev, struct gadget_ep *pep)
+{
+	int ret;
+
+	gadget_queue_flush_endpoint(pdev, pep->idx);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+
+	return ret;
+}
+
+static struct gadget_ring *gadget_get_transfer_ring(struct phytium_device *pdev,
+							struct gadget_ep *pep,
+							unsigned int stream_id)
+{
+	if (!(pep->ep_state & EP_HAS_STREAMS))
+		return pep->ring;
+
+	if (stream_id == 0 || stream_id >= pep->stream_info.num_streams) {
+		dev_err(pdev->dev, "Err:%s ring doesn't exist for SID:%d\n", pep->name, stream_id);
+		return NULL;
+	}
+
+	return pep->stream_info.stream_rings[stream_id];
+}
+
+static struct gadget_ring *
+	gadget_request_to_transfer_ring(struct phytium_device *pdev,
+			struct gadget_request *preq)
+{
+	return gadget_get_transfer_ring(pdev, preq->pep, preq->request.stream_id);
+}
+
+static u64 gadget_get_hw_deq(struct phytium_device *pdev, unsigned int ep_index,
+			unsigned int stream_id)
+{
+	struct gadget_stream_ctx *st_ctx;
+	struct gadget_ep *pep;
+
+	pep = &pdev->eps[stream_id];
+
+	if (pep->ep_state & EP_HAS_STREAMS) {
+		st_ctx = &pep->stream_info.stream_ctx_array[stream_id];
+		return le64_to_cpu(st_ctx->stream_ring);
+	}
+
+	return le64_to_cpu(pep->out_ctx->deq);
+}
+
+static struct gadget_segment *gadget_trb_in_td(struct phytium_device *pdev,
+				struct gadget_segment *start_seg, union gadget_trb *start_trb,
+				union gadget_trb *end_trb, dma_addr_t suspect_dma)
+{
+	struct gadget_segment *cur_seg;
+	union gadget_trb *temp_trb;
+	dma_addr_t end_seg_dma;
+	dma_addr_t end_trb_dma;
+	dma_addr_t start_dma;
+
+	start_dma = gadget_trb_virt_to_dma(start_seg, start_trb);
+	cur_seg = start_seg;
+
+	do {
+		if (start_dma == 0)
+			return NULL;
+
+		temp_trb = &cur_seg->trbs[TRBS_PER_SEGMENT - 1];
+		end_seg_dma = gadget_trb_virt_to_dma(cur_seg, temp_trb);
+		end_trb_dma = gadget_trb_virt_to_dma(cur_seg, end_trb);
+
+		if (end_trb_dma > 0) {
+			if (start_dma <= end_trb_dma) {
+				if (suspect_dma >= start_dma && suspect_dma <= end_trb_dma)
+					return cur_seg;
+			} else {
+				if ((suspect_dma >= start_dma && suspect_dma <= end_seg_dma) ||
+					(suspect_dma >= cur_seg->dma && suspect_dma <= end_trb_dma))
+					return cur_seg;
+			}
+
+			return NULL;
+		}
+		if (suspect_dma >= start_dma && suspect_dma <= end_seg_dma)
+			return cur_seg;
+
+		cur_seg = cur_seg->next;
+		start_dma = gadget_trb_virt_to_dma(cur_seg, &cur_seg->trbs[0]);
+	} while (cur_seg != start_seg);
+
+	return NULL;
+}
+
+static void gadget_next_trb(struct phytium_device *pdev, struct gadget_ring *ring,
+			struct gadget_segment **seg, union gadget_trb **trb)
+{
+	if (gadget_trb_is_link(*trb)) {
+		*seg = (*seg)->next;
+		*trb = ((*seg)->trbs);
+	} else {
+		(*trb)++;
+	}
+}
+
+static void gadget_find_new_dequeue_state(struct phytium_device *pdev,
+			struct gadget_ep *pep, unsigned int stream_id, struct gadget_td *cur_td,
+			struct gadget_dequeue_state *state)
+{
+	bool td_last_trb_found = false;
+	struct gadget_segment *new_seg;
+	struct gadget_ring *ep_ring;
+	union gadget_trb *new_deq;
+	bool cycle_found = false;
+	u64 hw_dequeue;
+
+	ep_ring = gadget_get_transfer_ring(pdev, pep, stream_id);
+	if (!ep_ring)
+		return;
+
+	hw_dequeue = gadget_get_hw_deq(pdev, pep->idx, stream_id);
+	new_seg = ep_ring->deq_seg;
+	new_deq = ep_ring->dequeue;
+	state->new_cycle_state = hw_dequeue & 0x1;
+	state->stream_id = stream_id;
+
+	do {
+		if (!cycle_found && gadget_trb_virt_to_dma(new_seg, new_deq) ==
+			(dma_addr_t)(hw_dequeue & ~0xf)) {
+			cycle_found = true;
+			if (td_last_trb_found)
+				break;
+		}
+
+		if (new_deq == cur_td->last_trb)
+			td_last_trb_found = true;
+
+		if (cycle_found && gadget_trb_is_link(new_deq) &&
+				gadget_link_trb_toggles_cycle(new_deq))
+			state->new_cycle_state ^= 0x1;
+
+		gadget_next_trb(pdev, ep_ring, &new_seg, &new_deq);
+
+		if (new_deq == pep->ring->dequeue) {
+			dev_err(pdev->dev, "Error: Failed finding new deuque state\n");
+			state->new_deq_seg = NULL;
+			state->new_deq_ptr = NULL;
+			return;
+		}
+	} while (!cycle_found || !td_last_trb_found);
+
+	state->new_deq_seg = new_seg;
+	state->new_deq_ptr = new_deq;
+
+}
+
+static void gadget_trb_to_noop(union gadget_trb *trb, u32 noop_type)
+{
+	if (gadget_trb_is_link(trb)) {
+		trb->link.control &= cpu_to_le32(~TRB_CHAIN);
+	} else {
+		trb->generic.field[0] = 0;
+		trb->generic.field[1] = 0;
+		trb->generic.field[2] = 0;
+		trb->generic.field[3] &= cpu_to_le32(TRB_CYCLE);
+		trb->generic.field[3] |= cpu_to_le32(TRB_TYPE(noop_type));
+	}
+}
+
+static void gadget_td_to_noop(struct phytium_device *pdev,
+			struct gadget_ring *ep_ring, struct gadget_td *td, bool flip_cycle)
+{
+	struct gadget_segment *seg = td->start_seg;
+	union gadget_trb *trb = td->first_trb;
+
+	while (1) {
+		gadget_trb_to_noop(trb, TRB_TR_NOOP);
+
+		if (flip_cycle && trb != td->first_trb && trb != td->last_trb)
+			trb->generic.field[3] ^= cpu_to_le32(TRB_CYCLE);
+
+		if (trb == td->last_trb)
+			break;
+
+		gadget_next_trb(pdev, ep_ring, &seg, &trb);
+	}
+}
+
+void gadget_set_link_state(struct phytium_device *pdev,
+		__le32 __iomem *port_regs, u32 link_state)
+{
+	int port_num = 0xff;
+	u32 temp;
+
+	temp = readl(port_regs);
+	temp = gadget_port_state_to_neutral(temp);
+	temp |= PORT_WKCONN_E | PORT_WKDISC_E;
+	writel(temp, port_regs);
+
+	temp &= ~PORT_PLS_MASK;
+	temp |= PORT_LINK_STROBE | link_state;
+
+	if (pdev->active_port)
+		port_num = pdev->active_port->port_num;
+
+	writel(temp, port_regs);
+}
+
+static void gadget_force_10_go(struct phytium_device *pdev)
+{
+	if (pdev->active_port == &pdev->usb2_port && pdev->gadget.lpm_capable)
+		gadget_set_link_state(pdev, &pdev->active_port->regs->portsc, XDEV_U0);
+}
+
+static bool gadget_ring_ep_doorbell(struct phytium_device *pdev,
+			struct gadget_ep *pep, unsigned int stream_id)
+{
+	__le32 __iomem *reg_addr = &pdev->dba->ep_db;
+	unsigned int ep_state = pep->ep_state;
+	unsigned int db_value;
+
+	if (ep_state & EP_HALTED || !(ep_state & EP_ENABLED))
+		return false;
+
+	if (pep->ep_state & EP_HAS_STREAMS) {
+		if (pep->stream_info.drbls_count >= 2)
+			return false;
+
+		pep->stream_info.drbls_count++;
+	}
+
+	pep->ep_state &= ~EP_STOPPED;
+
+	if (pep->idx == 0 && pdev->ep0_stage == GADGET_DATA_STAGE &&
+			!pdev->ep0_expect_in)
+		db_value = DB_VALUE_EP0_OUT(pep->idx, stream_id);
+	else
+		db_value = DB_VALUE(pep->idx, stream_id);
+
+	writel(db_value, reg_addr);
+
+	gadget_force_10_go(pdev);
+
+	return true;
+}
+
+void gadget_ring_doorbell_for_active_rings(struct phytium_device *pdev,
+		struct gadget_ep *pep)
+{
+	struct gadget_stream_info *stream_info;
+	unsigned int stream_id;
+	int ret;
+
+	if (pep->ep_state & EP_DIS_IN_PROGRESS)
+		return;
+
+	if (!(pep->ep_state & EP_HAS_STREAMS) && pep->number) {
+		if (pep->ring && !list_empty(&pep->ring->td_list))
+			gadget_ring_ep_doorbell(pdev, pep, 0);
+
+		return;
+	}
+
+	stream_info = &pep->stream_info;
+	for (stream_id = 1; stream_id < stream_info->num_streams; stream_id++) {
+		struct gadget_td *td, *td_temp;
+		struct gadget_ring *ep_ring;
+
+		if (stream_info->drbls_count >= 2)
+			return;
+
+		ep_ring = gadget_get_transfer_ring(pdev, pep, stream_id);
+		if (!ep_ring)
+			continue;
+
+		if (!ep_ring->stream_active || ep_ring->stream_rejected)
+			continue;
+
+		list_for_each_entry_safe(td, td_temp, &ep_ring->td_list, td_list) {
+			if (td->drbl)
+				continue;
+
+			ret = gadget_ring_ep_doorbell(pdev, pep, stream_id);
+			if (ret)
+				td->drbl = 1;
+		}
+	}
+}
+
+void gadget_queue_new_dequeue_state(struct phytium_device *pdev,
+	struct gadget_ep *pep, struct gadget_dequeue_state *deq_state)
+{
+	u32 trb_stream_id = STREAM_ID_FOR_TRB(deq_state->stream_id);
+	u32 trb_slot_id = SLOT_ID_FOR_TRB(pdev->slot_id);
+	u32 type = TRB_TYPE(TRB_SET_DEQ);
+	u32 trb_sct = 0;
+	dma_addr_t addr;
+
+	addr = gadget_trb_virt_to_dma(deq_state->new_deq_seg, deq_state->new_deq_ptr);
+
+	if (deq_state->stream_id)
+		trb_sct = SCT_FOR_TRB(SCT_PRI_TR);
+
+	gadget_queue_command(pdev, lower_32_bits(addr) | trb_sct |
+			deq_state->new_cycle_state, upper_32_bits(addr), trb_stream_id,
+			trb_slot_id | EP_ID_FOR_TRB(pep->idx) | type);
+}
+
+static int gadget_cmd_set_deq(struct phytium_device *pdev,
+			struct gadget_ep *pep, struct gadget_dequeue_state *deq_state)
+{
+	struct gadget_ring *ep_ring;
+	int ret;
+
+	if (!deq_state->new_deq_ptr || !deq_state->new_deq_seg) {
+		gadget_ring_doorbell_for_active_rings(pdev, pep);
+
+		return 0;
+	}
+
+	gadget_queue_new_dequeue_state(pdev, pep, deq_state);
+	gadget_ring_cmd_db(pdev);
+	ret = gadget_wait_for_cmd_compl(pdev);
+
+	ep_ring = gadget_get_transfer_ring(pdev, pep, deq_state->stream_id);
+
+	if (gadget_trb_is_link(ep_ring->dequeue)) {
+		ep_ring->deq_seg = ep_ring->deq_seg->next;
+		ep_ring->dequeue = ep_ring->deq_seg->trbs;
+	}
+
+	while (ep_ring->dequeue != deq_state->new_deq_ptr) {
+		ep_ring->num_trbs_free++;
+		ep_ring->dequeue++;
+
+		if (gadget_trb_is_link(ep_ring->dequeue)) {
+			if (ep_ring->dequeue == deq_state->new_deq_ptr)
+				break;
+
+			ep_ring->deq_seg = ep_ring->deq_seg->next;
+			ep_ring->dequeue = ep_ring->deq_seg->trbs;
+		}
+	}
+
+	if (ret)
+		return -ESHUTDOWN;
+
+	gadget_ring_doorbell_for_active_rings(pdev, pep);
+
+	return 0;
+}
+
+static void gadget_unmap_td_bounce_buffer(struct phytium_device *pdev,
+			struct gadget_ring *ring, struct gadget_td *td)
+{
+	struct gadget_segment *seg = td->bounce_seg;
+	struct gadget_request *preq;
+	size_t len;
+
+	if (!seg)
+		return;
+
+	preq = td->preq;
+
+	if (!preq->direction) {
+		dma_unmap_single(pdev->dev, seg->bounce_dma, ring->bounce_buf_len, DMA_TO_DEVICE);
+		return;
+	}
+
+	dma_unmap_single(pdev->dev, seg->bounce_dma, ring->bounce_buf_len, DMA_FROM_DEVICE);
+
+	len = sg_pcopy_from_buffer(preq->request.sg, preq->request.num_sgs,
+		seg->bounce_buf, seg->bounce_len, seg->bounce_offs);
+	if (len != seg->bounce_len)
+		dev_warn(pdev->dev, "WARN Wrong bounce buffer read length:%ld != %d\n",
+				len, seg->bounce_len);
+
+	seg->bounce_len = 0;
+	seg->bounce_offs = 0;
+}
+
+static void gadget_giveback(struct gadget_ep *pep, struct gadget_request *preq, int status)
+{
+	struct phytium_device *pdev = pep->pdev;
+
+	list_del(&preq->list);
+
+	if (preq->request.status == -EINPROGRESS)
+		preq->request.status = status;
+
+	usb_gadget_unmap_request_by_dev(pdev->dev, &preq->request, preq->direction);
+
+	if (preq != &pdev->ep0_preq) {
+		spin_unlock(&pdev->lock);
+		usb_gadget_giveback_request(&pep->endpoint, &preq->request);
+		spin_lock(&pdev->lock);
+	}
+}
+
+int gadget_remove_request(struct phytium_device *pdev, struct gadget_request *preq,
+			struct gadget_ep *pep)
+{
+	struct gadget_dequeue_state deq_state;
+	struct gadget_td *cur_td = NULL;
+	struct gadget_ring *ep_ring;
+	struct gadget_segment *seg;
+	int status = -ECONNRESET;
+	int ret = 0;
+	u64 hw_deq;
+
+	memset(&deq_state, 0, sizeof(deq_state));
+
+	cur_td = &preq->td;
+	ep_ring = gadget_request_to_transfer_ring(pdev, preq);
+
+	hw_deq = gadget_get_hw_deq(pdev, pep->idx, preq->request.stream_id);
+	hw_deq &= ~0xf;
+
+	seg = gadget_trb_in_td(pdev, cur_td->start_seg, cur_td->first_trb,
+					cur_td->last_trb, hw_deq);
+	if (seg && (pep->ep_state & EP_ENABLED))
+		gadget_find_new_dequeue_state(pdev, pep, preq->request.stream_id,
+					cur_td, &deq_state);
+	else
+		gadget_td_to_noop(pdev, ep_ring, cur_td, false);
+
+	list_del_init(&cur_td->td_list);
+	ep_ring->num_tds--;
+	pep->stream_info.td_count--;
+
+	if (pdev->gadget_state & GADGET_STATE_DISCONNECT_PENDING) {
+		status = -ESHUTDOWN;
+		ret = gadget_cmd_set_deq(pdev, pep, &deq_state);
+	}
+
+	gadget_unmap_td_bounce_buffer(pdev, ep_ring, cur_td);
+	gadget_giveback(pep, cur_td->preq, status);
+
+	return ret;
+}
+
+void gadget_queue_slot_control(struct phytium_device *pdev, u32 trb_type)
+{
+	gadget_queue_command(pdev, 0, 0, 0, TRB_TYPE(trb_type) |
+		SLOT_ID_FOR_TRB(pdev->slot_id));
+}
+
+void gadget_inc_deq(struct phytium_device *pdev, struct gadget_ring *ring)
+{
+	if (ring->type == TYPE_EVENT) {
+		if (!gadget_last_trb_on_seg(ring->deq_seg, ring->dequeue)) {
+			ring->dequeue++;
+			return;
+		}
+
+		if (gadget_last_trb_on_ring(ring, ring->deq_seg, ring->dequeue))
+			ring->cycle_state ^= 1;
+
+		ring->deq_seg = ring->deq_seg->next;
+		ring->dequeue = ring->deq_seg->trbs;
+		return;
+	}
+
+	if (!gadget_trb_is_link(ring->dequeue)) {
+		ring->dequeue++;
+		ring->num_trbs_free++;
+	}
+
+	while (gadget_trb_is_link(ring->dequeue)) {
+		ring->deq_seg = ring->deq_seg->next;
+		ring->dequeue = ring->deq_seg->trbs;
+	}
+}
+
+void gadget_queue_reset_ep(struct phytium_device *pdev, unsigned int ep_index)
+{
+	return gadget_queue_command(pdev, 0, 0, 0, SLOT_ID_FOR_TRB(pdev->slot_id) |
+		EP_ID_FOR_TRB(ep_index) | TRB_TYPE(TRB_RESET_EP));
+}
+
+void gadget_queue_halt_endpoint(struct phytium_device *pdev, unsigned int ep_index)
+{
+	return gadget_queue_command(pdev, 0, 0, 0, TRB_TYPE(TRB_HALT_ENDPOINT) |
+		SLOT_ID_FOR_TRB(pdev->slot_id) | EP_ID_FOR_TRB(ep_index));
+}
+
+void gadget_queue_reset_device(struct phytium_device *pdev)
+{
+	gadget_queue_command(pdev, 0, 0, 0, TRB_TYPE(TRB_RESET_DEV) |
+			SLOT_ID_FOR_TRB(pdev->slot_id));
+}
+
+static int gadget_update_port_id(struct phytium_device *pdev, u32 port_id)
+{
+	struct gadget_port *port = pdev->active_port;
+	u8 old_port = 0;
+
+	if (port && port->port_num == port_id)
+		return 0;
+
+	if (port)
+		old_port = port->port_num;
+
+	if (port_id == pdev->usb2_port.port_num)
+		port = &pdev->usb2_port;
+	else if (port_id == pdev->usb3_port.port_num)
+		port = &pdev->usb3_port;
+	else {
+		dev_err(pdev->dev, "Port event with invalid port ID %d\n", port_id);
+		return -EINVAL;
+	}
+
+	if (port_id != old_port) {
+		gadget_disable_slot(pdev);
+		pdev->active_port = port;
+		gadget_enable_slot(pdev);
+	}
+
+	if (port_id == pdev->usb2_port.port_num)
+		gadget_set_usb2_hardware_lpm(pdev, NULL, 1);
+	else
+		writel(PORT_U1_TIMEOUT(1) | PORT_U2_TIMEOUT(1), &pdev->usb3_port.regs->portpmsc);
+
+	return 0;
+}
+
+void gadget_force_header_wakeup(struct phytium_device *pdev, int intf_num)
+{
+	u32 lo, mid;
+
+	lo = TRB_FH_TO_PACKET_TYPE(TRB_FH_TR_PACKET) |
+			TRB_FH_TO_DEVICE_ADDRESS(pdev->device_address);
+
+	mid = TRB_FH_TR_PACKET_DEV_NOT | TRB_FH_TO_NOT_TYPE(TRB_FH_TR_PACKET_FUNCTION_WAKE) |
+			TRB_FH_TO_INTERFACE(intf_num);
+
+	gadget_queue_command(pdev, lo, mid, 0, TRB_TYPE(TRB_FORCE_HEADER) | SET_PORT_ID(2));
+}
+
+static void gadget_handle_port_status(struct phytium_device *pdev, union gadget_trb *event)
+{
+	struct gadget_port_regs __iomem *port_regs;
+	u32 portsc, cmd_regs, link_state, port_id;
+	bool port2 = false;
+
+	if (GET_COMP_CODE(le32_to_cpu(event->generic.field[2])) != COMP_SUCCESS)
+		dev_err(pdev->dev, "Err: incorrect PSC event\n");
+
+	port_id = GET_PORT_ID(le32_to_cpu(event->generic.field[0]));
+
+	if (gadget_update_port_id(pdev, port_id))
+		goto cleanup;
+
+	port_regs = pdev->active_port->regs;
+
+	if (port_id == pdev->usb2_port.port_num)
+		port2 = true;
+
+new_event:
+	portsc = readl(&port_regs->portsc);
+	writel(gadget_port_state_to_neutral(portsc) |
+		(portsc & PORT_CHANGE_BITS), &port_regs->portsc);
+
+	pdev->gadget.speed = gadget_port_speed(portsc);
+	link_state = portsc & PORT_PLS_MASK;
+
+	if (portsc & PORT_PLC) {
+		if (!(pdev->gadget_state & GADGET_WAKEUP_PENDING) && link_state == XDEV_RESUME) {
+			cmd_regs = readl(&pdev->op_regs->command);
+			if (!(cmd_regs & CMD_R_S))
+				goto cleanup;
+
+			if (DEV_SUPERSPEED_ANY(portsc)) {
+				gadget_set_link_state(pdev, &port_regs->portsc, XDEV_U0);
+				resume_gadget(pdev);
+			}
+		}
+
+		if ((pdev->gadget_state & GADGET_WAKEUP_PENDING) && link_state == XDEV_U0) {
+			pdev->gadget_state &= ~GADGET_WAKEUP_PENDING;
+			gadget_force_header_wakeup(pdev, 1);
+			gadget_ring_cmd_db(pdev);
+			gadget_wait_for_cmd_compl(pdev);
+		}
+
+		if (link_state == XDEV_U0 && pdev->link_state == XDEV_U3 &&
+				!DEV_SUPERSPEED_ANY(portsc))
+			resume_gadget(pdev);
+
+		if (link_state == XDEV_U3 && pdev->link_state != XDEV_U3)
+			suspend_gadget(pdev);
+
+		pdev->link_state = link_state;
+	}
+
+	if (portsc & PORT_CSC) {
+		if (pdev->gadget.connected && !(portsc & PORT_CONNECT))
+			disconnect_gadget(pdev);
+
+		if (portsc & PORT_CONNECT) {
+			if (!port2)
+				gadget_irq_reset(pdev);
+
+			usb_gadget_set_state(&pdev->gadget, USB_STATE_ATTACHED);
+		}
+	}
+
+	if ((portsc & (PORT_RC | PORT_WRC)) && (portsc & PORT_CONNECT)) {
+		gadget_irq_reset(pdev);
+		pdev->u1_allowed = 0;
+		pdev->u2_allowed = 0;
+		pdev->may_wakeup = 0;
+	}
+
+	if (portsc & PORT_CEC)
+		dev_err(pdev->dev, "Port Over Current detected\n");
+
+	if (portsc & PORT_CEC)
+		dev_err(pdev->dev, "Port Configure Error detected\n");
+
+	if (readl(&port_regs->portsc) & PORT_CHANGE_BITS)
+		goto new_event;
+
+cleanup:
+	gadget_inc_deq(pdev, pdev->event_ring);
+}
+
+static void gadget_td_cleanup(struct phytium_device *pdev, struct gadget_td *td,
+				struct gadget_ring *ep_ring, int *status)
+{
+	struct gadget_request *preq = td->preq;
+
+	gadget_unmap_td_bounce_buffer(pdev, ep_ring, td);
+
+	if (preq->request.actual > preq->request.length) {
+		preq->request.actual = 0;
+		*status = 0;
+	}
+
+	list_del_init(&td->td_list);
+	ep_ring->num_tds--;
+	preq->pep->stream_info.td_count--;
+
+	gadget_giveback(preq->pep, preq, *status);
+}
+
+static void gadget_skip_isoc_td(struct phytium_device *pdev, struct gadget_td *td,
+				struct gadget_transfer_event *event,
+				struct gadget_ep *pep, int status)
+{
+	struct gadget_ring *ep_ring;
+
+	ep_ring = gadget_dma_to_transfer_ring(pep, le64_to_cpu(event->buffer));
+	td->preq->request.status = -EXDEV;
+	td->preq->request.actual = 0;
+
+	while (ep_ring->dequeue != td->last_trb)
+		gadget_inc_deq(pdev, ep_ring);
+
+	gadget_inc_deq(pdev, ep_ring);
+
+	gadget_td_cleanup(pdev, td, ep_ring, &status);
+}
+
+static int gadget_giveback_first_trb(struct phytium_device *pdev, struct gadget_ep *pep,
+			unsigned int stream_id, int start_cycle,
+			struct gadget_generic_trb *start_trb)
+{
+	/*
+	 * Pass all the TRBs to the hardware at once and make sure this write
+	 * isn't reordered.
+	 */
+	wmb();
+
+	if (start_cycle)
+		start_trb->field[3] |= cpu_to_le32(start_cycle);
+	else
+		start_trb->field[3] &= cpu_to_le32(~TRB_CYCLE);
+
+	if ((pep->ep_state & EP_HAS_STREAMS) && !pep->stream_info.first_prime_det)
+		return 0;
+
+	return gadget_ring_ep_doorbell(pdev, pep, stream_id);
+}
+
+static void gadget_finish_td(struct phytium_device *pdev, struct gadget_td *td,
+			struct gadget_transfer_event *event, struct gadget_ep *ep, int *status)
+{
+	struct gadget_ring *ep_ring;
+	u32 trb_comp_code;
+
+	ep_ring = gadget_dma_to_transfer_ring(ep, le64_to_cpu(event->buffer));
+	trb_comp_code = GET_COMP_CODE(le32_to_cpu(event->transfer_len));
+
+	if (trb_comp_code == COMP_STOPPED_LENGTH_INVALID ||
+		trb_comp_code == COMP_STOPPED_SHORT_PACKET || trb_comp_code == COMP_STOPPED)
+		return;
+
+	while (ep_ring->dequeue != td->last_trb)
+		gadget_inc_deq(pdev, ep_ring);
+
+	gadget_inc_deq(pdev, ep_ring);
+
+	gadget_td_cleanup(pdev, td, ep_ring, status);
+}
+
+static void gadget_process_ctrl_td(struct phytium_device *pdev, struct gadget_td *td,
+				union gadget_trb *event_trb, struct gadget_transfer_event *event,
+				struct gadget_ep *pep, int *status)
+{
+	struct gadget_ring *ep_ring;
+	u32 remaining;
+	u32 trb_type;
+
+	trb_type = TRB_FIELD_TO_TYPE(le32_to_cpu(event_trb->generic.field[3]));
+	ep_ring = gadget_dma_to_transfer_ring(pep, le64_to_cpu(event->buffer));
+	remaining = EVENT_TRB_LEN(le32_to_cpu(event->transfer_len));
+
+	if (trb_type == TRB_DATA) {
+		td->request_length_set = true;
+		td->preq->request.actual = td->preq->request.length - remaining;
+	}
+
+	if (!td->request_length_set)
+		td->preq->request.actual = td->preq->request.length;
+
+	if (pdev->ep0_stage == GADGET_DATA_STAGE && pep->number == 0 && pdev->three_stage_setup) {
+		td = list_entry(ep_ring->td_list.next, struct gadget_td, td_list);
+		pdev->ep0_stage = GADGET_STATUS_STAGE;
+
+		gadget_giveback_first_trb(pdev, pep, 0, ep_ring->cycle_state,
+				&td->last_trb->generic);
+
+		return;
+	}
+
+	*status = 0;
+
+	gadget_finish_td(pdev, td, event, pep, status);
+}
+
+static int gadget_sum_trb_lengths(struct phytium_device *pdev,
+			struct gadget_ring *ring, union gadget_trb *stop_trb)
+{
+	struct gadget_segment *seg = ring->deq_seg;
+	union gadget_trb *trb = ring->dequeue;
+	u32 sum;
+
+	for (sum = 0; trb != stop_trb; gadget_next_trb(pdev, ring, &seg, &trb)) {
+		if (!gadget_trb_is_noop(trb) && !gadget_trb_is_link(trb))
+			sum += TRB_LEN(le32_to_cpu(trb->generic.field[2]));
+	}
+
+	return sum;
+}
+
+static void gadget_process_isoc_td(struct phytium_device *pdev,
+				struct gadget_td *td, union gadget_trb *ep_trb,
+				struct gadget_transfer_event *event,
+				struct gadget_ep *pep, int status)
+{
+	struct gadget_request *preq = td->preq;
+	u32 remaining, requested, ep_trb_len;
+	bool sum_trbs_for_length = false;
+	struct gadget_ring *ep_ring;
+	u32 trb_comp_code, td_length;
+
+	ep_ring = gadget_dma_to_transfer_ring(pep, le64_to_cpu(event->buffer));
+	trb_comp_code = GET_COMP_CODE(le32_to_cpu(event->transfer_len));
+	remaining = EVENT_TRB_LEN(le32_to_cpu(event->transfer_len));
+	ep_trb_len = TRB_LEN(le32_to_cpu(ep_trb->generic.field[2]));
+
+	requested = preq->request.length;
+
+	switch (trb_comp_code) {
+	case COMP_SUCCESS:
+		preq->request.status = 0;
+		break;
+	case COMP_SHORT_PACKET:
+		preq->request.status = 0;
+		sum_trbs_for_length = true;
+		break;
+	case COMP_ISOCH_BUFFER_OVERRUN:
+	case COMP_BABBLE_DETECTED_ERROR:
+		preq->request.status = -EOVERFLOW;
+		break;
+	case COMP_STOPPED:
+		sum_trbs_for_length = true;
+		break;
+	case COMP_STOPPED_SHORT_PACKET:
+		preq->request.status = 0;
+		requested = remaining;
+		break;
+	case COMP_STOPPED_LENGTH_INVALID:
+		requested = 0;
+		remaining = 0;
+		break;
+	default:
+		sum_trbs_for_length = true;
+		preq->request.status = -1;
+		break;
+	}
+
+	if (sum_trbs_for_length) {
+		td_length = gadget_sum_trb_lengths(pdev, ep_ring, ep_trb);
+		td_length += ep_trb_len - remaining;
+	} else {
+		td_length = requested;
+	}
+
+	td->preq->request.actual += td_length;
+
+	gadget_finish_td(pdev, td, event, pep, &status);
+}
+
+static void gadget_process_bulk_intr_td(struct phytium_device *pdev,
+			struct gadget_td *td, union gadget_trb *ep_trb,
+			struct gadget_transfer_event *event, struct gadget_ep *ep, int *status)
+{
+	u32 remaining, requested, ep_trb_len, trb_comp_code;
+	struct gadget_ring *ep_ring;
+
+	ep_ring = gadget_dma_to_transfer_ring(ep, le64_to_cpu(event->buffer));
+	trb_comp_code = GET_COMP_CODE(le32_to_cpu(event->transfer_len));
+	remaining = EVENT_TRB_LEN(le32_to_cpu(event->transfer_len));
+	ep_trb_len = TRB_LEN(le32_to_cpu(ep_trb->generic.field[2]));
+	requested = td->preq->request.length;
+
+	switch (trb_comp_code) {
+	case COMP_SUCCESS:
+	case COMP_SHORT_PACKET:
+		*status = 0;
+		break;
+	case COMP_STOPPED_SHORT_PACKET:
+		td->preq->request.actual = remaining;
+		goto finish_td;
+	case COMP_STOPPED_LENGTH_INVALID:
+		ep_trb_len = 0;
+		remaining = 0;
+		break;
+	}
+
+	if (ep_trb == td->last_trb)
+		ep_trb_len = gadget_sum_trb_lengths(pdev, ep_ring, ep_trb) + ep_trb_len - remaining;
+
+	td->preq->request.actual = ep_trb_len;
+
+finish_td:
+	ep->stream_info.drbls_count--;
+
+	gadget_finish_td(pdev, td, event, ep, status);
+}
+
+static int gadget_handle_tx_event(struct phytium_device *pdev,
+			struct gadget_transfer_event *event)
+{
+	const struct usb_endpoint_descriptor *desc;
+	bool handling_skipped_tds = false;
+	struct gadget_segment *ep_seg;
+	struct gadget_ring *ep_ring;
+	int status = -EINPROGRESS;
+	union gadget_trb *ep_trb;
+	dma_addr_t ep_trb_dma;
+	struct gadget_ep *pep;
+	struct gadget_td *td;
+	u32 trb_comp_code;
+	int invalidate, ep_index;
+
+	invalidate = le32_to_cpu(event->flags) & TRB_EVENT_INVALIDATE;
+	ep_index = TRB_TO_EP_ID(le32_to_cpu(event->flags)) - 1;
+	trb_comp_code = GET_COMP_CODE(le32_to_cpu(event->transfer_len));
+	ep_trb_dma = le64_to_cpu(event->buffer);
+
+	pep = &pdev->eps[ep_index];
+	ep_ring = gadget_dma_to_transfer_ring(pep, le64_to_cpu(event->buffer));
+
+	if (invalidate || !pdev->gadget.connected)
+		goto cleanup;
+
+	if (GET_EP_CTX_STATE(pep->out_ctx) == EP_STATE_DISABLED)
+		goto err_out;
+
+	if (!ep_ring) {
+		switch (trb_comp_code) {
+		case COMP_INVALID_STREAM_TYPE_ERROR:
+		case COMP_INVALID_STREAM_ID_ERROR:
+		case COMP_RING_OVERRUN:
+		case COMP_RING_UNDERRUN:
+			goto cleanup;
+		default:
+			dev_err(pdev->dev, "Err: %s event for unknown ring\n", pep->name);
+			goto err_out;
+		}
+	}
+
+	switch (trb_comp_code) {
+	case COMP_BABBLE_DETECTED_ERROR:
+		status = -EOVERFLOW;
+		break;
+	case COMP_RING_UNDERRUN:
+	case COMP_RING_OVERRUN:
+		goto cleanup;
+	case COMP_MISSED_SERVICE_ERROR:
+		pep->skip = true;
+		break;
+	}
+
+	do {
+		if (list_empty(&ep_ring->td_list))
+			goto cleanup;
+
+		td = list_entry(ep_ring->td_list.next, struct gadget_td, td_list);
+
+		ep_seg = gadget_trb_in_td(pdev, ep_ring->deq_seg,
+				ep_ring->dequeue, td->last_trb, ep_trb_dma);
+
+		if (!ep_seg && (trb_comp_code == COMP_STOPPED ||
+					trb_comp_code == COMP_STOPPED_LENGTH_INVALID)) {
+			pep->skip = false;
+			goto cleanup;
+		}
+
+		desc = td->preq->pep->endpoint.desc;
+		if (!ep_seg) {
+			if (!pep->skip || !usb_endpoint_xfer_isoc(desc))
+				dev_err(pdev->dev, "Err Transfer event ep_index %d comp_code %u\n",
+						ep_index, trb_comp_code);
+
+			gadget_skip_isoc_td(pdev, td, event, pep, status);
+			goto cleanup;
+		}
+
+		if (trb_comp_code == COMP_SHORT_PACKET)
+			ep_ring->last_td_was_short = true;
+		else
+			ep_ring->last_td_was_short = false;
+
+		if (pep->skip) {
+			pep->skip = false;
+			gadget_skip_isoc_td(pdev, td, event, pep, status);
+			goto cleanup;
+		}
+
+		ep_trb = &ep_seg->trbs[(ep_trb_dma - ep_seg->dma) / sizeof(*ep_trb)];
+
+		if (gadget_trb_is_noop(ep_trb))
+			goto cleanup;
+
+		if (usb_endpoint_xfer_control(desc))
+			gadget_process_ctrl_td(pdev, td, ep_trb, event, pep, &status);
+		else if (usb_endpoint_xfer_isoc(desc))
+			gadget_process_isoc_td(pdev, td, ep_trb, event, pep, status);
+		else
+			gadget_process_bulk_intr_td(pdev, td, ep_trb, event, pep, &status);
+
+cleanup:
+		handling_skipped_tds = pep->skip;
+
+		if (!handling_skipped_tds)
+			gadget_inc_deq(pdev, pdev->event_ring);
+	} while (handling_skipped_tds);
+
+	return 0;
+
+err_out:
+	dev_err(pdev->dev, "0x%llx %08x %08x %08x %08x\n",
+		(unsigned long long)gadget_trb_virt_to_dma(pdev->event_ring->deq_seg,
+		pdev->event_ring->dequeue), lower_32_bits(le64_to_cpu(event->buffer)),
+		upper_32_bits(le64_to_cpu(event->buffer)), le32_to_cpu(event->transfer_len),
+		le32_to_cpu(event->flags));
+
+	return -EINVAL;
+}
+
+static int gadget_ep0_delegate_req(struct phytium_device *pdev, struct usb_ctrlrequest *ctrl)
+{
+	int ret;
+
+	spin_unlock(&pdev->lock);
+	ret = pdev->gadget_driver->setup(&pdev->gadget, ctrl);
+	spin_lock(&pdev->lock);
+
+	return ret;
+}
+
+static int gadget_w_index_to_ep_index(u16 wIndex)
+{
+	if (!(wIndex & USB_ENDPOINT_NUMBER_MASK))
+		return 0;
+
+	return ((wIndex & USB_ENDPOINT_NUMBER_MASK) * 2) +
+			(wIndex & USB_ENDPOINT_DIR_MASK ? 1 : 0) - 1;
+}
+
+
+static int gadget_ep0_handle_status(struct phytium_device *pdev, struct usb_ctrlrequest *ctrl)
+{
+	struct gadget_ep *pep;
+	__le16 *response;
+	int ep_sts = 0;
+	u16 status = 0;
+	u32 recipient;
+
+	recipient = ctrl->bRequestType & USB_RECIP_MASK;
+
+	switch (recipient) {
+	case USB_RECIP_DEVICE:
+		status = pdev->gadget.is_selfpowered;
+		status |= pdev->may_wakeup << USB_DEVICE_REMOTE_WAKEUP;
+
+		if (pdev->gadget.speed >= USB_SPEED_SUPER) {
+			status |= pdev->u1_allowed << USB_DEV_STAT_U1_ENABLED;
+			status |= pdev->u2_allowed << USB_DEV_STAT_U2_ENABLED;
+		}
+		break;
+	case USB_RECIP_INTERFACE:
+		return gadget_ep0_delegate_req(pdev, ctrl);
+	case USB_RECIP_ENDPOINT:
+		ep_sts = gadget_w_index_to_ep_index(le16_to_cpu(ctrl->wIndex));
+		pep = &pdev->eps[ep_sts];
+		ep_sts = GET_EP_CTX_STATE(pep->out_ctx);
+
+		if (ep_sts == EP_STATE_HALTED)
+			status = BIT(USB_ENDPOINT_HALT);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	response = (__le16 *)pdev->setup_buf;
+	*response = cpu_to_le16(status);
+
+	pdev->ep0_preq.request.length = sizeof(*response);
+	pdev->ep0_preq.request.buf = pdev->setup_buf;
+
+	return gadget_ep_enqueue(pdev->ep0_preq.pep, &pdev->ep0_preq);
+}
+
+static void gadget_enter_test_mode(struct phytium_device *pdev)
+{
+	u32 temp;
+
+	temp = readl(&pdev->active_port->regs->portpmsc) & ~GENMASK(31, 28);
+	temp |= PORT_TEST_MODE(pdev->test_mode);
+	writel(temp, &pdev->active_port->regs->portpmsc);
+}
+
+static int gadget_ep0_handle_feature_device(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl, int set)
+{
+	enum usb_device_state state;
+	enum usb_device_speed speed;
+	u16 tmode;
+
+	state = pdev->gadget.state;
+	speed = pdev->gadget.speed;
+
+	switch (le16_to_cpu(ctrl->wValue)) {
+	case USB_DEVICE_REMOTE_WAKEUP:
+		pdev->may_wakeup = !!set;
+		break;
+	case USB_DEVICE_U1_ENABLE:
+		if (state != USB_STATE_CONFIGURED || speed < USB_SPEED_SUPER)
+			return -EINVAL;
+
+		pdev->u1_allowed = !!set;
+		break;
+	case USB_DEVICE_U2_ENABLE:
+		if (state != USB_STATE_CONFIGURED || speed < USB_SPEED_SUPER)
+			return -EINVAL;
+
+		pdev->u2_allowed = !!set;
+		break;
+	case USB_DEVICE_LTM_ENABLE:
+		return -EINVAL;
+	case USB_DEVICE_TEST_MODE:
+		if (state != USB_STATE_CONFIGURED || speed < USB_SPEED_SUPER)
+			return -EINVAL;
+
+		tmode = le16_to_cpu(ctrl->wIndex);
+
+		if (!set || (tmode & 0xff) != 0)
+			return -EINVAL;
+
+		tmode = tmode >> 8;
+
+		if (tmode > USB_TEST_FORCE_ENABLE || tmode < USB_TEST_J)
+			return -EINVAL;
+
+		pdev->test_mode = tmode;
+		gadget_enter_test_mode(pdev);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int gadget_ep0_handle_feature_intf(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl, int set)
+{
+	u16 wValue, wIndex;
+	int ret;
+
+	wValue = le16_to_cpu(ctrl->wValue);
+	wIndex = le16_to_cpu(ctrl->wIndex);
+
+	switch (wValue) {
+	case USB_INTRF_FUNC_SUSPEND:
+		ret = gadget_ep0_delegate_req(pdev, ctrl);
+		if (ret)
+			return ret;
+
+		if (wIndex & USB_INTRF_FUNC_SUSPEND_RW)
+			pdev->may_wakeup++;
+		else
+			if (pdev->may_wakeup > 0)
+				pdev->may_wakeup--;
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int gadget_ep0_handle_feature_endpoint(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl, int set)
+{
+	struct gadget_ep *pep;
+	u16 wValue;
+
+	wValue = le16_to_cpu(ctrl->wValue);
+	pep = &pdev->eps[gadget_w_index_to_ep_index(le16_to_cpu(ctrl->wIndex))];
+
+	switch (wValue) {
+	case USB_ENDPOINT_HALT:
+		if (!set && (pep->ep_state & EP_WEDGE)) {
+			gadget_halt_endpoint(pdev, pep, 0);
+			gadget_halt_endpoint(pdev, pep, 1);
+			break;
+		}
+		return gadget_halt_endpoint(pdev, pep, set);
+	default:
+		dev_warn(pdev->dev, "Warn Incorrect wValue %04x\n", wValue);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int gadget_ep0_handle_feature(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl, int set)
+{
+	switch (ctrl->bRequestType & USB_RECIP_MASK) {
+	case USB_RECIP_DEVICE:
+		return gadget_ep0_handle_feature_device(pdev, ctrl, set);
+	case USB_RECIP_INTERFACE:
+		return gadget_ep0_handle_feature_intf(pdev, ctrl, set);
+	case USB_RECIP_ENDPOINT:
+		return gadget_ep0_handle_feature_endpoint(pdev, ctrl, set);
+	default:
+		return -EINVAL;
+	}
+}
+
+static int gadget_ep0_set_address(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl)
+{
+	enum usb_device_state state = pdev->gadget.state;
+	struct gadget_slot_ctx *slot_ctx;
+	unsigned int slot_state;
+	int ret;
+	u32 addr;
+
+	addr = le16_to_cpu(ctrl->wValue);
+	if (addr > 127) {
+		dev_err(pdev->dev, "Invalid device address %d\n", addr);
+		return -EINVAL;
+	}
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->out_ctx);
+
+	if (state == USB_STATE_CONFIGURED) {
+		dev_err(pdev->dev, "Can't Set Address from Configured State\n");
+		return -EINVAL;
+	}
+
+	pdev->device_address = le16_to_cpu(ctrl->wValue);
+
+	slot_ctx = gadget_get_slot_ctx(&pdev->out_ctx);
+	slot_state = GET_SLOT_STATE(le32_to_cpu(slot_ctx->dev_state));
+	if (slot_state == SLOT_STATE_ADDRESSED)
+		gadget_reset_device(pdev);
+
+	ret = gadget_setup_device(pdev, SETUP_CONTEXT_ADDRESS);
+	if (ret)
+		return ret;
+
+	if (addr)
+		usb_gadget_set_state(&pdev->gadget, USB_STATE_ADDRESS);
+	else
+		usb_gadget_set_state(&pdev->gadget, USB_STATE_DEFAULT);
+
+	return 0;
+}
+
+static int gadget_ep0_set_config(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl)
+{
+	enum usb_device_state state = pdev->gadget.state;
+	u32 cfg;
+	int ret;
+
+	cfg = le16_to_cpu(ctrl->wValue);
+
+	switch (state) {
+	case USB_STATE_ADDRESS:
+		break;
+	case USB_STATE_CONFIGURED:
+		break;
+	default:
+		dev_err(pdev->dev, "Set Configuration - bad device state\n");
+		return -EINVAL;
+	}
+
+	ret = gadget_ep0_delegate_req(pdev, ctrl);
+	if (ret)
+		return ret;
+
+	if (!cfg)
+		usb_gadget_set_state(&pdev->gadget, USB_STATE_ADDRESS);
+
+	return 0;
+}
+
+static int gadget_ep0_set_sel(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl)
+{
+	enum usb_device_state state = pdev->gadget.state;
+	u16 wLength;
+
+	if (state == USB_STATE_DEFAULT)
+		return -EINVAL;
+
+	wLength = le16_to_cpu(ctrl->wLength);
+
+	if (wLength != 6) {
+		dev_err(pdev->dev, "Set SEL should be 6 bytes, got %d\n", wLength);
+		return -EINVAL;
+	}
+
+	pdev->ep0_preq.request.length = 6;
+	pdev->ep0_preq.request.buf = pdev->setup_buf;
+
+	return gadget_ep_enqueue(pdev->ep0_preq.pep, &pdev->ep0_preq);
+}
+
+static int gadget_ep0_set_isoch_delay(struct phytium_device *pdev,
+			struct usb_ctrlrequest *ctrl)
+{
+	if (le16_to_cpu(ctrl->wIndex) || le16_to_cpu(ctrl->wLength))
+		return -EINVAL;
+
+	pdev->gadget.isoch_delay = le16_to_cpu(ctrl->wValue);
+
+	return 0;
+}
+
+static int gadget_ep0_std_request(struct phytium_device *pdev, struct usb_ctrlrequest *ctrl)
+{
+	int ret;
+
+	switch (ctrl->bRequest) {
+	case USB_REQ_GET_STATUS:
+		ret = gadget_ep0_handle_status(pdev, ctrl);
+		break;
+	case USB_REQ_CLEAR_FEATURE:
+		ret = gadget_ep0_handle_feature(pdev, ctrl, 0);
+		break;
+	case USB_REQ_SET_FEATURE:
+		ret = gadget_ep0_handle_feature(pdev, ctrl, 1);
+		break;
+	case USB_REQ_SET_ADDRESS:
+		ret = gadget_ep0_set_address(pdev, ctrl);
+		break;
+	case USB_REQ_SET_CONFIGURATION:
+		ret = gadget_ep0_set_config(pdev, ctrl);
+		break;
+	case USB_REQ_SET_SEL:
+		ret = gadget_ep0_set_sel(pdev, ctrl);
+		break;
+	case USB_REQ_SET_ISOCH_DELAY:
+		ret = gadget_ep0_set_isoch_delay(pdev, ctrl);
+		break;
+	case USB_REQ_SET_INTERFACE:
+		list_add_tail(&pdev->ep0_preq.list, &pdev->ep0_preq.pep->pending_list);
+		ret = gadget_ep0_delegate_req(pdev, ctrl);
+		if (ret == -EBUSY)
+			ret = 0;
+
+		list_del(&pdev->ep0_preq.list);
+		break;
+	default:
+		ret = gadget_ep0_delegate_req(pdev, ctrl);
+		break;
+	}
+
+	return ret;
+}
+
+int gadget_status_stage(struct phytium_device *pdev)
+{
+	pdev->ep0_stage = GADGET_STATUS_STAGE;
+	pdev->ep0_preq.request.length = 0;
+
+	return gadget_ep_enqueue(pdev->ep0_preq.pep, &pdev->ep0_preq);
+}
+
+static void gadget_ep0_stall(struct phytium_device *pdev)
+{
+	struct gadget_request *preq;
+	struct gadget_ep *pep;
+
+	pep = &pdev->eps[0];
+	preq = next_request(&pep->pending_list);
+
+	if (pdev->three_stage_setup) {
+		gadget_halt_endpoint(pdev, pep, true);
+		if (preq)
+			gadget_giveback(pep, preq, -ECONNRESET);
+	} else {
+		pep->ep_state |= EP0_HALTED_STATUS;
+
+		if (preq)
+			list_del(&preq->list);
+
+		gadget_status_stage(pdev);
+	}
+}
+
+static void gadget_setup_analyze(struct phytium_device *pdev)
+{
+	struct usb_ctrlrequest *ctrl = &pdev->setup;
+	int ret = 0;
+	u16 len;
+
+	if (!pdev->gadget_driver)
+		goto out;
+
+	if (pdev->gadget.state == USB_STATE_NOTATTACHED) {
+		dev_err(pdev->dev, "Err: Setup detected in unattached state\n");
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (pdev->eps[0].ep_state & EP_HALTED)
+		gadget_halt_endpoint(pdev, &pdev->eps[0], 0);
+
+	if (!list_empty(&pdev->eps[0].pending_list)) {
+		struct gadget_request *req;
+
+		req = next_request(&pdev->eps[0].pending_list);
+		ep_dequeue(&pdev->eps[0], req);
+	}
+
+	len = le16_to_cpu(ctrl->wLength);
+	if (!len) {
+		pdev->three_stage_setup = false;
+		pdev->ep0_expect_in = false;
+	} else {
+		pdev->three_stage_setup = true;
+		pdev->ep0_expect_in = !!(ctrl->bRequestType & USB_DIR_IN);
+	}
+
+	if ((ctrl->bRequestType & USB_TYPE_MASK) == USB_TYPE_STANDARD)
+		ret = gadget_ep0_std_request(pdev, ctrl);
+	else
+		ret = gadget_ep0_delegate_req(pdev, ctrl);
+
+	if (!len)
+		pdev->ep0_stage = GADGET_STATUS_STAGE;
+
+	if (ret == USB_GADGET_DELAYED_STATUS)
+		return;
+
+out:
+	if (ret < 0)
+		gadget_ep0_stall(pdev);
+	else if (pdev->ep0_stage == GADGET_STATUS_STAGE)
+		gadget_status_stage(pdev);
+}
+
+static void gadget_handle_tx_nrdy(struct phytium_device *pdev, struct gadget_transfer_event *event)
+{
+	struct gadget_generic_trb *generic;
+	struct gadget_ring *ep_ring;
+	struct gadget_ep *pep;
+	int cur_stream, ep_index, host_sid, dev_sid;
+
+	generic = (struct gadget_generic_trb *)event;
+	ep_index = TRB_TO_EP_ID(le32_to_cpu(event->flags)) - 1;
+	dev_sid = TRB_TO_DEV_STREAM(le32_to_cpu(generic->field[0]));
+	host_sid = TRB_TO_HOST_STREAM(le32_to_cpu(generic->field[2]));
+
+	pep = &pdev->eps[ep_index];
+
+	if (!(pep->ep_state & EP_HAS_STREAMS))
+		return;
+
+	if (host_sid == STREAM_PRIME_ACK) {
+		pep->stream_info.first_prime_det = 1;
+		for (cur_stream = 1; cur_stream < pep->stream_info.num_streams; cur_stream++) {
+			ep_ring = pep->stream_info.stream_rings[cur_stream];
+			ep_ring->stream_active = 1;
+			ep_ring->stream_rejected = 0;
+		}
+	}
+
+	if (host_sid == STREAM_REJECTED) {
+		struct gadget_td *td, *td_temp;
+
+		pep->stream_info.drbls_count--;
+		ep_ring = pep->stream_info.stream_rings[dev_sid];
+		ep_ring->stream_active = 0;
+		ep_ring->stream_rejected = 1;
+
+		list_for_each_entry_safe(td, td_temp, &ep_ring->td_list, td_list)
+			td->drbl = 0;
+	}
+
+	gadget_ring_doorbell_for_active_rings(pdev, pep);
+}
+
+static bool gadget_handle_event(struct phytium_device *pdev)
+{
+	unsigned int comp_code;
+	union gadget_trb *event;
+	bool update_ptrs = true;
+	u32 cycle_bit, flags;
+	int ret = 0;
+
+	event = pdev->event_ring->dequeue;
+	flags = le32_to_cpu(event->event_cmd.flags);
+	cycle_bit = (flags & TRB_CYCLE);
+
+	if (cycle_bit != pdev->event_ring->cycle_state)
+		return false;
+
+	/*
+	 * Barrier between reading the TRB_CYCLE (valid) flag above and any
+	 * reads of the event's flags/data below.
+	 */
+	rmb();
+
+	switch (flags & TRB_TYPE_BITMASK) {
+	case TRB_TYPE(TRB_COMPLETION):
+		gadget_inc_deq(pdev, pdev->cmd_ring);
+		break;
+	case TRB_TYPE(TRB_PORT_STATUS):
+		gadget_handle_port_status(pdev, event);
+		update_ptrs = false;
+		break;
+	case TRB_TYPE(TRB_TRANSFER):
+		ret = gadget_handle_tx_event(pdev, &event->trans_event);
+		if (ret >= 0)
+			update_ptrs = false;
+		break;
+	case TRB_TYPE(TRB_SETUP):
+		pdev->ep0_stage = GADGET_SETUP_STAGE;
+		pdev->setup_id = TRB_SETUPID_TO_TYPE(flags);
+		pdev->setup_speed = TRB_SETUP_SPEEDID(flags);
+		pdev->setup = *((struct usb_ctrlrequest *)&event->trans_event.buffer);
+
+		gadget_setup_analyze(pdev);
+		break;
+	case TRB_TYPE(TRB_ENDPOINT_NRDY):
+		gadget_handle_tx_nrdy(pdev, &event->trans_event);
+		break;
+	case TRB_TYPE(TRB_HC_EVENT): {
+		comp_code = GET_COMP_CODE(le32_to_cpu(event->generic.field[2]));
+		switch (comp_code) {
+		case COMP_EVENT_RING_FULL_ERROR:
+			dev_err(pdev->dev, "Event Ring Full\n");
+			break;
+		default:
+			dev_err(pdev->dev, "Controller error code 0x%02x\n", comp_code);
+		}
+		break;
+	}
+	default:
+		dev_warn(pdev->dev, "Error unknown event type %ld\n", TRB_FIELD_TO_TYPE(flags));
+	}
+
+	if (update_ptrs)
+		gadget_inc_deq(pdev, pdev->event_ring);
+
+	return true;
+}
+
+irqreturn_t gadget_irq_handler(int irq, void *priv)
+{
+	struct phytium_device *pdev = (struct phytium_device *)priv;
+	u32 irq_pending;
+	u32 status;
+	union gadget_trb *event_ring_deq;
+	unsigned long flags;
+	int counter = 0;
+
+	spin_lock_irqsave(&pdev->lock, flags);
+	status = readl(&pdev->op_regs->status);
+
+	if (status == ~(u32)0) {
+		gadget_died(pdev);
+		spin_unlock_irqrestore(&pdev->lock, flags);
+		return IRQ_HANDLED;
+	}
+
+	if (!(status & STS_EINT)) {
+		spin_unlock_irqrestore(&pdev->lock, flags);
+		return IRQ_NONE;
+	}
+
+	writel(status | STS_EINT, &pdev->op_regs->status);
+	irq_pending = readl(&pdev->ir_set->irq_pending);
+	irq_pending |= IMAN_IP;
+	writel(irq_pending, &pdev->ir_set->irq_pending);
+
+	if (status & STS_FATAL) {
+		gadget_died(pdev);
+		spin_unlock_irqrestore(&pdev->lock, flags);
+		return IRQ_HANDLED;
+	}
+
+	if (pdev->gadget_state & (GADGET_STATE_HALTED | GADGET_STATE_DYING)) {
+		if (pdev->gadget_driver)
+			gadget_died(pdev);
+
+		spin_unlock_irqrestore(&pdev->lock, flags);
+		return IRQ_HANDLED;
+	}
+
+	event_ring_deq = pdev->event_ring->dequeue;
+
+	while (gadget_handle_event(pdev)) {
+		if (++counter >= TRBS_PER_EV_DEQ_UPDATE) {
+			gadget_update_erst_dequeue(pdev, event_ring_deq, 0);
+			event_ring_deq = pdev->event_ring->dequeue;
+			counter = 0;
+		}
+	}
+
+	gadget_update_erst_dequeue(pdev, event_ring_deq, 1);
+	spin_unlock_irqrestore(&pdev->lock, flags);
+
+	return IRQ_HANDLED;
+}
+void gadget_queue_address_device(struct phytium_device *pdev,
+		dma_addr_t in_ctx_ptr, enum gadget_setup_dev setup)
+{
+	gadget_queue_command(pdev, lower_32_bits(in_ctx_ptr), upper_32_bits(in_ctx_ptr), 0,
+		TRB_TYPE(TRB_ADDR_DEV) | SLOT_ID_FOR_TRB(pdev->slot_id) |
+		(setup == SETUP_CONTEXT_ONLY ? TRB_BSR : 0));
+}
+
+static int gadget_prepare_transfer(struct phytium_device *pdev,
+				struct gadget_request *preq, unsigned int num_trbs)
+{
+	struct gadget_ring *ep_ring;
+	int ret;
+
+	ep_ring = gadget_get_transfer_ring(pdev, preq->pep, preq->request.stream_id);
+	if (!ep_ring)
+		return -EINVAL;
+
+	ret = gadget_prepare_ring(pdev, ep_ring, GET_EP_CTX_STATE(preq->pep->out_ctx),
+			num_trbs, GFP_ATOMIC);
+	if (ret)
+		return ret;
+
+	INIT_LIST_HEAD(&preq->td.td_list);
+	preq->td.preq = preq;
+
+	list_add_tail(&preq->td.td_list, &ep_ring->td_list);
+	ep_ring->num_tds++;
+	preq->pep->stream_info.td_count++;
+
+	preq->td.start_seg = ep_ring->enq_seg;
+	preq->td.first_trb = ep_ring->enqueue;
+
+	return 0;
+}
+
+static u32 gadget_td_remainder(struct phytium_device *pdev, int transferred, int trb_buff_len,
+				unsigned int td_total_len, struct gadget_request *preq,
+				bool more_trbs_coming, bool zlp)
+{
+	u32 maxp, total_packet_count;
+
+	if (zlp)
+		return 1;
+
+	if (!more_trbs_coming || (transferred == 0 && trb_buff_len == 0)
+			|| trb_buff_len == td_total_len)
+		return 0;
+
+	maxp = usb_endpoint_maxp(preq->pep->endpoint.desc);
+	total_packet_count = DIV_ROUND_UP(td_total_len, maxp);
+
+	return (total_packet_count - ((transferred + trb_buff_len) / maxp));
+}
+
+int gadget_queue_ctrl_tx(struct phytium_device *pdev, struct gadget_request *preq)
+{
+	u32 field, length_field, remainder;
+	struct gadget_ep *pep = preq->pep;
+	struct gadget_ring *ep_ring;
+	int num_trbs;
+	int ret;
+
+	ep_ring = gadget_request_to_transfer_ring(pdev, preq);
+	if (!ep_ring)
+		return -EINVAL;
+
+	num_trbs = (pdev->three_stage_setup) ? 2 : 1;
+
+	ret = gadget_prepare_transfer(pdev, preq, num_trbs);
+	if (ret)
+		return ret;
+
+	if (pdev->ep0_expect_in)
+		field = TRB_TYPE(TRB_DATA) | TRB_IOC;
+	else
+		field = TRB_ISP | TRB_TYPE(TRB_DATA) | TRB_IOC;
+
+	if (preq->request.length > 0) {
+		remainder = gadget_td_remainder(pdev, 0, preq->request.length,
+				preq->request.length, preq, 1, 0);
+
+		length_field = TRB_LEN(preq->request.length) | TRB_TD_SIZE(remainder) |
+			TRB_INTR_TARGET(0);
+
+		if (pdev->ep0_expect_in)
+			field |= TRB_DIR_IN;
+
+		gadget_queue_trb(pdev, ep_ring, true, lower_32_bits(preq->request.dma),
+				upper_32_bits(preq->request.dma), length_field, field |
+				ep_ring->cycle_state | TRB_SETUPID(pdev->setup_id) |
+				pdev->setup_speed);
+
+				pdev->ep0_stage = GADGET_DATA_STAGE;
+	}
+
+	preq->td.last_trb = ep_ring->enqueue;
+
+	if (preq->request.length == 0)
+		field = ep_ring->cycle_state;
+	else
+		field = (ep_ring->cycle_state ^ 1);
+
+	if (preq->request.length > 0 && pdev->ep0_expect_in)
+		field |= TRB_DIR_IN;
+
+	if (pep->ep_state & EP0_HALTED_STATUS) {
+		pep->ep_state &= ~EP0_HALTED_STATUS;
+		field |= TRB_SETUPSTAT(TRB_SETUPSTAT_STALL);
+	} else {
+		field |= TRB_SETUPSTAT(TRB_SETUPSTAT_ACK);
+	}
+
+	gadget_queue_trb(pdev, ep_ring, false, 0, 0, TRB_INTR_TARGET(0), field | TRB_IOC |
+			TRB_SETUPID(pdev->setup_id) | TRB_TYPE(TRB_STATUS) | pdev->setup_speed);
+
+	gadget_ring_ep_doorbell(pdev, pep, preq->request.stream_id);
+
+	return 0;
+}
+
+static unsigned int gadget_count_trbs(u64 addr, u64 len)
+{
+	unsigned int num_trbs;
+
+	num_trbs = DIV_ROUND_UP(len + (addr & (TRB_MAX_BUFF_SIZE - 1)), TRB_MAX_BUFF_SIZE);
+
+	if (num_trbs == 0)
+		num_trbs++;
+
+	return num_trbs;
+}
+
+static unsigned int count_trbs_needed(struct gadget_request *preq)
+{
+	return gadget_count_trbs(preq->request.dma, preq->request.length);
+}
+
+static unsigned int count_sg_trbs_needed(struct gadget_request *preq)
+{
+	unsigned int i, len, full_len, num_trbs = 0;
+	struct scatterlist *sg;
+
+	full_len = preq->request.length;
+
+	for_each_sg(preq->request.sg, sg, preq->request.num_sgs, i) {
+		len = sg_dma_len(sg);
+		num_trbs += gadget_count_trbs(sg_dma_address(sg), len);
+		len = min(len, full_len);
+		full_len -= len;
+		if (full_len == 0)
+			break;
+	}
+
+	return num_trbs;
+}
+
+static int gadget_align_td(struct phytium_device *pdev, struct gadget_request *preq,
+			u32 enqd_len, u32 *trb_buff_len, struct gadget_segment *seg)
+{
+	struct device *dev = pdev->dev;
+	unsigned int unalign, max_pkt;
+	u32 new_buff_len;
+
+	max_pkt = usb_endpoint_maxp(preq->pep->endpoint.desc);
+	unalign = (enqd_len + *trb_buff_len) % max_pkt;
+
+	if (unalign == 0)
+		return 0;
+
+	if (*trb_buff_len > unalign) {
+		*trb_buff_len -= unalign;
+		return 0;
+	}
+
+	new_buff_len = max_pkt - (enqd_len % max_pkt);
+
+	if (new_buff_len > (preq->request.length - enqd_len))
+		new_buff_len = preq->request.length - enqd_len;
+
+	if (preq->direction) {
+		sg_pcopy_to_buffer(preq->request.sg, preq->request.num_mapped_sgs,
+			seg->bounce_buf, new_buff_len, enqd_len);
+
+		seg->bounce_dma = dma_map_single(dev, seg->bounce_buf, max_pkt, DMA_TO_DEVICE);
+	} else {
+		seg->bounce_dma = dma_map_single(dev, seg->bounce_buf, max_pkt, DMA_FROM_DEVICE);
+	}
+
+	if (dma_mapping_error(dev, seg->bounce_dma)) {
+		dev_warn(dev, "Failed mapping bounce buffer, not aligning\n");
+		return 0;
+	}
+
+	*trb_buff_len = new_buff_len;
+	seg->bounce_len = new_buff_len;
+	seg->bounce_offs = enqd_len;
+
+	return 1;
+}
+
+static void gadget_check_trb_math(struct gadget_request *preq, int running_total)
+{
+	if (running_total != preq->request.length)
+		dev_err(preq->pep->pdev->dev,
+				"%s - Miscalculated tx length, queued %#x, asked for %#x (%d)\n",
+				preq->pep->name, running_total, preq->request.length,
+				preq->request.actual);
+}
+
+int gadget_queue_bulk_tx(struct phytium_device *pdev, struct gadget_request *preq)
+{
+	unsigned int enqd_len, block_len, trb_buff_len, full_len;
+	unsigned int start_cycle, num_sgs = 0;
+	struct gadget_generic_trb *start_trb;
+	u32 field, length_field, remainder;
+	struct scatterlist *sg = NULL;
+	bool more_trbs_coming = true;
+	bool need_zero_pkt = false;
+	bool zero_len_trb = false;
+	struct gadget_ring *ring;
+	bool first_trb = true;
+	unsigned int num_trbs;
+	struct gadget_ep *pep;
+	u64 addr, send_addr;
+	int sent_len, ret;
+
+	ring = gadget_request_to_transfer_ring(pdev, preq);
+	if (!ring)
+		return -EINVAL;
+
+	full_len = preq->request.length;
+
+	if (preq->request.num_sgs) {
+		num_sgs = preq->request.num_sgs;
+		sg = preq->request.sg;
+		addr = (u64)sg_dma_address(sg);
+		block_len = sg_dma_len(sg);
+		num_trbs = count_sg_trbs_needed(preq);
+	} else {
+		num_trbs = count_trbs_needed(preq);
+		addr = (u64)preq->request.dma;
+		block_len = full_len;
+	}
+
+	pep = preq->pep;
+
+	if (preq->request.zero && preq->request.length &&
+		 IS_ALIGNED(full_len, usb_endpoint_maxp(pep->endpoint.desc))) {
+		need_zero_pkt = true;
+		num_trbs++;
+	}
+
+	ret = gadget_prepare_transfer(pdev, preq, num_trbs);
+	if (ret)
+		return ret;
+
+	start_trb = &ring->enqueue->generic;
+	start_cycle = ring->cycle_state;
+	send_addr = addr;
+
+	for (enqd_len = 0; zero_len_trb || first_trb || enqd_len < full_len;
+			enqd_len += trb_buff_len) {
+		field = TRB_TYPE(TRB_NORMAL);
+
+		trb_buff_len = TRB_BUFF_LEN_UP_TO_BOUNDARY(addr);
+		trb_buff_len = min(trb_buff_len, block_len);
+		if (enqd_len + trb_buff_len > full_len)
+			trb_buff_len = full_len - enqd_len;
+
+		if (first_trb) {
+			first_trb = false;
+			if (start_cycle == 0)
+				field |= TRB_CYCLE;
+		} else {
+			field |= ring->cycle_state;
+		}
+
+		if (enqd_len + trb_buff_len < full_len || need_zero_pkt) {
+			field |= TRB_CHAIN;
+			if (gadget_trb_is_link(ring->enqueue + 1)) {
+				if (gadget_align_td(pdev, preq, enqd_len,
+							&trb_buff_len, ring->enq_seg)) {
+					send_addr = ring->enq_seg->bounce_dma;
+					preq->td.bounce_seg = ring->enq_seg;
+				}
+			}
+		}
+
+		if (enqd_len + trb_buff_len >= full_len) {
+			if (need_zero_pkt && !zero_len_trb) {
+				zero_len_trb = true;
+			} else {
+				zero_len_trb = false;
+				field &= ~TRB_CHAIN;
+				field |= TRB_IOC;
+				more_trbs_coming = false;
+				need_zero_pkt = false;
+				preq->td.last_trb = ring->enqueue;
+			}
+		}
+
+		if (!preq->direction)
+			field |= TRB_ISP;
+
+		remainder = gadget_td_remainder(pdev, enqd_len, trb_buff_len, full_len, preq,
+						more_trbs_coming, zero_len_trb);
+
+		length_field = TRB_LEN(trb_buff_len) | TRB_TD_SIZE(remainder) | TRB_INTR_TARGET(0);
+
+		gadget_queue_trb(pdev, ring, more_trbs_coming, lower_32_bits(send_addr),
+						 upper_32_bits(send_addr), length_field, field);
+
+		addr += trb_buff_len;
+		sent_len = trb_buff_len;
+
+		while (sg && sent_len >= block_len) {
+			--num_sgs;
+			sent_len -= block_len;
+			if (num_sgs != 0) {
+				sg = sg_next(sg);
+				block_len = sg_dma_len(sg);
+				addr = (u64)sg_dma_address(sg);
+				addr += sent_len;
+			}
+		}
+
+		block_len -= sent_len;
+		send_addr = addr;
+	}
+
+	gadget_check_trb_math(preq, enqd_len);
+	ret = gadget_giveback_first_trb(pdev, pep, preq->request.stream_id, start_cycle, start_trb);
+	if (ret)
+		preq->td.drbl = 1;
+
+	return 0;
+}
+
+static unsigned int count_isoc_trbs_needed(struct gadget_request *preq)
+{
+	return gadget_count_trbs(preq->request.dma, preq->request.length);
+}
+
+static unsigned int gadget_get_burst_count(struct phytium_device *pdev,
+				struct gadget_request *preq, unsigned int total_packet_count)
+{
+	unsigned int max_burst;
+
+	if (pdev->gadget.speed < USB_SPEED_SUPER)
+		return 0;
+
+	max_burst = preq->pep->endpoint.comp_desc->bMaxBurst;
+
+	return DIV_ROUND_UP(total_packet_count, max_burst + 1) - 1;
+}
+
+static unsigned int gadget_get_last_burst_packet_count(struct phytium_device *pdev,
+			struct gadget_request *preq, unsigned int total_packet_count)
+{
+	unsigned int max_burst, residue;
+
+	if (pdev->gadget.speed >= USB_SPEED_SUPER) {
+		max_burst = preq->pep->endpoint.comp_desc->bMaxBurst;
+		residue = total_packet_count % (max_burst + 1);
+
+		if (residue == 0)
+			return max_burst;
+
+		return residue - 1;
+	}
+
+	if (total_packet_count == 0)
+		return 0;
+
+	return total_packet_count - 1;
+}
+
+static int gadget_queue_isoc_tx(struct phytium_device *pdev, struct gadget_request *preq)
+{
+	int trb_buff_len, td_len, td_remain_len, ret;
+	unsigned int burst_count, last_burst_pkt, total_pkt_count, max_pkt;
+	struct gadget_generic_trb *start_trb;
+	bool more_trbs_coming = true;
+	struct gadget_ring *ep_ring;
+	u32 field, length_field;
+	int start_cycle, trbs_per_td, i;
+	int running_total = 0;
+	u64 addr;
+
+	ep_ring = preq->pep->ring;
+	start_trb = &ep_ring->enqueue->generic;
+	start_cycle = ep_ring->cycle_state;
+	td_len = preq->request.length;
+	addr = (u64)preq->request.dma;
+	td_remain_len = td_len;
+
+	max_pkt = usb_endpoint_maxp(preq->pep->endpoint.desc);
+	total_pkt_count = DIV_ROUND_UP(td_len, max_pkt);
+
+	if (total_pkt_count == 0)
+		total_pkt_count++;
+
+	burst_count = gadget_get_burst_count(pdev, preq, total_pkt_count);
+	last_burst_pkt = gadget_get_last_burst_packet_count(pdev, preq, total_pkt_count);
+	trbs_per_td = count_isoc_trbs_needed(preq);
+
+	ret = gadget_prepare_transfer(pdev, preq, trbs_per_td);
+	if (ret)
+		goto cleanup;
+
+	field = TRB_TYPE(TRB_ISOC) | TRB_TLBPC(last_burst_pkt) | TRB_SIA | TRB_TBC(burst_count);
+
+	if	(!start_cycle)
+		field |= TRB_CYCLE;
+
+	for (i = 0; i < trbs_per_td; i++) {
+		u32 remainder;
+
+		trb_buff_len = TRB_BUFF_LEN_UP_TO_BOUNDARY(addr);
+		if (trb_buff_len > td_remain_len)
+			trb_buff_len = td_remain_len;
+
+		remainder = gadget_td_remainder(pdev, running_total, trb_buff_len, td_len,
+						preq, more_trbs_coming, 0);
+
+		length_field = TRB_LEN(trb_buff_len) | TRB_INTR_TARGET(0);
+
+		if (i) {
+			field = TRB_TYPE(TRB_NORMAL) | ep_ring->cycle_state;
+			length_field |= TRB_TD_SIZE(remainder);
+		} else {
+			length_field |= TRB_TD_SIZE_TBC(burst_count);
+		}
+
+		if (usb_endpoint_dir_out(preq->pep->endpoint.desc))
+			field |= TRB_ISP;
+
+		if (i < trbs_per_td - 1) {
+			more_trbs_coming = true;
+			field |= TRB_CHAIN;
+		} else {
+			more_trbs_coming = false;
+			preq->td.last_trb = ep_ring->enqueue;
+			field |= TRB_IOC;
+		}
+
+		gadget_queue_trb(pdev, ep_ring, more_trbs_coming, lower_32_bits(addr),
+					upper_32_bits(addr), length_field, field);
+
+		running_total += trb_buff_len;
+		addr += trb_buff_len;
+		td_remain_len -= trb_buff_len;
+	}
+
+	if (running_total != td_len) {
+		dev_err(pdev->dev, "ISOC TD length unmatch\n");
+		ret = -EINVAL;
+		goto cleanup;
+	}
+
+	gadget_giveback_first_trb(pdev, preq->pep, preq->request.stream_id, start_cycle, start_trb);
+
+	return 0;
+
+cleanup:
+	list_del_init(&preq->td.td_list);
+	ep_ring->num_tds--;
+	preq->td.last_trb = ep_ring->enqueue;
+	gadget_td_to_noop(pdev, ep_ring, &preq->td, true);
+
+	ep_ring->enqueue = preq->td.first_trb;
+	ep_ring->enq_seg = preq->td.start_seg;
+	ep_ring->cycle_state = start_cycle;
+
+	return ret;
+}
+
+int gadget_queue_isoc_tx_prepare(struct phytium_device *pdev, struct gadget_request *preq)
+{
+	struct gadget_ring *ep_ring;
+	u32 ep_state;
+	int num_trbs, ret;
+
+	ep_ring = preq->pep->ring;
+	ep_state = GET_EP_CTX_STATE(preq->pep->out_ctx);
+	num_trbs = count_isoc_trbs_needed(preq);
+
+	ret = gadget_prepare_ring(pdev, ep_ring, ep_state, num_trbs, GFP_ATOMIC);
+	if (ret)
+		return ret;
+
+	return gadget_queue_isoc_tx(pdev, preq);
+}

--- a/drivers/usb/phytium_usb_v2/ring.h
+++ b/drivers/usb/phytium_usb_v2/ring.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __LINUX_PHYTIUM_USB_RING_H__
+#define __LINUX_PHYTIUM_USB_RING_H__
+
+#include "gadget.h"
+#include <linux/irq.h>
+
+dma_addr_t gadget_trb_virt_to_dma(struct gadget_segment *seg,
+		union gadget_trb *trb);
+
+void gadget_queue_configure_endpoint(struct phytium_device *pdev,
+		dma_addr_t in_ctx_ptr);
+
+void gadget_ring_doorbell_for_active_rings(struct phytium_device *pdev,
+		struct gadget_ep *pep);
+
+void gadget_initialize_ring_info(struct gadget_ring *ring);
+
+irqreturn_t gadget_irq_handler(int irq, void *priv);
+
+irqreturn_t gadget_thread_irq_handler(int irq, void *data);
+
+void gadget_queue_address_device(struct phytium_device *pdev,
+		dma_addr_t in_ctx_ptr, enum gadget_setup_dev setup);
+
+int gadget_queue_ctrl_tx(struct phytium_device *pdev, struct gadget_request *preq);
+int gadget_queue_bulk_tx(struct phytium_device *pdev, struct gadget_request *preq);
+int gadget_queue_isoc_tx_prepare(struct phytium_device *pdev, struct gadget_request *preq);
+#endif

--- a/drivers/usb/typec/Kconfig
+++ b/drivers/usb/typec/Kconfig
@@ -64,6 +64,18 @@ config TYPEC_ANX7411
 	  If you choose to build this driver as a dynamically linked module, the
 	  module will be called anx7411.ko.
 
+config TYPEC_PHYTIUM_RS
+	tristate "Phytium USB Type-C DRP Port controller driver"
+	depends on I2C
+	depends on USB_ROLE_SWITCH
+	depends on POWER_SUPPLY
+	help
+	  Say Y or M here if your system has PHYTIUM USB Type-C DRP Port
+	  controller driver.
+
+	  If you choose to build this driver as a dynamically linked module, the
+	  module will be called role-switch-phytium.ko.
+
 config TYPEC_RT1719
 	tristate "Richtek RT1719 Sink Only Type-C controller driver"
 	depends on USB_ROLE_SWITCH || !USB_ROLE_SWITCH

--- a/drivers/usb/typec/Makefile
+++ b/drivers/usb/typec/Makefile
@@ -7,6 +7,7 @@ obj-$(CONFIG_TYPEC_TCPM)	+= tcpm/
 obj-$(CONFIG_TYPEC_UCSI)	+= ucsi/
 obj-$(CONFIG_TYPEC_TPS6598X)	+= tipd/
 obj-$(CONFIG_TYPEC_ANX7411)	+= anx7411.o
+obj-$(CONFIG_TYPEC_PHYTIUM_RS)	+= role-switch-phytium.o
 obj-$(CONFIG_TYPEC_HD3SS3220)	+= hd3ss3220.o
 obj-$(CONFIG_TYPEC_STUSB160X) 	+= stusb160x.o
 obj-$(CONFIG_TYPEC_RT1719)	+= rt1719.o

--- a/drivers/usb/typec/role-switch-phytium.c
+++ b/drivers/usb/typec/role-switch-phytium.c
@@ -1,0 +1,1655 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Driver for USB Type-C and PD controller
+ *
+ * Copyright (C) 2021-2023, Phytium Technology Co., Ltd.
+ *
+ */
+#include <linux/acpi.h>
+#include <acpi/acpi_bus.h>
+#include <linux/gpio/consumer.h>
+#include <linux/i2c.h>
+#include <linux/interrupt.h>
+#include <linux/iopoll.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/of_graph.h>
+#include <linux/of_platform.h>
+#include <linux/pm_runtime.h>
+#include <linux/regulator/consumer.h>
+#include <linux/slab.h>
+#include <linux/types.h>
+#include <linux/usb/pd.h>
+#include <linux/usb/role.h>
+#include <linux/usb/tcpci.h>
+#include <linux/usb/typec.h>
+#include <linux/usb/typec_dp.h>
+#include <linux/usb/typec_mux.h>
+#include <linux/workqueue.h>
+#include <linux/power_supply.h>
+
+#define RS_PHYTIUM_DRV_VERSION			"1.0.0"
+
+#define RS_PHYTIUM_TCPC_ADDRESS1		0x58
+#define RS_PHYTIUM_TCPC_ADDRESS2		0x56
+#define RS_PHYTIUM_TCPC_ADDRESS3		0x54
+#define RS_PHYTIUM_TCPC_ADDRESS4		0x52
+#define RS_PHYTIUM_SPI_ADDRESS1		0x7e
+#define RS_PHYTIUM_SPI_ADDRESS2		0x6e
+#define RS_PHYTIUM_SPI_ADDRESS3		0x64
+#define RS_PHYTIUM_SPI_ADDRESS4		0x62
+
+struct role_sw_phytium_i2c_select {
+	u8 tcpc_address;
+	u8 spi_address;
+};
+
+#define RS_PHYTIUM_VID_ANALOGIX		0x1F29
+#define RS_PHYTIUM_PID_ANALOGIX		0x7411
+
+/* TCPC register define */
+
+#define RS_PHYTIUM_ANALOG_CTRL_10		0xAA
+
+#define RS_PHYTIUM_STATUS_LEN		2
+#define RS_PHYTIUM_ALERT_0			0xCB
+#define RS_PHYTIUM_RECEIVED_MSG		BIT(7)
+#define RS_PHYTIUM_SOFTWARE_INT		BIT(6)
+#define RS_PHYTIUM_MSG_LEN			32
+#define RS_PHYTIUM_HEADER_LEN		2
+#define RS_PHYTIUM_MSG_HEADER		0x00
+#define RS_PHYTIUM_MSG_TYPE		0x01
+#define RS_PHYTIUM_MSG_RAWDATA		0x02
+#define RS_PHYTIUM_MSG_LEN_MASK		0x1F
+
+#define RS_PHYTIUM_ALERT_1			0xCC
+#define RS_PHYTIUM_INTP_POW_ON		BIT(7)
+#define RS_PHYTIUM_INTP_POW_OFF		BIT(6)
+
+#define RS_PHYTIUM_VBUS_THRESHOLD_H	0xDD
+#define RS_PHYTIUM_VBUS_THRESHOLD_L	0xDE
+
+#define RS_PHYTIUM_FW_CTRL_0		0xF0
+#define RS_PHYTIUM_UNSTRUCT_VDM_EN		BIT(0)
+#define RS_PHYTIUM_DELAY_200MS		BIT(1)
+#define RS_PHYTIUM_VSAFE0			0
+#define RS_PHYTIUM_VSAFE1			BIT(2)
+#define RS_PHYTIUM_VSAFE2			BIT(3)
+#define RS_PHYTIUM_VSAFE3			(BIT(2) | BIT(3))
+#define RS_PHYTIUM_FRS_EN			BIT(7)
+
+#define RS_PHYTIUM_FW_PARAM		0xF1
+#define RS_PHYTIUM_DONGLE_IOP		BIT(0)
+
+#define RS_PHYTIUM_FW_CTRL_2		0xF7
+#define RS_PHYTIUM_SINK_CTRL_DIS_FLAG	BIT(5)
+
+/* SPI register define */
+#define RS_PHYTIUM_OCM_CTRL_0		0x6E
+#define RS_PHYTIUM_OCM_RESET		BIT(6)
+
+#define RS_PHYTIUM_MAX_VOLTAGE		0xAC
+#define RS_PHYTIUM_MAX_POWER		0xAD
+#define RS_PHYTIUM_MIN_POWER		0xAE
+
+#define RS_PHYTIUM_REQUEST_VOLTAGE		0xAF
+#define RS_PHYTIUM_VOLTAGE_UNIT		100 /* mV per unit */
+
+#define RS_PHYTIUM_REQUEST_CURRENT		0xB1
+#define RS_PHYTIUM_CURRENT_UNIT		50 /* mA per unit */
+
+#define RS_PHYTIUM_CMD_SEND_BUF		0xC0
+#define RS_PHYTIUM_CMD_RECV_BUF		0xE0
+
+#define RS_PHYTIUM_REQ_VOL_20V_IN_100MV	0xC8
+#define RS_PHYTIUM_REQ_CUR_2_25A_IN_50MA	0x2D
+#define RS_PHYTIUM_REQ_CUR_3_25A_IN_50MA	0x41
+
+#define RS_PHYTIUM_DEF_5V			5000
+#define RS_PHYTIUM_DEF_1_5A		1500
+
+#define RS_PHYTIUM_LOBYTE(w)		((u8)((w) & 0xFF))
+#define RS_PHYTIUM_HIBYTE(w)		((u8)(((u16)(w) >> 8) & 0xFF))
+
+enum role_sw_phytium_typec_message_type {
+	RS_PHYTIUM_TYPE_SRC_CAP = 0x00,
+	RS_PHYTIUM_TYPE_SNK_CAP = 0x01,
+	RS_PHYTIUM_TYPE_SNK_IDENTITY = 0x02,
+	RS_PHYTIUM_TYPE_SVID = 0x03,
+	RS_PHYTIUM_TYPE_SET_SNK_DP_CAP = 0x08,
+	RS_PHYTIUM_TYPE_PSWAP_REQ = 0x10,
+	RS_PHYTIUM_TYPE_DSWAP_REQ = 0x11,
+	RS_PHYTIUM_TYPE_VDM = 0x14,
+	RS_PHYTIUM_TYPE_OBJ_REQ = 0x16,
+	RS_PHYTIUM_TYPE_DP_ALT_ENTER = 0x19,
+	RS_PHYTIUM_TYPE_DP_DISCOVER_MODES_INFO = 0x27,
+	RS_PHYTIUM_TYPE_GET_DP_CONFIG = 0x29,
+	RS_PHYTIUM_TYPE_DP_CONFIGURE = 0x2A,
+	RS_PHYTIUM_TYPE_GET_DP_DISCOVER_MODES_INFO = 0x2E,
+	RS_PHYTIUM_TYPE_GET_DP_ALT_ENTER = 0x2F,
+};
+
+#define RS_PHYTIUM_FW_CTRL_1		0xB2
+#define RS_PHYTIUM_AUTO_PD_EN		BIT(1)
+#define RS_PHYTIUM_TRYSRC_EN		BIT(2)
+#define RS_PHYTIUM_TRYSNK_EN		BIT(3)
+#define RS_PHYTIUM_FORCE_SEND_RDO		BIT(6)
+
+#define RS_PHYTIUM_FW_VER			0xB4
+#define RS_PHYTIUM_FW_SUBVER		0xB5
+
+#define RS_PHYTIUM_INT_MASK		0xB6
+#define RS_PHYTIUM_INT_STS			0xB7
+#define RS_PHYTIUM_OCM_BOOT_UP		BIT(0)
+#define RS_PHYTIUM_OC_OV_EVENT		BIT(1)
+#define RS_PHYTIUM_VCONN_CHANGE		BIT(2)
+#define RS_PHYTIUM_VBUS_CHANGE		BIT(3)
+#define RS_PHYTIUM_CC_STATUS_CHANGE	BIT(4)
+#define RS_PHYTIUM_DATA_ROLE_CHANGE	BIT(5)
+#define RS_PHYTIUM_PR_CONSUMER_GOT_POWER	BIT(6)
+#define RS_PHYTIUM_HPD_STATUS_CHANGE	BIT(7)
+
+#define RS_PHYTIUM_SYSTEM_STSTUS		0xB8
+/* 0: SINK off; 1: SINK on */
+#define RS_PHYTIUM_SINK_STATUS		BIT(1)
+/* 0: VCONN off; 1: VCONN on*/
+#define RS_PHYTIUM_VCONN_STATUS		BIT(2)
+/* 0: vbus off; 1: vbus on*/
+#define RS_PHYTIUM_VBUS_STATUS		BIT(3)
+/* 1: host; 0:device*/
+#define RS_PHYTIUM_DATA_ROLE		BIT(5)
+/* 0: Chunking; 1: Unchunked*/
+#define RS_PHYTIUM_SUPPORT_UNCHUNKING	BIT(6)
+/* 0: HPD low; 1: HPD high*/
+#define RS_PHYTIUM_HPD_STATUS		BIT(7)
+
+#define RS_PHYTIUM_DATA_DFP		1
+#define RS_PHYTIUM_DATA_UFP		2
+#define RS_PHYTIUM_POWER_SOURCE		1
+#define RS_PHYTIUM_POWER_SINK		2
+
+#define RS_PHYTIUM_CC_STATUS		0xB9
+#define RS_PHYTIUM_CC1_RD			BIT(0)
+#define RS_PHYTIUM_CC2_RD			BIT(4)
+#define RS_PHYTIUM_CC1_RA			BIT(1)
+#define RS_PHYTIUM_CC2_RA			BIT(5)
+#define RS_PHYTIUM_CC1_RD			BIT(0)
+#define RS_PHYTIUM_CC1_RP(cc)		(((cc) >> 2) & 0x03)
+#define RS_PHYTIUM_CC2_RP(cc)		(((cc) >> 6) & 0x03)
+
+#define RS_PHYTIUM_PD_REV_INIT		0xBA
+
+#define RS_PHYTIUM_PD_EXT_MSG_CTRL		0xBB
+#define RS_PHYTIUM_SRC_CAP_EXT_REPLY	BIT(0)
+#define RS_PHYTIUM_MANUFACTURER_INFO_REPLY	BIT(1)
+#define RS_PHYTIUM_BATTERY_STS_REPLY	BIT(2)
+#define RS_PHYTIUM_BATTERY_CAP_REPLY	BIT(3)
+#define RS_PHYTIUM_ALERT_REPLY		BIT(4)
+#define RS_PHYTIUM_STATUS_REPLY		BIT(5)
+#define RS_PHYTIUM_PPS_STATUS_REPLY	BIT(6)
+#define RS_PHYTIUM_SNK_CAP_EXT_REPLY	BIT(7)
+
+#define RS_PHYTIUM_NO_CONNECT		0x00
+#define RS_PHYTIUM_USB3_1_CONNECTED	0x01
+#define RS_PHYTIUM_DP_ALT_4LANES		0x02
+#define RS_PHYTIUM_USB3_1_DP_2LANES	0x03
+#define RS_PHYTIUM_CC1_CONNECTED		0x01
+#define RS_PHYTIUM_CC2_CONNECTED		0x02
+#define RS_PHYTIUM_SELECT_PIN_ASSIGMENT_C	0x04
+#define RS_PHYTIUM_SELECT_PIN_ASSIGMENT_D	0x08
+#define RS_PHYTIUM_SELECT_PIN_ASSIGMENT_E	0x10
+#define RS_PHYTIUM_SELECT_PIN_ASSIGMENT_U	0x00
+#define RS_PHYTIUM_REDRIVER_ADDRESS	0x20
+#define RS_PHYTIUM_REDRIVER_OFFSET		0x00
+
+#define RS_PHYTIUM_DP_SVID			0xFF01
+#define RS_PHYTIUM_VDM_ACK			0x40
+#define RS_PHYTIUM_VDM_CMD_RES		0x00
+#define RS_PHYTIUM_VDM_CMD_DIS_ID		0x01
+#define RS_PHYTIUM_VDM_CMD_DIS_SVID	0x02
+#define RS_PHYTIUM_VDM_CMD_DIS_MOD		0x03
+#define RS_PHYTIUM_VDM_CMD_ENTER_MODE	0x04
+#define RS_PHYTIUM_VDM_CMD_EXIT_MODE	0x05
+#define RS_PHYTIUM_VDM_CMD_ATTENTION	0x06
+#define RS_PHYTIUM_VDM_CMD_GET_STS		0x10
+#define RS_PHYTIUM_VDM_CMD_AND_ACK_MASK	0x5F
+
+#define RS_PHYTIUM_MAX_ALTMODE		2
+
+#define RS_PHYTIUM_HAS_SOURCE_CAP		BIT(0)
+#define RS_PHYTIUM_HAS_SINK_CAP		BIT(1)
+#define RS_PHYTIUM_HAS_SINK_WATT		BIT(2)
+
+enum role_sw_phytium_psy_state {
+	/* copy from drivers/usb/typec/tcpm */
+	RS_PHYTIUM_PSY_OFFLINE = 0,
+	RS_PHYTIUM_PSY_FIXED_ONLINE,
+
+	/* private */
+	/* PD keep in, but disconnct power to bq25700,
+	 * this state can be active when higher capacity adapter plug in,
+	 * and change to ONLINE state when higher capacity adapter plug out
+	 */
+	RS_PHYTIUM_PSY_HANG = 0xff,
+};
+
+struct role_sw_phytium_typec_params {
+	int request_current; /* ma */
+	int request_voltage; /* mv */
+	int cc_connect;
+	int cc_orientation_valid;
+	int cc_status;
+	int data_role;
+	int power_role;
+	int vconn_role;
+	int dp_altmode_enter;
+	int cust_altmode_enter;
+	struct usb_role_switch *role_sw;
+	struct typec_port *port;
+	struct typec_partner *partner;
+	struct typec_mux_dev *typec_mux;
+	struct typec_switch_dev *typec_switch;
+	struct typec_altmode *amode[RS_PHYTIUM_MAX_ALTMODE];
+	struct typec_altmode *port_amode[RS_PHYTIUM_MAX_ALTMODE];
+	struct typec_displayport_data data;
+	int pin_assignment;
+	struct typec_capability caps;
+	u32 src_pdo[PDO_MAX_OBJECTS];
+	u32 sink_pdo[PDO_MAX_OBJECTS];
+	u8 caps_flags;
+	u8 src_pdo_nr;
+	u8 sink_pdo_nr;
+	u8 sink_watt;
+	u8 sink_voltage;
+};
+
+#define RS_PHYTIUM_MAX_BUF_LEN	30
+struct role_sw_phytium_fw_msg {
+	u8 msg_len;
+	u8 msg_type;
+	u8 buf[RS_PHYTIUM_MAX_BUF_LEN];
+} __packed;
+
+struct role_sw_phytium_data {
+	int fw_version;
+	int fw_subversion;
+	struct i2c_client *tcpc_client;
+	struct i2c_client *spi_client;
+	struct role_sw_phytium_fw_msg send_msg;
+	struct role_sw_phytium_fw_msg recv_msg;
+	struct gpio_desc *intp_gpiod;
+	struct fwnode_handle *connector_fwnode;
+	struct acpi_device *adev;
+	struct role_sw_phytium_typec_params typec;
+	int intp_irq;
+	struct work_struct work;
+	struct workqueue_struct *workqueue;
+	/* Lock for interrupt work queue */
+	struct mutex lock;
+
+	enum role_sw_phytium_psy_state psy_online;
+	enum power_supply_usb_type usb_type;
+	struct power_supply *psy;
+	struct power_supply_desc psy_desc;
+	struct device *dev;
+};
+
+static u8 snk_identity[] = {
+	RS_PHYTIUM_LOBYTE(RS_PHYTIUM_VID_ANALOGIX),
+	RS_PHYTIUM_HIBYTE(RS_PHYTIUM_VID_ANALOGIX), 0x00, 0x82, /* snk_id_hdr */
+	0x00, 0x00, 0x00, 0x00,                                 /* snk_cert */
+	0x00, 0x00, RS_PHYTIUM_LOBYTE(RS_PHYTIUM_PID_ANALOGIX),
+	RS_PHYTIUM_HIBYTE(RS_PHYTIUM_PID_ANALOGIX), /* 5snk_ama */
+};
+
+static u8 dp_caps[4] = {0xC6, 0x00, 0x00, 0x00};
+
+static int role_sw_phytium_reg_read(struct i2c_client *client,
+			    u8 reg_addr)
+{
+	return i2c_smbus_read_byte_data(client, reg_addr);
+}
+
+static int role_sw_phytium_reg_block_read(struct i2c_client *client,
+				  u8 reg_addr, u8 len, u8 *buf)
+{
+	return i2c_smbus_read_i2c_block_data(client, reg_addr, len, buf);
+}
+
+static int role_sw_phytium_reg_write(struct i2c_client *client,
+			     u8 reg_addr, u8 reg_val)
+{
+	return i2c_smbus_write_byte_data(client, reg_addr, reg_val);
+}
+
+static int role_sw_phytium_reg_block_write(struct i2c_client *client,
+				   u8 reg_addr, u8 len, u8 *buf)
+{
+	return i2c_smbus_write_i2c_block_data(client, reg_addr, len, buf);
+}
+
+static struct role_sw_phytium_i2c_select role_sw_phytium_i2c_addr[] = {
+	{RS_PHYTIUM_TCPC_ADDRESS1, RS_PHYTIUM_SPI_ADDRESS1},
+	{RS_PHYTIUM_TCPC_ADDRESS2, RS_PHYTIUM_SPI_ADDRESS2},
+	{RS_PHYTIUM_TCPC_ADDRESS3, RS_PHYTIUM_SPI_ADDRESS3},
+	{RS_PHYTIUM_TCPC_ADDRESS4, RS_PHYTIUM_SPI_ADDRESS4},
+};
+
+static int role_sw_phytium_detect_power_mode(struct role_sw_phytium_data *ctx)
+{
+	int ret;
+	int mode;
+
+	ret = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_REQUEST_CURRENT);
+	if (ret < 0)
+		return ret;
+
+	ctx->typec.request_current = ret * RS_PHYTIUM_CURRENT_UNIT; /* 50ma per unit */
+
+	ret = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_REQUEST_VOLTAGE);
+	if (ret < 0)
+		return ret;
+
+	ctx->typec.request_voltage = ret * RS_PHYTIUM_VOLTAGE_UNIT; /* 100mv per unit */
+
+	if (ctx->psy_online == RS_PHYTIUM_PSY_OFFLINE) {
+		ctx->psy_online = RS_PHYTIUM_PSY_FIXED_ONLINE;
+		ctx->usb_type = POWER_SUPPLY_USB_TYPE_PD;
+		power_supply_changed(ctx->psy);
+	}
+
+	if (!ctx->typec.cc_orientation_valid)
+		return 0;
+
+	if (ctx->typec.cc_connect == RS_PHYTIUM_CC1_CONNECTED)
+		mode = RS_PHYTIUM_CC1_RP(ctx->typec.cc_status);
+	else
+		mode = RS_PHYTIUM_CC2_RP(ctx->typec.cc_status);
+	if (mode) {
+		typec_set_pwr_opmode(ctx->typec.port, mode - 1);
+		return 0;
+	}
+
+	typec_set_pwr_opmode(ctx->typec.port, TYPEC_PWR_MODE_PD);
+
+	return 0;
+}
+
+static int role_sw_phytium_register_partner(struct role_sw_phytium_data *ctx,
+				    int pd, int accessory)
+{
+	struct typec_partner_desc desc;
+	struct typec_partner *partner;
+
+	if (ctx->typec.partner)
+		return 0;
+
+	desc.usb_pd = pd;
+	desc.accessory = accessory;
+	desc.identity = NULL;
+	partner = typec_register_partner(ctx->typec.port, &desc);
+	if (IS_ERR(partner))
+		return PTR_ERR(partner);
+
+	ctx->typec.partner = partner;
+
+	return 0;
+}
+
+static int role_sw_phytium_detect_cc_orientation(struct role_sw_phytium_data *ctx)
+{
+	struct device *dev = &ctx->spi_client->dev;
+	int ret;
+	int cc1_rd, cc2_rd;
+	int cc1_ra, cc2_ra;
+	int cc1_rp, cc2_rp;
+
+	ret = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_CC_STATUS);
+	if (ret < 0)
+		return ret;
+
+	ctx->typec.cc_status = ret;
+
+	cc1_rd = ret & RS_PHYTIUM_CC1_RD ? 1 : 0;
+	cc2_rd = ret & RS_PHYTIUM_CC2_RD ? 1 : 0;
+	cc1_ra = ret & RS_PHYTIUM_CC1_RA ? 1 : 0;
+	cc2_ra = ret & RS_PHYTIUM_CC2_RA ? 1 : 0;
+	cc1_rp = RS_PHYTIUM_CC1_RP(ret);
+	cc2_rp = RS_PHYTIUM_CC2_RP(ret);
+
+	/* Debug cable, nothing to do */
+	if (cc1_rd && cc2_rd) {
+		ctx->typec.cc_orientation_valid = 0;
+		return role_sw_phytium_register_partner(ctx, 0, TYPEC_ACCESSORY_DEBUG);
+	}
+
+	if (cc1_ra && cc2_ra) {
+		ctx->typec.cc_orientation_valid = 0;
+		return role_sw_phytium_register_partner(ctx, 0, TYPEC_ACCESSORY_AUDIO);
+	}
+
+	ctx->typec.cc_orientation_valid = 1;
+
+	ret = role_sw_phytium_register_partner(ctx, 1, TYPEC_ACCESSORY_NONE);
+	if (ret) {
+		dev_err(dev, "register partner\n");
+		return ret;
+	}
+
+	if (cc1_rd || cc1_rp) {
+		typec_set_orientation(ctx->typec.port, TYPEC_ORIENTATION_NORMAL);
+		ctx->typec.cc_connect = RS_PHYTIUM_CC1_CONNECTED;
+	}
+
+	if (cc2_rd || cc2_rp) {
+		typec_set_orientation(ctx->typec.port, TYPEC_ORIENTATION_REVERSE);
+		ctx->typec.cc_connect = RS_PHYTIUM_CC2_CONNECTED;
+	}
+
+	return 0;
+}
+
+static int role_sw_phytium_set_mux(struct role_sw_phytium_data *ctx, int pin_assignment)
+{
+	int mode = TYPEC_STATE_SAFE;
+
+	switch (pin_assignment) {
+	case RS_PHYTIUM_SELECT_PIN_ASSIGMENT_U:
+		/* default 4 line USB 3.1 */
+		mode = TYPEC_STATE_MODAL;
+		break;
+	case RS_PHYTIUM_SELECT_PIN_ASSIGMENT_C:
+	case RS_PHYTIUM_SELECT_PIN_ASSIGMENT_E:
+		/* 4 line DP */
+		mode = TYPEC_STATE_SAFE;
+		break;
+	case RS_PHYTIUM_SELECT_PIN_ASSIGMENT_D:
+		/* 2 line DP, 2 line USB */
+		mode = TYPEC_MODE_USB3;
+		break;
+	default:
+		mode = TYPEC_STATE_SAFE;
+		break;
+	}
+
+	ctx->typec.pin_assignment = pin_assignment;
+
+	return typec_set_mode(ctx->typec.port, mode);
+}
+
+static int role_sw_phytium_set_usb_role(struct role_sw_phytium_data *ctx, enum usb_role role)
+{
+	if (!ctx->typec.role_sw)
+		return 0;
+
+	return usb_role_switch_set_role(ctx->typec.role_sw, role);
+}
+
+static int role_sw_phytium_data_role_detect(struct role_sw_phytium_data *ctx)
+{
+	int ret;
+
+	ret = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_SYSTEM_STSTUS);
+	if (ret < 0)
+		return ret;
+
+	ctx->typec.data_role = (ret & RS_PHYTIUM_DATA_ROLE) ? TYPEC_HOST : TYPEC_DEVICE;
+	ctx->typec.vconn_role = (ret & RS_PHYTIUM_VCONN_STATUS) ? TYPEC_SOURCE : TYPEC_SINK;
+
+	typec_set_data_role(ctx->typec.port, ctx->typec.data_role);
+
+	typec_set_vconn_role(ctx->typec.port, ctx->typec.vconn_role);
+
+	if (ctx->typec.data_role == TYPEC_HOST)
+		return role_sw_phytium_set_usb_role(ctx, USB_ROLE_HOST);
+
+	return role_sw_phytium_set_usb_role(ctx, USB_ROLE_DEVICE);
+}
+
+static int role_sw_phytium_power_role_detect(struct role_sw_phytium_data *ctx)
+{
+	int ret;
+
+	ret = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_SYSTEM_STSTUS);
+	if (ret < 0)
+		return ret;
+
+	ctx->typec.power_role = (ret & RS_PHYTIUM_SINK_STATUS) ? TYPEC_SINK : TYPEC_SOURCE;
+
+	if (ctx->typec.power_role == TYPEC_SOURCE) {
+		ctx->typec.request_current = RS_PHYTIUM_DEF_1_5A;
+		ctx->typec.request_voltage = RS_PHYTIUM_DEF_5V;
+	}
+
+	typec_set_pwr_role(ctx->typec.port, ctx->typec.power_role);
+
+	return 0;
+}
+
+static int role_sw_phytium_cc_status_detect(struct role_sw_phytium_data *ctx)
+{
+	role_sw_phytium_detect_cc_orientation(ctx);
+	role_sw_phytium_detect_power_mode(ctx);
+
+	return 0;
+}
+
+static void role_sw_phytium_partner_unregister_altmode(struct role_sw_phytium_data *ctx)
+{
+	int i;
+
+	ctx->typec.dp_altmode_enter = 0;
+	ctx->typec.cust_altmode_enter = 0;
+
+	for (i = 0; i < RS_PHYTIUM_MAX_ALTMODE; i++)
+		if (ctx->typec.amode[i]) {
+			typec_unregister_altmode(ctx->typec.amode[i]);
+			ctx->typec.amode[i] = NULL;
+		}
+
+	ctx->typec.pin_assignment = 0;
+}
+
+static int role_sw_phytium_typec_register_altmode(struct role_sw_phytium_data *ctx,
+					  int svid, int vdo)
+{
+	struct device *dev = &ctx->spi_client->dev;
+	struct typec_altmode_desc desc;
+	int err;
+	int i;
+
+	desc.svid = svid;
+	desc.vdo = vdo;
+
+	for (i = 0; i < RS_PHYTIUM_MAX_ALTMODE; i++)
+		if (!ctx->typec.amode[i])
+			break;
+
+	desc.mode = i + 1; /* start with 1 */
+
+	if (i >= RS_PHYTIUM_MAX_ALTMODE) {
+		dev_err(dev, "no altmode space for registering\n");
+		return -ENOMEM;
+	}
+
+	ctx->typec.amode[i] = typec_partner_register_altmode(ctx->typec.partner,
+							     &desc);
+	if (IS_ERR(ctx->typec.amode[i])) {
+		dev_err(dev, "failed to register altmode\n");
+		err = PTR_ERR(ctx->typec.amode[i]);
+		ctx->typec.amode[i] = NULL;
+		return err;
+	}
+
+	return 0;
+}
+
+static void role_sw_phytium_unregister_partner(struct role_sw_phytium_data *ctx)
+{
+	if (ctx->typec.partner) {
+		typec_unregister_partner(ctx->typec.partner);
+		ctx->typec.partner = NULL;
+	}
+}
+
+static int role_sw_phytium_update_altmode(struct role_sw_phytium_data *ctx, int svid)
+{
+	int i;
+
+	if (svid == RS_PHYTIUM_DP_SVID)
+		ctx->typec.dp_altmode_enter = 1;
+	else
+		ctx->typec.cust_altmode_enter = 1;
+
+	for (i = 0; i < RS_PHYTIUM_MAX_ALTMODE; i++) {
+		if (!ctx->typec.amode[i])
+			continue;
+
+		if (ctx->typec.amode[i]->svid == svid) {
+			typec_altmode_update_active(ctx->typec.amode[i], true);
+			typec_altmode_notify(ctx->typec.amode[i],
+					     ctx->typec.pin_assignment,
+					     &ctx->typec.data);
+			break;
+		}
+	}
+
+	return 0;
+}
+
+static int role_sw_phytium_register_altmode(struct role_sw_phytium_data *ctx,
+				    bool dp_altmode, u8 *buf)
+{
+	int ret;
+	int svid;
+	int mid;
+
+	if (!ctx->typec.partner)
+		return 0;
+
+	svid = RS_PHYTIUM_DP_SVID;
+	if (dp_altmode) {
+		mid = buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24);
+
+		return role_sw_phytium_typec_register_altmode(ctx, svid, mid);
+	}
+
+	svid = (buf[3] << 8) | buf[2];
+	if ((buf[0] & RS_PHYTIUM_VDM_CMD_AND_ACK_MASK) !=
+			(RS_PHYTIUM_VDM_ACK | RS_PHYTIUM_VDM_CMD_ENTER_MODE))
+		return role_sw_phytium_update_altmode(ctx, svid);
+
+	if ((buf[0] & RS_PHYTIUM_VDM_CMD_AND_ACK_MASK) !=
+			(RS_PHYTIUM_VDM_ACK | RS_PHYTIUM_VDM_CMD_DIS_MOD))
+		return 0;
+
+	mid = buf[4] | (buf[5] << 8) | (buf[6] << 16) | (buf[7] << 24);
+
+	ret = role_sw_phytium_typec_register_altmode(ctx, svid, mid);
+	if (ctx->typec.cust_altmode_enter)
+		ret |= role_sw_phytium_update_altmode(ctx, svid);
+
+	return ret;
+}
+
+static int role_sw_phytium_parse_cmd(struct role_sw_phytium_data *ctx, u8 type, u8 *buf, u8 len)
+{
+	struct device *dev = &ctx->spi_client->dev;
+	u8 cur_50ma, vol_100mv;
+
+	switch (type) {
+	case RS_PHYTIUM_TYPE_SRC_CAP:
+		cur_50ma = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_REQUEST_CURRENT);
+		vol_100mv = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_REQUEST_VOLTAGE);
+
+		ctx->typec.request_voltage = vol_100mv * RS_PHYTIUM_VOLTAGE_UNIT;
+		ctx->typec.request_current = cur_50ma * RS_PHYTIUM_CURRENT_UNIT;
+
+		ctx->psy_online = RS_PHYTIUM_PSY_FIXED_ONLINE;
+		ctx->usb_type = POWER_SUPPLY_USB_TYPE_PD;
+		power_supply_changed(ctx->psy);
+		break;
+	case RS_PHYTIUM_TYPE_SNK_CAP:
+		break;
+	case RS_PHYTIUM_TYPE_SVID:
+		break;
+	case RS_PHYTIUM_TYPE_SNK_IDENTITY:
+		break;
+	case RS_PHYTIUM_TYPE_GET_DP_ALT_ENTER:
+		/* DP alt mode enter success */
+		if (buf[0])
+			role_sw_phytium_update_altmode(ctx, RS_PHYTIUM_DP_SVID);
+		break;
+	case RS_PHYTIUM_TYPE_DP_ALT_ENTER:
+		/* Update DP altmode */
+		role_sw_phytium_update_altmode(ctx, RS_PHYTIUM_DP_SVID);
+		break;
+	case RS_PHYTIUM_TYPE_OBJ_REQ:
+		role_sw_phytium_detect_power_mode(ctx);
+		break;
+	case RS_PHYTIUM_TYPE_DP_CONFIGURE:
+		role_sw_phytium_set_mux(ctx, buf[1]);
+		break;
+	case RS_PHYTIUM_TYPE_DP_DISCOVER_MODES_INFO:
+		/* Make sure discover modes valid */
+		if (buf[0] | buf[1])
+			/* Register DP Altmode */
+			role_sw_phytium_register_altmode(ctx, 1, buf);
+		break;
+	case RS_PHYTIUM_TYPE_VDM:
+		/* Register other altmode */
+		role_sw_phytium_register_altmode(ctx, 0, buf);
+		break;
+	default:
+		dev_err(dev, "ignore message(0x%.02x).\n", type);
+		break;
+	}
+
+	return 0;
+}
+
+static u8 checksum(struct device *dev, u8 *buf, u8 len)
+{
+	u8 ret = 0;
+	u8 i;
+
+	for (i = 0; i < len; i++)
+		ret += buf[i];
+
+	return ret;
+}
+
+static int role_sw_phytium_read_msg_ctrl_status(struct i2c_client *client)
+{
+	return role_sw_phytium_reg_read(client, RS_PHYTIUM_CMD_SEND_BUF);
+}
+
+static int role_sw_phytium_wait_msg_empty(struct i2c_client *client)
+{
+	int val;
+
+	return readx_poll_timeout(role_sw_phytium_read_msg_ctrl_status,
+				  client, val, (val < 0) || (val == 0),
+				  2000, 2000 * 150);
+}
+
+static int role_sw_phytium_send_msg(struct role_sw_phytium_data *ctx, u8 type, u8 *buf, u8 size)
+{
+	struct device *dev = &ctx->spi_client->dev;
+	struct role_sw_phytium_fw_msg *msg = &ctx->send_msg;
+	u8 crc;
+	int ret;
+
+	size = min_t(u8, size, (u8)RS_PHYTIUM_MAX_BUF_LEN);
+	memcpy(msg->buf, buf, size);
+	msg->msg_type = type;
+	/* msg len equals buffer length + msg_type */
+	msg->msg_len = size + 1;
+
+	/* Do CRC check for all buffer data and msg_len and msg_type */
+	crc = checksum(dev, (u8 *)msg, size + RS_PHYTIUM_HEADER_LEN);
+	msg->buf[size] = 0 - crc;
+
+	ret = role_sw_phytium_wait_msg_empty(ctx->spi_client);
+	if (ret)
+		return ret;
+
+	ret = role_sw_phytium_reg_block_write(ctx->spi_client,
+				      RS_PHYTIUM_CMD_SEND_BUF + 1, size + RS_PHYTIUM_HEADER_LEN,
+				      &msg->msg_type);
+	ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_CMD_SEND_BUF,
+				 msg->msg_len);
+	return ret;
+}
+
+static int role_sw_phytium_process_cmd(struct role_sw_phytium_data *ctx)
+{
+	struct device *dev = &ctx->spi_client->dev;
+	struct role_sw_phytium_fw_msg *msg = &ctx->recv_msg;
+	u8 len;
+	u8 crc;
+	int ret;
+
+	/* Read message from firmware */
+	ret = role_sw_phytium_reg_block_read(ctx->spi_client, RS_PHYTIUM_CMD_RECV_BUF,
+				     RS_PHYTIUM_MSG_LEN, (u8 *)msg);
+	if (ret < 0)
+		return 0;
+
+	if (!msg->msg_len)
+		return 0;
+
+	ret = role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_CMD_RECV_BUF, 0);
+	if (ret)
+		return ret;
+
+	len = msg->msg_len & RS_PHYTIUM_MSG_LEN_MASK;
+	crc = checksum(dev, (u8 *)msg, len + RS_PHYTIUM_HEADER_LEN);
+	if (crc) {
+		dev_err(dev, "message error crc(0x%.02x)\n", crc);
+		return -ERANGE;
+	}
+
+	return role_sw_phytium_parse_cmd(ctx, msg->msg_type, msg->buf, len - 1);
+}
+
+static void role_sw_phytium_translate_payload(struct device *dev, __le32 *payload,
+				      u32 *pdo, int nr, const char *type)
+{
+	int i;
+
+	if (nr > PDO_MAX_OBJECTS) {
+		dev_err(dev, "nr(%d) exceed PDO_MAX_OBJECTS(%d)\n",
+			nr, PDO_MAX_OBJECTS);
+
+		return;
+	}
+
+	for (i = 0; i < nr; i++)
+		payload[i] = cpu_to_le32(pdo[i]);
+}
+
+static int role_sw_phytium_config(struct role_sw_phytium_data *ctx)
+{
+	struct device *dev = &ctx->spi_client->dev;
+	struct role_sw_phytium_typec_params *typecp = &ctx->typec;
+	__le32 payload[PDO_MAX_OBJECTS];
+	int ret;
+
+	/* Config PD FW work under PD 2.0 */
+	ret = role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_PD_REV_INIT, PD_REV20);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_FW_CTRL_0,
+				 RS_PHYTIUM_UNSTRUCT_VDM_EN | RS_PHYTIUM_DELAY_200MS |
+				 RS_PHYTIUM_VSAFE1 | RS_PHYTIUM_FRS_EN);
+	ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_FW_CTRL_1,
+				 RS_PHYTIUM_AUTO_PD_EN | RS_PHYTIUM_FORCE_SEND_RDO);
+
+	/* Set VBUS current threshold */
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_VBUS_THRESHOLD_H, 0xff);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_VBUS_THRESHOLD_L, 0x03);
+
+	/* Fix dongle compatible issue */
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_FW_PARAM,
+				 role_sw_phytium_reg_read(ctx->tcpc_client, RS_PHYTIUM_FW_PARAM) |
+				 RS_PHYTIUM_DONGLE_IOP);
+	ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_INT_MASK, 0);
+
+	ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_PD_EXT_MSG_CTRL, 0xFF);
+	if (ret)
+		return ret;
+
+	if (typecp->caps_flags & RS_PHYTIUM_HAS_SOURCE_CAP) {
+		role_sw_phytium_translate_payload(dev, payload, typecp->src_pdo,
+					  typecp->src_pdo_nr, "source");
+		role_sw_phytium_send_msg(ctx, RS_PHYTIUM_TYPE_SRC_CAP, (u8 *)&payload,
+				 typecp->src_pdo_nr * 4);
+		role_sw_phytium_send_msg(ctx, RS_PHYTIUM_TYPE_SNK_IDENTITY, snk_identity,
+				 sizeof(snk_identity));
+		role_sw_phytium_send_msg(ctx, RS_PHYTIUM_TYPE_SET_SNK_DP_CAP, dp_caps,
+				 sizeof(dp_caps));
+	}
+
+	if (typecp->caps_flags & RS_PHYTIUM_HAS_SINK_CAP) {
+		role_sw_phytium_translate_payload(dev, payload, typecp->sink_pdo,
+					  typecp->sink_pdo_nr, "sink");
+		role_sw_phytium_send_msg(ctx, RS_PHYTIUM_TYPE_SNK_CAP, (u8 *)&payload,
+				 typecp->sink_pdo_nr * 4);
+	}
+
+	if (typecp->caps_flags & RS_PHYTIUM_HAS_SINK_WATT) {
+		if (typecp->sink_watt) {
+			ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_MAX_POWER,
+						 typecp->sink_watt);
+			/* Set min power to 1W */
+			ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_MIN_POWER, 2);
+		}
+
+		if (typecp->sink_voltage)
+			ret |= role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_MAX_VOLTAGE,
+					  typecp->sink_voltage);
+		if (ret)
+			return ret;
+	}
+
+	if (!typecp->caps_flags)
+		usleep_range(5000, 6000);
+
+	ctx->fw_version = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_FW_VER);
+	ctx->fw_subversion = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_FW_SUBVER);
+
+	return 0;
+}
+
+static void role_sw_phytium_chip_standby(struct role_sw_phytium_data *ctx)
+{
+	int ret;
+	u8 cc1, cc2;
+	struct device *dev = &ctx->spi_client->dev;
+
+	ret = role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_OCM_CTRL_0,
+				role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_OCM_CTRL_0) |
+				RS_PHYTIUM_OCM_RESET);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_ANALOG_CTRL_10, 0x80);
+	/* Set TCPC to RD and DRP enable */
+	cc1 = TCPC_ROLE_CTRL_CC_RD << TCPC_ROLE_CTRL_CC1_SHIFT;
+	cc2 = TCPC_ROLE_CTRL_CC_RD << TCPC_ROLE_CTRL_CC2_SHIFT;
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, TCPC_ROLE_CTRL,
+				 TCPC_ROLE_CTRL_DRP | cc1 | cc2);
+
+	/* Send DRP toggle command */
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, TCPC_COMMAND,
+				 TCPC_CMD_LOOK4CONNECTION);
+
+	/* Send TCPC enter standby command */
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client,
+				 TCPC_COMMAND, TCPC_CMD_I2C_IDLE);
+	if (ret)
+		dev_err(dev, "Chip standby failed\n");
+}
+
+static void role_sw_phytium_work_func(struct work_struct *work)
+{
+	int ret;
+	u8 buf[RS_PHYTIUM_STATUS_LEN];
+	u8 int_change; /* Interrupt change */
+	u8 int_status; /* Firmware status update */
+	u8 alert0, alert1; /* Interrupt alert source */
+	struct role_sw_phytium_data *ctx = container_of(work, struct role_sw_phytium_data, work);
+	struct device *dev = &ctx->spi_client->dev;
+
+	mutex_lock(&ctx->lock);
+
+	/* Read interrupt change status */
+	ret = role_sw_phytium_reg_block_read(ctx->spi_client, RS_PHYTIUM_INT_STS,
+						 RS_PHYTIUM_STATUS_LEN, buf);
+	if (ret < 0) {
+		/* Power standby mode, just return */
+		goto unlock;
+	}
+	int_change = buf[0];
+	int_status = buf[1];
+
+	/* Read alert register */
+	ret = role_sw_phytium_reg_block_read(ctx->tcpc_client, RS_PHYTIUM_ALERT_0,
+						 RS_PHYTIUM_STATUS_LEN, buf);
+	if (ret < 0)
+		goto unlock;
+
+	alert0 = buf[0];
+	alert1 = buf[1];
+
+	/* Clear interrupt and alert status */
+	ret = role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_INT_STS, 0);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_ALERT_0, alert0);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_ALERT_1, alert1);
+	if (ret)
+		goto unlock;
+
+	if (alert1 & RS_PHYTIUM_INTP_POW_OFF) {
+		role_sw_phytium_partner_unregister_altmode(ctx);
+		if (role_sw_phytium_set_usb_role(ctx, USB_ROLE_NONE))
+			dev_err(dev, "Set usb role\n");
+		role_sw_phytium_unregister_partner(ctx);
+		ctx->psy_online = RS_PHYTIUM_PSY_OFFLINE;
+		ctx->usb_type = POWER_SUPPLY_USB_TYPE_C;
+		ctx->typec.request_voltage = 0;
+		ctx->typec.request_current = 0;
+		power_supply_changed(ctx->psy);
+		role_sw_phytium_chip_standby(ctx);
+		goto unlock;
+	}
+
+	if ((alert0 & RS_PHYTIUM_SOFTWARE_INT) && (int_change & RS_PHYTIUM_OCM_BOOT_UP)) {
+		if (role_sw_phytium_config(ctx))
+			dev_err(dev, "Config failed\n");
+		if (role_sw_phytium_data_role_detect(ctx))
+			dev_err(dev, "set PD data role\n");
+		if (role_sw_phytium_power_role_detect(ctx))
+			dev_err(dev, "set PD power role\n");
+		role_sw_phytium_set_mux(ctx, RS_PHYTIUM_SELECT_PIN_ASSIGMENT_C);
+	}
+
+	if (alert0 & RS_PHYTIUM_RECEIVED_MSG)
+		role_sw_phytium_process_cmd(ctx);
+
+	ret = (int_status & RS_PHYTIUM_DATA_ROLE) ? TYPEC_HOST : TYPEC_DEVICE;
+	if (ctx->typec.data_role != ret)
+		if (role_sw_phytium_data_role_detect(ctx))
+			dev_err(dev, "set PD data role\n");
+
+	ret = (int_status & RS_PHYTIUM_SINK_STATUS) ? TYPEC_SINK : TYPEC_SOURCE;
+	if (ctx->typec.power_role != ret)
+		if (role_sw_phytium_power_role_detect(ctx))
+			dev_err(dev, "set PD power role\n");
+
+	if ((alert0 & RS_PHYTIUM_SOFTWARE_INT) && (int_change & RS_PHYTIUM_CC_STATUS_CHANGE))
+		role_sw_phytium_cc_status_detect(ctx);
+
+unlock:
+	mutex_unlock(&ctx->lock);
+}
+
+static irqreturn_t role_sw_phytium_intr_isr(int irq, void *data)
+{
+	struct role_sw_phytium_data *ctx = (struct role_sw_phytium_data *)data;
+
+	queue_work(ctx->workqueue, &ctx->work);
+
+	return IRQ_HANDLED;
+}
+
+static int role_sw_phytium_register_i2c_dummy_clients(struct role_sw_phytium_data *ctx,
+					      struct i2c_client *client)
+{
+	int i;
+	u8 spi_addr;
+
+	for (i = 0; i < ARRAY_SIZE(role_sw_phytium_i2c_addr); i++) {
+		if (client->addr == (role_sw_phytium_i2c_addr[i].tcpc_address >> 1)) {
+			spi_addr = role_sw_phytium_i2c_addr[i].spi_address >> 1;
+			ctx->spi_client = i2c_new_dummy_device(client->adapter,
+							       spi_addr);
+			if (!IS_ERR(ctx->spi_client))
+				return 0;
+		}
+	}
+
+	dev_err(&client->dev, "unable to get SPI slave\n");
+	return -ENOMEM;
+}
+
+static void role_sw_phytium_port_unregister_altmodes(struct typec_altmode **adev)
+{
+	int i;
+
+	for (i = 0; i < RS_PHYTIUM_MAX_ALTMODE; i++)
+		if (adev[i]) {
+			typec_unregister_altmode(adev[i]);
+			adev[i] = NULL;
+		}
+}
+
+static int role_sw_phytium_usb_mux_set(struct typec_mux_dev *mux,
+			       struct typec_mux_state *state)
+{
+	struct role_sw_phytium_data *ctx = typec_mux_get_drvdata(mux);
+	struct device *dev = &ctx->spi_client->dev;
+	int has_dp;
+
+	has_dp = (state->alt && state->alt->svid == USB_TYPEC_DP_SID &&
+		  state->alt->mode == USB_TYPEC_DP_MODE);
+	if (!has_dp)
+		dev_err(dev, "dp altmode not register\n");
+
+	return 0;
+}
+
+static int role_sw_phytium_usb_set_orientation(struct typec_switch_dev *sw,
+				       enum typec_orientation orientation)
+{
+	/* No need set */
+
+	return 0;
+}
+
+static int role_sw_phytium_register_switch(struct role_sw_phytium_data *ctx,
+				   struct device *dev,
+				   struct fwnode_handle *fwnode)
+{
+	struct typec_switch_desc sw_desc = { };
+
+	sw_desc.fwnode = fwnode;
+	sw_desc.drvdata = ctx;
+	sw_desc.name = fwnode_get_name(fwnode);
+	sw_desc.set = role_sw_phytium_usb_set_orientation;
+
+	ctx->typec.typec_switch = typec_switch_register(dev, &sw_desc);
+	if (IS_ERR(ctx->typec.typec_switch)) {
+		dev_err(dev, "switch register failed\n");
+		return PTR_ERR(ctx->typec.typec_switch);
+	}
+
+	return 0;
+}
+
+static int role_sw_phytium_register_mux(struct role_sw_phytium_data *ctx,
+				struct device *dev,
+				struct fwnode_handle *fwnode)
+{
+	struct typec_mux_desc mux_desc = { };
+
+	mux_desc.fwnode = fwnode;
+	mux_desc.drvdata = ctx;
+	mux_desc.name = fwnode_get_name(fwnode);
+	mux_desc.set = role_sw_phytium_usb_mux_set;
+
+	ctx->typec.typec_mux = typec_mux_register(dev, &mux_desc);
+	if (IS_ERR(ctx->typec.typec_mux)) {
+		dev_err(dev, "mux register failed\n");
+		return PTR_ERR(ctx->typec.typec_mux);
+	}
+
+	return 0;
+}
+
+static void role_sw_phytium_unregister_mux(struct role_sw_phytium_data *ctx)
+{
+	if (ctx->typec.typec_mux) {
+		typec_mux_unregister(ctx->typec.typec_mux);
+		ctx->typec.typec_mux = NULL;
+	}
+}
+
+static void role_sw_phytium_unregister_switch(struct role_sw_phytium_data *ctx)
+{
+	if (ctx->typec.typec_switch) {
+		typec_switch_unregister(ctx->typec.typec_switch);
+		ctx->typec.typec_switch = NULL;
+	}
+}
+
+static int role_sw_phytium_typec_switch_probe(struct role_sw_phytium_data *ctx,
+				      struct device *dev)
+{
+	int ret;
+	struct fwnode_handle *fwnode;
+	char sw_str[32] = {0}, almode_str[32] = {0};
+
+	if (has_acpi_companion(dev)) {
+		strscpy(sw_str, "ORSW", sizeof(sw_str));
+		strscpy(almode_str, "ALSW", sizeof(almode_str));
+	} else {
+		strscpy(sw_str, "orientation_switch", sizeof(sw_str));
+		strscpy(almode_str, "mode_switch", sizeof(almode_str));
+	}
+
+	fwnode = device_get_named_child_node(dev, sw_str);
+	if (!fwnode) {
+		dev_err(dev, "Err:cannot find %s\n", sw_str);
+		return -EINVAL;
+	}
+
+	ret = role_sw_phytium_register_switch(ctx, dev, fwnode);
+	if (ret) {
+		dev_err(dev, "failed register switch");
+		return ret;
+	}
+
+	fwnode = device_get_named_child_node(dev, almode_str);
+	if (!fwnode) {
+		dev_err(dev, "no typec mux exist");
+		ret = -ENODEV;
+		goto unregister_switch;
+	}
+	ret = role_sw_phytium_register_mux(ctx, dev, fwnode);
+	if (ret) {
+		dev_err(dev, "failed register mode switch");
+		ret = -ENODEV;
+		goto unregister_switch;
+	}
+
+	return 0;
+
+unregister_switch:
+	role_sw_phytium_unregister_switch(ctx);
+
+	return ret;
+}
+
+static int role_sw_phytium_typec_port_probe(struct role_sw_phytium_data *ctx,
+				    struct device *dev)
+{
+	struct typec_capability *cap = &ctx->typec.caps;
+	struct role_sw_phytium_typec_params *typecp = &ctx->typec;
+	struct fwnode_handle *fwnode;
+	const char *buf;
+	int ret, i;
+	char conc_str[32] = {0};
+
+	if (has_acpi_companion(dev))
+		strscpy(conc_str, "CONC", sizeof(conc_str));
+	else
+		strscpy(conc_str, "connector", sizeof(conc_str));
+
+	fwnode = device_get_named_child_node(dev, conc_str);
+	if (!fwnode)
+		return -EINVAL;
+
+	ret = fwnode_property_read_string(fwnode, "power-role", &buf);
+	if (ret) {
+		dev_err(dev, "power-role not found: %d\n", ret);
+		return ret;
+	}
+
+	ret = typec_find_port_power_role(buf);
+	if (ret < 0)
+		return ret;
+	cap->type = ret;
+
+	ret = fwnode_property_read_string(fwnode, "data-role", &buf);
+	if (ret) {
+		dev_err(dev, "data-role not found: %d\n", ret);
+		return ret;
+	}
+
+	ret = typec_find_port_data_role(buf);
+	if (ret < 0)
+		return ret;
+	cap->data = ret;
+
+	ret = fwnode_property_read_string(fwnode, "try-power-role", &buf);
+	if (ret) {
+		dev_err(dev, "try-power-role not found: %d\n", ret);
+		return ret;
+	}
+
+	ret = typec_find_power_role(buf);
+	if (ret < 0)
+		return ret;
+	cap->prefer_role = ret;
+
+	/* Get source pdos */
+	ret = fwnode_property_count_u32(fwnode, "source-pdos");
+	if (ret > 0) {
+		typecp->src_pdo_nr = min_t(u8, ret, PDO_MAX_OBJECTS);
+		ret = fwnode_property_read_u32_array(fwnode, "source-pdos",
+						     typecp->src_pdo,
+						     typecp->src_pdo_nr);
+		if (ret < 0) {
+			dev_err(dev, "source cap validate failed: %d\n", ret);
+			return -EINVAL;
+		}
+
+		typecp->caps_flags |= RS_PHYTIUM_HAS_SOURCE_CAP;
+	}
+
+	ret = fwnode_property_count_u32(fwnode, "sink-pdos");
+	if (ret > 0) {
+		typecp->sink_pdo_nr = min_t(u8, ret, PDO_MAX_OBJECTS);
+		ret = fwnode_property_read_u32_array(fwnode, "sink-pdos",
+						     typecp->sink_pdo,
+						     typecp->sink_pdo_nr);
+		if (ret < 0) {
+			dev_err(dev, "sink cap validate failed: %d\n", ret);
+			return -EINVAL;
+		}
+
+		for (i = 0; i < typecp->sink_pdo_nr; i++) {
+			ret = 0;
+			switch (pdo_type(typecp->sink_pdo[i])) {
+			case PDO_TYPE_FIXED:
+				ret = pdo_fixed_voltage(typecp->sink_pdo[i]);
+				break;
+			case PDO_TYPE_BATT:
+			case PDO_TYPE_VAR:
+				ret = pdo_max_voltage(typecp->sink_pdo[i]);
+				break;
+			case PDO_TYPE_APDO:
+			default:
+				ret = 0;
+				break;
+			}
+
+			/* 100mv per unit */
+			typecp->sink_voltage = max(5000, ret) / 100;
+		}
+
+		typecp->caps_flags |= RS_PHYTIUM_HAS_SINK_CAP;
+	}
+
+	if (!fwnode_property_read_u32(fwnode, "op-sink-microwatt", &ret)) {
+		typecp->sink_watt = ret / 500000; /* 500mw per unit */
+		typecp->caps_flags |= RS_PHYTIUM_HAS_SINK_WATT;
+	}
+
+	cap->fwnode = fwnode;
+
+	ctx->typec.role_sw = usb_role_switch_get(dev);
+	if (IS_ERR(ctx->typec.role_sw)) {
+		dev_err(dev, "USB role switch not found.\n");
+		ctx->typec.role_sw = NULL;
+	}
+
+	ctx->typec.port = typec_register_port(dev, cap);
+	if (IS_ERR(ctx->typec.port)) {
+		ret = PTR_ERR(ctx->typec.port);
+		ctx->typec.port = NULL;
+		dev_err(dev, "Failed to register type c port %d\n", ret);
+		return ret;
+	}
+
+	typec_port_register_altmodes(ctx->typec.port, NULL, ctx,
+				     ctx->typec.port_amode,
+				     RS_PHYTIUM_MAX_ALTMODE);
+	return 0;
+}
+
+static int role_sw_phytium_typec_check_connection(struct role_sw_phytium_data *ctx)
+{
+	int ret;
+
+	ret = role_sw_phytium_reg_read(ctx->spi_client, RS_PHYTIUM_FW_VER);
+	if (ret < 0)
+		return 0; /* No device attached in typec port */
+
+	/* Clear interrupt and alert status */
+	ret = role_sw_phytium_reg_write(ctx->spi_client, RS_PHYTIUM_INT_STS, 0);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_ALERT_0, 0xFF);
+	ret |= role_sw_phytium_reg_write(ctx->tcpc_client, RS_PHYTIUM_ALERT_1, 0xFF);
+	if (ret)
+		return ret;
+
+	ret = role_sw_phytium_cc_status_detect(ctx);
+	ret |= role_sw_phytium_power_role_detect(ctx);
+	ret |= role_sw_phytium_data_role_detect(ctx);
+	ret |= role_sw_phytium_set_mux(ctx, RS_PHYTIUM_SELECT_PIN_ASSIGMENT_C);
+	if (ret)
+		return ret;
+
+	ret = role_sw_phytium_send_msg(ctx, RS_PHYTIUM_TYPE_GET_DP_ALT_ENTER, NULL, 0);
+	ret |= role_sw_phytium_send_msg(ctx, RS_PHYTIUM_TYPE_GET_DP_DISCOVER_MODES_INFO, NULL, 0);
+
+	return ret;
+}
+
+static int __maybe_unused role_sw_phytium_runtime_pm_suspend(struct device *dev)
+{
+	struct role_sw_phytium_data *ctx = dev_get_drvdata(dev);
+
+	mutex_lock(&ctx->lock);
+
+	role_sw_phytium_partner_unregister_altmode(ctx);
+
+	if (ctx->typec.partner)
+		role_sw_phytium_unregister_partner(ctx);
+
+	mutex_unlock(&ctx->lock);
+
+	return 0;
+}
+
+static int __maybe_unused role_sw_phytium_runtime_pm_resume(struct device *dev)
+{
+	struct role_sw_phytium_data *ctx = dev_get_drvdata(dev);
+
+	mutex_lock(&ctx->lock);
+	/* Detect PD connection */
+	if (role_sw_phytium_typec_check_connection(ctx))
+		dev_err(dev, "check connection");
+
+	mutex_unlock(&ctx->lock);
+
+	return 0;
+}
+
+static const struct dev_pm_ops role_sw_phytium_pm_ops = {
+	SET_SYSTEM_SLEEP_PM_OPS(pm_runtime_force_suspend,
+				pm_runtime_force_resume)
+	SET_RUNTIME_PM_OPS(role_sw_phytium_runtime_pm_suspend,
+			   role_sw_phytium_runtime_pm_resume, NULL)
+};
+
+static void role_sw_phytium_get_gpio_irq_acpi(struct role_sw_phytium_data *ctx)
+{
+	struct device *dev = &ctx->tcpc_client->dev;
+
+	if (!ctx->adev) {
+		dev_err(dev, "Err: no valid fwnode\n");
+		return;
+	}
+
+	ctx->intp_irq = acpi_dev_gpio_irq_get(ctx->adev, 0);
+	if (ctx->intp_irq < 0)
+		dev_err(dev, "failed to get GPIO IRQ\n");
+}
+
+static void role_sw_phytium_get_gpio_irq(struct role_sw_phytium_data *ctx)
+{
+	struct device *dev = &ctx->tcpc_client->dev;
+
+	ctx->intp_gpiod = devm_gpiod_get_optional(dev, "interrupt", GPIOD_IN);
+	if (IS_ERR_OR_NULL(ctx->intp_gpiod)) {
+		dev_err(dev, "no interrupt gpio property\n");
+		return;
+	}
+
+	ctx->intp_irq = gpiod_to_irq(ctx->intp_gpiod);
+	if (ctx->intp_irq < 0)
+		dev_err(dev, "failed to get GPIO IRQ\n");
+}
+
+static enum power_supply_usb_type role_sw_phytium_psy_usb_types[] = {
+	POWER_SUPPLY_USB_TYPE_C,
+	POWER_SUPPLY_USB_TYPE_PD,
+	POWER_SUPPLY_USB_TYPE_PD_PPS,
+};
+
+static enum power_supply_property role_sw_phytium_psy_props[] = {
+	POWER_SUPPLY_PROP_USB_TYPE,
+	POWER_SUPPLY_PROP_ONLINE,
+	POWER_SUPPLY_PROP_VOLTAGE_MIN,
+	POWER_SUPPLY_PROP_VOLTAGE_MAX,
+	POWER_SUPPLY_PROP_VOLTAGE_NOW,
+	POWER_SUPPLY_PROP_CURRENT_MAX,
+	POWER_SUPPLY_PROP_CURRENT_NOW,
+};
+
+static int role_sw_phytium_psy_set_prop(struct power_supply *psy,
+				enum power_supply_property psp,
+				const union power_supply_propval *val)
+{
+	struct role_sw_phytium_data *ctx = power_supply_get_drvdata(psy);
+	int ret = 0;
+
+	if (psp == POWER_SUPPLY_PROP_ONLINE)
+		ctx->psy_online = val->intval;
+	else
+		ret = -EINVAL;
+
+	power_supply_changed(ctx->psy);
+	return ret;
+}
+
+static int role_sw_phytium_psy_prop_writeable(struct power_supply *psy,
+				      enum power_supply_property psp)
+{
+	return psp == POWER_SUPPLY_PROP_ONLINE;
+}
+
+static int role_sw_phytium_psy_get_prop(struct power_supply *psy,
+				enum power_supply_property psp,
+				union power_supply_propval *val)
+{
+	struct role_sw_phytium_data *ctx = power_supply_get_drvdata(psy);
+	int ret = 0;
+
+	if (!ctx) {
+		pr_err("ctx is null.\n");
+		return -EINVAL;
+	}
+	switch (psp) {
+	case POWER_SUPPLY_PROP_USB_TYPE:
+		val->intval = ctx->usb_type;
+		break;
+	case POWER_SUPPLY_PROP_ONLINE:
+		val->intval = ctx->psy_online;
+		break;
+	case POWER_SUPPLY_PROP_VOLTAGE_NOW:
+	case POWER_SUPPLY_PROP_VOLTAGE_MIN:
+	case POWER_SUPPLY_PROP_VOLTAGE_MAX:
+		val->intval = (ctx->psy_online) ?
+			ctx->typec.request_voltage * 1000 : 0;
+		break;
+	case POWER_SUPPLY_PROP_CURRENT_NOW:
+	case POWER_SUPPLY_PROP_CURRENT_MAX:
+		val->intval = (ctx->psy_online) ?
+			ctx->typec.request_current * 1000 : 0;
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+	return ret;
+}
+
+static int role_sw_phytium_psy_register(struct role_sw_phytium_data *ctx)
+{
+	struct power_supply_desc *psy_desc = &ctx->psy_desc;
+	struct power_supply_config psy_cfg = {};
+	char *psy_name;
+
+	psy_name = devm_kasprintf(ctx->dev, GFP_KERNEL, "anx7411-source-psy-%s",
+				  dev_name(ctx->dev));
+	if (!psy_name)
+		return -ENOMEM;
+
+	psy_desc->name = psy_name;
+	psy_desc->type = POWER_SUPPLY_TYPE_USB;
+	psy_desc->usb_types = role_sw_phytium_psy_usb_types;
+	psy_desc->num_usb_types = ARRAY_SIZE(role_sw_phytium_psy_usb_types);
+	psy_desc->properties = role_sw_phytium_psy_props;
+	psy_desc->num_properties = ARRAY_SIZE(role_sw_phytium_psy_props);
+
+	psy_desc->get_property = role_sw_phytium_psy_get_prop;
+	psy_desc->set_property = role_sw_phytium_psy_set_prop;
+	psy_desc->property_is_writeable = role_sw_phytium_psy_prop_writeable;
+	psy_cfg.drv_data = ctx;
+	ctx->usb_type = POWER_SUPPLY_USB_TYPE_C;
+	ctx->psy = devm_power_supply_register(ctx->dev, psy_desc, &psy_cfg);
+
+	if (IS_ERR(ctx->psy))
+		dev_warn(ctx->dev, "unable to register psy\n");
+
+	return PTR_ERR_OR_ZERO(ctx->psy);
+}
+
+static int role_sw_phytium_i2c_probe(struct i2c_client *client)
+{
+	struct role_sw_phytium_data *plat;
+	struct device *dev = &client->dev;
+	int ret;
+
+	dev_info(dev, "probe start\n");
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_I2C_BLOCK))
+		return -ENODEV;
+
+	plat = devm_kzalloc(dev, sizeof(*plat), GFP_KERNEL);
+	if (!plat)
+		return -ENOMEM;
+
+	plat->tcpc_client = client;
+	i2c_set_clientdata(client, plat);
+
+	mutex_init(&plat->lock);
+
+	ret = role_sw_phytium_register_i2c_dummy_clients(plat, client);
+	if (ret) {
+		dev_err(dev, "fail to reserve I2C bus\n");
+		return ret;
+	}
+
+	ret = role_sw_phytium_typec_switch_probe(plat, dev);
+	if (ret) {
+		dev_err(dev, "fail to probe typec switch\n");
+		goto free_i2c_dummy;
+	}
+
+	ret = role_sw_phytium_typec_port_probe(plat, dev);
+	if (ret) {
+		dev_err(dev, "fail to probe typec property.\n");
+		ret = -ENODEV;
+		goto free_typec_switch;
+	}
+
+	plat->intp_irq = client->irq;
+	plat->adev = ACPI_COMPANION(dev);
+	if (!client->irq) {
+		if (has_acpi_companion(dev))
+			role_sw_phytium_get_gpio_irq_acpi(plat);
+		else
+			role_sw_phytium_get_gpio_irq(plat);
+	}
+
+	if (!plat->intp_irq) {
+		dev_err(dev, "fail to get interrupt IRQ\n");
+		ret = -EINVAL;
+		goto free_typec_port;
+	}
+
+	plat->dev = dev;
+	plat->psy_online = RS_PHYTIUM_PSY_OFFLINE;
+	ret = role_sw_phytium_psy_register(plat);
+	if (ret) {
+		dev_err(dev, "register psy\n");
+		goto free_typec_port;
+	}
+
+	INIT_WORK(&plat->work, role_sw_phytium_work_func);
+	plat->workqueue = alloc_workqueue("rs_phytium_work",
+					  WQ_FREEZABLE |
+					  WQ_MEM_RECLAIM,
+					  1);
+	if (!plat->workqueue) {
+		dev_err(dev, "fail to create work queue\n");
+		ret = -ENOMEM;
+		goto free_typec_port;
+	}
+
+	ret = devm_request_threaded_irq(dev, plat->intp_irq,
+					NULL, role_sw_phytium_intr_isr,
+					IRQF_TRIGGER_FALLING |
+					IRQF_ONESHOT,
+					"rs-phytium-intp", plat);
+	if (ret) {
+		dev_err(dev, "fail to request irq\n");
+		goto free_wq;
+	}
+
+	if (role_sw_phytium_typec_check_connection(plat))
+		dev_err(dev, "check status\n");
+
+	pm_runtime_enable(dev);
+
+	dev_info(dev, "probe ok\n");
+	return 0;
+
+free_wq:
+	destroy_workqueue(plat->workqueue);
+
+free_typec_port:
+	typec_unregister_port(plat->typec.port);
+	role_sw_phytium_port_unregister_altmodes(plat->typec.port_amode);
+
+free_typec_switch:
+	role_sw_phytium_unregister_switch(plat);
+	role_sw_phytium_unregister_mux(plat);
+
+free_i2c_dummy:
+	i2c_unregister_device(plat->spi_client);
+
+	return ret;
+}
+
+static void role_sw_phytium_i2c_remove(struct i2c_client *client)
+{
+	struct role_sw_phytium_data *plat = i2c_get_clientdata(client);
+
+	role_sw_phytium_partner_unregister_altmode(plat);
+	role_sw_phytium_unregister_partner(plat);
+
+	if (plat->workqueue)
+		destroy_workqueue(plat->workqueue);
+
+	if (plat->spi_client)
+		i2c_unregister_device(plat->spi_client);
+
+	if (plat->typec.role_sw)
+		usb_role_switch_put(plat->typec.role_sw);
+
+	role_sw_phytium_unregister_mux(plat);
+
+	role_sw_phytium_unregister_switch(plat);
+
+	if (plat->typec.port)
+		typec_unregister_port(plat->typec.port);
+
+	role_sw_phytium_port_unregister_altmodes(plat->typec.port_amode);
+}
+
+static const struct i2c_device_id role_sw_phytium_id[] = {
+	{"role-sw", 0},
+	{}
+};
+
+MODULE_DEVICE_TABLE(i2c, role_sw_phytium_id);
+
+static const struct of_device_id role_sw_phytium_match_table[] = {
+	{.compatible = "phytium,role-sw",},
+	{},
+};
+static const struct acpi_device_id role_sw_phytium_acpi_match[] = {
+	{ "PHYT0066", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, role_sw_phytium_acpi_match);
+static struct i2c_driver role_sw_phytium_driver = {
+	.driver = {
+		.name = "phytium_role_sw",
+		.of_match_table = role_sw_phytium_match_table,
+		.acpi_match_table = ACPI_PTR(role_sw_phytium_acpi_match),
+		.pm = &role_sw_phytium_pm_ops,
+	},
+	.probe = role_sw_phytium_i2c_probe,
+	.remove = role_sw_phytium_i2c_remove,
+
+	.id_table = role_sw_phytium_id,
+};
+
+module_i2c_driver(role_sw_phytium_driver);
+
+MODULE_DESCRIPTION("Phytium USB Type-C PD driver");
+MODULE_AUTHOR("Wu Jinyong <wujinyong1788@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_VERSION(RS_PHYTIUM_DRV_VERSION);

--- a/drivers/usb/typec/role-switch-phytium.c
+++ b/drivers/usb/typec/role-switch-phytium.c
@@ -1630,7 +1630,7 @@ static const struct of_device_id role_sw_phytium_match_table[] = {
 	{},
 };
 static const struct acpi_device_id role_sw_phytium_acpi_match[] = {
-	{ "PHYT0066", 0 },
+	{ "PHYT8011", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, role_sw_phytium_acpi_match);


### PR DESCRIPTION
Fix some problem about usb and xHCI.
Add support for the phytium typec driver.
Patch documents the DT binding.

## Summary by Sourcery

Add Phytium USB v2 DRD and Type-C role switch drivers, and fix issues in the existing Phytium USB host and generic XHCI drivers.

New Features:
- Add Phytium USB v2 DRD controller driver.
- Add Phytium Type-C role switch driver.
- Add devicetree bindings for the new Phytium USB v2 and Type-C role switch drivers.
- Add build system support for the new Phytium drivers.
- Add Kconfig options for the new Phytium drivers.
- Add support for XHCI S1 suspend/wakeup quirk on Phytium platforms.
- Add version string to the Phytium OTG platform driver.
- Add debug function to dump endpoint remap pool.
- Add error handling for endpoint resource exhaustion.
- Add handling for STS_WAKEUP in XHCI IRQ handler.
- Add XHCI quirk for S1 suspend/wakeup support.
- Add copyright headers to Phytium driver files.
- Update MAINTAINERS file.
- Add build configuration for Phytium USB v2 driver.
- Add build configuration for Phytium Type-C role switch driver.
- Add Kconfig option for Phytium USB v2 driver.
- Add Kconfig option for Phytium Type-C role switch driver.
- Add Phytium USB v2 DRD driver implementation.
- Add Phytium Type-C role switch driver implementation.
- Add devicetree binding documentation for Phytium Type-C role switch.
- Add devicetree binding documentation for Phytium USB v2.