### PR TITLE
gpio: phytium: Update support for Phytium GPIO controller driver

### DIFF
--- a/drivers/gpio/gpio-phytium-core.c
+++ b/drivers/gpio/gpio-phytium-core.c
@@ -129,13 +129,12 @@ int phytium_gpio_direction_output(struct gpio_chip *gc, unsigned int offset,
 		return -EINVAL;
 	ddr = gpio->regs + GPIO_SWPORTA_DDR + (loc.port * GPIO_PORT_STRIDE);
 
+	phytium_gpio_set(gc, offset, value);
 	raw_spin_lock_irqsave(&gpio->lock, flags);
 
 	writel(readl(ddr) | BIT(loc.offset), ddr);
 
 	raw_spin_unlock_irqrestore(&gpio->lock, flags);
-
-	phytium_gpio_set(gc, offset, value);
 
 	return 0;
 }

--- a/drivers/gpio/gpio-phytium-core.c
+++ b/drivers/gpio/gpio-phytium-core.c
@@ -271,6 +271,8 @@ void phytium_gpio_irq_enable(struct irq_data *d)
 	unsigned long flags;
 	u32 val;
 
+	if (gpio->is_resuming)
+		return;
 	/* Only port A can provide interrupt source */
 	if (irqd_to_hwirq(d) >= gpio->ngpio[0])
 		return;

--- a/drivers/gpio/gpio-phytium-core.c
+++ b/drivers/gpio/gpio-phytium-core.c
@@ -327,19 +327,36 @@ void phytium_gpio_irq_handler(struct irq_desc *desc)
 	struct irq_chip *irqchip = irq_desc_get_chip(desc);
 	unsigned long pending;
 	int offset;
+	int index = -1;
+	unsigned int index_found = 0;
 
 	chained_irq_enter(irqchip, desc);
 
 	pending = readl(gpio->regs + GPIO_INTSTATUS);
+
+	if (gc->irq.num_parents > 1) {
+		for (index = 0 ; index < gc->irq.num_parents; index++) {
+			if (gc->irq.parents[index] == desc->irq_data.irq) {
+				index_found = 1;
+				break;
+			}
+		}
+		if (index_found == 0) {
+			pr_err("Can't find index for this gpio interrupt.\n");
+			index = -1;
+		}
+	}
+
 	if (pending) {
 		for_each_set_bit(offset, &pending, gpio->ngpio[0]) {
-			int gpio_irq = irq_find_mapping(gc->irq.domain,
-							offset);
-			generic_handle_irq(gpio_irq);
-
-			if ((irq_get_trigger_type(gpio_irq) &
-			    IRQ_TYPE_SENSE_MASK) == IRQ_TYPE_EDGE_BOTH)
-				phytium_gpio_toggle_trigger(gpio, offset);
+			if (index == -1 || offset == index) {
+				int gpio_irq = irq_find_mapping(gc->irq.domain,
+						offset);
+				generic_handle_irq(gpio_irq);
+				if ((irq_get_trigger_type(gpio_irq) &
+					IRQ_TYPE_SENSE_MASK) == IRQ_TYPE_EDGE_BOTH)
+					phytium_gpio_toggle_trigger(gpio, offset);
+			}
 		}
 	}
 

--- a/drivers/gpio/gpio-phytium-core.h
+++ b/drivers/gpio/gpio-phytium-core.h
@@ -63,6 +63,7 @@ struct phytium_gpio {
 	struct gpio_chip	gc;
 	unsigned int		ngpio[2];
 	int			irq[32];
+	int			is_resuming;
 #ifdef CONFIG_PM_SLEEP
 	struct phytium_gpio_ctx	ctx;
 #endif

--- a/drivers/gpio/gpio-phytium-pci.c
+++ b/drivers/gpio/gpio-phytium-pci.c
@@ -85,6 +85,7 @@ static int phytium_gpio_pci_probe(struct pci_dev *pdev, const struct pci_device_
 	girq = &gpio->gc.irq;
 	girq->handler = handle_bad_irq;
 	girq->default_type = IRQ_TYPE_NONE;
+	gpio->is_resuming = 0;
 
 	girq->num_parents = 1;
 	girq->parents = devm_kcalloc(&pdev->dev, girq->num_parents,
@@ -132,11 +133,13 @@ static int phytium_gpio_pci_suspend(struct device *dev)
 	gpio->ctx.ext_portb = readl(gpio->regs + GPIO_EXT_PORTB);
 
 	gpio->ctx.inten = readl(gpio->regs + GPIO_INTEN);
+	gpio->is_resuming = 1;
 	gpio->ctx.intmask = readl(gpio->regs + GPIO_INTMASK);
 	gpio->ctx.inttype_level = readl(gpio->regs + GPIO_INTTYPE_LEVEL);
 	gpio->ctx.int_polarity = readl(gpio->regs + GPIO_INT_POLARITY);
 	gpio->ctx.debounce = readl(gpio->regs + GPIO_DEBOUNCE);
 
+	writel(0, gpio->regs + GPIO_INTEN);
 	raw_spin_unlock_irqrestore(&gpio->lock, flags);
 
 	return 0;
@@ -157,13 +160,15 @@ static int phytium_gpio_pci_resume(struct device *dev)
 	writel(gpio->ctx.swportb_ddr, gpio->regs + GPIO_SWPORTB_DDR);
 	writel(gpio->ctx.ext_portb, gpio->regs + GPIO_EXT_PORTB);
 
-	writel(gpio->ctx.inten, gpio->regs + GPIO_INTEN);
 	writel(gpio->ctx.intmask, gpio->regs + GPIO_INTMASK);
 	writel(gpio->ctx.inttype_level, gpio->regs + GPIO_INTTYPE_LEVEL);
 	writel(gpio->ctx.int_polarity, gpio->regs + GPIO_INT_POLARITY);
 	writel(gpio->ctx.debounce, gpio->regs + GPIO_DEBOUNCE);
 
 	writel(0xffffffff, gpio->regs + GPIO_PORTA_EOI);
+
+	writel(gpio->ctx.inten, gpio->regs + GPIO_INTEN);
+	gpio->is_resuming = 0;
 
 	raw_spin_unlock_irqrestore(&gpio->lock, flags);
 

--- a/drivers/gpio/gpio-phytium-platform.c
+++ b/drivers/gpio/gpio-phytium-platform.c
@@ -105,6 +105,7 @@ static int phytium_gpio_probe(struct platform_device *pdev)
 	girq = &gpio->gc.irq;
 	girq->handler = handle_bad_irq;
 	girq->default_type = IRQ_TYPE_NONE;
+	gpio->is_resuming = 0;
 
 	for (irq_count = 0; irq_count < platform_irq_count(pdev); irq_count++) {
 		gpio->irq[irq_count] = -ENXIO;
@@ -149,11 +150,13 @@ static int phytium_gpio_suspend(struct device *dev)
 	gpio->ctx.ext_portb = readl(gpio->regs + GPIO_EXT_PORTB);
 
 	gpio->ctx.inten = readl(gpio->regs + GPIO_INTEN);
+	gpio->is_resuming = 1;
 	gpio->ctx.intmask = readl(gpio->regs + GPIO_INTMASK);
 	gpio->ctx.inttype_level = readl(gpio->regs + GPIO_INTTYPE_LEVEL);
 	gpio->ctx.int_polarity = readl(gpio->regs + GPIO_INT_POLARITY);
 	gpio->ctx.debounce = readl(gpio->regs + GPIO_DEBOUNCE);
 
+	writel(0, gpio->regs + GPIO_INTEN);
 	raw_spin_unlock_irqrestore(&gpio->lock, flags);
 
 	return 0;
@@ -174,13 +177,15 @@ static int phytium_gpio_resume(struct device *dev)
 	writel(gpio->ctx.swportb_ddr, gpio->regs + GPIO_SWPORTB_DDR);
 	writel(gpio->ctx.ext_portb, gpio->regs + GPIO_EXT_PORTB);
 
-	writel(gpio->ctx.inten, gpio->regs + GPIO_INTEN);
 	writel(gpio->ctx.intmask, gpio->regs + GPIO_INTMASK);
 	writel(gpio->ctx.inttype_level, gpio->regs + GPIO_INTTYPE_LEVEL);
 	writel(gpio->ctx.int_polarity, gpio->regs + GPIO_INT_POLARITY);
 	writel(gpio->ctx.debounce, gpio->regs + GPIO_DEBOUNCE);
 
 	writel(0xffffffff, gpio->regs + GPIO_PORTA_EOI);
+
+	writel(gpio->ctx.inten, gpio->regs + GPIO_INTEN);
+	gpio->is_resuming = 0;
 
 	raw_spin_unlock_irqrestore(&gpio->lock, flags);
 


### PR DESCRIPTION
This patch updates the support for Phytium GPIO controller driver

## Summary by Sourcery

Update the Phytium GPIO driver to enhance interrupt handling during resume and support multiple parent interrupts.

Bug Fixes:
- Prevent spurious interrupts during system resume.
- Ensure GPIO output value is set before changing the pin direction to output.

Enhancements:
- Add support for handling interrupts from multiple parent controllers.
- Refine suspend/resume logic by disabling interrupts during suspend and restoring them correctly during resume.