### PR TITLE
iommu: smmuv3: Support bypass single device

### DIFF
--- a/drivers/iommu/Kconfig
+++ b/drivers/iommu/Kconfig
@@ -461,6 +461,12 @@ config QCOM_IOMMU
 	help
 	  Support for IOMMU on certain Qualcomm SoCs.
 
+config  SMMU_BYPASS_DEV
+	bool "SMMU bypass streams for some specific devices"
+	help
+	  according smmu.bypassdev cmdline, SMMU performs attribute
+	  transformation only,with no address translation.
+
 config HYPERV_IOMMU
 	bool "Hyper-V IRQ Handling"
 	depends on HYPERV && X86

--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -41,6 +41,42 @@ module_param(disable_msipolling, bool, 0444);
 MODULE_PARM_DESC(disable_msipolling,
 	"Disable MSI-based polling for CMD_SYNC completion.");
 
+#ifdef CONFIG_SMMU_BYPASS_DEV
+struct smmu_bypass_device {
+	unsigned short vendor;
+	unsigned short device;
+};
+#define MAX_CMDLINE_SMMU_BYPASS_DEV 16
+
+static struct smmu_bypass_device smmu_bypass_devices[MAX_CMDLINE_SMMU_BYPASS_DEV];
+static int smmu_bypass_devices_num;
+
+static int __init arm_smmu_bypass_dev_setup(char *str)
+{
+	unsigned short vendor;
+	unsigned short device;
+	int ret;
+
+	if (!str)
+		return -EINVAL;
+
+	ret = sscanf(str, "%hx:%hx", &vendor, &device);
+	if (ret != 2)
+		return -EINVAL;
+
+	if (smmu_bypass_devices_num >= MAX_CMDLINE_SMMU_BYPASS_DEV)
+		return -ERANGE;
+
+	smmu_bypass_devices[smmu_bypass_devices_num].vendor = vendor;
+	smmu_bypass_devices[smmu_bypass_devices_num].device = device;
+	smmu_bypass_devices_num++;
+
+	return 0;
+}
+
+__setup("smmu.bypassdev=", arm_smmu_bypass_dev_setup);
+#endif
+
 enum arm_smmu_msi_index {
 	EVTQ_MSI_INDEX,
 	GERROR_MSI_INDEX,
@@ -2859,6 +2895,30 @@ static void arm_smmu_remove_dev_pasid(struct device *dev, ioasid_t pasid)
 	arm_smmu_sva_remove_dev_pasid(domain, dev, pasid);
 }
 
+#ifdef CONFIG_SMMU_BYPASS_DEV
+static int arm_smmu_device_domain_type(struct device *dev, unsigned int *type)
+{
+	int i;
+	struct pci_dev *pdev;
+
+	if (!dev_is_pci(dev))
+		return -ERANGE;
+
+	pdev = to_pci_dev(dev);
+	for (i = 0; i < smmu_bypass_devices_num; i++) {
+		if ((smmu_bypass_devices[i].vendor == pdev->vendor)
+			&& (smmu_bypass_devices[i].device == pdev->device)) {
+			dev_info(dev, "device 0x%x:0x%x uses identity mapping.",
+				pdev->vendor, pdev->device);
+			*type = IOMMU_DOMAIN_IDENTITY;
+			return 0;
+		}
+	}
+
+	return -ERANGE;
+}
+#endif
+
 static struct iommu_ops arm_smmu_ops = {
 	.capable		= arm_smmu_capable,
 	.domain_alloc		= arm_smmu_domain_alloc,
@@ -2874,6 +2934,9 @@ static struct iommu_ops arm_smmu_ops = {
 	.def_domain_type	= arm_smmu_def_domain_type,
 	.pgsize_bitmap		= -1UL, /* Restricted during device attach */
 	.owner			= THIS_MODULE,
+#ifdef CONFIG_SMMU_BYPASS_DEV
+	.device_domain_type	= arm_smmu_device_domain_type,
+#endif
 	.default_domain_ops = &(const struct iommu_domain_ops) {
 		.attach_dev		= arm_smmu_attach_dev,
 		.map_pages		= arm_smmu_map_pages,
@@ -3003,12 +3066,59 @@ static int arm_smmu_init_l1_strtab(struct arm_smmu_device *smmu)
 	return 0;
 }
 
+#ifdef CONFIG_SMMU_BYPASS_DEV
+static void arm_smmu_install_bypass_ste_for_dev(struct arm_smmu_device *smmu,
+						u32 sid)
+{
+	u64 val;
+	__le64 *step = arm_smmu_get_step_for_sid(smmu, sid);
+
+	if (!step)
+		return;
+
+	val = STRTAB_STE_0_V;
+	val |= FIELD_PREP(STRTAB_STE_0_CFG, STRTAB_STE_0_CFG_BYPASS);
+	step[0] = cpu_to_le64(val);
+	step[1] = cpu_to_le64(FIELD_PREP(STRTAB_STE_1_SHCFG,
+				STRTAB_STE_1_SHCFG_INCOMING));
+	step[2] = 0;
+}
+
+static int arm_smmu_prepare_init_l2_strtab(struct device *dev, void *data)
+{
+	u32 sid;
+	int ret;
+	unsigned int type;
+	struct pci_dev *pdev;
+	struct arm_smmu_device *smmu = (struct arm_smmu_device *)data;
+
+	if (arm_smmu_device_domain_type(dev, &type))
+		return 0;
+
+	pdev = to_pci_dev(dev);
+	sid = PCI_DEVID(pdev->bus->number, pdev->devfn);
+	if (!arm_smmu_sid_in_range(smmu, sid))
+		return -ERANGE;
+
+	ret = arm_smmu_init_l2_strtab(smmu, sid);
+	if (ret)
+		return ret;
+
+	arm_smmu_install_bypass_ste_for_dev(smmu, sid);
+
+	return 0;
+}
+#endif
+
 static int arm_smmu_init_strtab_2lvl(struct arm_smmu_device *smmu)
 {
 	void *strtab;
 	u64 reg;
 	u32 size, l1size;
 	struct arm_smmu_strtab_cfg *cfg = &smmu->strtab_cfg;
+#ifdef CONFIG_SMMU_BYPASS_DEV
+	int ret;
+#endif
 
 	/* Calculate the L1 size, capped to the SIDSIZE. */
 	size = STRTAB_L1_SZ_SHIFT - (ilog2(STRTAB_L1_DESC_DWORDS) + 3);
@@ -3038,7 +3148,19 @@ static int arm_smmu_init_strtab_2lvl(struct arm_smmu_device *smmu)
 	reg |= FIELD_PREP(STRTAB_BASE_CFG_SPLIT, STRTAB_SPLIT);
 	cfg->strtab_base_cfg = reg;
 
+#ifdef CONFIG_SMMU_BYPASS_DEV
+	ret = arm_smmu_init_l1_strtab(smmu);
+	if (ret)
+		return ret;
+
+	if (smmu_bypass_devices_num) {
+		ret = bus_for_each_dev(&pci_bus_type, NULL, (void *)smmu,
+			arm_smmu_prepare_init_l2_strtab);
+	}
+	return ret;
+#else
 	return arm_smmu_init_l1_strtab(smmu);
+#endif
 }
 
 static int arm_smmu_init_strtab_linear(struct arm_smmu_device *smmu)

--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -1755,14 +1755,30 @@ iommu_group_alloc_default_domain(struct iommu_group *group, int req_type)
 		list_first_entry(&group->devices, struct group_device, list)
 			->dev->bus;
 	struct iommu_domain *dom;
+#ifdef CONFIG_SMMU_BYPASS_DEV
+	struct device *dev =
+		list_first_entry(&group->devices, struct group_device, list)->dev;
+	const struct iommu_ops *ops = dev_iommu_ops(dev);
+	unsigned int type = iommu_def_domain_type;
+#endif
 
 	lockdep_assert_held(&group->mutex);
 
 	if (req_type)
 		return __iommu_group_alloc_default_domain(bus, group, req_type);
 
+#ifdef CONFIG_SMMU_BYPASS_DEV
+		/* direct allocate required default domain type for some specific devices. */
+		if (ops->device_domain_type != NULL) {
+			if (ops->device_domain_type(dev, &type))
+				type = iommu_def_domain_type;
+		}
+
+		dom = __iommu_group_alloc_default_domain(bus, group, type);
+#else
 	/* The driver gave no guidance on what type to use, try the default */
 	dom = __iommu_group_alloc_default_domain(bus, group, iommu_def_domain_type);
+#endif
 	if (dom)
 		return dom;
 

--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -308,6 +308,12 @@ struct iommu_ops {
 	DEEPIN_KABI_RESERVE(6)
 	DEEPIN_KABI_RESERVE(7)
 	DEEPIN_KABI_RESERVE(8)
+
+#ifdef CONFIG_SMMU_BYPASS_DEV
+#ifndef __GENKSYMS__
+	int (*device_domain_type)(struct device *dev, unsigned int *type);
+#endif
+#endif
 };
 
 /**

--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -310,9 +310,7 @@ struct iommu_ops {
 	DEEPIN_KABI_RESERVE(8)
 
 #ifdef CONFIG_SMMU_BYPASS_DEV
-#ifndef __GENKSYMS__
 	int (*device_domain_type)(struct device *dev, unsigned int *type);
-#endif
 #endif
 };
 


### PR DESCRIPTION
Add smmu.bypassdev cmdline to allow SMMU bypass
streams for some specific devices.

Mainline: NA

## Summary by Sourcery

Introduce a kernel command line option to bypass SMMU for specific PCI devices.

New Features:
- Add the `smmu.bypassdev` command line parameter to specify PCI devices (by vendor and device ID) that should bypass the SMMU and use identity mapping.
- Implement the necessary logic in the Arm SMMUv3 driver to parse the command line parameter and configure bypass Stream Table Entries (STEs) for the specified devices during initialization.
- Modify the generic IOMMU core to allow drivers to specify a domain type per device, enabling the SMMUv3 driver to request an identity domain for bypass devices.