### PR TITLE
hda: phytium: update phytium hda controller driver support

### DIFF
--- a/sound/pci/hda/hda_phytium.c
+++ b/sound/pci/hda/hda_phytium.c
@@ -966,6 +966,7 @@ out_free:
 	return err;
 }
 
+#define codec_power_count(codec) codec->core.dev.power.usage_count.counter
 /* number of codec slots for each chipset: 0 = default slots (i.e. 4) */
 static unsigned int azx_max_codecs[AZX_NUM_DRIVERS] = {
 	[AZX_DRIVER_FT] = 4,
@@ -978,6 +979,7 @@ static int azx_probe_continue(struct azx *chip)
 	int dev = chip->dev_index;
 	int err;
 	struct hdac_bus *bus = azx_bus(chip);
+	struct hda_codec *codec;
 
 	hda->probe_continued = 1;
 
@@ -1010,6 +1012,14 @@ static int azx_probe_continue(struct azx *chip)
 
 	if (azx_has_pm_runtime(chip))
 		pm_runtime_put_noidle(hddev);
+
+	list_for_each_codec(codec, &chip->bus) {
+		if (codec_power_count(codec) > 0) {
+			pm_runtime_mark_last_busy(&codec->core.dev);
+			pm_runtime_put_autosuspend(&codec->core.dev);
+		}
+	}
+
 	return err;
 
 out_free:

--- a/sound/pci/hda/hda_phytium.c
+++ b/sound/pci/hda/hda_phytium.c
@@ -477,7 +477,7 @@ static int azx_resume(struct device *dev)
 	snd_hdac_bus_exit_link_reset(bus);
 	usleep_range(1000, 1200);
 
-	azx_init_chip(chip, 0);
+	azx_init_chip(chip, 1);
 
 	snd_power_change_state(card, SNDRV_CTL_POWER_D0);
 


### PR DESCRIPTION
This patch updates the support for phytium hda controller driver.

## Summary by Sourcery

Update the Phytium HDA driver to improve resume handling and codec runtime power management.

Bug Fixes:
- Ensure the HDA chip is fully re-initialized upon system resume to fix potential audio issues after suspend/resume cycles.
- Fix runtime power management for codecs by ensuring they are properly suspended after probing if they were powered up during the process.