### PR TITLE
i2s: phytium: update phytium i2s controller driver support

### DIFF
--- a/Documentation/devicetree/bindings/sound/phytium,codec-2.0.yaml
+++ b/Documentation/devicetree/bindings/sound/phytium,codec-2.0.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/sound/phytium,codec-2.0.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium Codec V2 Controller
+
+maintainers:
+  - Dai Jingtao <daijingtao1503@phytium.com.cn>
+  - Zhou Zheng <zhouzheng2069@phytium.com.cn>
+
+properties:
+  compatible:
+    enum:
+      - phytium,codec-2.0
+
+  reg:
+    items:
+      - first is for physical base address and length of regfile.
+      - second is for sharemem to send command.
+
+  interrupts:
+    maxItems: 1
+
+required:
+  - compatible
+  - reg
+  - interrupts
+
+examples:
+  - |
+    codec_v2: codec@27010800 {
+	compatible = "phytium,codec-2.0";
+	#sound-dai-cells = <0x0>;
+	reg = <0x0 0x27010800 0x0 0x800>,
+		< 0x0 0x26fe3100 0x0 0x100>;
+	interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL_HIGH>;
+	status = "disabled";
+    };

--- a/Documentation/devicetree/bindings/sound/phytium,i2s-2.0.yaml
+++ b/Documentation/devicetree/bindings/sound/phytium,i2s-2.0.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/sound/phytium,virt-i2s.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium I2S V2 Controller
+
+maintainers:
+  - Dai Jingtao <daijingtao1503@phytium.com.cn>
+
+properties:
+  compatible:
+    enum:
+      - phytium,i2s-2.0
+
+  reg:
+    items:
+      - first is for physical base address and length of I2S regfile.
+      - second is for sharemem to send command.
+      - third is for physical base address and length of DMA_BDL controller.
+
+  interrupts:
+    maxItems: 2
+
+  clocks:
+    items:
+      - description: Bus Clock
+
+  clock-names:
+    items:
+      - const: i2s_clk
+
+required:
+  - compatible
+  - reg
+  - interrupts
+  - clocks
+  - clock-names
+
+
+examples:
+  - |
+    i2s_v2: i2s@27010000 {
+	compatible = "phytium,i2s-2.0";
+	reg = <0x0 0x27010000 0x0 0x800>,
+		  <0x0 0x26fe3000 0x0 0x100>,
+		  <0x0 0x18000000 0x0 0x1000>;
+	interrupts = <GIC_SPI 110 IRQ_TYPE_LEVEL_HIGH>,
+                <GIC_SPI 83 IRQ_TYPE_LEVEL_HIGH>;
+	clocks = <&sysclk_1200mhz>;
+	clock-names = "i2s_clk";
+    };

--- a/sound/soc/codecs/Kconfig
+++ b/sound/soc/codecs/Kconfig
@@ -1379,6 +1379,11 @@ config SND_SOC_PEB2466
 	  To compile this driver as a module, choose M here: the module
 	  will be called snd-soc-peb2466.
 
+config SND_SOC_PHYTIUM_CODEC_V2
+	tristate "Phytium Codec V2 driver"
+	help
+	  Select Y if you want to add Phytium codec V2 driver.
+
 config SND_SOC_RK3328
 	tristate "Rockchip RK3328 audio CODEC"
 	select REGMAP_MMIO

--- a/sound/soc/codecs/Makefile
+++ b/sound/soc/codecs/Makefile
@@ -374,6 +374,8 @@ snd-soc-wsa881x-objs := wsa881x.o
 snd-soc-wsa883x-objs := wsa883x.o
 snd-soc-wsa884x-objs := wsa884x.o
 snd-soc-zl38060-objs := zl38060.o
+snd-soc-phytium-codec-v2-objs := phytium-codec-v2.o
+
 # Amp
 snd-soc-max9877-objs := max9877.o
 snd-soc-max98504-objs := max98504.o
@@ -762,6 +764,7 @@ obj-$(CONFIG_SND_SOC_WSA881X)	+= snd-soc-wsa881x.o
 obj-$(CONFIG_SND_SOC_WSA883X)	+= snd-soc-wsa883x.o
 obj-$(CONFIG_SND_SOC_WSA884X)	+= snd-soc-wsa884x.o
 obj-$(CONFIG_SND_SOC_ZL38060)	+= snd-soc-zl38060.o
+obj-$(CONFIG_SND_SOC_PHYTIUM_CODEC_V2)	+= snd-soc-phytium-codec-v2.o
 
 # Amp
 obj-$(CONFIG_SND_SOC_MAX9877)	+= snd-soc-max9877.o

--- a/sound/soc/codecs/es8336.c
+++ b/sound/soc/codecs/es8336.c
@@ -31,6 +31,7 @@
 #include <linux/regmap.h>
 #include "es8336.h"
 
+#define ES8336_V1_VERSION "1.0.0"
 #define INVALID_GPIO -1
 #define GPIO_LOW  0
 #define GPIO_HIGH 1
@@ -1081,3 +1082,4 @@ static struct i2c_driver es8336_i2c_driver = {
 module_i2c_driver(es8336_i2c_driver);
 MODULE_DESCRIPTION("ASoC es8336 driver");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(ES8336_V1_VERSION);

--- a/sound/soc/codecs/es8336.c
+++ b/sound/soc/codecs/es8336.c
@@ -832,31 +832,14 @@ static int es8336_suspend(struct snd_soc_component *component)
 
 static int es8336_resume(struct snd_soc_component *component)
 {
-	struct es8336_priv *es8336 = snd_soc_component_get_drvdata(component);
+	struct regmap *regmap = dev_get_regmap(component->dev, NULL);
 	int ret;
 
-	es8336_reset(component); /* UPDATED BY DAVID,15-3-5 */
-	ret = snd_soc_component_read(component, ES8336_CLKMGR_ADCDIV2_REG05);
-	if (!ret) {
-		es8336_init_regs(component);
-		snd_soc_component_write(component, ES8336_GPIO_SEL_REG4D, 0x02);
-		/* max debance time, enable interrupt, low active */
-		snd_soc_component_write(component, ES8336_GPIO_DEBUNCE_INT_REG4E, 0xf3);
-		/* es8336_set_bias_level(component, SND_SOC_BIAS_OFF); */
-		snd_soc_component_write(component, ES8336_CPHP_OUTEN_REG17, 0x00);
-		snd_soc_component_write(component, ES8336_DAC_PDN_REG2F, 0x11);
-		snd_soc_component_write(component, ES8336_CPHP_LDOCTL_REG1B, 0x03);
-		snd_soc_component_write(component, ES8336_CPHP_PDN2_REG1A, 0x22);
-		snd_soc_component_write(component, ES8336_CPHP_PDN1_REG19, 0x06);
-		snd_soc_component_write(component, ES8336_HPMIX_SWITCH_REG14, 0x00);
-		snd_soc_component_write(component, ES8336_HPMIX_PDN_REG15, 0x33);
-		snd_soc_component_write(component, ES8336_HPMIX_VOL_REG16, 0x00);
-		if (!es8336->hp_inserted)
-			snd_soc_component_write(component, ES8336_SYS_PDN_REG0D, 0x3F);
-		snd_soc_component_write(component, ES8336_SYS_LP1_REG0E, 0xFF);
-		snd_soc_component_write(component, ES8336_SYS_LP2_REG0F, 0xFF);
-		snd_soc_component_write(component, ES8336_CLKMGR_CLKSW_REG01, 0xF3);
-		snd_soc_component_write(component, ES8336_ADC_PDN_LINSEL_REG22, 0xc0);
+	regcache_mark_dirty(regmap);
+	ret = regcache_sync(regmap);
+	if (ret) {
+		dev_err(component->dev, "unable to sync regcache\n");
+		return ret;
 	}
 	return 0;
 }
@@ -942,6 +925,8 @@ const struct regmap_config es8336_regmap_config = {
 	.cache_type	= REGCACHE_RBTREE,
 	.reg_defaults = es8336_reg_defaults,
 	.num_reg_defaults = ARRAY_SIZE(es8336_reg_defaults),
+	.use_single_read = true,
+	.use_single_write = true,
 };
 
 static const struct snd_soc_component_driver soc_component_dev_es8336 = {

--- a/sound/soc/codecs/es8388.c
+++ b/sound/soc/codecs/es8388.c
@@ -23,6 +23,8 @@
 #include <linux/i2c.h>
 #include <linux/regmap.h>
 
+#define ES8388_V1_VERSION "1.0.0"
+
 static const unsigned int rates_12288[] = {
 	8000, 12000, 16000, 24000, 32000, 48000, 96000,
 };
@@ -817,3 +819,4 @@ module_i2c_driver(es8388_i2c_driver);
 MODULE_DESCRIPTION("ASoC ES8388 driver");
 MODULE_AUTHOR("Yiqun Zhang <zhangyiqun@phytium.com.cn>");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(ES8388_V1_VERSION);

--- a/sound/soc/codecs/phytium-codec-v2.c
+++ b/sound/soc/codecs/phytium-codec-v2.c
@@ -1,0 +1,739 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium CODEC ALSA SoC Audio driver
+ *
+ * Copyright (C) 2024, Phytium Technology Co., Ltd.
+ *
+ */
+
+#include <linux/clk.h>
+#include <linux/device.h>
+#include <linux/init.h>
+#include <linux/io.h>
+#include <linux/interrupt.h>
+#include <linux/module.h>
+#include <linux/dma-mapping.h>
+#include <linux/slab.h>
+#include <linux/pm_runtime.h>
+#include <sound/pcm.h>
+#include <sound/pcm_params.h>
+#include <sound/soc.h>
+#include <sound/dmaengine_pcm.h>
+#include <linux/clocksource.h>
+#include <linux/random.h>
+#include <linux/timecounter.h>
+#include <sound/core.h>
+#include <sound/initval.h>
+#include <linux/pci.h>
+#include <linux/version.h>
+#include <linux/acpi.h>
+#include <sound/tlv.h>
+#include <linux/i2c.h>
+
+#include "phytium-codec-v2.h"
+
+#define PHYT_CODEC_V2_VERSION "1.0.0"
+#define PHYTIUM_RATES (SNDRV_PCM_RATE_192000 | \
+		SNDRV_PCM_RATE_96000 | \
+		SNDRV_PCM_RATE_88200 | \
+		SNDRV_PCM_RATE_8000_48000)
+#define PHYTIUM_FORMATS (SNDRV_PCM_FMTBIT_S16_LE | \
+		SNDRV_PCM_FMTBIT_S18_3LE | \
+		SNDRV_PCM_FMTBIT_S20_3LE | \
+		SNDRV_PCM_FMTBIT_S24_LE | \
+		SNDRV_PCM_FMTBIT_S32_LE)
+
+static const struct snd_kcontrol_new phyt_snd_controls[] = {
+	SOC_SINGLE("PCM Volume", PHYTIUM_CODEC_PLAYBACKE_VOL, 0, 0xc0, 0),
+	SOC_SINGLE("Playback Volume1", PHYTIUM_CODEC_PLAYBACKE_OUT1_VOL, 0, 0x24, 0),
+	SOC_SINGLE("Playback Volume2", PHYTIUM_CODEC_PLAYBACKE_OUT2_VOL, 0, 0x24, 0),
+
+	SOC_SINGLE("Capture Digital Volume", PHYTIUM_CODEC_CAPTURE_VOL, 0, 0xc0, 0),
+	SOC_SINGLE("Mic PGA Volume", PHYTIUM_CODEC_CAPTURE_IN1_VOL, 0, 8, 0),
+};
+
+/*
+ * DAPM Controls
+ */
+
+/* Input Mux */
+static const char * const phyt_mux_sel[] = {
+	"Line 1", "Line 2"};
+
+static const struct soc_enum phyt_mux_enum =
+	SOC_ENUM_SINGLE(PHYTIUM_CODEC_INMUX_SEL, 0,
+			ARRAY_SIZE(phyt_mux_sel),
+			phyt_mux_sel);
+
+static const struct snd_kcontrol_new phyt_pga_controls =
+	SOC_DAPM_ENUM("Route", phyt_mux_enum);
+
+/* dapm widgets */
+static const struct snd_soc_dapm_widget phyt_dapm_widgets[] = {
+	/* Input Signal */
+	SND_SOC_DAPM_INPUT("INPUT1"),
+	SND_SOC_DAPM_INPUT("INPUT2"),
+
+	/* Input Mux */
+	SND_SOC_DAPM_MUX("Input Mux", PHYTIUM_CODEC_INMUX_ENABLE, 0, 0, &phyt_pga_controls),
+
+	/* Input ADC */
+	SND_SOC_DAPM_ADC("Input ADC", "Capture", PHYTIUM_CODEC_ADC_ENABLE, 0, 0),
+
+	/* Output DAC */
+	SND_SOC_DAPM_DAC("Output DAC", "Playback", PHYTIUM_CODEC_DAC_ENABLE, 0, 0),
+
+	/* Output Signal */
+	SND_SOC_DAPM_OUTPUT("OUTPUT1"),
+	SND_SOC_DAPM_OUTPUT("OUTPUT2"),
+};
+
+static const struct snd_soc_dapm_route phyt_dapm_routes[] = {
+	{ "Input Mux", "Line 1", "INPUT1"},
+	{ "Input Mux", "Line 2", "INPUT2"},
+
+	{ "Input ADC", NULL, "Input Mux"},
+
+	{ "OUTPUT1", NULL, "Output DAC"},
+	{ "OUTPUT2", NULL, "Output DAC"},
+};
+
+static void phyt_codec_show_status(uint8_t status)
+{
+	switch (status) {
+	case 0:
+		pr_err("success\n");
+		break;
+	case 2:
+		pr_err("device busy\n");
+		break;
+	case 3:
+		pr_err("read/write error\n");
+		break;
+	case 4:
+		pr_err("no device\n");
+		break;
+	default:
+		pr_err("unknown error: %d\n", status);
+		break;
+	}
+}
+
+int phyt_codec_msg_set_cmd(struct phytium_codec *priv)
+{
+	struct phytcodec_cmd *ans_msg;
+	int timeout = 5000, ret = 0;
+
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_CODEC_AP2RV_INT_STATE, SEND_INTR);
+
+	ans_msg = priv->sharemem_base;
+
+	while (timeout && (ans_msg->complete == PHYTCODEC_COMPLETE_NOT_READY
+			|| ans_msg->complete == PHYTCODEC_COMPLETE_GOING)) {
+		udelay(200);
+		timeout--;
+	}
+
+	if (timeout == 0) {
+		dev_err(priv->dev, "failed to receive msg, timeout\n");
+		ret = -EINVAL;
+	} else if (ans_msg->complete >= PHYTCODEC_COMPLETE_GENERIC_ERROR) {
+		dev_err(priv->dev, "receive msg; generic_error, error code:%d\n",
+					ans_msg->complete);
+		ret = -EINVAL;
+	} else if (ans_msg->complete == PHYTCODEC_COMPLETE_SUCCESS) {
+		dev_dbg(priv->dev, "receive msg successfully\n");
+	}
+
+	if (ans_msg->complete != PHYTCODEC_COMPLETE_SUCCESS)
+		phyt_codec_show_status(ans_msg->status);
+	return ret;
+}
+
+static int phyt_cmd(struct snd_soc_component *component,
+				unsigned int cmd)
+{
+	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+	int ret = 0;
+
+	msg->reserved = 0;
+	msg->seq = 0;
+	msg->cmd_id = PHYTCODEC_MSG_CMD_SET;
+	msg->cmd_subid = cmd;
+	msg->complete = 0;
+	ret = phyt_codec_msg_set_cmd(priv);
+	if (ret < 0) {
+		dev_err(priv->dev, "set cmd_subid 0x%x failed\n", cmd);
+		ret = -EINVAL;
+		goto error;
+	}
+error:
+	return ret;
+}
+
+static int phyt_pm_cmd(struct snd_soc_component *component,
+				unsigned int cmd)
+{
+	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+	uint16_t total_regs_len;
+	uint8_t *regs;
+	int ret = 0;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
+
+	msg->reserved = 0;
+	msg->seq = 0;
+	msg->cmd_id = PHYTCODEC_MSG_CMD_SET;
+	msg->cmd_subid = cmd;
+	msg->complete = 0;
+	msg->cmd_para.phytcodec_reg.cnt = 0;
+	if (cmd == PHYTCODEC_MSG_CMD_SET_RESUME)
+		memcpy(msg->cmd_para.phytcodec_reg.regs, priv->regs, REG_SH_LEN);
+	ret = phyt_codec_msg_set_cmd(priv);
+	if (ret < 0) {
+		dev_err(priv->dev, "set cmd_subid 0x%x failed\n", cmd);
+		ret = -EINVAL;
+		goto error;
+	}
+	total_regs_len = msg->cmd_para.phytcodec_reg.total_regs_len;
+
+	if (cmd == PHYTCODEC_MSG_CMD_SET_SUSPEND) {
+		regs = kmalloc(total_regs_len, GFP_KERNEL);
+		priv->regs = regs;
+		while (total_regs_len > REG_SH_LEN * msg->cmd_para.phytcodec_reg.cnt) {
+			memcpy(regs, msg->cmd_para.phytcodec_reg.regs, REG_SH_LEN);
+			regs += REG_SH_LEN;
+			msg->complete = 0;
+			ret = phyt_codec_msg_set_cmd(priv);
+			if (ret < 0) {
+				dev_err(priv->dev, "set cmd_subid 0x%x failed\n", cmd);
+				ret = -EINVAL;
+				goto error;
+			}
+		}
+		memcpy(regs, msg->cmd_para.phytcodec_reg.regs,
+			total_regs_len - REG_SH_LEN * (msg->cmd_para.phytcodec_reg.cnt - 1));
+	} else if (cmd == PHYTCODEC_MSG_CMD_SET_RESUME) {
+		regs = priv->regs;
+		while (total_regs_len > REG_SH_LEN * msg->cmd_para.phytcodec_reg.cnt) {
+			regs += REG_SH_LEN;
+			memcpy(msg->cmd_para.phytcodec_reg.regs, regs, REG_SH_LEN);
+			msg->complete = 0;
+			ret = phyt_codec_msg_set_cmd(priv);
+			if (ret < 0) {
+				dev_err(priv->dev, "set cmd_subid 0x%x failed\n", cmd);
+				ret = -EINVAL;
+				goto error;
+			}
+		}
+		kfree(priv->regs);
+	}
+error:
+	return ret;
+}
+
+static int phyt_show_registers(struct phytium_codec *priv)
+{
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+	int ret = 0, i;
+
+	msg->reserved = 0;
+	msg->seq = 0;
+	msg->cmd_id = PHYTCODEC_MSG_CMD_GET;
+	msg->cmd_subid = 0;
+	msg->complete = 0;
+	ret = phyt_codec_msg_set_cmd(priv);
+	if (ret < 0) {
+		dev_err(priv->dev, "failed to get codec registers\n");
+		ret = -EINVAL;
+		goto error;
+	} else {
+		dev_dbg(priv->dev, "show codec registers\n");
+		for (i = 0; i < msg->len && i < 56; i++) {
+			dev_dbg(priv->dev, "%d ", msg->cmd_para.para[i]);
+			if (i % 16 == 0)
+				dev_dbg(priv->dev, "\n");
+		}
+	}
+error:
+	return ret;
+}
+
+static int phyt_probe(struct snd_soc_component *component)
+{
+	return phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_PROBE);
+}
+
+static void phyt_remove(struct snd_soc_component *component)
+{
+	phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_REMOVE);
+}
+
+static int phyt_suspend(struct snd_soc_component *component)
+{
+	return phyt_pm_cmd(component, PHYTCODEC_MSG_CMD_SET_SUSPEND);
+}
+
+static int phyt_resume(struct snd_soc_component *component)
+{
+	return phyt_pm_cmd(component, PHYTCODEC_MSG_CMD_SET_RESUME);
+}
+
+static int phyt_set_bias_level(struct snd_soc_component *component,
+				 enum snd_soc_bias_level level)
+{
+	int ret;
+	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
+	msg->cmd_para.para[0] = priv->channels/2;
+
+	switch (level) {
+	case SND_SOC_BIAS_ON:
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_BIAS_ON);
+		break;
+
+	case SND_SOC_BIAS_PREPARE:
+		ret = phyt_cmd(component,  PHYTCODEC_MSG_CMD_SET_BIAS_PREPARE);
+		break;
+
+	case SND_SOC_BIAS_STANDBY:
+		if (snd_soc_component_get_bias_level(component) == SND_SOC_BIAS_OFF)
+			ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_BIAS_STANDBY);
+		else
+			ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_BIAS_STANDBY);
+		break;
+
+	case SND_SOC_BIAS_OFF:
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_BIAS_OFF);
+		break;
+	}
+
+	return ret;
+}
+
+static const struct snd_soc_component_driver phyt_component_driver = {
+	.probe			= phyt_probe,
+	.remove			= phyt_remove,
+	.suspend		= phyt_suspend,
+	.resume			= phyt_resume,
+	.set_bias_level		= phyt_set_bias_level,
+	.controls		= phyt_snd_controls,
+	.num_controls		= ARRAY_SIZE(phyt_snd_controls),
+	.dapm_widgets		= phyt_dapm_widgets,
+	.num_dapm_widgets	= ARRAY_SIZE(phyt_dapm_widgets),
+	.dapm_routes		= phyt_dapm_routes,
+	.num_dapm_routes	= ARRAY_SIZE(phyt_dapm_routes),
+	.suspend_bias_off	= 1,
+	.idle_bias_on		= 1,
+	.use_pmdown_time	= 1,
+	.endianness		= 1,
+};
+
+static int phyt_mute(struct snd_soc_dai *dai, int mute, int direction)
+{
+	int ret;
+	struct snd_soc_component *component = dai->component;
+	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
+	msg->cmd_para.para[0] = (uint8_t)direction;
+	if (mute)
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_MUTE);
+	else
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_UNMUTE);
+
+	return ret;
+}
+
+static int phyt_startup(struct snd_pcm_substream *substream,
+			  struct snd_soc_dai *dai)
+{
+	int ret;
+	struct snd_soc_component *component = dai->component;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_STARTUP);
+	else
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_STARTUP_RC);
+
+	return ret;
+}
+
+static void phyt_shutdown(struct snd_pcm_substream *substream,
+			  struct snd_soc_dai *dai)
+{
+	int ret;
+	struct snd_soc_component *component = dai->component;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_SHUTDOWN);
+	else
+		ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_SHUTDOWN_RC);
+}
+
+static int phyt_hw_params(struct snd_pcm_substream *substream,
+	struct snd_pcm_hw_params *params,
+	struct snd_soc_dai *dai)
+{
+	int wl, ret = 0;
+	struct snd_soc_component *component = dai->component;
+	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+
+	priv->channels = params_channels(params);
+	switch (params_width(params)) {
+	case 16:
+		wl = 3;
+		break;
+	case 18:
+		wl = 2;
+		break;
+	case 20:
+		wl = 1;
+		break;
+	case 24:
+		wl = 0;
+		break;
+	case 32:
+		wl = 4;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		snd_soc_component_write(component, PHYTIUM_CODEC_HW_PARAM, wl);
+	else
+		snd_soc_component_write(component, PHYTIUM_CODEC_HW_PARAM_RC, wl);
+
+error:
+	return ret;
+}
+
+static int phyt_set_dai_fmt(struct snd_soc_dai *codec_dai,
+		unsigned int fmt)
+{
+	int ret;
+	struct snd_soc_component *component = codec_dai->component;
+
+	if ((fmt & SND_SOC_DAIFMT_MASTER_MASK) != SND_SOC_DAIFMT_CBS_CFS)
+		return -EINVAL;
+
+	if ((fmt & SND_SOC_DAIFMT_FORMAT_MASK) != SND_SOC_DAIFMT_I2S)
+		return -EINVAL;
+
+	if ((fmt & SND_SOC_DAIFMT_INV_MASK) != SND_SOC_DAIFMT_NB_NF)
+		return -EINVAL;
+
+	ret = phyt_cmd(component, PHYTCODEC_MSG_CMD_SET_DAI_FMT);
+
+	return ret;
+}
+
+static const struct snd_soc_dai_ops phyt_dai_ops = {
+	.startup	 = phyt_startup,
+	.shutdown	 = phyt_shutdown,
+	.hw_params	 = phyt_hw_params,
+	.mute_stream	= phyt_mute,
+	.set_fmt	 = phyt_set_dai_fmt,
+};
+
+static struct snd_soc_dai_driver phyt_dai = {
+	.name = "phytium-hifi-v2",
+	.playback = {
+		.stream_name = "Playback",
+		.channels_min = 2,
+		.channels_max = 2,
+		.rates = PHYTIUM_RATES,
+		.formats = PHYTIUM_FORMATS,
+	},
+	.capture = {
+		.stream_name = "Capture",
+		.channels_min = 2,
+		.channels_max = 2,
+		.rates = PHYTIUM_RATES,
+		.formats = PHYTIUM_FORMATS,
+	},
+	.ops = &phyt_dai_ops,
+	.symmetric_rate = 1,
+};
+
+static const struct regmap_config phyt_codec_regmap_config = {
+	.reg_bits = 32,
+	.reg_stride = 4,
+	.val_bits = 32,
+	.max_register = REG_MAX,
+	.cache_type = REGCACHE_NONE,
+};
+
+void phyt_enable_debug(struct phytium_codec *priv)
+{
+	u32 reg;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	phyt_writel_reg(priv->regfile_base,
+		PHYTIUM_CODEC_DEBUG, reg | PHYTIUM_CODEC_DEBUG_ENABLE);
+}
+
+void phyt_disable_debug(struct phytium_codec *priv)
+{
+	u32 reg;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	reg &= ~PHYTIUM_CODEC_DEBUG_ENABLE;
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG, reg);
+}
+
+void phyt_enable_alive(struct phytium_codec *priv)
+{
+	u32 reg;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	phyt_writel_reg(priv->regfile_base,
+		PHYTIUM_CODEC_DEBUG, reg | PHYTIUM_CODEC_ALIVE_ENABLE);
+}
+
+void phyt_disable_alive(struct phytium_codec *priv)
+{
+	u32 reg;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	reg &= ~PHYTIUM_CODEC_ALIVE_ENABLE;
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG, reg);
+}
+
+void phyt_heartbeat(struct phytium_codec *priv)
+{
+	u32 reg;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	phyt_writel_reg(priv->regfile_base,
+		PHYTIUM_CODEC_DEBUG, reg | PHYTIUM_CODEC_HEARTBIT_VAL);
+}
+
+static void phyt_timer_handle(struct timer_list *t)
+{
+	struct phytium_codec *priv = from_timer(priv, t, timer);
+
+	if (priv->alive_enabled && priv->heartbeat)
+		priv->heartbeat(priv);
+
+	mod_timer(&priv->timer, jiffies + msecs_to_jiffies(2000));
+}
+
+static ssize_t debug_show(struct device *dev, struct device_attribute *da, char *buf)
+{
+	struct phytium_codec *priv = dev_get_drvdata(dev);
+	ssize_t ret;
+	u32 reg;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	ret = sprintf(buf, "%x\n", reg);
+
+	return ret;
+}
+
+static ssize_t debug_store(struct device *dev, struct device_attribute *da,
+		const char *buf, size_t size)
+{
+	struct phytium_codec *priv = dev_get_drvdata(dev);
+	u8 loc, dis_en, status = 0;
+	char *p;
+	char *token;
+	long value;
+	u32 reg;
+
+	dev_info(dev, "first number is debug/alive/register, the second number is disable/enable");
+	dev_info(dev, "echo 2 1 > debug, print all codec register");
+
+	p = kmalloc(size, GFP_KERNEL);
+	strscpy(p, buf, sizeof(p));
+	token = strsep(&p, " ");
+	if (!token)
+		return -EINVAL;
+	status = kstrtol(token, 0, &value);
+	if (status)
+		return status;
+	loc = (u8)value;
+
+	token = strsep(&p, " ");
+	if (!token)
+		return -EINVAL;
+	status = kstrtol(token, 0, &value);
+	if (status)
+		return status;
+	dis_en = value;
+
+	reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG);
+	if (loc == 1) {
+		if (dis_en == 1) {
+			priv->alive_enabled = true;
+			reg |= BIT(loc);
+		} else if (dis_en == 0) {
+			priv->alive_enabled = false;
+			reg &= ~BIT(loc);
+		}
+	} else if (loc == 0) {
+		if (dis_en == 1) {
+			priv->debug_enabled = true;
+			reg |= BIT(loc);
+		} else if (dis_en == 0) {
+			priv->debug_enabled = false;
+			reg &= ~BIT(loc);
+		}
+	} else if (loc == 2)
+		if (dis_en == 1)
+			phyt_show_registers(priv);
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_CODEC_DEBUG, reg);
+	kfree(p);
+
+	return size;
+}
+
+static DEVICE_ATTR_RW(debug);
+
+static struct attribute *phyt_codec_device_attr[] = {
+	&dev_attr_debug.attr,
+	NULL,
+};
+
+static const struct attribute_group phyt_codec_device_group = {
+	.attrs = phyt_codec_device_attr,
+};
+
+static int phyt_get_channels(struct phytium_codec *priv)
+{
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+	int ret = 0;
+	uint8_t channels;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
+	msg->reserved = 0;
+	msg->seq = 0;
+	msg->cmd_id = PHYTCODEC_MSG_CMD_GET;
+	msg->cmd_subid = PHYTCODEC_MSG_CMD_GET_CHANNELS;
+	msg->complete = 0;
+
+	ret = phyt_codec_msg_set_cmd(priv);
+	if (ret < 0) {
+		dev_err(priv->dev, "failed to get codec channels\n");
+		return -EINVAL;
+	}
+	channels = msg->cmd_para.para[0] * 2;
+	return channels;
+}
+
+static int phyt_codec_probe(struct platform_device *pdev)
+{
+	struct phytium_codec *priv;
+	struct resource *res;
+	int ret;
+	struct device *dev;
+
+	dev = &pdev->dev;
+	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv) {
+		dev_err(dev, "failed to alloc struct phytium_codec\n");
+		ret = -ENOMEM;
+		goto failed_alloc_phytium_codec;
+	}
+
+	dev_set_drvdata(dev, priv);
+	priv->dev = dev;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	priv->regfile_base = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(priv->regfile_base)) {
+		dev_err(&pdev->dev, "failed to ioremap resource0\n");
+		ret = PTR_ERR(priv->regfile_base);
+		goto failed_ioremap_res0;
+	}
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
+	priv->sharemem_base = devm_ioremap_wc(&pdev->dev, res->start, resource_size(res));
+	if (IS_ERR(priv->sharemem_base)) {
+		dev_err(&pdev->dev, "failed to ioremap resource1\n");
+		ret = PTR_ERR(priv->sharemem_base);
+		goto failed_ioremap_res1;
+	}
+
+	priv->regmap = devm_regmap_init_mmio(dev, priv->regfile_base,
+			     &phyt_codec_regmap_config);
+	if (IS_ERR(priv->regmap)) {
+		dev_err(dev, "failed to init regmap\n");
+		ret = PTR_ERR(priv->regmap);
+		goto failed_regmap_init;
+	}
+
+	phyt_disable_debug(priv);
+	phyt_disable_alive(priv);
+	priv->debug_enabled = false;
+	priv->alive_enabled = false;
+	priv->heartbeat = phyt_heartbeat;
+	priv->timer.expires = jiffies + msecs_to_jiffies(10000);
+	timer_setup(&priv->timer, phyt_timer_handle, 0);
+	add_timer(&priv->timer);
+
+	if (sysfs_create_group(&pdev->dev.kobj, &phyt_codec_device_group))
+		dev_warn(dev, "failed to create sysfs\n");
+
+	phyt_dai.playback.channels_max = phyt_get_channels(priv);
+	phyt_dai.capture.channels_max = phyt_dai.playback.channels_max;
+
+	ret = devm_snd_soc_register_component(dev, &phyt_component_driver,
+					      &phyt_dai, 1);
+	if (ret != 0) {
+		dev_err(dev, "not able to register codec dai\n");
+		goto failed_register_com;
+	}
+
+	return 0;
+failed_register_com:
+failed_regmap_init:
+failed_ioremap_res1:
+failed_ioremap_res0:
+failed_alloc_phytium_codec:
+	return ret;
+}
+
+static int phyt_codec_remove(struct platform_device *pdev)
+{
+	struct phytium_codec *priv = dev_get_drvdata(&pdev->dev);
+
+	sysfs_remove_group(&pdev->dev.kobj, &phyt_codec_device_group);
+	del_timer(&priv->timer);
+	return 0;
+}
+
+static const struct of_device_id phyt_codec_of_match[] = {
+	{ .compatible = "phytium,codec-2.0", },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, phyt_codec_of_match);
+
+static const struct acpi_device_id phyt_codec_acpi_match[] = {
+	{ "PHYT1002", 0},
+	{ },
+};
+MODULE_DEVICE_TABLE(acpi, phyt_codec_acpi_match);
+
+static struct platform_driver phyt_codec_driver = {
+	.probe	= phyt_codec_probe,
+	.remove = phyt_codec_remove,
+	.driver	= {
+		.name = "phytium-codec-v2",
+		.of_match_table = of_match_ptr(phyt_codec_of_match),
+		.acpi_match_table = phyt_codec_acpi_match,
+	},
+};
+
+module_platform_driver(phyt_codec_driver);
+MODULE_DESCRIPTION("Phytium CODEC V2 Driver");
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Yang Xun <yangxun@phytium.com.cn>");
+MODULE_VERSION(PHYT_CODEC_V2_VERSION);

--- a/sound/soc/codecs/phytium-codec-v2.h
+++ b/sound/soc/codecs/phytium-codec-v2.h
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: GPL-2.0
+ *
+ * Phytium CODEC ASoC driver
+ *
+ * Copyright (C) 2024, Phytium Technology Co., Ltd.
+ *
+ */
+
+#ifndef __PHYTIUM_CODEC_V2_H
+#define __PHYTIUM_CODEC_V2_H
+
+#include <linux/io.h>
+#include <sound/memalloc.h>
+
+/****************register *****************/
+#define PHYTIUM_CODEC_AP2RV_INT_MASK	0x20
+#define PHYTIUM_CODEC_AP2RV_INT_STATE	0x24
+	#define SEND_INTR		(1 << 4)
+
+#define PHYTIUM_CODEC_DEBUG	0x58
+	#define PHYTIUM_CODEC_DEBUG_ENABLE	(1 << 0)
+	#define PHYTIUM_CODEC_ALIVE_ENABLE	(1 << 1)
+	#define PHYTIUM_CODEC_HEARTBIT_VAL	(1 << 2)
+
+#define PHYTIUM_CODEC_PLAYBACKE_VOL		0X500
+#define PHYTIUM_CODEC_PLAYBACKE_OUT1_VOL	0X504
+#define PHYTIUM_CODEC_PLAYBACKE_OUT2_VOL	0X508
+#define PHYTIUM_CODEC_CAPTURE_VOL		0X50c
+#define PHYTIUM_CODEC_CAPTURE_IN1_VOL		0X510
+#define PHYTIUM_CODEC_HW_PARAM			0X514
+#define PHYTIUM_CODEC_HW_PARAM_RC		0X518
+#define PHYTIUM_CODEC_INMUX_ENABLE		0X51c
+#define PHYTIUM_CODEC_INMUX_SEL			0X520
+#define PHYTIUM_CODEC_ADC_ENABLE		0X524
+#define PHYTIUM_CODEC_DAC_ENABLE		0x528
+#define PHYTIUM_CODEC_INT_STATUS		0x560
+	#define PIPE_NUM			11
+
+#define REG_MAX	0x52c
+#define REG_SH_LEN	52
+
+/****************register end *****************/
+
+#define PHYTIUM_CODEC_LSD_ID		0x701
+
+enum phytcodec_msg_cmd_id {
+	PHYTCODEC_MSG_CMD_DEFAULT = 0,
+	PHYTCODEC_MSG_CMD_SET,
+	PHYTCODEC_MSG_CMD_GET,
+	PHYTCODEC_MSG_CMD_DATA,
+	PHYTCODEC_MSG_CMD_REPORT,
+	PHYTCODEC_MSG_PROTOCOL = 0x10,
+};
+
+enum phytcodec_get_subid {
+	PHYTCODEC_MSG_CMD_GET_CHANNELS = 0,
+};
+
+enum phytcodec_set_subid {
+	PHYTCODEC_MSG_CMD_SET_PROBE = 0,
+	PHYTCODEC_MSG_CMD_SET_REMOVE,
+	PHYTCODEC_MSG_CMD_SET_SUSPEND,
+	PHYTCODEC_MSG_CMD_SET_RESUME,
+	PHYTCODEC_MSG_CMD_SET_STARTUP,
+	PHYTCODEC_MSG_CMD_SET_STARTUP_RC,
+	PHYTCODEC_MSG_CMD_SET_MUTE,
+	PHYTCODEC_MSG_CMD_SET_UNMUTE,
+	PHYTCODEC_MSG_CMD_SET_DAI_FMT,
+	PHYTCODEC_MSG_CMD_SET_BIAS_ON,
+	PHYTCODEC_MSG_CMD_SET_BIAS_OFF,
+	PHYTCODEC_MSG_CMD_SET_BIAS_PREPARE,
+	PHYTCODEC_MSG_CMD_SET_BIAS_STANDBY,
+	PHYTCODEC_MSG_CMD_SET_SHUTDOWN,
+	PHYTCODEC_MSG_CMD_SET_SHUTDOWN_RC,
+};
+
+enum phytcodec_complete {
+	PHYTCODEC_COMPLETE_NOT_READY = 0,
+	PHYTCODEC_COMPLETE_SUCCESS,
+	PHYTCODEC_COMPLETE_GOING,
+	PHYTCODEC_COMPLETE_GENERIC_ERROR = 0x10,
+	PHYTCODEC_COMPLETE_TYPE_NOT_SUPPORTED,
+	PHYTCODEC_COMPLETE_CMD_NOT_SUPPORTED,
+	PHYTCODEC_COMPLETE_INVALID_PARAMETERS,
+};
+
+struct phytcodec_reg {
+	uint16_t total_regs_len;
+	uint8_t one_reg_len;
+	uint8_t cnt;
+	uint8_t regs[52];
+};
+
+struct phytcodec_cmd {
+	uint8_t reserved;
+	uint8_t seq;
+	uint8_t cmd_id;
+	uint8_t cmd_subid;
+	uint16_t len;
+	uint8_t status;
+	uint8_t complete;
+	union {
+		uint8_t para[56];
+		struct phytcodec_reg phytcodec_reg;
+	} cmd_para;
+};
+
+struct phytium_codec {
+	void __iomem *regfile_base;
+	void __iomem *sharemem_base;
+	struct device *dev;
+	uint8_t *regs;
+	uint8_t channels;
+
+	struct regmap *regmap;
+	struct completion comp;
+	bool deemph;
+
+	bool debug_enabled;
+	bool alive_enabled;
+	struct timer_list timer;
+	void (*heartbeat)(struct phytium_codec *priv);
+};
+
+static inline unsigned int
+phyt_readl_reg(void *base, uint32_t offset)
+{
+	unsigned int data;
+
+	data = readl(base + offset);
+
+	return data;
+}
+
+static inline void
+phyt_writel_reg(void *base, uint32_t offset, uint32_t data)
+{
+	writel(data, base + offset);
+}
+#endif

--- a/sound/soc/phytium/Kconfig
+++ b/sound/soc/phytium/Kconfig
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
+comment "Phytium I2S Driver and Phytium I2S V2 Driver are generally not used together"
+	depends on SND_SOC_PHYTIUM_I2S && SND_SOC_PHYTIUM_I2S_V2
+
 config SND_SOC_PHYTIUM_I2S
 	tristate "Phytium I2S Device Driver"
 	depends on ARCH_PHYTIUM
@@ -23,10 +26,25 @@ config SND_PMDK_ES8336
 	 Say Y if you want to add Phytium machine support for
 	 ES8336 codecs.
 
+config SND_SOC_PHYTIUM_I2S_V2
+        tristate "Phytium I2S V2 Device Driver"
+        help
+         Say Y or M if you want to add support for I2S v2 driver for
+         Phytium I2S device . The device supports 2 channels each
+         for play and record.
+
+config SND_SOC_PHYTIUM_MACHINE_V2
+        tristate "Phytium Machine V2 Driver"
+        depends on SND_SOC_PHYTIUM_I2S_V2
+        help
+         Say Y or M if you want to add Phytium machine v2 support for
+         codecs.
+
 config SND_PMDK_DP
 	tristate "Phytium machine support with DP"
-	depends on I2C && SND_SOC_PHYTIUM_I2S
+	depends on SND_SOC_PHYTIUM_I2S || SND_SOC_PHYTIUM_I2S_V2
 	select SND_SOC_HDMI_CODEC
 	help
 	 Say Y if you want to add Phytium machine support for
 	 Displayport.
+

--- a/sound/soc/phytium/Makefile
+++ b/sound/soc/phytium/Makefile
@@ -12,3 +12,9 @@ obj-$(CONFIG_SND_PMDK_ES8336) += snd-soc-pmdk-es8336.o
 
 snd-soc-pmdk-dp-objs :=pmdk_dp.o
 obj-$(CONFIG_SND_PMDK_DP) += snd-soc-pmdk-dp.o
+
+snd-soc-phytium-i2s-v2-objs := phytium-i2s-v2.o
+obj-$(CONFIG_SND_SOC_PHYTIUM_I2S_V2) += snd-soc-phytium-i2s-v2.o
+
+snd-soc-phytium-machine-v2-objs := phytium-machine-v2.o
+obj-$(CONFIG_SND_SOC_PHYTIUM_MACHINE_V2) += snd-soc-phytium-machine-v2.o

--- a/sound/soc/phytium/local.h
+++ b/sound/soc/phytium/local.h
@@ -81,6 +81,36 @@
 
 #define DMA_STS			0x0008
 
+#define I2S_HEADPHONE_ENABLE 1
+#define I2S_HEADPHONE_DISABLE 0
+
+#define I2S_GPIO(x) BIT(x)
+#define I2S_GPIO_BASE 0xD00
+
+/* I2S GPIO registers */
+#define I2S_GPIO_SWPORTA_DR         0x00 /* WR Port A Output Data Register */
+	#define I2S_HEADPHONE_FRONT	(!I2S_GPIO(1))
+	#define I2S_HEADPHONE_REAR	I2S_GPIO(1)
+#define I2S_GPIO_SWPORTA_DDR        0x04 /* WR Port A Data Direction Register */
+	#define I2S_GPIO_INPUT(x)	(!I2S_GPIO(x))
+	#define I2S_GPIO_OUTPUT(x)	I2S_GPIO(x)
+#define I2S_GPIO_EXT_PORTA          0x08 /* RO Port A Input Data Register */
+#define I2S_GPIO_SWPORTB_DR         0x0c /* WR Port B Output Data Register */
+#define I2S_GPIO_SWPORTB_DDR        0x10 /* WR Port B Data Direction Register */
+#define I2S_GPIO_EXT_PORTB          0x14 /* RO Port B Input Data Register */
+
+#define I2S_GPIO_INTEN              0x18 /* WR Port A Interrput Enable Register */
+#define I2S_GPIO_INTMASK            0x1c /* WR Port A Interrupt Mask Register */
+#define I2S_GPIO_INTTYPE_LEVEL      0x20 /* WR Port A Interrupt Level Register */
+	#define I2S_GPIO_LEVEL(x)	(!I2S_GPIO(x))
+	#define I2S_GPIO_EDGE(x)	I2S_GPIO(x)
+#define I2S_GPIO_INT_POLARITY       0x24 /* WR Port A Interrupt Polarity Register */
+	#define I2S_GPIO_DOWN(x)	(!I2S_GPIO(x))
+	#define I2S_GPIO_UP(x)		I2S_GPIO(x)
+#define I2S_GPIO_INTSTATUS          0x28 /* RO Port A Interrupt Status Register */
+#define I2S_GPIO_DEBOUNCE           0x34 /* WR Debounce Enable Register */
+#define I2S_GPIO_PORTA_EOI          0x38 /* WO Port A Clear Interrupt Register */
+
 /* max number of fragments - we may use more if allocating more pages for BDL */
 #define BDL_SIZE		4096
 #define AZX_MAX_BDL_ENTRIES	(BDL_SIZE / 16)
@@ -281,7 +311,10 @@ struct i2s_phytium {
 	u32 paddr;
 	void __iomem *regs;
 	void __iomem *regs_db;
+	void __iomem *regs_gpio;
 	int irq_id;
+	int gpio_irq_id;
+	bool detect;
 
 	/* for pending irqs */
 	struct work_struct irq_pending_work;
@@ -289,6 +322,7 @@ struct i2s_phytium {
 	/* sync probing */
 	struct completion probe_wait;
 	struct work_struct probe_work;
+	struct delayed_work i2s_gpio_work;
 
 	/* extra flags */
 	unsigned int pcie:1;

--- a/sound/soc/phytium/phytium-i2s-v2.c
+++ b/sound/soc/phytium/phytium-i2s-v2.c
@@ -1,0 +1,1164 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Phytium I2S ASoC driver
+ *
+ * Copyright (C) 2024, Phytium Technology Co., Ltd.
+ *
+ */
+
+#include <linux/clk.h>
+#include <linux/device.h>
+#include <linux/init.h>
+#include <linux/io.h>
+#include <linux/interrupt.h>
+#include <linux/module.h>
+#include <linux/dma-mapping.h>
+#include <linux/slab.h>
+#include <linux/pm_runtime.h>
+#include <sound/pcm.h>
+#include <sound/pcm_params.h>
+#include <sound/soc.h>
+#include <sound/dmaengine_pcm.h>
+#include <linux/clocksource.h>
+#include <linux/random.h>
+#include <linux/timecounter.h>
+#include <sound/core.h>
+#include <sound/initval.h>
+#include <linux/pci.h>
+#include <linux/version.h>
+#include <linux/acpi.h>
+#include <sound/jack.h>
+#include "phytium-i2s-v2.h"
+
+#define PHYT_I2S_V2_VERSION "1.0.0"
+
+static struct snd_soc_jack hs_jack;
+
+/* Headset jack detection DAPM pins */
+static struct snd_soc_jack_pin hs_jack_pins[] = {
+	{
+		.pin	= "Front",
+		.mask	= SND_JACK_HEADPHONE,
+	},
+};
+
+static const struct snd_pcm_hardware phytium_pcm_hardware = {
+	.info = SNDRV_PCM_INFO_INTERLEAVED |
+		SNDRV_PCM_INFO_MMAP |
+		SNDRV_PCM_INFO_MMAP_VALID |
+		SNDRV_PCM_INFO_BLOCK_TRANSFER,
+	.rates = SNDRV_PCM_RATE_8000 |
+		SNDRV_PCM_RATE_32000 |
+		SNDRV_PCM_RATE_44100 |
+		SNDRV_PCM_RATE_48000,
+	.rate_min = 8000,
+	.rate_max = 48000,
+	.formats = (SNDRV_PCM_FMTBIT_S8 |
+		SNDRV_PCM_FMTBIT_S16_LE |
+		SNDRV_PCM_FMTBIT_S20_LE |
+		SNDRV_PCM_FMTBIT_S24_LE |
+		SNDRV_PCM_FMTBIT_S32_LE),
+	.channels_min = 2,
+	.channels_max = 4,
+	.buffer_bytes_max = 4096*16,
+	.period_bytes_min = 1024,
+	.period_bytes_max = 4096*4,
+	.periods_min = 2,
+	.periods_max = 16,
+};
+
+static int phyt_pcm_new(struct snd_soc_component *component,
+				struct snd_soc_pcm_runtime *rtd)
+{
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+	size_t size = phytium_pcm_hardware.buffer_bytes_max;
+	int ret = 0;
+
+	snd_pcm_lib_preallocate_pages_for_all(rtd->pcm,
+				      SNDRV_DMA_TYPE_DEV,
+				      priv->dev, size, size);
+
+	if (ret < 0) {
+		dev_err(priv->dev, "can't alloc preallocate buffer\n");
+		goto failed_preallocate_buffer;
+	}
+
+	ret = snd_dma_alloc_pages(SNDRV_DMA_TYPE_DEV, priv->dev, BDL_SIZE,
+				&priv->pcm_config[0].bdl_dmab);
+	if (ret < 0) {
+		dev_err(priv->dev, "can't alloc bdl0 buffer\n");
+		goto failed_alloc_bdl0;
+	}
+
+	ret = snd_dma_alloc_pages(SNDRV_DMA_TYPE_DEV, priv->dev, BDL_SIZE,
+				&priv->pcm_config[1].bdl_dmab);
+	if (ret < 0) {
+		dev_err(priv->dev, "can't alloc bdl1 buffer\n");
+		goto failed_alloc_bdl1;
+	}
+	return 0;
+
+failed_alloc_bdl1:
+	snd_dma_free_pages(&priv->pcm_config[0].bdl_dmab);
+failed_alloc_bdl0:
+	snd_pcm_lib_preallocate_free_for_all(rtd->pcm);
+failed_preallocate_buffer:
+	return ret;
+}
+
+static void phyt_pcm_free(struct snd_soc_component *component,
+			     struct snd_pcm *pcm)
+{
+	struct snd_soc_pcm_runtime *rtd = pcm->private_data;
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+
+	snd_dma_free_pages(&priv->pcm_config[1].bdl_dmab);
+	snd_dma_free_pages(&priv->pcm_config[0].bdl_dmab);
+	snd_pcm_lib_preallocate_free_for_all(pcm);
+}
+
+static int phyt_pcm_component_probe(struct snd_soc_component *component)
+{
+	struct phytium_i2s *priv = snd_soc_component_get_drvdata(component);
+	struct snd_soc_card *card = component->card;
+	int ret;
+
+	if (priv->insert < 0)
+		return 0;
+
+	ret = snd_soc_card_jack_new_pins(card, "Headset Jack", SND_JACK_HEADSET,
+				    &hs_jack, hs_jack_pins,
+				    ARRAY_SIZE(hs_jack_pins));
+	if (ret < 0) {
+		dev_err(component->dev, "Cannot create jack\n");
+		return ret;
+	}
+	return 0;
+}
+
+static int phyt_pcm_open(struct snd_soc_component *component,
+			struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+	struct snd_pcm_runtime *runtime = substream->runtime;
+
+	snd_soc_set_runtime_hwparams(substream, &phytium_pcm_hardware);
+	snd_pcm_hw_constraint_integer(runtime, SNDRV_PCM_HW_PARAM_PERIODS);
+	snd_pcm_hw_constraint_step(runtime, 0, SNDRV_PCM_HW_PARAM_PERIOD_BYTES, 128);
+	runtime->private_data = priv;
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		priv->substream_playback = substream;
+	else
+		priv->substream_capture = substream;
+
+	return 0;
+}
+
+static int phyt_pcm_close(struct snd_soc_component *component,
+			struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		priv->substream_playback = NULL;
+	else
+		priv->substream_capture = NULL;
+
+	return 0;
+}
+
+static int phyt_pcm_hw_params(struct snd_soc_component *component,
+					struct snd_pcm_substream *substream,
+					struct snd_pcm_hw_params *hw_params)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+	int ret;
+	uint32_t format_val;
+
+	switch (params_format(hw_params)) {
+	case SNDRV_PCM_FORMAT_S16_LE:
+		format_val = BYTE_2;
+		break;
+
+	case SNDRV_PCM_FORMAT_S24_LE:
+		format_val = BYTE_4;
+		break;
+
+	case SNDRV_PCM_FORMAT_S32_LE:
+		format_val = BYTE_4;
+		break;
+
+	default:
+		dev_err(priv->dev, "phytium-i2s: unsupported PCM fmt");
+		return -EINVAL;
+	}
+
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		priv->pcm_config[DIRECTION_PLAYBACK].format_val = format_val;
+	else
+		priv->pcm_config[DIRECTION_CAPTURE].format_val = format_val;
+
+	ret = snd_pcm_lib_malloc_pages(substream, params_buffer_bytes(hw_params));
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static void phyt_bdl_entry_setup(dma_addr_t addr, uint32_t **pbdl,
+				uint32_t period_bytes, uint32_t with_ioc)
+{
+	uint32_t *bdl = *pbdl;
+	uint32_t chunk;
+
+	while (period_bytes > 0) {
+		bdl[0] = cpu_to_le32((u32)addr);
+		bdl[1] = cpu_to_le32(upper_32_bits(addr));
+		if (period_bytes > BDL_BUFFER_MAX_SIZE)
+			chunk = BDL_BUFFER_MAX_SIZE;
+		else
+			chunk = period_bytes;
+
+		bdl[2] = cpu_to_le32(chunk);
+		period_bytes -= chunk;
+		bdl[3] = (period_bytes || !with_ioc) ? 0 : cpu_to_le32(0x01);
+		bdl += 4;
+	}
+
+	*pbdl = bdl;
+}
+
+
+static int phyt_pcm_prepare(struct snd_soc_component *component,
+			      struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+	struct snd_pcm_runtime *runtime = substream->runtime;
+	struct phytium_pcm_config *pcm_config;
+	int periods = 0, i, offset = 0;
+	uint32_t *bdl = NULL;
+	struct snd_dma_buffer *data_dmab = NULL;
+	int direction;
+	uint32_t frags = 0;
+	uint32_t config = 0, format_val;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
+		priv->pcm_config[DIRECTION_PLAYBACK].buffer_size =
+				snd_pcm_lib_buffer_bytes(substream);
+		priv->pcm_config[DIRECTION_PLAYBACK].period_bytes =
+				snd_pcm_lib_period_bytes(substream);
+		priv->pcm_config[DIRECTION_PLAYBACK].no_period_wakeup =
+				runtime->no_period_wakeup;
+		direction = DIRECTION_PLAYBACK;
+		format_val = priv->pcm_config[DIRECTION_PLAYBACK].format_val;
+	} else {
+		priv->pcm_config[DIRECTION_CAPTURE].buffer_size =
+				snd_pcm_lib_buffer_bytes(substream);
+		priv->pcm_config[DIRECTION_CAPTURE].period_bytes =
+				snd_pcm_lib_period_bytes(substream);
+		priv->pcm_config[DIRECTION_CAPTURE].no_period_wakeup =
+				runtime->no_period_wakeup;
+		direction = DIRECTION_CAPTURE;
+		format_val = priv->pcm_config[DIRECTION_CAPTURE].format_val;
+	}
+
+	pcm_config = &priv->pcm_config[direction];
+
+	periods = pcm_config->buffer_size / pcm_config->period_bytes;
+	bdl = (uint32_t *)pcm_config->bdl_dmab.area;
+	data_dmab = snd_pcm_get_dma_buf(substream);
+	for (i = 0; i < periods; i++) {
+		phyt_bdl_entry_setup(data_dmab->addr + offset, &bdl,
+					pcm_config->period_bytes,
+					!pcm_config->no_period_wakeup);
+		offset += pcm_config->period_bytes;
+		frags += DIV_ROUND_UP(pcm_config->period_bytes, BDL_BUFFER_MAX_SIZE);
+	}
+
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHAL_CONFG0, CHANNEL_0_1_ENABLE);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_MASK_INT, CHANNEL_0_1_INT_MASK);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_BDLPL(direction),
+			(uint32_t)(pcm_config->bdl_dmab.addr));
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_BDLPU(direction),
+			upper_32_bits(pcm_config->bdl_dmab.addr));
+	if (direction == DIRECTION_PLAYBACK)
+		config = PLAYBACK_ADDRESS_OFFSET;
+	else
+		config = CAPTRUE_ADDRESS_OFFSET;
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_DEV_ADDR(direction),
+			E2000_LSD_I2S_BASE + config);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_LVI(direction), frags - 1);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_CBL(direction),
+			pcm_config->buffer_size);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_DSIZE(direction),
+			D_SIZE(format_val, direction));
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_DLENTH(direction), D_LENTH);
+
+	return 0;
+}
+
+static int phyt_pcm_hw_free(struct snd_soc_component *component,
+			       struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+	int direction;
+	u32 mask;
+	int cnt = 10;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		direction = DIRECTION_PLAYBACK;
+	else
+		direction = DIRECTION_CAPTURE;
+
+	mask = readl(priv->dma_reg_base + PHYTIUM_DMA_MASK_INT);
+	mask &= ~BIT(direction);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_MASK_INT, mask);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_CTL(direction), 0);
+	while (cnt--) {
+		if (readl(priv->dma_reg_base + PHYTIUM_DMA_CHALX_CTL(direction)) == 0)
+			break;
+		udelay(200);
+	}
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_CTL(direction), 2);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_CTL(direction), 0);
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_STS, DMA_TX_DONE);
+	else
+		phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_STS, DMA_RX_DONE);
+
+	return snd_pcm_lib_free_pages(substream);
+}
+
+static int phyt_pcm_trigger(struct snd_soc_component *component,
+			       struct snd_pcm_substream *substream, int cmd)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+	bool start =  false;
+	int direction = 0, value = 0;
+
+	switch (cmd) {
+	case SNDRV_PCM_TRIGGER_START:
+	case SNDRV_PCM_TRIGGER_RESUME:
+	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
+		start = true;
+		break;
+	case SNDRV_PCM_TRIGGER_STOP:
+	case SNDRV_PCM_TRIGGER_SUSPEND:
+	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
+		start = false;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	direction = ((substream->stream ==
+		 SNDRV_PCM_STREAM_PLAYBACK) ? DIRECTION_PLAYBACK:DIRECTION_CAPTURE);
+
+	if (start)
+		value = (substream->stream ==
+			SNDRV_PCM_STREAM_PLAYBACK) ? PLAYBACK_START:CAPTURE_START;
+	else
+		value = CTL_STOP;
+
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CHALX_CTL(direction), value);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CTL, DMA_ENABLE);
+
+	return 0;
+}
+
+static snd_pcm_uframes_t phyt_pcm_pointer(struct snd_soc_component *component,
+					    struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(asoc_rtd_to_cpu(rtd, 0));
+
+	uint32_t pos = 0;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		pos = readl(priv->dma_reg_base + PHYTIUM_DMA_LPIB(DIRECTION_PLAYBACK));
+	else
+		pos = readl(priv->dma_reg_base + PHYTIUM_DMA_LPIB(DIRECTION_CAPTURE));
+
+	return bytes_to_frames(substream->runtime, pos);
+}
+
+int phyt_i2s_msg_set_cmd(struct phytium_i2s *priv, struct phyti2s_cmd *msg)
+{
+	struct phyti2s_cmd *ans_msg;
+	int timeout = 40, ret = 0;
+
+	mutex_lock(&priv->sharemem_mutex);
+	memcpy(priv->sharemem_base, msg, sizeof(struct phyti2s_cmd));
+
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_AP2RV_INT_STATE, SEND_INTR);
+
+	ans_msg = priv->sharemem_base;
+
+	while ((ans_msg->complete == PHYTI2S_COMPLETE_NONE
+			|| ans_msg->complete == PHYTI2S_COMPLETE_GOING)
+			&& timeout) {
+		if (preempt_count() != 0)
+			udelay(500);
+		else
+			usleep_range(500, 1000);
+		timeout--;
+	}
+
+	if (timeout == 0) {
+		dev_err(priv->dev, "wait cmd reply timeout\n");
+		ret = -EBUSY;
+	}
+
+	if (ans_msg->complete == PHYTI2S_COMPLETE_ERROR) {
+		dev_err(priv->dev, "handle cmd failed\n");
+		ret = -EINVAL;
+	}
+
+	if (ans_msg->complete == PHYTI2S_COMPLETE_ID_NOT_SUPPORTED) {
+		dev_err(priv->dev, "cmd not support!\n");
+		ret = -EINVAL;
+	}
+
+	if (ans_msg->complete == PHYTI2S_COMPLETE_SUBID_NOT_SUPPORTED) {
+		dev_err(priv->dev, "cmd subid not support!\n");
+		ret = -EINVAL;
+	}
+
+	if (ans_msg->complete == PHYTI2S_COMPLETE_INVALID_PARAMETERS) {
+		dev_err(priv->dev, "cmd params not support!\n");
+		ret = -EINVAL;
+	}
+	mutex_unlock(&priv->sharemem_mutex);
+	return ret;
+}
+
+static int phyt_i2s_enable_gpio(struct phytium_i2s *priv)
+{
+	struct phyti2s_cmd *msg = priv->msg;
+	struct gpio_i2s_data *data = &msg->cmd_para.gpio_i2s_data;
+	int ret = 0;
+
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_GPIO;
+	msg->complete = 0;
+	data->enable = 1;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret)
+		dev_err(priv->dev, "PHYTI2S_MSG_CMD_SET_GPIO enable failed: %d\n", ret);
+
+	return ret;
+}
+
+static int phyt_i2s_disable_gpioint(struct phytium_i2s *priv)
+{
+	struct phyti2s_cmd *msg = priv->msg;
+	struct gpio_i2s_data *data = &msg->cmd_para.gpio_i2s_data;
+	int ret = 0;
+
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_GPIO;
+	msg->complete = 0;
+	data->enable = 0;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret)
+		dev_err(priv->dev, "PHYTIUM_MSG_CMD_SET_GPIO disable failed: %d\n", ret);
+
+	return ret;
+}
+
+static int phyt_pcm_suspend(struct snd_soc_component *component)
+{
+	return 0;
+}
+
+static int phyt_pcm_resume(struct snd_soc_component *component)
+{
+	struct phytium_i2s *priv = snd_soc_component_get_drvdata(component);
+	struct snd_soc_dai *dai;
+	struct phyti2s_cmd *msg = priv->msg;
+	struct set_mode_data *data = &msg->cmd_para.set_mode_data;
+	int ret = 0;
+
+	for_each_component_dais(component, dai) {
+		if (snd_soc_dai_stream_active(dai, SNDRV_PCM_STREAM_PLAYBACK)) {
+			data->direction = DIRECTION_PLAYBACK;
+			data->data_width = priv->data_width;
+			data->sample_rate = priv->sample_rate;
+			data->chan_nr = priv->chan_nr;
+			data->clk_base = priv->clk_base;
+			data->enable = 1;
+			msg->id = PHYTIUM_I2S_LSD_ID;
+			msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+			msg->cmd_subid = PHYTI2S_MSG_CMD_SET_MODE;
+			msg->complete = 0;
+			ret = phyt_i2s_msg_set_cmd(priv, msg);
+			if (ret) {
+				dev_err(priv->dev, "phytium-i2s: resume failed: %d\n", ret);
+				ret = -EINVAL;
+				goto error;
+			}
+		}
+		if (snd_soc_dai_stream_active(dai, SNDRV_PCM_STREAM_CAPTURE)) {
+			data->direction = DIRECTION_CAPTURE;
+			data->data_width = priv->data_width;
+			data->sample_rate = priv->sample_rate;
+			data->chan_nr = priv->chan_nr;
+			data->clk_base = priv->clk_base;
+			data->enable = 1;
+			msg->id = PHYTIUM_I2S_LSD_ID;
+			msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+			msg->cmd_subid = PHYTI2S_MSG_CMD_SET_MODE;
+			msg->complete = 0;
+			ret = phyt_i2s_msg_set_cmd(priv, msg);
+			if (ret) {
+				dev_err(priv->dev, "phytium-i2s: resume failed: %d\n", ret);
+				ret = -EINVAL;
+				goto error;
+			}
+		}
+	}
+	phyt_i2s_enable_gpio(priv);
+error:
+	return ret;
+}
+
+static const struct snd_soc_component_driver phytium_i2s_component = {
+	.name = "phytium-i2s",
+	.pcm_construct = phyt_pcm_new,
+	.pcm_destruct = phyt_pcm_free,
+	.suspend = phyt_pcm_suspend,
+	.resume  = phyt_pcm_resume,
+	.probe = phyt_pcm_component_probe,
+	.open = phyt_pcm_open,
+	.close = phyt_pcm_close,
+	.hw_params = phyt_pcm_hw_params,
+	.prepare = phyt_pcm_prepare,
+	.hw_free = phyt_pcm_hw_free,
+	.trigger = phyt_pcm_trigger,
+	.pointer = phyt_pcm_pointer,
+	.legacy_dai_naming = 1,
+};
+
+static int phyt_i2s_hw_params(struct snd_pcm_substream *substream,
+		struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
+{
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(dai);
+	struct phyti2s_cmd *msg = priv->msg;
+	struct set_mode_data *data = &msg->cmd_para.set_mode_data;
+	int ret = 0;
+
+	memset(msg, 0, sizeof(struct phyti2s_cmd));
+
+	data->direction = ((substream->stream ==
+		SNDRV_PCM_STREAM_PLAYBACK) ? DIRECTION_PLAYBACK:DIRECTION_CAPTURE);
+	switch (params_format(params)) {
+	case SNDRV_PCM_FORMAT_S16_LE:
+		data->data_width = 16;
+		break;
+	case SNDRV_PCM_FORMAT_S24_LE:
+		data->data_width = 24;
+		break;
+	case SNDRV_PCM_FORMAT_S32_LE:
+		data->data_width = 32;
+		break;
+	default:
+		dev_err(priv->dev, "phytium-i2s: unsupported dai fmt");
+		ret = -EINVAL;
+		goto error;
+	}
+
+	data->sample_rate = params_rate(params);
+	data->chan_nr = params_channels(params);
+	data->enable = 1;
+	data->clk_base = priv->clk_base;
+	priv->data_width = data->data_width;
+	priv->sample_rate = data->sample_rate;
+	priv->chan_nr = data->chan_nr;
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_MODE;
+	msg->complete = 0;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret) {
+		dev_err(priv->dev, "phytium-i2s: PHYTI2S_MSG_CMD_SET_MODE failed: %d\n", ret);
+		ret = -EINVAL;
+	}
+
+error:
+	return ret;
+}
+
+static void i2s_interrupt_playback_stop_work(struct work_struct *work)
+{
+	struct phytium_i2s *priv = container_of(work, struct phytium_i2s,
+			i2s_playback_stop_work.work);
+	struct phyti2s_cmd *msg;
+	struct trigger_i2s_data *data;
+	int ret = 0;
+
+	msg = kmalloc(sizeof(struct phyti2s_cmd), GFP_KERNEL);
+	if (!msg)
+		return;
+	data = &msg->cmd_para.trigger_i2s_data;
+
+	data->direction = DIRECTION_PLAYBACK;
+	data->start = 0;
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_TRIGGER;
+	msg->complete = 0;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret)
+		dev_err(priv->dev, "PHYTI2S_MSG_CMD_SET_MODE stop playback failed: %d\n", ret);
+	kfree(msg);
+}
+
+static void i2s_interrupt_capture_stop_work(struct work_struct *work)
+{
+	struct phytium_i2s *priv = container_of(work, struct phytium_i2s,
+			i2s_capture_stop_work.work);
+	struct phyti2s_cmd *msg;
+	struct trigger_i2s_data *data;
+	int ret = 0;
+
+	msg = kmalloc(sizeof(struct phyti2s_cmd), GFP_KERNEL);
+	if (!msg)
+		return;
+	data = &msg->cmd_para.trigger_i2s_data;
+
+	data->direction = DIRECTION_CAPTURE;
+	data->start = 0;
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_TRIGGER;
+	msg->complete = 0;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret)
+		dev_err(priv->dev, "PHYTI2S_MSG_CMD_SET_MODE stop capture failed: %d\n", ret);
+	kfree(msg);
+}
+
+static int phyt_i2s_trigger(struct snd_pcm_substream *substream,
+		int cmd, struct snd_soc_dai *dai)
+{
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(dai);
+	struct phyti2s_cmd *msg = priv->msg;
+	struct trigger_i2s_data *data = &msg->cmd_para.trigger_i2s_data;
+	bool start =  false;
+	int ret = 0;
+
+	memset(msg, 0, sizeof(struct phyti2s_cmd));
+
+	data->direction = ((substream->stream ==
+		SNDRV_PCM_STREAM_PLAYBACK) ? DIRECTION_PLAYBACK:DIRECTION_CAPTURE);
+	switch (cmd) {
+	case SNDRV_PCM_TRIGGER_START:
+	case SNDRV_PCM_TRIGGER_RESUME:
+	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
+		priv->running += 1;
+		start = true;
+		break;
+
+	case SNDRV_PCM_TRIGGER_STOP:
+	case SNDRV_PCM_TRIGGER_SUSPEND:
+	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
+		priv->running -= 1;
+		// Use delay work to avoid waiting too long in interrupt.
+		if (priv->interrupt) {
+			if (data->direction == SNDRV_PCM_STREAM_PLAYBACK)
+				queue_delayed_work(system_power_efficient_wq,
+					&priv->i2s_playback_stop_work,
+					usecs_to_jiffies(200));
+			else
+				queue_delayed_work(system_power_efficient_wq,
+					&priv->i2s_capture_stop_work,
+					usecs_to_jiffies(200));
+			return ret;
+		}
+		start = false;
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	if (!start && priv->running)
+		goto error;
+
+	data->start = start ? 1:0;
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_TRIGGER;
+	msg->complete = 0;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret) {
+		dev_err(priv->dev, "phytium-i2s: PHYTI2S_MSG_CMD_SET_TRIGGER failed: %d\n", ret);
+		ret = -EINVAL;
+	}
+
+error:
+	return ret;
+}
+
+static int phyt_i2s_hw_free(struct snd_pcm_substream *substream,
+				struct snd_soc_dai *dai)
+{
+	struct phytium_i2s *priv = snd_soc_dai_get_drvdata(dai);
+	struct phyti2s_cmd *msg = priv->msg;
+	struct set_mode_data *data = &msg->cmd_para.set_mode_data;
+	int ret = 0;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		flush_delayed_work(&priv->i2s_playback_stop_work);
+	else
+		flush_delayed_work(&priv->i2s_capture_stop_work);
+	if (priv->running > 0)
+		return 0;
+
+	memset(msg, 0, sizeof(struct phyti2s_cmd));
+
+	data->direction = ((substream->stream ==
+		SNDRV_PCM_STREAM_PLAYBACK) ? DIRECTION_PLAYBACK:DIRECTION_CAPTURE);
+	data->enable = 0;
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_MODE;
+	msg->complete = 0;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret) {
+		dev_err(priv->dev, "phytium-i2s: SET_MODE disable failed: %d\n", ret);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static const struct snd_soc_dai_ops phytium_i2s_dai_ops = {
+	.hw_params	= phyt_i2s_hw_params,
+	.trigger	= phyt_i2s_trigger,
+	.hw_free	= phyt_i2s_hw_free,
+};
+
+static void phyt_i2s_gpio_jack_work(struct work_struct *work)
+{
+	struct phytium_i2s *priv = container_of(work, struct phytium_i2s,
+		phyt_i2s_gpio_work.work);
+	struct phyti2s_cmd *msg;
+	struct gpio_i2s_data *data;
+	int ret = 0;
+
+	if (priv->insert == 1) {
+		snd_soc_jack_report(&hs_jack, HEADPHONE_DISABLE, SND_JACK_HEADSET);
+		priv->insert = 0;
+	} else {
+		snd_soc_jack_report(&hs_jack, HEADPHONE_ENABLE, SND_JACK_HEADSET);
+		priv->insert = 1;
+	}
+
+	msg = kmalloc(sizeof(struct phyti2s_cmd), GFP_KERNEL);
+	if (!msg)
+		return;
+	data = &msg->cmd_para.gpio_i2s_data;
+
+	msg->id = PHYTIUM_I2S_LSD_ID;
+	msg->cmd_id = PHYTI2S_MSG_CMD_SET;
+	msg->cmd_subid = PHYTI2S_MSG_CMD_SET_GPIO;
+	msg->complete = 0;
+	data->enable = -1;
+	data->insert = priv->insert;
+	ret = phyt_i2s_msg_set_cmd(priv, msg);
+	if (ret)
+		dev_err(priv->dev, "PHYTI2S_MSG_CMD_SET_GPIO report jack failed: %d\n", ret);
+	kfree(msg);
+}
+
+static irqreturn_t phyt_i2s_gpio_interrupt(int irq, void *dev_id)
+{
+	struct phytium_i2s *priv = dev_id;
+
+	queue_delayed_work(system_power_efficient_wq, &priv->phyt_i2s_gpio_work,
+		      msecs_to_jiffies(100));
+
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_GPIO_PORTA_EOI, BIT(0));
+	return IRQ_HANDLED;
+}
+
+static irqreturn_t phyt_i2s_interrupt(int irq, void *dev_id)
+{
+	struct phytium_i2s *priv = dev_id;
+	uint32_t status;
+	int ret = IRQ_NONE;
+
+	priv->interrupt = 1;
+	status = readl(priv->dma_reg_base + PHYTIUM_DMA_STS);
+
+	if (status & DMA_TX_DONE) {
+		snd_pcm_period_elapsed(priv->substream_playback);
+		writel(DMA_TX_DONE, priv->dma_reg_base + PHYTIUM_DMA_STS);
+		ret = IRQ_HANDLED;
+	}
+
+	if (status & DMA_RX_DONE) {
+		snd_pcm_period_elapsed(priv->substream_capture);
+		writel(DMA_RX_DONE, priv->dma_reg_base + PHYTIUM_DMA_STS);
+		ret = IRQ_HANDLED;
+	}
+
+	priv->interrupt = 0;
+
+	return ret;
+}
+
+static int phyt_configure_dai_driver(struct phytium_i2s *priv,
+					    struct snd_soc_dai_driver *dai_driver)
+{
+	dai_driver->playback.stream_name = "i2s-Playback";
+	dai_driver->playback.channels_min = MIN_CHANNEL_NUM;
+	dai_driver->playback.channels_max = 4;
+	dai_driver->playback.rates = SNDRV_PCM_RATE_8000_192000;
+	dai_driver->playback.formats = SNDRV_PCM_FMTBIT_S8 |
+				       SNDRV_PCM_FMTBIT_S16_LE |
+				       SNDRV_PCM_FMTBIT_S20_LE |
+				       SNDRV_PCM_FMTBIT_S24_LE |
+				       SNDRV_PCM_FMTBIT_S32_LE;
+	dai_driver->capture.stream_name = "i2s-Capture";
+	dai_driver->capture.channels_min = 2;
+	dai_driver->capture.channels_max = 4;
+	dai_driver->capture.rates = SNDRV_PCM_RATE_8000_192000;
+	dai_driver->capture.formats = SNDRV_PCM_FMTBIT_S8 |
+				      SNDRV_PCM_FMTBIT_S16_LE |
+				      SNDRV_PCM_FMTBIT_S20_LE |
+				      SNDRV_PCM_FMTBIT_S24_LE |
+				      SNDRV_PCM_FMTBIT_S32_LE;
+	dai_driver->symmetric_rate = 1;
+	dai_driver->ops = &phytium_i2s_dai_ops;
+
+	return 0;
+}
+
+static void phyt_i2s_heartbeat(struct phytium_i2s *priv)
+{
+	u32 debug_reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG);
+
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG,
+		debug_reg | HEARTBEAT);
+}
+
+static void phyt_i2s_enable_heartbeat(struct phytium_i2s *priv)
+{
+	u32 debug_reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG);
+
+	priv->heart_enable = true;
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG,
+		debug_reg | HEART_ENABLE);
+}
+
+static void phyt_i2s_disable_heartbeat(struct phytium_i2s *priv)
+{
+	u32 debug_reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG);
+
+	priv->heart_enable = false;
+	debug_reg &= ~HEART_ENABLE;
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG, debug_reg);
+}
+
+static void phyt_i2s_enable_debug(struct phytium_i2s *priv)
+{
+	u32 debug_reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG);
+
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG,
+		debug_reg | DEBUG_ENABLE);
+}
+
+static void phyt_i2s_disable_debug(struct phytium_i2s *priv)
+{
+	u32 debug_reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG);
+
+	debug_reg &= ~DEBUG_ENABLE;
+	phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG, debug_reg);
+}
+
+static void phyt_i2s_timer_handler(struct timer_list *timer)
+{
+	struct phytium_i2s *priv = from_timer(priv, timer, timer);
+
+	if (priv->heart_enable)
+		phyt_i2s_heartbeat(priv);
+
+	mod_timer(&priv->timer, jiffies + msecs_to_jiffies(2000));
+}
+
+static ssize_t phyt_i2s_debug_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct phytium_i2s *priv = dev_get_drvdata(dev);
+	u32 debug_reg = phyt_readl_reg(priv->regfile_base, PHYTIUM_REGFILE_DEBUG);
+
+	return sprintf(buf, "%x\n", debug_reg);
+}
+
+static ssize_t phyt_i2s_debug_store(struct device *dev,
+		struct device_attribute *attr,
+		const char *buf, size_t size)
+{
+	struct phytium_i2s *priv = dev_get_drvdata(dev);
+	char *p;
+	char *token;
+	u8 loc, dis_en;
+	int ret;
+	long value;
+
+	dev_info(dev, "echo debug(1)/alive(0) enable(1)/disable(0) > debug\n");
+
+	p = kmalloc(size, GFP_KERNEL);
+	if (p == NULL)
+		return -EINVAL;
+	strscpy(p, buf, sizeof(p));
+
+	token = strsep(&p, " ");
+	if (!token) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = kstrtol(token, 0, &value);
+	if (ret)
+		goto error;
+	loc = (u8)value;
+
+	token = strsep(&p, " ");
+	if (!token) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = kstrtol(token, 0, &value);
+	if (ret)
+		goto error;
+	dis_en = value;
+
+	if (loc == 1) {
+		if (dis_en)
+			phyt_i2s_enable_debug(priv);
+		else
+			phyt_i2s_disable_debug(priv);
+	} else if (loc == 0) {
+		if (dis_en)
+			phyt_i2s_enable_heartbeat(priv);
+		else
+			phyt_i2s_disable_heartbeat(priv);
+	}
+
+	kfree(p);
+	return size;
+error:
+	kfree(p);
+	return ret;
+}
+
+static DEVICE_ATTR_RW(phyt_i2s_debug);
+
+static struct attribute *phyt_i2s_device_attrs[] = {
+	&dev_attr_phyt_i2s_debug.attr,
+	NULL,
+};
+
+static const struct attribute_group phyt_i2s_device_group = {
+	.attrs = phyt_i2s_device_attrs,
+};
+
+static int phyt_i2s_probe(struct platform_device *pdev)
+{
+	struct phytium_i2s *priv;
+	struct snd_soc_dai_driver *dai_driver;
+	struct resource *res;
+	int ret, irq, gpio_irq;
+	struct clk *clk;
+	struct fwnode_handle *np;
+	uint32_t status;
+
+	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv) {
+		ret = -ENOMEM;
+		goto failed_alloc_phytium_i2s;
+	}
+
+	priv->msg = devm_kzalloc(&pdev->dev, sizeof(struct phyti2s_cmd), GFP_KERNEL);
+	if (!priv->msg) {
+		ret = -ENOMEM;
+		goto failed_alloc_phytium_i2s;
+	}
+
+	dev_set_drvdata(&pdev->dev, priv);
+	priv->dev = &pdev->dev;
+
+	dai_driver = devm_kzalloc(&pdev->dev, sizeof(*dai_driver), GFP_KERNEL);
+	if (!dai_driver) {
+		ret = -ENOMEM;
+		goto failed_alloc_dai_driver;
+	}
+
+	phyt_configure_dai_driver(priv, dai_driver);
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	priv->regfile_base = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(priv->regfile_base)) {
+		dev_err(&pdev->dev, "failed to ioremap resource0\n");
+		ret = PTR_ERR(priv->regfile_base);
+		goto failed_ioremap_res0;
+	}
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
+	priv->sharemem_base = devm_ioremap_wc(&pdev->dev, res->start, resource_size(res));
+	if (IS_ERR(priv->sharemem_base)) {
+		dev_err(&pdev->dev, "failed to ioremap resource1\n");
+		ret = PTR_ERR(priv->sharemem_base);
+		goto failed_ioremap_res1;
+	}
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 2);
+	priv->dma_reg_base = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(priv->dma_reg_base)) {
+		dev_err(&pdev->dev, "failed to ioremap resource2\n");
+		ret = PTR_ERR(priv->dma_reg_base);
+		goto failed_ioremap_res2;
+	}
+
+	status = readl(priv->dma_reg_base + PHYTIUM_DMA_STS);
+	if (status & DMA_TX_DONE)
+		writel(DMA_TX_DONE, priv->dma_reg_base + PHYTIUM_DMA_STS);
+	if (status & DMA_RX_DONE)
+		writel(DMA_RX_DONE, priv->dma_reg_base + PHYTIUM_DMA_STS);
+	phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_MASK_INT, 0x0);
+
+	irq = platform_get_irq(pdev, 0);
+	ret = devm_request_irq(&pdev->dev, irq, phyt_i2s_interrupt, IRQF_SHARED,
+		pdev->name, priv);
+	if (ret < 0) {
+		dev_err(&pdev->dev, "failed to request irq\n");
+		goto failed_request_irq;
+	}
+
+	gpio_irq = platform_get_irq_optional(pdev, 1);
+	priv->insert = -1;
+	if (gpio_irq > 0) {
+		phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_GPIO_PORTA_EOI, BIT(0));
+		ret = phyt_i2s_disable_gpioint(priv);
+		if (ret < 0) {
+			dev_err(&pdev->dev, "failed to disable gpioint\n");
+			goto failed_disable_gpioint;
+		}
+		priv->insert = 0;
+		ret = devm_request_irq(&pdev->dev, gpio_irq, phyt_i2s_gpio_interrupt,
+				IRQF_SHARED, pdev->name, priv);
+		if (ret < 0) {
+			dev_err(&pdev->dev, "failed to request gpio irq\n");
+			goto failed_request_irq;
+		}
+		ret = phyt_i2s_enable_gpio(priv);
+		if (ret < 0) {
+			dev_err(&pdev->dev, "failed to enable gpio\n");
+			goto failed_enable_gpio;
+		}
+		INIT_DELAYED_WORK(&priv->phyt_i2s_gpio_work, phyt_i2s_gpio_jack_work);
+	}
+
+	if (pdev->dev.of_node) {
+		device_property_read_string(&pdev->dev, "dai-name", &dai_driver->name);
+		clk = devm_clk_get(&pdev->dev, NULL);
+		priv->clk_base = clk_get_rate(clk);
+	} else if (has_acpi_companion(&pdev->dev)) {
+		np = dev_fwnode(&(pdev->dev));
+		ret = fwnode_property_read_string(np, "dai-name", &dai_driver->name);
+		if (ret < 0) {
+			dev_err(&pdev->dev, "missing dai-name property from acpi\n");
+			goto failed_get_dai_name;
+		}
+		ret = fwnode_property_read_u32(np, "i2s_clk", &priv->clk_base);
+		if (ret < 0) {
+			dev_err(&pdev->dev, "missing i2s_clk property from acpi\n");
+			goto failed_get_dai_name;
+		}
+	}
+
+	ret = devm_snd_soc_register_component(&pdev->dev, &phytium_i2s_component,
+					      dai_driver, 1);
+	if (ret != 0) {
+		dev_err(&pdev->dev, "not able to register dai\n");
+		goto failed_register_com;
+	}
+
+	INIT_DELAYED_WORK(&priv->i2s_playback_stop_work, i2s_interrupt_playback_stop_work);
+	INIT_DELAYED_WORK(&priv->i2s_capture_stop_work, i2s_interrupt_capture_stop_work);
+	mutex_init(&priv->sharemem_mutex);
+
+	if (sysfs_create_group(&priv->dev->kobj, &phyt_i2s_device_group))
+		dev_warn(&pdev->dev, "failed create sysfs\n");
+
+	phyt_i2s_disable_heartbeat(priv);
+	phyt_i2s_disable_debug(priv);
+	priv->timer.expires = jiffies + msecs_to_jiffies(5000);
+	timer_setup(&priv->timer, phyt_i2s_timer_handler, 0);
+	add_timer(&priv->timer);
+
+	return 0;
+failed_register_com:
+failed_get_dai_name:
+failed_request_irq:
+failed_disable_gpioint:
+failed_enable_gpio:
+failed_ioremap_res2:
+failed_ioremap_res1:
+failed_ioremap_res0:
+failed_alloc_dai_driver:
+failed_alloc_phytium_i2s:
+	return ret;
+}
+
+static int phyt_i2s_remove(struct platform_device *pdev)
+{
+	struct phytium_i2s *priv = dev_get_drvdata(&pdev->dev);
+
+	sysfs_remove_group(&priv->dev->kobj, &phyt_i2s_device_group);
+	del_timer(&priv->timer);
+	return 0;
+}
+
+static const struct of_device_id phyt_i2s_of_match[] = {
+	{ .compatible = "phytium,i2s-2.0", },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, phyt_i2s_of_match);
+
+static const struct acpi_device_id phyt_i2s_acpi_match[] = {
+	{ "PHYT0062", 0},
+	{ },
+};
+MODULE_DEVICE_TABLE(acpi, phyt_i2s_acpi_match);
+
+static struct platform_driver phyt_i2s_driver = {
+	.probe	= phyt_i2s_probe,
+	.remove	= phyt_i2s_remove,
+	.driver	= {
+		.name = "phytium-i2s-v2",
+		.of_match_table = of_match_ptr(phyt_i2s_of_match),
+		.acpi_match_table = phyt_i2s_acpi_match,
+	},
+};
+
+module_platform_driver(phyt_i2s_driver);
+
+MODULE_DESCRIPTION("Phytium I2S V2 Driver");
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Yang Xun <yangxun@phytium.com.cn>");
+MODULE_VERSION(PHYT_I2S_V2_VERSION);

--- a/sound/soc/phytium/phytium-i2s-v2.h
+++ b/sound/soc/phytium/phytium-i2s-v2.h
@@ -1,0 +1,192 @@
+/* SPDX-License-Identifier: GPL-2.0
+ *
+ * Phytium I2S ASoC driver
+ *
+ * Copyright (C) 2024, Phytium Technology Co., Ltd.
+ *
+ */
+
+#ifndef __PHYTIUM_VIRT_I2S_H
+#define __PHYTIUM_VIRT_I2S_H
+
+#include <linux/io.h>
+#include <sound/memalloc.h>
+
+struct phytium_pcm_config {
+	uint32_t buffer_size;
+	uint32_t period_bytes;
+	uint32_t frags;
+	uint32_t format_val;
+	unsigned int no_period_wakeup: 1;
+	struct snd_dma_buffer bdl_dmab;
+};
+
+struct phytium_i2s {
+	void __iomem *regfile_base;
+	void __iomem *sharemem_base;
+	void __iomem *dma_reg_base;
+	struct device *dev;
+	struct device *parent;
+
+	struct snd_pcm_substream *substream_playback;
+	struct snd_pcm_substream *substream_capture;
+	u32 clk_base;
+	struct phytium_pcm_config pcm_config[2];
+	struct delayed_work i2s_playback_stop_work;
+	struct delayed_work i2s_capture_stop_work;
+	struct delayed_work phyt_i2s_gpio_work;
+	struct phyti2s_cmd *msg;
+	int interrupt;
+	int running;
+	struct timer_list timer;
+	bool heart_enable;
+	uint32_t chan_nr;
+	uint32_t data_width;
+	uint32_t sample_rate;
+	int insert;
+	struct mutex sharemem_mutex;
+};
+
+struct pdata_pd230x_mfd {
+	struct device *dev;
+	char *name;
+	int clk_base;
+};
+
+#define MAX_CHANNEL_NUM         8
+#define MIN_CHANNEL_NUM         2
+
+#define BDL_SIZE		4096
+#define BDL_BUFFER_MAX_SIZE	0x100000
+
+#define DIRECTION_PLAYBACK	0
+#define DIRECTION_CAPTURE	1
+
+#define HEADPHONE_DISABLE	0
+#define HEADPHONE_ENABLE	1
+
+/* *******************msg*****************************/
+#define PHYTIUM_I2S_LSD_ID		0x00
+
+enum phyti2s_msg_cmd_id {
+	PHYTI2S_MSG_CMD_DEFAULT = 0,
+	PHYTI2S_MSG_CMD_SET,
+	PHYTI2S_MSG_CMD_GET,
+	PHYTI2S_MSG_CMD_DATA,
+	PHYTI2S_MSG_CMD_REPORT,
+	PHYTI2S_SYS_PROTOCOL = 0x10,
+};
+
+enum phyti2s_set_subid {
+	PHYTI2S_MSG_CMD_SET_MODE = 0,
+	PHYTI2S_MSG_CMD_SET_TRIGGER,
+	PHYTI2S_MSG_CMD_SET_GPIO,
+};
+
+enum phyti2s_complete {
+	PHYTI2S_COMPLETE_NONE = 0,
+	PHYTI2S_COMPLETE_DONE,
+	PHYTI2S_COMPLETE_GOING,
+	PHYTI2S_COMPLETE_ERROR = 0x10,
+	PHYTI2S_COMPLETE_ID_NOT_SUPPORTED,
+	PHYTI2S_COMPLETE_SUBID_NOT_SUPPORTED,
+	PHYTI2S_COMPLETE_INVALID_PARAMETERS,
+};
+
+struct set_mode_data {
+	int direction;
+	uint32_t chan_nr;
+	uint32_t data_width;
+	uint32_t sample_rate;
+	uint32_t enable;
+	uint32_t clk_base;
+};
+
+struct trigger_i2s_data {
+	int direction;
+	uint32_t start;
+};
+
+struct gpio_i2s_data {
+	int enable;
+	int insert;
+};
+
+struct phyti2s_cmd {
+	uint16_t id;
+	uint8_t cmd_id;
+	uint8_t cmd_subid;
+	uint16_t len;
+	uint16_t complete;
+	union {
+		uint8_t para[56];
+		struct set_mode_data set_mode_data;
+		struct trigger_i2s_data trigger_i2s_data;
+		struct gpio_i2s_data gpio_i2s_data;
+	} cmd_para;
+};
+/* *******************msg end ****************************/
+
+
+/*********************register ***************************/
+/* regfile */
+#define PHYTIUM_REGFILE_TX_HEAD	0x00
+	#define TX_HEAD_INTR		(1 << 16)
+#define PHYTIUM_REGFILE_TX_TAIL	0X04
+
+#define PHYTIUM_REGFILE_AP2RV_INT_MASK	0x20
+#define PHYTIUM_REGFILE_AP2RV_INT_STATE	0x24
+	#define SEND_INTR		(1 << 4)
+#define PHYTIUM_REGFILE_GPIO_PORTA_EOI		0x30
+#define PHYTIUM_REGFILE_DEBUG			0x58
+	#define DEBUG_ENABLE	(1 << 0)
+	#define HEART_ENABLE	(1 << 1)
+	#define HEARTBEAT		(1 << 2)
+
+/* DMA register */
+#define PHYTIUM_DMA_CTL			0x0000
+	#define DMA_ENABLE			0x1
+#define PHYTIUM_DMA_CHAL_CONFG0		0x0004
+	#define CHANNEL_0_1_ENABLE		0x8180
+#define PHYTIUM_DMA_STS			0x0008
+	#define DMA_TX_DONE			0x1
+	#define DMA_RX_DONE			0x100
+#define PHYTIUM_DMA_MASK_INT		0x000c
+	#define	CHANNEL_0_1_INT_MASK		0x80000003
+#define PHYTIUM_DMA_BDLPU(x)		(0x40 * x + 0x0040)
+#define PHYTIUM_DMA_BDLPL(x)		(0x40 * x + 0x0044)
+#define PHYTIUM_DMA_CHALX_DEV_ADDR(x)	(0x40 * x + 0x0048)
+	#define E2000_LSD_I2S_BASE		0x28009000
+	#define PLAYBACK_ADDRESS_OFFSET		0x1c8
+	#define CAPTRUE_ADDRESS_OFFSET		0x1c0
+#define PHYTIUM_DMA_CHALX_LVI(x)	(0x40 * x + 0x004c)
+#define PHYTIUM_DMA_LPIB(x)		(0x40 * x + 0x0050)
+#define PHYTIUM_DMA_CHALX_CBL(x)	(0x40 * x + 0x0054)
+#define PHYTIUM_DMA_CHALX_CTL(x)	(0x40 * x + 0x0058)
+	#define PLAYBACK_START			0x1
+	#define CAPTURE_START			0x5
+	#define CTL_STOP			0x0
+#define PHYTIUM_DMA_CHALX_DSIZE(x)	(0x40 * x + 0x0064)
+	#define BYTE_4				0x0
+	#define BYTE_2				0x2
+	#define D_SIZE(byte_mode, dir)		(byte_mode << (dir*2))
+#define PHYTIUM_DMA_CHALX_DLENTH(x)	(0x40 * x + 0x0068)
+	#define D_LENTH				0x0
+/*********************register end ***************************/
+
+
+static inline unsigned int
+phyt_readl_reg(void *base, uint32_t offset)
+{
+	unsigned int data;
+
+	data = readl(base + offset);
+	return data;
+}
+
+static inline void
+phyt_writel_reg(void *base, uint32_t offset, uint32_t data)
+{
+	writel(data, base + offset);
+}
+#endif

--- a/sound/soc/phytium/phytium-machine-v2.c
+++ b/sound/soc/phytium/phytium-machine-v2.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ *  Copyright (c) 2024, Phytium Techonology Co., Ltd.
+ */
+
+#include <linux/module.h>
+#include <linux/gpio.h>
+#include <sound/soc.h>
+#include <sound/pcm_params.h>
+#include <sound/jack.h>
+#include <linux/version.h>
+
+#define PHYT_MACHINE_V2_VERSION "1.0.0"
+
+/* PMDK widgets */
+static const struct snd_soc_dapm_widget phyt_machine_dapm_widgets[] = {
+	SND_SOC_DAPM_HP("Front", NULL),
+	SND_SOC_DAPM_HP("Rear", NULL),
+
+	SND_SOC_DAPM_MIC("FrontIn", NULL),
+	SND_SOC_DAPM_MIC("RearIn", NULL),
+};
+
+/* PMDK control */
+static const struct snd_kcontrol_new phyt_machine_controls[] = {
+	SOC_DAPM_PIN_SWITCH("Front"),
+	SOC_DAPM_PIN_SWITCH("Rear"),
+	SOC_DAPM_PIN_SWITCH("FrontIn"),
+	SOC_DAPM_PIN_SWITCH("RearIn"),
+};
+
+/* PMDK connections */
+static const struct snd_soc_dapm_route phyt_machine_audio_map[] = {
+	{"INPUT1", NULL, "FrontIn"},
+	{"INPUT2", NULL, "RearIn"},
+	{"Front", NULL, "OUTPUT1"},
+	{"Rear", NULL, "OUTPUT2"},
+};
+
+#define PMDK_DAI_FMT (SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF | \
+	SND_SOC_DAIFMT_CBS_CFS)
+
+SND_SOC_DAILINK_DEFS(phyt_machine,
+	DAILINK_COMP_ARRAY(COMP_CPU("phytium-i2s-v2")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("PHYT1002:00", "phytium-hifi-v2")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("snd-soc-dummy")));
+
+static struct snd_soc_dai_link phyt_machine_dai[] = {
+	{
+		.name = "PHYTIUM HIFI V2",
+		.stream_name = "PHYTIUM HIFT V2",
+		.dai_fmt = PMDK_DAI_FMT,
+		SND_SOC_DAILINK_REG(phyt_machine),
+	},
+};
+
+static struct snd_soc_card phyt_machine_card = {
+	.name = "PHYT-MIE-V2",
+	.owner = THIS_MODULE,
+	.dai_link = phyt_machine_dai,
+	.num_links = ARRAY_SIZE(phyt_machine_dai),
+
+	.dapm_widgets = phyt_machine_dapm_widgets,
+	.num_dapm_widgets = ARRAY_SIZE(phyt_machine_dapm_widgets),
+	.controls = phyt_machine_controls,
+	.num_controls = ARRAY_SIZE(phyt_machine_controls),
+	.dapm_routes = phyt_machine_audio_map,
+	.num_dapm_routes = ARRAY_SIZE(phyt_machine_audio_map),
+};
+
+static int phyt_machine_probe(struct platform_device *pdev)
+{
+	struct snd_soc_card *card = &phyt_machine_card;
+	struct device *dev = &pdev->dev;
+
+	card->dev = dev;
+
+	return devm_snd_soc_register_card(&pdev->dev, card);
+}
+
+static const struct acpi_device_id phyt_machine_match[] = {
+	{ "PHYT1001", 0},
+	{ }
+};
+MODULE_DEVICE_TABLE(acpi, phyt_machine_match);
+
+static struct platform_driver phyt_machine_driver = {
+	.probe = phyt_machine_probe,
+	.driver = {
+		.name = "phyt_machine",
+		.acpi_match_table = phyt_machine_match,
+#ifdef CONFIG_PM
+		.pm = &snd_soc_pm_ops,
+#endif
+	},
+};
+
+module_platform_driver(phyt_machine_driver);
+
+MODULE_DESCRIPTION("ALSA SoC Phytium Machine V2");
+MODULE_AUTHOR("Yang Xun <yangxun@phytium.com.cn>");
+MODULE_LICENSE("GPL");
+MODULE_VERSION(PHYT_MACHINE_V2_VERSION);

--- a/sound/soc/phytium/phytium_i2s.c
+++ b/sound/soc/phytium/phytium_i2s.c
@@ -27,6 +27,7 @@
 #include <linux/timecounter.h>
 #include <sound/core.h>
 #include <sound/initval.h>
+#include <sound/jack.h>
 #include <linux/pci.h>
 #include "local.h"
 
@@ -46,9 +47,23 @@
 #define EIGHT_CHANNEL_SUPPORT	8	/* up to 7.1 */
 
 struct pdata_px210_mfd {
-	struct device		*dev;
+	struct device *dev;
 	char *name;
 	int clk_base;
+};
+
+static struct snd_soc_jack hs_jack;
+
+/* Headset jack detection DAPM pins */
+static struct snd_soc_jack_pin hs_jack_pins[] = {
+	{
+		.pin	= "FrontIn",
+		.mask	= SND_JACK_MICROPHONE,
+	},
+	{
+		.pin	= "Front",
+		.mask	= SND_JACK_HEADPHONE,
+	},
 };
 
 static inline void i2s_write_reg(void __iomem *io_base, int reg, u32 val)
@@ -151,6 +166,72 @@ irqreturn_t azx_i2s_interrupt(int irq, void *dev_id)
 	return IRQ_RETVAL(handled);
 }
 
+int azx_i2s_enable_gpio(struct i2s_phytium *i2s)
+{
+	u32 val;
+
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_SWPORTA_DDR,
+			(I2S_GPIO_INPUT(0) | I2S_GPIO_OUTPUT(1)));
+	val = i2s_read_reg(i2s->regs_gpio, I2S_GPIO_SWPORTA_DDR);
+	if (val != (I2S_GPIO_INPUT(0) | I2S_GPIO_OUTPUT(1)))
+		goto enable_err;
+
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_INTMASK, !I2S_GPIO(0));
+	val = i2s_read_reg(i2s->regs_gpio, I2S_GPIO_INTMASK);
+	if (val != !I2S_GPIO(0))
+		goto enable_err;
+
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_INTTYPE_LEVEL, I2S_GPIO_EDGE(0));
+	val = i2s_read_reg(i2s->regs_gpio, I2S_GPIO_INTTYPE_LEVEL);
+	if (val != I2S_GPIO_EDGE(0))
+		goto enable_err;
+
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_INT_POLARITY, I2S_GPIO_DOWN(0));
+	val = i2s_read_reg(i2s->regs_gpio, I2S_GPIO_INT_POLARITY);
+	if (val != I2S_GPIO_DOWN(0))
+		goto enable_err;
+
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_INTEN, I2S_GPIO(0));
+	val = i2s_read_reg(i2s->regs_gpio, I2S_GPIO_INTEN);
+	if (val != I2S_GPIO(0))
+		goto enable_err;
+
+	return 0;
+enable_err:
+	return -EBUSY;
+}
+
+static void i2s_gpio_jack_work(struct work_struct *work)
+{
+	struct i2s_phytium *i2s = container_of(work, struct i2s_phytium, i2s_gpio_work.work);
+	u32 val;
+
+	val = i2s_read_reg(i2s->regs_gpio, I2S_GPIO_INT_POLARITY);
+	if (val == 1) {
+		snd_soc_jack_report(&hs_jack, I2S_HEADPHONE_DISABLE, SND_JACK_HEADSET);
+		i2s_write_reg(i2s->regs_gpio, I2S_GPIO_SWPORTA_DR, I2S_HEADPHONE_REAR);
+	} else {
+		snd_soc_jack_report(&hs_jack, I2S_HEADPHONE_ENABLE, SND_JACK_HEADSET);
+		i2s_write_reg(i2s->regs_gpio, I2S_GPIO_SWPORTA_DR, I2S_HEADPHONE_FRONT);
+	}
+	val = ~val;
+	val &= 0x1;
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_INT_POLARITY, val);
+}
+
+irqreturn_t azx_i2s_gpio_interrupt(int irq, void *dev_id)
+{
+	struct azx *chip = dev_id;
+	struct i2s_phytium *i2s = container_of(chip, struct i2s_phytium, chip);
+	bool handled = true;
+
+	queue_delayed_work(system_power_efficient_wq, &i2s->i2s_gpio_work,
+			      msecs_to_jiffies(100));
+
+	i2s_write_reg(i2s->regs_gpio, I2S_GPIO_PORTA_EOI, I2S_GPIO(0));
+	return IRQ_RETVAL(handled);
+}
+
 static int azx_acquire_irq(struct azx *chip, int do_disconnect)
 {
 	struct i2sc_bus *bus = azx_bus(chip);
@@ -163,6 +244,22 @@ static int azx_acquire_irq(struct azx *chip, int do_disconnect)
 	if (err < 0) {
 		dev_err(i2s->dev, "failed to request irq\n");
 		return err;
+	}
+
+	if (i2s->detect) {
+		err = azx_i2s_enable_gpio(i2s);
+		if (err < 0) {
+			dev_err(i2s->dev, "failed to enable gpio irq\n");
+			return err;
+		}
+
+		err = devm_request_irq(i2s->dev, i2s->gpio_irq_id, azx_i2s_gpio_interrupt,
+					IRQF_SHARED,
+					"phytium i2s gpio", chip);
+		if (err < 0) {
+			dev_err(i2s->dev, "failed to request gpio irq\n");
+			return err;
+		}
 	}
 
 	bus->irq = i2s->irq_id;
@@ -370,12 +467,31 @@ static int phytium_i2s_resume(struct snd_soc_component *component)
 	}
 	i2s_write_reg(dev->regs, CLK_CFG0, dev->cfg);
 	i2s_write_reg(dev->regs, CLK_CFG1, 0xf);
+
+	if (dev->detect)
+		azx_i2s_enable_gpio(dev);
+
 	return 0;
 }
 #else
 #define phytium_i2s_suspend NULL
 #define phytium_i2s_resume  NULL
 #endif
+
+static int phytium_i2s_component_probe(struct snd_soc_component *component)
+{
+	struct snd_soc_card *card = component->card;
+	int ret;
+
+	ret = snd_soc_card_jack_new_pins(card, "Headset Jack", SND_JACK_HEADSET,
+			    &hs_jack, hs_jack_pins,
+			    ARRAY_SIZE(hs_jack_pins));
+	if (ret < 0) {
+		dev_err(component->dev, "Cannot create jack\n");
+		return ret;
+	}
+	return 0;
+}
 
 static struct snd_soc_dai_driver phytium_i2s_dai = {
 	.playback = {
@@ -967,6 +1083,7 @@ static const struct snd_soc_component_driver phytium_i2s_component = {
 	.pointer	= phytium_pcm_pointer,
 	.suspend	= phytium_i2s_suspend,
 	.resume		= phytium_i2s_resume,
+	.probe = phytium_i2s_component_probe,
 	.legacy_dai_naming = 1,
 };
 
@@ -1265,6 +1382,8 @@ static int i2s_phytium_create(struct platform_device *pdev,
 	}
 
 	INIT_WORK(&i2s->probe_work, azx_probe_work);
+	if (i2s->detect)
+		INIT_DELAYED_WORK(&i2s->i2s_gpio_work, i2s_gpio_jack_work);
 	*rchip = chip;
 	return 0;
 }
@@ -1324,16 +1443,27 @@ static int phytium_i2s_probe(struct platform_device *pdev)
 	i2s->paddr = res->start;
 	i2s->regs = devm_ioremap_resource(&pdev->dev, res);
 
+	if (IS_ERR(i2s->regs))
+		return PTR_ERR(i2s->regs);
+
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
 	i2s->regs_db = devm_ioremap_resource(&pdev->dev, res);
 
-	if (IS_ERR(i2s->regs))
-		return PTR_ERR(i2s->regs);
+	if (IS_ERR(i2s->regs_db))
+		return PTR_ERR(i2s->regs_db);
 
 	i2s->irq_id = platform_get_irq(pdev, 0);
 
 	if (i2s->irq_id < 0)
 		return i2s->irq_id;
+
+	i2s->gpio_irq_id = platform_get_irq(pdev, 1);
+	i2s->detect = true;
+
+	if (i2s->gpio_irq_id < 0)
+		i2s->detect = false;
+	else
+		i2s->regs_gpio = i2s->regs + I2S_GPIO_BASE;
 
 	i2s->i2s_reg_comp1 = I2S_COMP_PARAM_1;
 	i2s->i2s_reg_comp2 = I2S_COMP_PARAM_2;

--- a/sound/soc/phytium/phytium_i2s.c
+++ b/sound/soc/phytium/phytium_i2s.c
@@ -31,6 +31,7 @@
 #include <linux/pci.h>
 #include "local.h"
 
+#define PHYTIUM_I2S_V1_VERSION "1.0.0"
 #define NUM_CAPTURE	1
 #define NUM_PLAYBACK	1
 
@@ -1574,3 +1575,4 @@ module_platform_driver(phytium_i2s_driver);
 MODULE_DESCRIPTION("Phytium I2S Driver");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Zhang Yiqun <zhangyiqun@phytium.com.cn>");
+MODULE_VERSION(PHYTIUM_I2S_V1_VERSION);

--- a/sound/soc/phytium/phytium_i2s.c
+++ b/sound/soc/phytium/phytium_i2s.c
@@ -237,6 +237,15 @@ static int azx_acquire_irq(struct azx *chip, int do_disconnect)
 	struct i2sc_bus *bus = azx_bus(chip);
 	struct i2s_phytium *i2s = container_of(chip, struct i2s_phytium, chip);
 	int err;
+	u32 status;
+
+	status = i2s_read_reg(i2s->regs_db, DMA_STS);
+	if (status & 0x1)
+		i2s_write_reg(i2s->regs_db, DMA_STS, 0x1);
+	if (status & 0x100)
+		i2s_write_reg(i2s->regs_db, DMA_STS, 0x100);
+
+	i2s_write_reg(i2s->regs_db, DMA_MASK_INT, 0x0);
 
 	err = devm_request_irq(i2s->dev, i2s->irq_id, azx_i2s_interrupt, IRQF_SHARED,
 			       "phytium i2s", chip);
@@ -247,11 +256,8 @@ static int azx_acquire_irq(struct azx *chip, int do_disconnect)
 	}
 
 	if (i2s->detect) {
-		err = azx_i2s_enable_gpio(i2s);
-		if (err < 0) {
-			dev_err(i2s->dev, "failed to enable gpio irq\n");
-			return err;
-		}
+		i2s_write_reg(i2s->regs_gpio, I2S_GPIO_PORTA_EOI, I2S_GPIO(0));
+		i2s_write_reg(i2s->regs_gpio, I2S_GPIO_INTMASK, 0x1);
 
 		err = devm_request_irq(i2s->dev, i2s->gpio_irq_id, azx_i2s_gpio_interrupt,
 					IRQF_SHARED,
@@ -260,6 +266,13 @@ static int azx_acquire_irq(struct azx *chip, int do_disconnect)
 			dev_err(i2s->dev, "failed to request gpio irq\n");
 			return err;
 		}
+
+		err = azx_i2s_enable_gpio(i2s);
+		if (err < 0) {
+			dev_err(i2s->dev, "failed to enable gpio irq\n");
+			return err;
+		}
+
 	}
 
 	bus->irq = i2s->irq_id;

--- a/sound/soc/phytium/phytium_i2s.c
+++ b/sound/soc/phytium/phytium_i2s.c
@@ -494,8 +494,12 @@ static int phytium_i2s_resume(struct snd_soc_component *component)
 
 static int phytium_i2s_component_probe(struct snd_soc_component *component)
 {
+	struct i2s_phytium *dev = snd_soc_component_get_drvdata(component);
 	struct snd_soc_card *card = component->card;
 	int ret;
+
+	if (!dev->detect)
+		return 0;
 
 	ret = snd_soc_card_jack_new_pins(card, "Headset Jack", SND_JACK_HEADSET,
 			    &hs_jack, hs_jack_pins,
@@ -1471,7 +1475,7 @@ static int phytium_i2s_probe(struct platform_device *pdev)
 	if (i2s->irq_id < 0)
 		return i2s->irq_id;
 
-	i2s->gpio_irq_id = platform_get_irq(pdev, 1);
+	i2s->gpio_irq_id = platform_get_irq_optional(pdev, 1);
 	i2s->detect = true;
 
 	if (i2s->gpio_irq_id < 0)
@@ -1556,6 +1560,7 @@ static const struct acpi_device_id phytium_i2s_acpi_match[] = {
 	{ "PHYT0016", 0 },
 	{ }
 };
+MODULE_DEVICE_TABLE(acpi, phytium_i2s_acpi_match);
 #else
 #define phytium_i2s_acpi_match NULL
 #endif

--- a/sound/soc/phytium/pmdk_es8336.c
+++ b/sound/soc/phytium/pmdk_es8336.c
@@ -8,6 +8,7 @@
 #include <sound/soc.h>
 #include <sound/pcm_params.h>
 
+#define PMDK_ES8336_VERSION "1.0.0"
 
 /* PMDK widgets */
 static const struct snd_soc_dapm_widget pmdk_es8336_dapm_widgets[] = {
@@ -95,3 +96,4 @@ module_platform_driver(pmdk_sound_driver);
 MODULE_AUTHOR("Zhang Yiqun <zhangyiqun@phytium.com.cn>");
 MODULE_DESCRIPTION("ALSA SoC PMDK ES8336");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(PMDK_ES8336_VERSION);

--- a/sound/soc/phytium/pmdk_es8388.c
+++ b/sound/soc/phytium/pmdk_es8388.c
@@ -9,6 +9,8 @@
 #include <sound/pcm_params.h>
 #include <sound/jack.h>
 
+#define PMDK_ES8388_VERSION "1.0.0"
+
 static struct snd_soc_jack hs_jack;
 
 /* Headset jack detection DAPM pins */
@@ -167,3 +169,4 @@ module_platform_driver(pmdk_sound_driver);
 MODULE_AUTHOR("Zhang Yiqun<zhangyiqun@phytium.com.cn>");
 MODULE_DESCRIPTION("ALSA SoC PMDK ES8388");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(PMDK_ES8388_VERSION);


### PR DESCRIPTION
This patch updates the support for phytium i2s controller driver.

## Summary by Sourcery

Introduce new drivers for Phytium I2S v2 and Codec v2, controlled via a shared memory interface, and add a machine driver to connect them. Enhance the original Phytium I2S driver with jack detection and refactor the ES8336 codec.

New Features:
- Add Phytium I2S v2 driver communicating via shared memory.
- Add Phytium Codec v2 driver communicating via shared memory.
- Add Phytium ASoC machine driver linking the I2S v2 and Codec v2 drivers.
- Implement headset jack detection using GPIO in the original Phytium I2S driver.

Enhancements:
- Refactor ES8336 codec resume logic to use regcache sync.
- Configure ES8336 regmap for single read/write operations.

Build:
- Add build rules for the new Phytium v2 sound drivers.

Documentation:
- Add devicetree binding documentation for Phytium I2S v2.
- Add devicetree binding documentation for Phytium Codec v2.

Chores:
- Add `MODULE_VERSION` to various Phytium-related sound drivers.
- Add ACPI ID matching for the original Phytium I2S driver.