### PR TITLE
[linux-6.6.y][Feature]Hygon: In a CSV3 VM, the hypercall should notify real page enc/dec status

### DIFF
--- a/arch/x86/kernel/kvm.c
+++ b/arch/x86/kernel/kvm.c
@@ -44,6 +44,8 @@
 #include <asm/svm.h>
 #include <asm/e820/api.h>
 
+#include <asm/csv.h>
+
 DEFINE_STATIC_KEY_FALSE(kvm_async_pf_enabled);
 
 static int kvmapf = 1;
@@ -938,6 +940,9 @@ static void __init kvm_init_platform(void)
 		pv_ops.mmu.notify_page_enc_status_changed =
 			kvm_sev_hc_page_enc_status;
 
+#ifdef CONFIG_HYGON_CSV
+		if (!csv3_active()) {
+#endif
 		/*
 		 * Reset the host's shared pages list related to kernel
 		 * specific page encryption status settings before we load a
@@ -961,6 +966,9 @@ static void __init kvm_init_platform(void)
 				       nr_pages,
 				       KVM_MAP_GPA_RANGE_ENCRYPTED | KVM_MAP_GPA_RANGE_PAGE_SZ_4K);
 		}
+#ifdef CONFIG_HYGON_CSV
+		}
+#endif
 
 		/*
 		 * Ensure that _bss_decrypted section is marked as decrypted in the


### PR DESCRIPTION
For confidential-computing VM, the guest kernel typically invokes a
dynamic page encryption/decryption status notification interface to
synchronize page attribute status with Hypervisor. In the guest, the
kvm_init_platform() function traverses the e820 table to find RAM with
the "usable" attribute and notifies that all usable RAM are encrypted.
However, this notification is not accurate at this point, because some
pages within the usable RAM are already decrypted (e.g., the .bss..decrypted
section). The CSV3 virtual machine does not support such notifications
that are inconsistent with the real page status.

## Summary by Sourcery

Modify KVM initialization for Hygon CSV3 virtual machines to handle page encryption status notifications more accurately

New Features:
- Add support for Hygon CSV3 virtual machines to handle page encryption status more precisely

Bug Fixes:
- Fix inaccurate page encryption status notifications for confidential computing VMs

Enhancements:
- Prevent inconsistent page encryption status notifications in Hygon CSV3 VMs