### PR TITLE
dt-bindings: PCI: phytium: Fix maxItems value

### DIFF
--- a/Documentation/devicetree/bindings/pci/phytium,pd2008-pcie-ep.yaml
+++ b/Documentation/devicetree/bindings/pci/phytium,pd2008-pcie-ep.yaml
@@ -17,7 +17,7 @@ properties:
     const: phytium,pd2008-pcie-ep
 
   reg:
-    maxItems: 2
+    maxItems: 3
 
   reg-names:
     items:


### PR DESCRIPTION
Fix maxItems value in the DT bindings for the Phytium PCIe controller.

## Summary by Sourcery

Documentation:
- Corrected maxItems value for Phytium PCIe endpoint controller device tree bindings from 2 to 3