### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] drm/i915/irq: Clear GFX_MSTR_IRQ as part of IRQ reset

### DIFF
--- a/drivers/gpu/drm/i915/i915_irq.c
+++ b/drivers/gpu/drm/i915/i915_irq.c
@@ -751,6 +751,8 @@ static void dg1_irq_reset(struct drm_i915_private *dev_priv)
 
 	GEN3_IRQ_RESET(uncore, GEN11_GU_MISC_);
 	GEN3_IRQ_RESET(uncore, GEN8_PCU_);
+
+	intel_uncore_write(uncore, GEN11_GFX_MSTR_IRQ, ~0);
 }
 
 static void cherryview_irq_reset(struct drm_i915_private *dev_priv)


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
category: bugfix

Starting with Xe_LP+, GFX_MSTR_IRQ contains status bits that have W1C behavior. If we do not properly reset them, we would miss delivery of interrupts if a pending bit is set when enabling IRQs.

As an example, the display part of our probe routine contains paths where we wait for vblank interrupts. If a display interrupt was already pending when enabling IRQs, we would time out waiting for the vblank.

Avoid the potential issue by clearing GFX_MSTR_IRQ as part of the IRQ reset.

v2:
  - Move logic from gen11_gt_irq_reset() to dg1_irq_reset(). (Matt)

BSpec: 50875, 54028
Cc: Matt Roper <matthew.d.roper@intel.com>

Reviewed-by: Ville Syrjälä <ville.syrjala@linux.intel.com>

Link: https://patchwork.freedesktop.org/patch/msgid/20230920195351.59421-2-gustavo.sousa@intel.com (cherry picked from commit 156adfa55f23620f5817e1cf93dd6f762c8890b4)

## Summary by Sourcery

Bug Fixes:
- Ensure GFX_MSTR_IRQ status bits are cleared during IRQ reset to prevent missed interrupts on Xe_LP+ platforms.