### PR TITLE
[Deepin Kernel SIG] [Phytium] ALSA: hda: Add FTHD0001 match for Phytium

### DIFF
--- a/sound/pci/hda/hda_phytium.c
+++ b/sound/pci/hda/hda_phytium.c
@@ -1070,6 +1070,7 @@ MODULE_DEVICE_TABLE(of, hda_ft_of_match);
 #ifdef CONFIG_ACPI
 static const struct acpi_device_id hda_ft_acpi_match[] = {
 	{ .id = "PHYT0006" },
+	{ .id = "FTHD0001" },
 	{}
 };
 MODULE_DEVICE_TABLE(acpi, hda_ft_acpi_match);


### PR DESCRIPTION
Some Phytium ALSA HDA devices declare their ID as FTHD0001 instead of PHYT0006 (following Phytium's deprecated older ACPI specification).

Add the old ID to the ACPI match list so that the audio driver for these devices can be loaded correctly.

Similar to ("ALSA: hda: Resolving the issue of the ALC662 sound card failing to load.") in openKylin tree.

Link: https://gitee.com/openkylin/linux/commit/6ad24efc4daecb54c99e31862d3cc0220e5d8a72
Codeveloped-by: wangdicheng <wangdicheng@kylinos.cn>

## Summary by Sourcery

Bug Fixes:
- Include FTHD0001 in the ACPI device ID table for the Phytium HDA driver to enable audio on hardware using the older ID