### PR TITLE
[6.6] HYGON: Add new pci device id and modify psp_do_cmd() interface

### DIFF
--- a/drivers/crypto/ccp/hygon/psp-dev.c
+++ b/drivers/crypto/ccp/hygon/psp-dev.c
@@ -23,6 +23,8 @@
 
 /* Function and variable pointers for hooks */
 struct hygon_psp_hooks_table hygon_psp_hooks;
+static unsigned int psp_int_rcvd;
+wait_queue_head_t psp_int_queue;
 
 static struct psp_misc_dev *psp_misc;
 #define HYGON_PSP_IOC_TYPE 'H'
@@ -533,64 +535,68 @@ int fixup_hygon_psp_caps(struct psp_device *psp)
 	return 0;
 }
 
+static int psp_wait_cmd_ioc(struct psp_device *psp,
+			    unsigned int *reg, unsigned int timeout)
+{
+	int ret;
+
+	ret = wait_event_timeout(psp_int_queue,
+			psp_int_rcvd, timeout * HZ);
+	if (!ret)
+		return -ETIMEDOUT;
+
+	*reg = ioread32(psp->io_regs + psp->vdata->sev->cmdresp_reg);
+
+	return 0;
+}
+
 static int __psp_do_cmd_locked(int cmd, void *data, int *psp_ret)
 {
 	struct psp_device *psp = psp_master;
-	struct sev_device *sev;
 	unsigned int phys_lsb, phys_msb;
 	unsigned int reg, ret = 0;
 
-	if (!psp || !psp->sev_data || !hygon_psp_hooks.sev_dev_hooks_installed)
+	if (!psp || !hygon_psp_hooks.sev_dev_hooks_installed)
 		return -ENODEV;
 
 	if (*hygon_psp_hooks.psp_dead)
 		return -EBUSY;
 
-	sev = psp->sev_data;
-
 	/* Get the physical address of the command buffer */
 	phys_lsb = data ? lower_32_bits(__psp_pa(data)) : 0;
 	phys_msb = data ? upper_32_bits(__psp_pa(data)) : 0;
 
-	dev_dbg(sev->dev, "sev command id %#x buffer 0x%08x%08x timeout %us\n",
-		cmd, phys_msb, phys_lsb, *hygon_psp_hooks.psp_timeout);
+	dev_dbg(psp->dev, "psp command id %#x buffer 0x%08x%08x timeout %us\n",
+		cmd, phys_msb, phys_lsb, *hygon_psp_hooks.psp_cmd_timeout);
 
-	print_hex_dump_debug("(in):  ", DUMP_PREFIX_OFFSET, 16, 2, data,
-			     hygon_psp_hooks.sev_cmd_buffer_len(cmd), false);
+	iowrite32(phys_lsb, psp->io_regs + psp->vdata->sev->cmdbuff_addr_lo_reg);
+	iowrite32(phys_msb, psp->io_regs + psp->vdata->sev->cmdbuff_addr_hi_reg);
 
-	iowrite32(phys_lsb, sev->io_regs + sev->vdata->cmdbuff_addr_lo_reg);
-	iowrite32(phys_msb, sev->io_regs + sev->vdata->cmdbuff_addr_hi_reg);
-
-	sev->int_rcvd = 0;
+	psp_int_rcvd = 0;
 
 	reg = FIELD_PREP(SEV_CMDRESP_CMD, cmd) | SEV_CMDRESP_IOC;
-	iowrite32(reg, sev->io_regs + sev->vdata->cmdresp_reg);
+	iowrite32(reg, psp->io_regs + psp->vdata->sev->cmdresp_reg);
 
 	/* wait for command completion */
-	ret = hygon_psp_hooks.sev_wait_cmd_ioc(sev, &reg, *hygon_psp_hooks.psp_timeout);
+	ret = psp_wait_cmd_ioc(psp, &reg, *hygon_psp_hooks.psp_cmd_timeout);
 	if (ret) {
 		if (psp_ret)
 			*psp_ret = 0;
 
-		dev_err(sev->dev, "sev command %#x timed out, disabling PSP\n", cmd);
+		dev_err(psp->dev, "psp command %#x timed out, disabling PSP\n", cmd);
 		*hygon_psp_hooks.psp_dead = true;
 
 		return ret;
 	}
 
-	*hygon_psp_hooks.psp_timeout = *hygon_psp_hooks.psp_cmd_timeout;
-
 	if (psp_ret)
 		*psp_ret = FIELD_GET(PSP_CMDRESP_STS, reg);
 
 	if (FIELD_GET(PSP_CMDRESP_STS, reg)) {
-		dev_dbg(sev->dev, "sev command %#x failed (%#010lx)\n",
+		dev_dbg(psp->dev, "psp command %#x failed (%#010lx)\n",
 			cmd, FIELD_GET(PSP_CMDRESP_STS, reg));
 		ret = -EIO;
 	}
-
-	print_hex_dump_debug("(out): ", DUMP_PREFIX_OFFSET, 16, 2, data,
-			     hygon_psp_hooks.sev_cmd_buffer_len(cmd), false);
 
 	return ret;
 }
@@ -689,8 +695,12 @@ static irqreturn_t psp_irq_handler_hygon(int irq, void *data)
 			/* Check if it is SEV command completion: */
 			reg = ioread32(psp->io_regs + psp->vdata->sev->cmdresp_reg);
 			if (reg & PSP_CMDRESP_RESP) {
-				sev->int_rcvd = 1;
-				wake_up(&sev->int_queue);
+				psp_int_rcvd = 1;
+				wake_up(&psp_int_queue);
+				if (sev != NULL) {
+					sev->int_rcvd = 1;
+					wake_up(&sev->int_queue);
+				}
 			}
 		}
 

--- a/drivers/crypto/ccp/hygon/psp-dev.h
+++ b/drivers/crypto/ccp/hygon/psp-dev.h
@@ -46,6 +46,8 @@ extern struct hygon_psp_hooks_table {
 	long (*sev_ioctl)(struct file *file, unsigned int ioctl, unsigned long arg);
 } hygon_psp_hooks;
 
+extern struct wait_queue_head psp_int_queue;
+
 #define PSP_MUTEX_TIMEOUT 60000
 struct psp_mutex {
 	uint64_t locked;

--- a/drivers/crypto/ccp/hygon/tdm-dev.c
+++ b/drivers/crypto/ccp/hygon/tdm-dev.c
@@ -315,7 +315,7 @@ static int tdm_get_cmd_context_hash(uint32_t flag, uint8_t *hash)
 #if IS_BUILTIN(CONFIG_CRYPTO_DEV_CCP_DD)
 	struct module *p_module = NULL;
 #elif IS_ENABLED(CONFIG_KALLSYMS)
-	char symbol_buf[128] = {0};
+	char symbol_buf[KSYM_NAME_LEN] = {0};
 	int symbol_len = 0;
 	char *symbol_begin = NULL;
 	char *symbol_end = NULL;

--- a/drivers/crypto/ccp/psp-dev.c
+++ b/drivers/crypto/ccp/psp-dev.c
@@ -217,6 +217,9 @@ int psp_dev_init(struct sp_device *sp)
 	if (ret)
 		goto e_irq;
 
+	if (is_vendor_hygon())
+		init_waitqueue_head(&psp_int_queue);
+
 	/**
 	 * hygon_psp_additional_setup() needs to wait for
 	 * sev_dev_install_hooks() to complete before it can be called.

--- a/drivers/crypto/ccp/sp-pci.c
+++ b/drivers/crypto/ccp/sp-pci.c
@@ -587,6 +587,8 @@ static const struct pci_device_id sp_pci_table[] = {
 	{ PCI_VDEVICE(HYGON, 0x1486), (kernel_ulong_t)&hygon_dev_vdata[2] },
 	{ PCI_VDEVICE(HYGON, 0x14b8), (kernel_ulong_t)&hygon_dev_vdata[1] },
 	{ PCI_VDEVICE(HYGON, 0x14a6), (kernel_ulong_t)&hygon_dev_vdata[2] },
+	{ PCI_VDEVICE(HYGON, 0x14d8), (kernel_ulong_t)&hygon_dev_vdata[1] },
+	{ PCI_VDEVICE(HYGON, 0x14c6), (kernel_ulong_t)&hygon_dev_vdata[2] },
 	/* Last entry must be zero */
 	{ 0, }
 };


### PR DESCRIPTION
1. add new psp/ccp device id and modify psp_do_cmd() interface to not rely on sev device.

Reference: https://gitee.com/openeuler/kernel/pulls/16281

2. bugfix: Fix for potential memory Out-of-Bounds access due to insufficient array size in TDM driver.

## Summary by Sourcery

Add new Hygon PCI device IDs, decouple PSP command execution from SEV, and correct TDM driver buffer sizing to avoid memory overflows.

New Features:
- Add support for two new Hygon PCI device IDs (0x14d8 and 0x14c6)

Bug Fixes:
- Fix potential out-of-bounds access in the TDM driver by using KSYM_NAME_LEN for the symbol buffer size

Enhancements:
- Refactor PSP command interface to remove dependency on the SEV device by introducing an internal wait queue and psp_wait_cmd_ioc function