### PR TITLE
HAOC: CREDP: Fix build error when CREDP is off

### DIFF
--- a/arch/arm64/kernel/vmlinux.lds.S
+++ b/arch/arm64/kernel/vmlinux.lds.S
@@ -153,6 +153,8 @@ jiffies = jiffies_64;
 	. = ALIGN(PAGE_SIZE);		\
 	*(.iee.cred)				\
 	. = ALIGN(PAGE_SIZE);
+#else
+#define CRED_DATA
 #endif
 
 #ifdef CONFIG_IEE

--- a/arch/x86/kernel/vmlinux.lds.S
+++ b/arch/x86/kernel/vmlinux.lds.S
@@ -119,6 +119,8 @@ __iee_si_data_end = .;
 	. = ALIGN(PAGE_SIZE);		\
 	*(.iee.cred)				\
 	. = ALIGN(PAGE_SIZE);
+#else
+#define CRED_DATA
 #endif
 
 PHDRS {


### PR DESCRIPTION
`CRED_DATA` is not defined in vmlinux.lds.S when CREDP is not defined, which could lead to build error. Fix this problem both in X86 and ARM64.

## Summary by Sourcery

Bug Fixes:
- Prevent undefined CRED_DATA in vmlinux.lds.S by providing an empty definition when CONFIG_CREDP is off