### PR TITLE
eth: mucse: Fix rx PAGE error in csum handler

### DIFF
--- a/drivers/net/ethernet/mucse/rnp/rnp_main.c
+++ b/drivers/net/ethernet/mucse/rnp/rnp_main.c
@@ -732,14 +732,6 @@ skip_fix:
 	if (err) {
 		u32 ntc = rx_ring->next_to_clean + 1;
 		struct rnp_rx_buffer *rx_buffer;
-#if (PAGE_SIZE < 8192)
-		unsigned int truesize = rnp_rx_pg_size(rx_ring) / 2;
-#else
-		unsigned int truesize =
-			ring_uses_build_skb(rx_ring) ?
-				SKB_DATA_ALIGN(RNP_SKB_PAD + size) :
-				SKB_DATA_ALIGN(size);
-#endif
 
 		/* if eop add drop_packets */
 		if (likely(rnp_test_staterr(rx_desc, RNP_RXD_STAT_EOP)))
@@ -754,11 +746,6 @@ skip_fix:
 		/* we should clean it since we used all info in it */
 		rx_desc->wb.cmd = 0;
 
-#if (PAGE_SIZE < 8192)
-		rx_buffer->page_offset ^= truesize;
-#else
-		rx_buffer->page_offset += truesize;
-#endif
 #ifdef OPTM_WITH_LPAGE
 		rnp_put_rx_buffer(rx_ring, rx_buffer);
 #else

--- a/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_main.c
+++ b/drivers/net/ethernet/mucse/rnpgbe/rnpgbe_main.c
@@ -761,14 +761,6 @@ skip_fix:
 	if (err) {
 		u32 ntc = rx_ring->next_to_clean + 1;
 		struct rnpgbe_rx_buffer *rx_buffer;
-#if (PAGE_SIZE < 8192)
-		unsigned int truesize = rnpgbe_rx_pg_size(rx_ring) / 2;
-#else
-		unsigned int truesize =
-			ring_uses_build_skb(rx_ring) ?
-				SKB_DATA_ALIGN(RNP_SKB_PAD + size) :
-				SKB_DATA_ALIGN(size);
-#endif
 
 		if (likely(rnpgbe_test_staterr(rx_desc, RNP_RXD_STAT_EOP)))
 			*driver_drop_packets = *driver_drop_packets + 1;
@@ -782,11 +774,6 @@ skip_fix:
 		/* we should clean it since we used all info in it */
 		rx_desc->wb.cmd = 0;
 
-#if (PAGE_SIZE < 8192)
-		rx_buffer->page_offset ^= truesize;
-#else
-		rx_buffer->page_offset += truesize;
-#endif
 #ifdef OPTM_WITH_LPAGE
 		rnpgbe_put_rx_buffer(rx_ring, rx_buffer);
 #else

--- a/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf_main.c
+++ b/drivers/net/ethernet/mucse/rnpgbevf/rnpgbevf_main.c
@@ -891,14 +891,6 @@ skip_fix:
 	if (err) {
 		u32 ntc = rx_ring->next_to_clean + 1;
 		struct rnpgbevf_rx_buffer *rx_buffer;
-#if (PAGE_SIZE < 8192)
-		unsigned int truesize = rnpgbevf_rx_pg_size(rx_ring) / 2;
-#else
-		unsigned int truesize =
-			ring_uses_build_skb(rx_ring) ?
-				SKB_DATA_ALIGN(RNPVF_SKB_PAD + size) :
-				SKB_DATA_ALIGN(size);
-#endif
 
 		if (likely(rnpgbevf_test_staterr(rx_desc, RNPGBE_RXD_STAT_EOP)))
 			*driver_drop_packets = *driver_drop_packets + 1;
@@ -911,11 +903,6 @@ skip_fix:
 		/* we should clean it since we used all info in it */
 		rx_desc->wb.cmd = 0;
 
-#if (PAGE_SIZE < 8192)
-		rx_buffer->page_offset ^= truesize;
-#else
-		rx_buffer->page_offset += truesize;
-#endif
 #ifdef OPTM_WITH_LPAGE
 		rnpgbevf_put_rx_buffer(rx_ring, rx_buffer);
 #else

--- a/drivers/net/ethernet/mucse/rnpvf/rnpvf_main.c
+++ b/drivers/net/ethernet/mucse/rnpvf/rnpvf_main.c
@@ -906,14 +906,6 @@ skip_fix:
 	if (err) {
 		u32 ntc = rx_ring->next_to_clean + 1;
 		struct rnpvf_rx_buffer *rx_buffer;
-#if (PAGE_SIZE < 8192)
-		unsigned int truesize = rnpvf_rx_pg_size(rx_ring) / 2;
-#else
-		unsigned int truesize =
-			ring_uses_build_skb(rx_ring) ?
-				SKB_DATA_ALIGN(RNPVF_SKB_PAD + size) :
-				SKB_DATA_ALIGN(size);
-#endif
 
 		if (likely(rnpvf_test_staterr(rx_desc, RNP_RXD_STAT_EOP)))
 			*driver_drop_packets = *driver_drop_packets + 1;
@@ -928,11 +920,6 @@ skip_fix:
 		/* we should clean it since we used all info in it */
 		rx_desc->wb.cmd = 0;
 
-#if (PAGE_SIZE < 8192)
-		rx_buffer->page_offset ^= truesize;
-#else
-		rx_buffer->page_offset += truesize;
-#endif
 #ifdef OPTM_WITH_LPAGE
 		rnpvf_put_rx_buffer(rx_ring, rx_buffer);
 #else


### PR DESCRIPTION
Drivers re-use half-page (may be used but not freed) to hardware by mistake, this may cause mutiple skbs use one physical address.

## Summary by Sourcery

Remove manual page offset manipulation in checksum error handlers to prevent reusing half-page buffers and fix RX page errors in MUCSE drivers.

Bug Fixes:
- Eliminate truesize calculation and page_offset updates in checksum error paths to prevent multiple SKBs from sharing the same physical page buffer

Enhancements:
- Standardize checksum error handling by removing redundant buffer reuse logic across rnp, rnpgbe, rnpgbevf, and rnpvf drivers