### PR TITLE
cpufreq: phytium: bugfix the null pointer of boost in high temperature

### DIFF
--- a/drivers/cpufreq/cpufreq.c
+++ b/drivers/cpufreq/cpufreq.c
@@ -2829,7 +2829,7 @@ err_reset_state:
 bool cpufreq_boost_supported(void)
 {
 	if (!cpufreq_driver)
-		return -EINVAL;
+		return 0;
 
 	return cpufreq_driver->set_boost;
 }
@@ -2871,7 +2871,7 @@ EXPORT_SYMBOL_GPL(cpufreq_enable_boost_support);
 int cpufreq_boost_enabled(void)
 {
 	if (!cpufreq_driver)
-		return -EINVAL;
+		return 0;
 
 	return cpufreq_driver->boost_enabled;
 }


### PR DESCRIPTION
Fix that when the temperature cotrol module determines whether boost is supported of not in a high temperature enviroment and boost is not enabled, the error code will be retured because the cpufreq_driver module is not initialized, resulting in entering the cpufreq module and writing a value to it, and a null pointer error will be reported.

## Summary by Sourcery

Bug Fixes:
- Return 0 instead of -EINVAL in cpufreq_boost_supported() and cpufreq_boost_enabled() when the driver is uninitialized to prevent null pointer dereferences