### PR TITLE
[linux-6.6.y][Bugfix]Hygon: Address boot failures of CSV1/CSV2 VMs on Hygon 2g and C86-3g CPUs with firmware build ID below 1878 and 1810.

### DIFF
--- a/arch/x86/kvm/svm/csv.h
+++ b/arch/x86/kvm/svm/csv.h
@@ -32,6 +32,8 @@ struct csv_ringbuf_infos {
 	int num;
 };
 
+extern u32 hygon_csv_build;
+
 #ifdef CONFIG_KVM_SUPPORTS_CSV_REUSE_ASID
 
 #define ASID_USERID_LENGTH 20

--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -164,10 +164,10 @@ static int sev_asid_new(struct kvm_sev_info *sev)
 	int ret;
 
 	/*
-	 * No matter what the min_sev_asid is, all asids in range
+	 * When the firmware is with build ID >= 1810, all asids in range
 	 * [1, max_sev_asid] can be used for CSV2 guest on Hygon CPUs.
 	 */
-	if (is_x86_vendor_hygon())
+	if (is_x86_vendor_hygon() && hygon_csv_build >= 1810)
 		max_asid = max_sev_asid;
 
 	if (min_asid > max_asid)
@@ -2415,7 +2415,7 @@ void __init sev_hardware_setup(void)
 		goto out;
 	}
 
-	if (is_x86_vendor_hygon()) {
+	if (is_x86_vendor_hygon() && hygon_csv_build >= 1810) {
 		/*
 		 * Ths ASIDs from 1 to max_sev_asid are available for hygon
 		 * CSV2 guest.
@@ -2443,8 +2443,10 @@ out:
 		pr_info("%s %s (ASIDs %u - %u)\n",
 			is_x86_vendor_hygon() ? "CSV2" : "SEV-ES",
 			sev_es_supported ? "enabled" : "disabled",
-			is_x86_vendor_hygon() ? 1 : (min_sev_asid > 1 ? 1 : 0),
-			is_x86_vendor_hygon() ? max_sev_asid : min_sev_asid - 1);
+			(is_x86_vendor_hygon() && hygon_csv_build >= 1810) ?
+			1 : (min_sev_asid > 1 ? 1 : 0),
+			(is_x86_vendor_hygon() && hygon_csv_build >= 1810) ?
+			max_sev_asid : min_sev_asid - 1);
 
 	sev_enabled = sev_supported;
 	sev_es_enabled = sev_es_supported;

--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -2342,6 +2342,9 @@ void __init sev_hardware_setup(void)
 	bool sev_es_supported = false;
 	bool sev_supported = false;
 
+	if (is_x86_vendor_hygon() && hygon_csv_build < 1878 && !sme_me_mask)
+		goto out;
+
 	if (!sev_enabled || !npt_enabled || !nrips)
 		goto out;
 

--- a/drivers/crypto/ccp/hygon/csv-dev.c
+++ b/drivers/crypto/ccp/hygon/csv-dev.c
@@ -28,6 +28,7 @@
  *    in AMD SEV.
  */
 u32 hygon_csv_build;
+EXPORT_SYMBOL_GPL(hygon_csv_build);
 
 int csv_comm_mode = CSV_COMM_MAILBOX_ON;
 


### PR DESCRIPTION
For firmware with a build ID < 1810, if CPUID_0x8000_001F_EDX.bits0-31 is 1, the ASID range available for CSV2 guests is [0, 0) (i.e., no ASIDs are available). Otherwise, the range is [1, CPUID_0x8000_001F_EDX.bits0-31).

For firmware with a build ID >= 1810, the ASID range available for CSV2 guests is [1, CPUID_0x8000_001F_ECX.bits0-31].

For firmware with a build ID < 1878, the CSV guest cannot run if the host kernel is not using SME.

## Summary by Sourcery

Use firmware build ID thresholds to adjust Hygon CSV ASID allocation and SEV initialization, preventing boot failures on older firmware builds.

Bug Fixes:
- Limit CSV2 guest ASID range to firmware build ID ≥ 1810.
- Abort SEV hardware setup on firmware build ID < 1878 without SME to avoid boot failure.

Enhancements:
- Introduce a global hygon_csv_build variable with extern declaration and export symbol for cross-module firmware ID access.