### PR TITLE
[linux-6.6.y][Bugfix]hugetlb: Fix NULL pointer dereference BUG

### DIFF
--- a/mm/hugetlb.c
+++ b/mm/hugetlb.c
@@ -3035,12 +3035,20 @@ int replace_free_hugepage_folios(unsigned long start_pfn, unsigned long end_pfn)
 
 	while (start_pfn < end_pfn) {
 		folio = pfn_folio(start_pfn);
+
+		/*
+		 * The folio might have been dissolved from under our feet, so make sure
+		 * to carefully check the state under the lock.
+		 */
+		spin_lock_irq(&hugetlb_lock);
 		if (folio_test_hugetlb(folio)) {
 			h = folio_hstate(folio);
 		} else {
+			spin_unlock_irq(&hugetlb_lock);
 			start_pfn++;
 			continue;
 		}
+		spin_unlock_irq(&hugetlb_lock);
 
 		if (!folio_ref_count(folio)) {
 			ret = alloc_and_dissolve_hugetlb_folio(h, folio,


### PR DESCRIPTION
This PR fixes the case show as follows:
```
There is a potential race between __update_and_free_hugetlb_folio() and
replace_free_hugepage_folios():

CPU1                              CPU2
__update_and_free_hugetlb_folio   replace_free_hugepage_folios
                                    folio_test_hugetlb(folio)
                                    -- It's still hugetlb folio.

  __folio_clear_hugetlb(folio)
  hugetlb_free_folio(folio)
                                    h = folio_hstate(folio)
                                    -- Here, h is NULL pointer

When the above race condition occurs, folio_hstate(folio) returns NULL,
and subsequent access to this NULL pointer will cause the system to crash.
To resolve this issue, execute folio_hstate(folio) under the protection
of the hugetlb_lock lock, ensuring that folio_hstate(folio) does not
return NULL.
```

Before this PR, we could reproduce the BUG:
1. The platform is with 1T RAM
2. Boot the platform with kernel cmdline 'hugetlb_cma=30G'
3. run the script test_cma.sh
```
#!/bin/bash

ALLOC_PATH="/sys/kernel/debug/cma/hugetlb3/alloc"

# 
if [ ! -w "$ALLOC_PATH" ]; then
  echo "  $ALLOC_PATH sudo "
  exit 1
fi

# 
STEP=512
# 
MAX=2621440

# 204826214402048
for (( val=$STEP; val<=$MAX; val+=$STEP ))
do
  echo "  $val ..."
  echo $val > "$ALLOC_PATH"
  sleep 1  # 
done

echo " "
```
4. Then the kernel will crash due to a NULL pointer dereference BUG.

## Summary by Sourcery

Bug Fixes:
- Acquire hugetlb_lock before calling folio_hstate() in replace_free_hugepage_folios() to avoid race conditions that could return NULL and cause a crash.