### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] bpf, docs: Fix non-standard line break

### DIFF
--- a/Documentation/bpf/bpf_iterators.rst
+++ b/Documentation/bpf/bpf_iterators.rst
@@ -323,8 +323,8 @@ Now, in the userspace program, pass the pointer of struct to the
 
 ::
 
-  link = bpf_program__attach_iter(prog, &opts); iter_fd =
-  bpf_iter_create(bpf_link__fd(link));
+  link = bpf_program__attach_iter(prog, &opts);
+  iter_fd = bpf_iter_create(bpf_link__fd(link));
 
 If both *tid* and *pid* are zero, an iterator created from this struct
 ``bpf_iter_attach_opts`` will include every opened file of every task in the


### PR DESCRIPTION
[ Upstream commit 4cc20482143c6dd009ea0c99762bb4bdeac98ec2 ]

Even though the kernel's coding-style document does not explicitly state this, we generally put a newline after the semicolon of every C language statement to enhance code readability.

Adjust the placement of newlines to adhere to this convention.

Reported-by: Chen Linxuan <chenlinxuan@uniontech.com>

Reviewed-by: Yanteng Si <si.yanteng@linux.dev>
Link: https://lore.kernel.org/r/DB66473733449DB0+20250423030632.17626-1-wangyuli@uniontech.com

[ Backport from v6.16-rc1 ]

## Summary by Sourcery

Documentation:
- Add newline after semicolons in C code examples in bpf_iterators.rst to conform to kernel coding style