### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] x86/selftests: Skip the tests if prerequisites aren't fulfilled

### DIFF
--- a/tools/testing/selftests/x86/amx.c
+++ b/tools/testing/selftests/x86/amx.c
@@ -103,21 +103,6 @@ static void clearhandler(int sig)
 
 #define CPUID_LEAF1_ECX_XSAVE_MASK	(1 << 26)
 #define CPUID_LEAF1_ECX_OSXSAVE_MASK	(1 << 27)
-static inline void check_cpuid_xsave(void)
-{
-	uint32_t eax, ebx, ecx, edx;
-
-	/*
-	 * CPUID.1:ECX.XSAVE[bit 26] enumerates general
-	 * support for the XSAVE feature set, including
-	 * XGETBV.
-	 */
-	__cpuid_count(1, 0, eax, ebx, ecx, edx);
-	if (!(ecx & CPUID_LEAF1_ECX_XSAVE_MASK))
-		fatal_error("cpuid: no CPU xsave support");
-	if (!(ecx & CPUID_LEAF1_ECX_OSXSAVE_MASK))
-		fatal_error("cpuid: no OS xsave support");
-}
 
 static uint32_t xbuf_size;
 
@@ -350,6 +335,7 @@ enum expected_result { FAIL_EXPECTED, SUCCESS_EXPECTED };
 
 /* arch_prctl() and sigaltstack() test */
 
+#define ARCH_GET_XCOMP_SUPP	0x1021
 #define ARCH_GET_XCOMP_PERM	0x1022
 #define ARCH_REQ_XCOMP_PERM	0x1023
 
@@ -928,8 +914,15 @@ static void test_ptrace(void)
 
 int main(void)
 {
-	/* Check hardware availability at first */
-	check_cpuid_xsave();
+	unsigned long features;
+	long rc;
+
+	rc = syscall(SYS_arch_prctl, ARCH_GET_XCOMP_SUPP, &features);
+	if (rc || (features & XFEATURE_MASK_XTILE) != XFEATURE_MASK_XTILE) {
+		ksft_print_msg("no AMX support\n");
+		return KSFT_SKIP;
+	}
+
 	check_cpuid_xtiledata();
 
 	init_stashed_xsave();

--- a/tools/testing/selftests/x86/lam.c
+++ b/tools/testing/selftests/x86/lam.c
@@ -1183,7 +1183,7 @@ int main(int argc, char **argv)
 
 	if (!cpu_has_lam()) {
 		ksft_print_msg("Unsupported LAM feature!\n");
-		return -1;
+		return KSFT_SKIP;
 	}
 
 	while ((c = getopt(argc, argv, "ht:")) != -1) {


### PR DESCRIPTION
commit 99c84311e35f9399bdce666f6306a048e2a5b404 upstream.

Skip instead of failing when prerequisite conditions aren't fulfilled, such as invalid xstate values etc.

Make the tests show as 'SKIP' when run:

  make -C tools/testing/selftests/ TARGETS=x86 run_tests

  ...
  # timeout set to 45
  # selftests: x86: amx_64
  # # xstate cpuid: invalid tile data size/offset: 0/0
  ok 42 selftests: x86: amx_64 # SKIP
  # timeout set to 45
  # selftests: x86: lam_64
  # # Unsupported LAM feature!
  ok 43 selftests: x86: lam_64 # SKIP
  ...

In the AMX test, Move away from check_cpuid_xsave() and start using arch_prctl() to find out if AMX support is present or not. In the kernels where AMX isn't present, arch_prctl() returns -EINVAL, hence it is backward compatible.



Reviewed-by: Chang S. Bae <chang.seok.bae@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@linux.intel.com>
Acked-by: Kirill A. Shutemov <kirill.shutemov@linux.intel.com>
Link: https://lore.kernel.org/r/20240327111720.3509180-1-usama.anjum@collabora.com
[ Zelin Deng: ANBZ: #8853 ]
Link: https://gitee.com/anolis/cloud-kernel/pulls/3125

[ WangYuli: Edit commit msg. ]
[ Backport from v6.9 ]

## Summary by Sourcery

Update x86 selftests to skip AMX and LAM tests when hardware or OS support is missing instead of failing.

Enhancements:
- Return KSFT_SKIP in AMX and LAM selftests when the corresponding CPU feature is unavailable
- Replace cpuid-based AMX detection with an arch_prctl syscall to check XFEATURE_MASK_XTILE support