### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] ACPI: resource: Use IRQ override on MACHENIKE 16P

### DIFF
--- a/drivers/acpi/resource.c
+++ b/drivers/acpi/resource.c
@@ -654,6 +654,13 @@ static const struct dmi_system_id lg_laptop[] = {
 		},
 	},
 	{
+		/* MACHENIKE L16P/L16P */
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "MACHENIKE"),
+			DMI_MATCH(DMI_BOARD_NAME, "L16P"),
+		},
+	},
+	{
 		/*
 		 * TongFang GM5HG0A in case of the SKIKK Vanaheim relabel the
 		 * board-name is changed, so check OEM strings instead. Note


### PR DESCRIPTION
Use ACPI IRQ override on MACHENIKE laptop to make the internal keyboard work.

Add a new entry to the irq1_edge_low_force_override structure, similar to the existing ones.

Link: https://bbs.deepin.org.cn/zh/post/287628

## Summary by Sourcery

Bug Fixes:
- Add ACPI IRQ override entry for MACHENIKE L16P in irq1_edge_low_force_override table