### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] [Intel] drm/i915/display: correct dual pps handling for MTL_PCH+

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_backlight.c
+++ b/drivers/gpu/drm/i915/display/intel_backlight.c
@@ -1448,6 +1448,9 @@ bxt_setup_backlight(struct intel_connector *connector, enum pipe unused)
 
 static int cnp_num_backlight_controllers(struct drm_i915_private *i915)
 {
+	if (INTEL_PCH_TYPE(i915) >= PCH_MTL)
+		return 2;
+
 	if (INTEL_PCH_TYPE(i915) >= PCH_DG1)
 		return 1;
 

--- a/drivers/gpu/drm/i915/display/intel_pps.c
+++ b/drivers/gpu/drm/i915/display/intel_pps.c
@@ -351,6 +351,9 @@ static int intel_num_pps(struct drm_i915_private *i915)
 	if (IS_GEMINILAKE(i915) || IS_BROXTON(i915))
 		return 2;
 
+	if (INTEL_PCH_TYPE(i915) >= PCH_MTL)
+		return 2;
+
 	if (INTEL_PCH_TYPE(i915) >= PCH_DG1)
 		return 1;
 


### PR DESCRIPTION
On the PCH side the second PPS was introduced in ICP+.Add condition On MTL_PCH and greater platform also having the second PPS.

Note that DG1/2 south block only has the single PPS, so need to exclude the fake DG1/2 PCHs

Closes: https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/11488
Fixes: 93cbc1accbce ("drm/i915/mtl: Add fake PCH for Meteor Lake")
Cc: <stable@vger.kernel.org> # v6.9+

Reviewed-by: Jani Nikula <jani.nikula@intel.com>

Link: https://patchwork.freedesktop.org/patch/msgid/20240801111141.574854-1-dnyaneshwar.bhadane@intel.com (cherry picked from commit da1878b61c8d480c361ba6a39ce8a31c80b65826)

(cherry picked from commit 1b85bdb0fadb42f5ef75ddcd259fc1ef13ec04de)

## Summary by Sourcery

Bug Fixes:
- Enable dual backlight controllers and PPS instances for MTL_PCH+ platforms