### PR TITLE
x86: Enhanced copy capabilities for Hygon processor

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -899,6 +899,7 @@ config INTEL_TDX_GUEST
 endif # HYPERVISOR_GUEST
 
 source "arch/x86/Kconfig.cpu"
+source "arch/x86/Kconfig.fpu"
 
 config HPET_TIMER
 	def_bool X86_64

--- a/arch/x86/Kconfig.fpu
+++ b/arch/x86/Kconfig.fpu
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-2.0
+
+menuconfig USING_FPU_IN_KERNEL_NONATOMIC
+	bool "Hygon large memory copy support"
+	depends on X86_64 && CPU_SUP_HYGON
+	default y
+	help
+	  This option enables support for optimized large memory copy operations
+	  on Hygon processors in the kernel space using SSE2 or AVX2 non-temporal (NT)
+	  copy instructions. NT instructions are streaming store instructions that bypass
+	  the on-chip cache and send data directly to a write-combining buffer.
+
+	  When this option is enabled, you can choose the specific instruction set to use
+	  for large memory copy: SSE2 or AVX2. Using these instruction sets can improve data
+	  throughput and reduce the number of cache misses during memory copy operations.
+
+if USING_FPU_IN_KERNEL_NONATOMIC
+
+choice
+	prompt "X86_HYGON_LMC"
+	depends on X86_64 && CPU_SUP_HYGON
+	default X86_HYGON_LMC_AVX2_ON
+	help
+	  Select the type of non-temporal (NT) copy instructions to use for
+	  large memory copy operations between kernel and user mode. You can
+	  choose between SSE2 or AVX2 instructions based on the processor
+	  capabilities and the size of the memory being copied.
+
+	  To use this feature, you also need to configure the data copy size.
+	  The file is in `/sys/c86_features/hygon_c86/nt_cpy_mini_len`. Please
+	  refer to configuration 4096 and above.
+
+config X86_HYGON_LMC_SSE2_ON
+	bool "Using sse2 nt copy for large memory copy"
+	help
+	  When this feature is enabled, the kernel will use the
+	  copy_user_sse2_opt_string function for large memory copy operations.
+
+	  SSE2 (Streaming SIMD Extensions 2) instructions support non-temporal
+	  (NT) stores that bypass the CPU cache and write data directly to
+	  memory. This can improve performance for large memory copies by reducing
+	  cache pollution and taking advantage of the write-combining buffer.
+
+	  However, using SSE2 NT copy may require saving and restoring MMX and
+	  SSE2 register contexts during thread switching if an interruption occurs.
+
+config X86_HYGON_LMC_AVX2_ON
+	bool "Using avx2 nt copy for large memory copy"
+	help
+	  When this feature is enabled, the kernel will use the
+	  copy_user_avx2_pf64_nt_string function for large memory copy operations.
+
+	  AVX2 (Advanced Vector Extensions 2) instructions provide enhanced
+	  vector processing capabilities and support for non-temporal (NT) stores,
+	  which can significantly improve memory copy performance for large blocks
+	  of data. By bypassing the cache and writing data directly to memory,
+	  AVX2 NT copy can achieve higher throughput than SSE2 NT copy.
+
+	  Similar to SSE2, using AVX2 NT copy may require saving and restoring
+	  AVX2 register contexts if an interruption occurs during large memory
+	  copying, to ensure the process continues smoothly after resuming.
+
+endchoice
+endif

--- a/arch/x86/include/asm/fpu/sched.h
+++ b/arch/x86/include/asm/fpu/sched.h
@@ -66,4 +66,62 @@ static inline void switch_fpu_finish(void)
 		set_thread_flag(TIF_NEED_FPU_LOAD);
 }
 
+/*
+ * Kernel FPU state switching for scheduling.
+ *
+ * This is a two-stage process:
+ *
+ *  - switch_kernel_fpu_prepare() saves the old kernel fpu state.
+ *    This is done within the context of the old process.
+ *
+ *  - switch_kernel_fpu_finish() restore new kernel fpu state.
+ *
+ * The kernel FPU context is only stored/restored for a user task in kernel
+ * mode and PF_KTHREAD is used to distinguish between kernel and user threads.
+ */
+#if defined(CONFIG_X86_HYGON_LMC_SSE2_ON) || \
+	defined(CONFIG_X86_HYGON_LMC_AVX2_ON)
+extern void save_fpregs_to_fpkernelstate(struct fpu *kfpu);
+extern unsigned long get_fpu_registers_pos(struct fpu *fpu, unsigned int off);
+static inline void switch_kernel_fpu_prepare(struct task_struct *prev, int cpu)
+{
+	struct fpu *old_fpu = &prev->thread.fpu;
+
+	if (!test_thread_flag(TIF_USING_FPU_NONATOMIC))
+		return;
+
+	if (static_cpu_has(X86_FEATURE_FPU) && !(prev->flags & PF_KTHREAD))
+		save_fpregs_to_fpkernelstate(old_fpu);
+}
+
+/* Internal helper for switch_kernel_fpu_finish() and signal frame setup */
+static inline void fpregs_restore_kernelregs(struct fpu *kfpu)
+{
+	kernel_fpu_states_restore(NULL, (void *)get_fpu_registers_pos(kfpu, MAX_FPU_CTX_SIZE),
+						MAX_FPU_CTX_SIZE);
+}
+
+/* Loading of the complete FPU state immediately. */
+static inline void switch_kernel_fpu_finish(struct task_struct *next)
+{
+	struct fpu *new_fpu = &next->thread.fpu;
+
+	if (next->flags & PF_KTHREAD)
+		return;
+
+	if (cpu_feature_enabled(X86_FEATURE_FPU) &&
+	    test_ti_thread_flag((struct thread_info *)next,
+				TIF_USING_FPU_NONATOMIC))
+		fpregs_restore_kernelregs(new_fpu);
+}
+#else
+static inline void switch_kernel_fpu_prepare(struct task_struct *prev, int cpu)
+{
+}
+static inline void switch_kernel_fpu_finish(struct task_struct *next)
+{
+}
+
+#endif
+
 #endif /* _ASM_X86_FPU_SCHED_H */

--- a/arch/x86/include/asm/thread_info.h
+++ b/arch/x86/include/asm/thread_info.h
@@ -103,6 +103,7 @@ struct thread_info {
 #define TIF_BLOCKSTEP		25	/* set when we want DEBUGCTLMSR_BTF */
 #define TIF_LAZY_MMU_UPDATES	27	/* task is updating the mmu lazily */
 #define TIF_ADDR32		29	/* 32-bit address space on 64 bits */
+#define TIF_USING_FPU_NONATOMIC 30      /* using fpu in kernel non-atomic context */
 
 #define _TIF_NOTIFY_RESUME	(1 << TIF_NOTIFY_RESUME)
 #define _TIF_SIGPENDING		(1 << TIF_SIGPENDING)

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -92,6 +92,9 @@ EXPORT_SYMBOL_GPL(get_llc_id);
 /* L2 cache ID of each logical CPU */
 DEFINE_PER_CPU_READ_MOSTLY(u16, cpu_l2c_id) = BAD_APICID;
 
+DEFINE_STATIC_KEY_FALSE(hygon_lmc_key);
+EXPORT_SYMBOL_GPL(hygon_lmc_key);
+
 static struct ppin_info {
 	int	feature;
 	int	msr_ppin_ctl;
@@ -2511,6 +2514,17 @@ void arch_smt_update(void)
 	apic_smt_update();
 }
 
+#if defined(CONFIG_X86_HYGON_LMC_SSE2_ON) || \
+	defined(CONFIG_X86_HYGON_LMC_AVX2_ON)
+static inline void update_lmc_branch_cond(void)
+{
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
+		static_branch_enable(&hygon_lmc_key);
+}
+#else
+static inline void update_lmc_branch_cond(void) { }
+#endif
+
 void __init arch_cpu_finalize_init(void)
 {
 	identify_boot_cpu();
@@ -2529,6 +2543,8 @@ void __init arch_cpu_finalize_init(void)
 	cpu_select_mitigations();
 
 	arch_smt_update();
+
+	update_lmc_branch_cond();
 
 	if (IS_ENABLED(CONFIG_X86_32)) {
 		/*

--- a/arch/x86/kernel/fpu/init.c
+++ b/arch/x86/kernel/fpu/init.c
@@ -133,6 +133,12 @@ static void __init fpu__init_system_generic(void)
 	fpu__init_system_mxcsr();
 }
 
+#if defined(CONFIG_X86_HYGON_LMC_SSE2_ON) || \
+	defined(CONFIG_X86_HYGON_LMC_AVX2_ON)
+unsigned int fpu_kernel_nonatomic_xstate_size;
+EXPORT_SYMBOL_GPL(fpu_kernel_nonatomic_xstate_size);
+#endif
+
 /*
  * Enforce that 'MEMBER' is the last field of 'TYPE'.
  *
@@ -161,6 +167,11 @@ static void __init fpu__init_task_struct_size(void)
 	 * size.
 	 */
 	task_size += fpu_kernel_cfg.default_size;
+#if defined(CONFIG_X86_HYGON_LMC_SSE2_ON) || \
+	defined(CONFIG_X86_HYGON_LMC_AVX2_ON)
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
+		task_size += fpu_kernel_nonatomic_xstate_size;
+#endif
 
 	/*
 	 * We dynamically size 'struct fpu', so we require that

--- a/arch/x86/kernel/fpu/xstate.c
+++ b/arch/x86/kernel/fpu/xstate.c
@@ -677,6 +677,11 @@ static unsigned int __init get_xsave_size_user(void)
 
 static int __init init_xstate_size(void)
 {
+#if defined(CONFIG_X86_HYGON_LMC_SSE2_ON) || \
+	defined(CONFIG_X86_HYGON_LMC_AVX2_ON)
+	extern unsigned int fpu_kernel_nonatomic_xstate_size;
+#endif
+
 	/* Recompute the context size for enabled features: */
 	unsigned int user_size, kernel_size, kernel_default_size;
 	bool compacted = cpu_feature_enabled(X86_FEATURE_XCOMPACTED);
@@ -710,6 +715,10 @@ static int __init init_xstate_size(void)
 	fpu_user_cfg.default_size =
 		xstate_calculate_size(fpu_user_cfg.default_features, false);
 
+#if defined(CONFIG_X86_HYGON_LMC_SSE2_ON) || \
+	defined(CONFIG_X86_HYGON_LMC_AVX2_ON)
+	fpu_kernel_nonatomic_xstate_size = KERNEL_FPU_NONATOMIC_SIZE;
+#endif
 	return 0;
 }
 

--- a/arch/x86/lib/Makefile
+++ b/arch/x86/lib/Makefile
@@ -60,5 +60,7 @@ endif
         lib-y += clear_page_64.o copy_page_64.o
         lib-y += memmove_64.o memset_64.o
         lib-y += copy_user_64.o copy_user_uncached_64.o
+	lib-$(CONFIG_X86_HYGON_LMC_SSE2_ON) += copy_user_sse2.o
+	lib-$(CONFIG_X86_HYGON_LMC_AVX2_ON) += copy_user_avx2.o
 	lib-y += cmpxchg16b_emu.o
 endif

--- a/arch/x86/lib/copy_user_avx2.S
+++ b/arch/x86/lib/copy_user_avx2.S
@@ -1,0 +1,335 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright © 2011 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#include <linux/linkage.h>
+#include <asm/current.h>
+#include <asm/asm-offsets.h>
+#include <asm/thread_info.h>
+#include <asm/cpufeatures.h>
+#include <asm/alternative.h>
+#include <asm/asm.h>
+#include <asm/smap.h>
+#include <asm/export.h>
+#include <asm/trapnr.h>
+
+#define PREFETCH_DISTANCE 64
+
+#define PREFETCH(addr)	prefetchnta addr
+
+.macro ALIGN_DESTINATION_32
+    /* check for bad alignment of destination, there is 32Bytes, for we will use vmovntdq */
+    /* if <32Bytes, jb .Lcopy_user_string */
+    cmpq $32, %rdx
+    jb .Lcopy_user_string
+
+    /*
+     * Adjust unaligned destination addresses, for 32-bit aligned ones,
+     * only the lower 32 bits need to be checked.
+     */
+    movl %edi, %ecx
+    andl $31, %ecx
+    jz .Lcopy_user_string                  /* already aligned */
+
+    subl $32, %ecx
+    negl %ecx
+    subl %ecx, %edx
+
+300:
+    movb (%rsi), %al
+301:
+    movb %al, (%rdi)
+    incq %rsi
+    incq %rdi
+    decl %ecx
+    jnz 300b
+    jmp .Lcopy_user_string
+
+303:
+    addl %ecx,%edx/* ecx is zerorest also */
+    jmp Lavx2_copy_user_handle_tail
+
+    _ASM_EXTABLE_UA(300b, 303b)
+    _ASM_EXTABLE_UA(301b, 303b)
+
+.Lcopy_user_string:
+.endm
+
+/*
+ * large block copy, use avx2 nt & prefetchnta
+ */
+SYM_FUNC_START(copy_user_avx2_pf64_nt_string)
+    ASM_STAC
+    ALIGN_DESTINATION_32
+
+    /* if len < 256 jmp to Lless_than_256_bytes_cpy  */
+    cmpq $256, %rdx
+    jb	Lless_than_256_bytes_cpy
+
+    /*
+     * Check if src is aligned, for 32-bit aligned ones,
+     * only the lower 32 bits need to be checked.
+     */
+    movl %esi, %ecx /* check if src is aligned */
+    andl $31, %ecx
+    jnz large_block_nt_unaligned_cpy
+
+large_block_nt_aligned_cpy:
+    PREFETCH(PREFETCH_DISTANCE(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 64)(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 128)(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 192)(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 256)(%rsi))
+
+32:
+    vmovdqa 0(%rsi), %ymm0
+33:
+    vmovdqa 32(%rsi), %ymm1
+34:
+    vmovdqa 64(%rsi), %ymm2
+35:
+    vmovdqa 96(%rsi), %ymm3
+36:
+    vmovdqa 128(%rsi), %ymm4
+37:
+    vmovdqa 160(%rsi), %ymm5
+38:
+    vmovdqa 192(%rsi), %ymm6
+39:
+    vmovdqa 224(%rsi), %ymm7
+
+40:
+    vmovntdq %ymm0, 0(%rdi)
+41:
+    vmovntdq %ymm1, 32(%rdi)
+42:
+    vmovntdq %ymm2, 64(%rdi)
+43:
+    vmovntdq %ymm3, 96(%rdi)
+44:
+    vmovntdq %ymm4, 128(%rdi)
+45:
+    vmovntdq %ymm5, 160(%rdi)
+46:
+    vmovntdq %ymm6, 192(%rdi)
+47:
+    vmovntdq %ymm7, 224(%rdi)
+
+    add $256, %rsi
+    add $256, %rdi
+    subq $256, %rdx
+    cmpq $256, %rdx
+    jg large_block_nt_aligned_cpy
+
+    vzeroupper
+    sfence
+    jmp Lless_than_256_bytes_cpy
+
+large_block_nt_unaligned_cpy:
+    PREFETCH(PREFETCH_DISTANCE(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 64)(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 128)(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 192)(%rsi))
+    PREFETCH((PREFETCH_DISTANCE + 256)(%rsi))
+
+48:
+    vmovdqu 0(%rsi), %ymm0
+49:
+    vmovdqu 32(%rsi), %ymm1
+50:
+    vmovdqu 64(%rsi), %ymm2
+51:
+    vmovdqu 96(%rsi), %ymm3
+52:
+    vmovdqu 128(%rsi), %ymm4
+53:
+    vmovdqu 160(%rsi), %ymm5
+54:
+    vmovdqu 192(%rsi), %ymm6
+55:
+    vmovdqu 224(%rsi), %ymm7
+
+56:
+    vmovntdq %ymm0, 0(%rdi)
+57:
+    vmovntdq %ymm1, 32(%rdi)
+58:
+    vmovntdq %ymm2, 64(%rdi)
+59:
+    vmovntdq %ymm3, 96(%rdi)
+60:
+    vmovntdq %ymm4, 128(%rdi)
+61:
+    vmovntdq %ymm5, 160(%rdi)
+62:
+    vmovntdq %ymm6, 192(%rdi)
+63:
+    vmovntdq %ymm7, 224(%rdi)
+
+    add $256, %rsi
+    add $256, %rdi
+    subq $256, %rdx
+    cmpq $256, %rdx
+    jg large_block_nt_unaligned_cpy
+
+    vzeroupper
+    sfence
+    jmp Lless_than_256_bytes_cpy
+
+88:
+    vzeroupper
+    jmp Lavx2_copy_user_handle_tail
+
+    _ASM_EXTABLE_UA(32b, 88b)
+    _ASM_EXTABLE_UA(33b, 88b)
+    _ASM_EXTABLE_UA(34b, 88b)
+    _ASM_EXTABLE_UA(35b, 88b)
+    _ASM_EXTABLE_UA(36b, 88b)
+    _ASM_EXTABLE_UA(37b, 88b)
+    _ASM_EXTABLE_UA(38b, 88b)
+    _ASM_EXTABLE_UA(39b, 88b)
+
+    _ASM_EXTABLE_UA(40b, 88b)
+    _ASM_EXTABLE_UA(41b, 88b)
+    _ASM_EXTABLE_UA(42b, 88b)
+    _ASM_EXTABLE_UA(43b, 88b)
+    _ASM_EXTABLE_UA(44b, 88b)
+    _ASM_EXTABLE_UA(45b, 88b)
+    _ASM_EXTABLE_UA(46b, 88b)
+    _ASM_EXTABLE_UA(47b, 88b)
+    _ASM_EXTABLE_UA(48b, 88b)
+    _ASM_EXTABLE_UA(49b, 88b)
+
+    _ASM_EXTABLE_UA(50b, 88b)
+    _ASM_EXTABLE_UA(51b, 88b)
+    _ASM_EXTABLE_UA(52b, 88b)
+    _ASM_EXTABLE_UA(53b, 88b)
+    _ASM_EXTABLE_UA(54b, 88b)
+    _ASM_EXTABLE_UA(55b, 88b)
+    _ASM_EXTABLE_UA(56b, 88b)
+    _ASM_EXTABLE_UA(57b, 88b)
+    _ASM_EXTABLE_UA(58b, 88b)
+    _ASM_EXTABLE_UA(59b, 88b)
+
+    _ASM_EXTABLE_UA(60b, 88b)
+    _ASM_EXTABLE_UA(61b, 88b)
+    _ASM_EXTABLE_UA(62b, 88b)
+    _ASM_EXTABLE_UA(63b, 88b)
+SYM_FUNC_END(copy_user_avx2_pf64_nt_string)
+EXPORT_SYMBOL(copy_user_avx2_pf64_nt_string)
+
+/*
+ * If len < 256 bytes, then we use rep mov directly.
+ *
+ * Input:
+ * rdi destination
+ * rsi source
+ * edx len
+ *
+ * Output:
+ * eax uncopied bytes or 0 if successful.
+ */
+SYM_CODE_START_LOCAL(Lless_than_256_bytes_cpy)
+    movl %edx, %ecx
+90:
+    rep movsb
+
+    xorl %eax,%eax
+    ASM_CLAC
+    RET
+
+99:
+    mov %ecx,%eax
+
+    ASM_CLAC
+    RET
+
+    _ASM_EXTABLE_UA(90b, 99b)
+SYM_CODE_END(Lless_than_256_bytes_cpy)
+
+/*
+ * Try to copy last bytes and clear the rest if needed.
+ * Since protection fault in copy_from/to_user is not a normal situation,
+ * it is not necessary to optimize tail handling.
+ * Don't try to copy the tail if machine check happened
+ *
+ * Input:
+ * rdi destination
+ * rsi source
+ * rdx count
+ *
+ * Output:
+ * eax uncopied bytes or 0 if successful.
+ */
+
+SYM_CODE_START_LOCAL(Lavx2_copy_user_handle_tail)
+    movq %rdx,%rcx
+    cmp $X86_TRAP_MC,%eax       /* check if X86_TRAP_MC */
+    je 3f
+
+1:  rep movsb
+2:  mov %rcx,%rax
+
+    ASM_CLAC
+    RET
+
+3:  xorl %eax,%eax
+    ASM_CLAC
+    RET
+
+    _ASM_EXTABLE_UA(1b, 2b)
+SYM_CODE_END(Lavx2_copy_user_handle_tail)
+
+/*
+ * Called when task schedule. we call fpu_save_%ymm0_7 to save old
+ * task's fpu states and we call fpu_restore_%ymm0_7 to restore new
+ * task's fpu states.
+ */
+SYM_FUNC_START(fpu_restore_ymm0_7)
+   vmovdqu 0(%rsi), %ymm0
+   vmovdqu 32(%rsi), %ymm1
+   vmovdqu 64(%rsi), %ymm2
+   vmovdqu 96(%rsi), %ymm3
+   vmovdqu 128(%rsi), %ymm4
+   vmovdqu 160(%rsi), %ymm5
+   vmovdqu 192(%rsi), %ymm6
+   vmovdqu 224(%rsi), %ymm7
+
+   xorl %eax,%eax
+   RET//ret
+SYM_FUNC_END(fpu_restore_ymm0_7)
+EXPORT_SYMBOL(fpu_restore_ymm0_7)
+
+SYM_FUNC_START(fpu_save_ymm0_7)
+   vmovdqu %ymm0, 0(%rdi)
+   vmovdqu %ymm1, 32(%rdi)
+   vmovdqu %ymm2, 64(%rdi)
+   vmovdqu %ymm3, 96(%rdi)
+   vmovdqu %ymm4, 128(%rdi)
+   vmovdqu %ymm5, 160(%rdi)
+   vmovdqu %ymm6, 192(%rdi)
+   vmovdqu %ymm7, 224(%rdi)
+
+   xorl %eax,%eax
+   RET
+SYM_FUNC_END(fpu_save_ymm0_7)
+EXPORT_SYMBOL(fpu_save_ymm0_7)

--- a/arch/x86/lib/copy_user_sse2.S
+++ b/arch/x86/lib/copy_user_sse2.S
@@ -1,0 +1,255 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright © 2011 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <linux/linkage.h>
+#include <asm/current.h>
+#include <asm/asm-offsets.h>
+#include <asm/thread_info.h>
+#include <asm/cpufeatures.h>
+#include <asm/alternative.h>
+#include <asm/asm.h>
+#include <asm/smap.h>
+#include <asm/export.h>
+#include <asm/trapnr.h>
+
+#define PREFETCH_DISTANCE 256
+
+.macro ALIGN_DESTINATION_16
+    /* check for bad alignment of destination, there is 16Bytes, for we will use movdqa */
+    /* if len<16Bytes, jb .Lcopy_user_string */
+    cmpq $16,%rdx
+    jb .Lcopy_user_string
+
+    /*
+     * Adjust unaligned destination addresses, for 16-bit aligned ones,
+     * only the lower 32 bits need to be checked.
+     */
+    movl %edi,%ecx
+    andl $15,%ecx
+    jz .Lcopy_user_string           /* already aligned */
+
+    subl $16,%ecx
+    negl %ecx
+    subl %ecx,%edx
+
+200:
+    movb (%rsi),%al
+201:
+    movb %al,(%rdi)
+    incq %rsi
+    incq %rdi
+    decl %ecx
+    jnz 200b
+    jmp .Lcopy_user_string
+
+203:
+    addl %ecx,%edx/* ecx is zerorest also */
+    jmp Lsse2_copy_user_handle_tail
+
+    _ASM_EXTABLE_UA(200b, 203b)
+    _ASM_EXTABLE_UA(201b, 203b)
+
+.Lcopy_user_string:
+.endm
+/*****************************************************************************/
+SYM_FUNC_START(copy_user_sse2_opt_string)
+    ASM_STAC
+    ALIGN_DESTINATION_16
+
+    cmpq $64,%rdx
+    jb 70f /* less then 64 bytes, avoid the costly 'rep' */
+
+    /*
+     * Check if src is aligned, for 16-bit aligned ones,
+     * only the lower 32 bits need to be checked.
+     */
+    movl %esi,%ecx
+    andl $15,%ecx
+    jnz 20f
+
+10:
+    prefetchnta PREFETCH_DISTANCE(%rsi)
+11:
+    prefetchnta (PREFETCH_DISTANCE + 32)(%rsi)
+12:
+    movdqa      (%rsi),%xmm0
+13:
+    movdqa      16(%rsi),%xmm1
+14:
+    movdqa      32(%rsi),%xmm2
+15:
+    movdqa      48(%rsi),%xmm3
+16:
+    movntdq     %xmm0,0(%rdi)
+17:
+    movntdq     %xmm1,16(%rdi)
+18:
+    movntdq     %xmm2,32(%rdi)
+19:
+    movntdq     %xmm3,48(%rdi)
+    add         $64,%rsi
+    add         $64,%rdi
+    subq        $64,%rdx
+    cmpq        $64,%rdx
+    jg          10b
+    sfence
+    jmp         70f
+
+20:
+    prefetchnta PREFETCH_DISTANCE(%rsi)
+21:
+    prefetchnta (PREFETCH_DISTANCE + 32)(%rsi)
+22:
+    movdqu      (%rsi),%xmm0
+23:
+    movdqu      16(%rsi),%xmm1
+24:
+    movdqu      32(%rsi),%xmm2
+25:
+    movdqu      48(%rsi),%xmm3
+26:
+    movntdq     %xmm0,0(%rdi)
+27:
+    movntdq     %xmm1,16(%rdi)
+28:
+    movntdq     %xmm2,32(%rdi)
+29:
+    movntdq     %xmm3,48(%rdi)
+    add         $64,%rsi
+    add         $64,%rdi
+    subq        $64,%rdx
+    cmpq        $64,%rdx
+    jg          20b
+    sfence
+
+70:
+    movl %edx,%ecx
+80:
+    rep
+    movsb
+
+    xorl %eax,%eax
+    ASM_CLAC
+    RET//ret
+
+99:
+    movl %ecx,%edx      /* ecx is zerorest also */
+100:
+    sfence
+    jmp Lsse2_copy_user_handle_tail
+
+  _ASM_EXTABLE_UA(10b, 100b)
+  _ASM_EXTABLE_UA(11b, 100b)
+  _ASM_EXTABLE_UA(12b, 100b)
+  _ASM_EXTABLE_UA(13b, 100b)
+  _ASM_EXTABLE_UA(14b, 100b)
+  _ASM_EXTABLE_UA(15b, 100b)
+  _ASM_EXTABLE_UA(16b, 100b)
+  _ASM_EXTABLE_UA(17b, 100b)
+  _ASM_EXTABLE_UA(18b, 100b)
+  _ASM_EXTABLE_UA(19b, 100b)
+
+  _ASM_EXTABLE_UA(20b, 100b)
+  _ASM_EXTABLE_UA(21b, 100b)
+  _ASM_EXTABLE_UA(22b, 100b)
+  _ASM_EXTABLE_UA(23b, 100b)
+  _ASM_EXTABLE_UA(24b, 100b)
+  _ASM_EXTABLE_UA(25b, 100b)
+  _ASM_EXTABLE_UA(26b, 100b)
+  _ASM_EXTABLE_UA(27b, 100b)
+  _ASM_EXTABLE_UA(28b, 100b)
+  _ASM_EXTABLE_UA(29b, 100b)
+
+  _ASM_EXTABLE_UA(80b, 99b)
+SYM_FUNC_END(copy_user_sse2_opt_string)
+EXPORT_SYMBOL(copy_user_sse2_opt_string)
+
+SYM_FUNC_START(fpu_restore_xmm0_3)
+    ASM_STAC
+    movdqu      (%rsi),%xmm0
+    movdqu      16(%rsi),%xmm1
+    movdqu      32(%rsi),%xmm2
+    movdqu      48(%rsi),%xmm3
+
+    xorl %eax,%eax
+    ASM_CLAC
+    RET//ret
+SYM_FUNC_END(fpu_restore_xmm0_3)
+EXPORT_SYMBOL(fpu_restore_xmm0_3)
+
+SYM_FUNC_START(fpu_save_xmm0_3)
+    ASM_STAC
+
+    movdqu      %xmm0,(%rdi)
+    movdqu      %xmm1,16(%rdi)
+    movdqu      %xmm2,32(%rdi)
+    movdqu      %xmm3,48(%rdi)
+
+    xorl %eax,%eax
+    ASM_CLAC
+    RET//ret
+SYM_FUNC_END(fpu_save_xmm0_3)
+EXPORT_SYMBOL(fpu_save_xmm0_3)
+
+/*
+ * Try to copy last bytes and clear the rest if needed.
+ * Since protection fault in copy_from/to_user is not a normal situation,
+ * it is not necessary to optimize tail handling.
+ * Don't try to copy the tail if machine check happened
+ *
+ * Input:
+ * rdi destination
+ * rsi source
+ * rdx count
+ *
+ * Output:
+ * eax uncopied bytes or 0 if successful.
+ */
+SYM_CODE_START_LOCAL(Lsse2_copy_user_handle_tail)
+    movq %rdx,%rcx
+    /*
+     * The trap number and error code are both 32 bits.
+     */
+    cmp $X86_TRAP_MC,%eax       /* check if X86_TRAP_MC */
+    je 3f
+1:  rep movsb
+2:  mov %rcx,%rax
+    ASM_CLAC
+    RET
+
+    /*
+     * Return zero to pretend that this copy succeeded. This
+     * is counter-intuitive, but needed to prevent the code
+     * in lib/iov_iter.c from retrying and running back into
+     * the poison cache line again. The machine check handler
+     * will ensure that a SIGBUS is sent to the task.
+     */
+3:  xorl %eax,%eax
+    ASM_CLAC
+    RET
+
+    _ASM_EXTABLE_UA(1b, 2b)
+SYM_CODE_END(Lsse2_copy_user_handle_tail)
+
+/*****************************************************************************/


### PR DESCRIPTION
hygon inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/IAQQDF CVE: NA

 ---------------------------

The following methods are used to improve the large memory copy performance of the Hygon processor between kernel and user mode.

Prefetch is a technique for reading blocks of data from main memory at very high data rates, then operating on them within the cache. Results are then written out to memory, all with high efficiency.

The code can employ a very special instruction: NT. This is a streaming store instruction for writing data to memory. This instruction bypasses the on-chip cache and sends data directly into a write-combining buffer. Because NT allows the CPU to avoid reading the old data from the memory destination address, NT can effectively improve the total write bandwidth. There are similar optimizations for reading data from memory.

Interruptions may occur when copying large memory, which may trigger thread switching. You need to save the current MMX register context and continue copying when switching back to the thread next time.

## Summary by Sourcery

Enable high-performance user-kernel memory copying on Hygon processors by adding streaming store and prefetch-accelerated routines, non-atomic FPU context support, and runtime toggles via a static key and sysfs control.

New Features:
- Add Hygon-specific optimized large memory copy routines using SSE2/AVX2 NT streaming stores and prefetch
- Introduce non-atomic kernel FPU APIs (kernel_fpu_begin_nonatomic and kernel_fpu_end_nonatomic) with scheduling hooks to preserve FPU state across preemptions
- Integrate a static branch to dynamically select Hygon large memory copy in the generic copy_user path
- Expose sysfs entries under c86_features to configure the minimum length for NT block copy