### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] CI: Add patch check by using build kernel s390x

### DIFF
--- a/.github/workflows/build-kernel-s390.yml
+++ b/.github/workflows/build-kernel-s390.yml
@@ -1,0 +1,41 @@
+name: build kernel s390
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  KBUILD_BUILD_USER: deepin-kernel-sig
+  KBUILD_BUILD_HOST: deepin-kernel-builder
+  email: support@deepin.org
+
+permissions:
+  pull-requests: read
+
+jobs:
+  build-kernel:
+    runs-on: [self-hosted, linux, S390]
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Install Deps"
+        run: |
+          git config --global user.email $email
+          git config --global user.name $KBUILD_BUILD_USER
+
+      - name: "Compile kernel"
+        run: |
+          # .config
+          make deepin_s390x_z13_defconfig
+          make -j$(nproc)
+
+      - name: 'Upload Kernel Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Kernel-ABI-s390
+          path: "Module.symvers"
+
+      - name: 'Clang build kernel'
+        run: |
+          # .config
+          make LLVM=-19 deepin_s390x_z13_defconfig
+          make LLVM=-19 -j$(nproc)


### PR DESCRIPTION
Powered by IBM LinuxONE Community Cloud.

## Summary by Sourcery

CI:
- Add 'build-kernel-s390' GitHub Actions workflow to build the kernel for s390x with both GCC and LLVM toolchains