### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] CI: fix clang-18 use LLVM=-18

### DIFF
--- a/.github/workflows/build-kernel-arm64.yml
+++ b/.github/workflows/build-kernel-arm64.yml
@@ -37,5 +37,5 @@ jobs:
       - name: 'Clang build kernel'
         run: |
           # .config
-          make LLVM=18 deepin_arm64_desktop_defconfig
-          make LLVM=18 -j$(nproc)
+          make LLVM=-18 deepin_arm64_desktop_defconfig
+          make LLVM=-18 -j$(nproc)

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -37,5 +37,5 @@ jobs:
       - name: "Clang build kernel"
         run: |
           # .config
-          make LLVM=18 deepin_x86_desktop_defconfig
-          make LLVM=18 -j$(nproc)
+          make LLVM=-18 deepin_x86_desktop_defconfig
+          make LLVM=-18 -j$(nproc)


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change LLVM flag to '-18' instead of '18' in build-kernel-arm64.yml and build-kernel.yml for clang kernel builds