### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Fromlist] LoongArch: Fix use of logical '&&' with constant operand

### DIFF
--- a/arch/loongarch/kernel/setup.c
+++ b/arch/loongarch/kernel/setup.c
@@ -346,7 +346,7 @@ static void __init bootcmdline_init(char **cmdline_p)
 	 * Append built-in command line to the bootloader command line if
 	 * CONFIG_CMDLINE_EXTEND is enabled.
 	 */
-	if (IS_ENABLED(CONFIG_CMDLINE_EXTEND) && CONFIG_CMDLINE[0]) {
+	if (IS_ENABLED(CONFIG_CMDLINE_EXTEND) && !!CONFIG_CMDLINE[0]) {
 		strlcat(boot_command_line, " ", COMMAND_LINE_SIZE);
 		strlcat(boot_command_line, CONFIG_CMDLINE, COMMAND_LINE_SIZE);
 	}


### PR DESCRIPTION
Fix follow error with clang-19:

arch/loongarch/kernel/setup.c:335:40: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
  335 |         if (IS_ENABLED(CONFIG_CMDLINE_EXTEND) && CONFIG_CMDLINE[0]) {
      |                                               ^  ~~~~~~~~~~~~~~~~~
arch/loongarch/kernel/setup.c:335:40: note: use '&' for a bitwise operation
  335 |         if (IS_ENABLED(CONFIG_CMDLINE_EXTEND) && CONFIG_CMDLINE[0]) {
      |                                               ^~
      |                                               &
arch/loongarch/kernel/setup.c:335:40: note: remove constant to silence this warning
  335 |         if (IS_ENABLED(CONFIG_CMDLINE_EXTEND) && CONFIG_CMDLINE[0]) {
      |                                               ^~~~~~~~~~~~~~~~~~~~
1 error generated.

NOTE:

The upstream view is that this is a compiler issue, and the kernel shouldn't have to compromise.

However, we need to ensure the Clang compiler works correctly for our use cases. Therefore, this patch cannot be mainlined and can only be integrated as an out-of-tree patch.

Fixes: 83da30d73b86 ("LoongArch: Fix CMDLINE_EXTEND and CMDLINE_BOOTLOADER handling")
Co-developed-by: Wentao Guan <guanwentao@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Avoid clang-19 constant-logical-operand error by replacing CONFIG_CMDLINE[0] with !!CONFIG_CMDLINE[0] when checking for command-line extension.