### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y]  deepin: CI: Disable LLVM check for s390x (only 6.6)

### DIFF
--- a/.github/workflows/build-kernel-s390.yml
+++ b/.github/workflows/build-kernel-s390.yml
@@ -33,9 +33,3 @@ jobs:
         with:
           name: Kernel-ABI-s390
           path: "Module.symvers"
-
-      - name: 'Clang build kernel'
-        run: |
-          # .config
-          make LLVM=-19 deepin_s390x_z13_defconfig
-          make LLVM=-19 -j$(nproc)


### PR DESCRIPTION
Linux kernel v6.6 does not support LLVM on s390x (fixed on v6.9). Disable it only for linux-6.6.

## Summary by Sourcery

CI:
- Remove Clang-based kernel build job for s390x in the linux-6.6 CI workflow