### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] net: rnpm: fix compiler error of rnpm

### DIFF
--- a/drivers/net/ethernet/mucse/rnpm/rnpm_main.c
+++ b/drivers/net/ethernet/mucse/rnpm/rnpm_main.c
@@ -1273,26 +1273,31 @@ skip_fix:
 static int rnpm_rx_ring_reinit(struct rnpm_adapter *adapter,
 			       struct rnpm_ring *rx_ring)
 {
-	struct rnpm_ring temp_ring;
+	struct rnpm_ring *temp_ring = NULL;
 	int err = 0;
 	struct rnpm_hw *hw = &adapter->hw;
 
+	temp_ring = vmalloc(array_size(1, sizeof(struct rnpm_ring)));
+	if (!temp_ring)
+		return -ENOMEM;
+
 	if (rx_ring->count == rx_ring->reset_count)
 		return 0;
-
+	/* stop rx queue */
 	rnpm_disable_rx_queue(adapter, rx_ring);
-	memset(&temp_ring, 0x00, sizeof(struct rnpm_ring));
-	memcpy(&temp_ring, rx_ring, sizeof(struct rnpm_ring));
-	temp_ring.count = rx_ring->reset_count;
-	err = rnpm_setup_rx_resources(&temp_ring, adapter);
+	memset(temp_ring, 0x00, sizeof(struct rnpm_ring));
+	memcpy(temp_ring, rx_ring, sizeof(struct rnpm_ring));
+	temp_ring->count = rx_ring->reset_count;
+	err = rnpm_setup_rx_resources(temp_ring, adapter);
 	if (err) {
-		rnpm_free_rx_resources(&temp_ring);
+		rnpm_free_rx_resources(temp_ring);
 		goto err_setup;
 	}
 	rnpm_free_rx_resources(rx_ring);
-	memcpy(rx_ring, &temp_ring, sizeof(struct rnpm_ring));
+	memcpy(rx_ring, temp_ring, sizeof(struct rnpm_ring));
 	rnpm_configure_rx_ring(adapter, rx_ring);
 err_setup:
+	vfree(temp_ring);
 	/* start rx */
 	wr32(hw, RNPM_DMA_RX_START(rx_ring->rnpm_queue_idx), 1);
 	return 0;

--- a/drivers/net/ethernet/mucse/rnpm/rnpm_mbx_fw.c
+++ b/drivers/net/ethernet/mucse/rnpm/rnpm_mbx_fw.c
@@ -468,11 +468,12 @@ int rnpm_mbx_fw_reset_phy(struct rnpm_hw *hw)
 
 int rnpm_maintain_req(struct rnpm_hw *hw, int cmd, int arg0,
 		      int req_data_bytes, int reply_bytes,
-		      dma_addr_t dma_phy_addr)
+		      dma_addr_t dma_phy)
 {
 	struct mbx_req_cookie *cookie = NULL;
 	struct mbx_fw_cmd_req req;
 	struct mbx_fw_cmd_reply reply;
+	u64 address;
 	int err;
 
 	cookie = mbx_cookie_zalloc(hw, 0);
@@ -482,10 +483,10 @@ int rnpm_maintain_req(struct rnpm_hw *hw, int cmd, int arg0,
 	memset(&req, 0, sizeof(req));
 	memset(&reply, 0, sizeof(reply));
 	cookie->timeout_jiffes = 60 * HZ;
-
+	address = dma_phy;
 	build_maintain_req(&req, cookie, cmd, arg0, req_data_bytes,
-			   reply_bytes, dma_phy_addr & 0xffffffff,
-			   (dma_phy_addr >> 32) & 0xffffffff);
+			   reply_bytes, dma_phy & 0xffffffff,
+			   (dma_phy >> 32) & 0xffffffff);
 
 	if (hw->mbx.irq_enabled) {
 		cookie->timeout_jiffes = 400 * HZ;
@@ -861,6 +862,7 @@ int rnpm_mbx_get_dump(struct rnpm_hw *hw, int flags, u8 *data_out,
 	struct get_dump_reply *get_dump;
 	void *dma_buf = NULL;
 	dma_addr_t dma_phy = 0;
+	u64 address;
 	int err;
 
 	cookie = mbx_cookie_zalloc(hw, sizeof(*get_dump));
@@ -879,9 +881,9 @@ int rnpm_mbx_get_dump(struct rnpm_hw *hw, int flags, u8 *data_out,
 			goto quit;
 		}
 	}
-
-	build_get_dump_req(&req, cookie, hw->nr_lane, dma_phy & 0xffffffff,
-			   (dma_phy >> 32) & 0xffffffff, bytes);
+	address = dma_phy;
+	build_get_dump_req(&req, cookie, hw->nr_lane, address & 0xffffffff,
+			   (address >> 32) & 0xffffffff, bytes);
 	if (hw->mbx.irq_enabled) {
 		err = rnpm_mbx_fw_post_req(hw, &req, cookie);
 	} else {
@@ -945,9 +947,10 @@ int rnpm_fw_update(struct rnpm_hw *hw, int partition, const u8 *fw_bin,
 	struct mbx_req_cookie *cookie = NULL;
 	struct mbx_fw_cmd_req req;
 	struct mbx_fw_cmd_reply reply;
-	int err;
 	void *dma_buf = NULL;
-	dma_addr_t dma_phy;
+	dma_addr_t dma_phy = 0;
+	u64 address;
+	int err;
 
 	cookie = mbx_cookie_zalloc(hw, 0);
 	if (!cookie)
@@ -964,8 +967,9 @@ int rnpm_fw_update(struct rnpm_hw *hw, int partition, const u8 *fw_bin,
 	}
 
 	memcpy(dma_buf, fw_bin, bytes);
-	build_fw_update_req(&req, cookie, partition, dma_phy & 0xffffffff,
-			    (dma_phy >> 32) & 0xffffffff, bytes);
+	address = dma_phy;
+	build_fw_update_req(&req, cookie, partition, address & 0xffffffff,
+			    (address >> 32) & 0xffffffff, bytes);
 	if (hw->mbx.irq_enabled) {
 		cookie->timeout_jiffes = 400 * HZ;
 		err = rnpm_mbx_fw_post_req(hw, &req, cookie);
@@ -1066,7 +1070,7 @@ int rnpm_mbx_lane_link_changed_event_enable(struct rnpm_hw *hw, int enable)
 	struct mbx_fw_cmd_req req;
 	int err;
 
-	if (!hw->single_lane_link_evt_ctrl_ablity == 0)
+	if (hw->single_lane_link_evt_ctrl_ablity == 0)
 		return rnpm_mbx_pf_link_event_enable(hw, enable);
 
 	memset(&req, 0, sizeof(req));
@@ -1733,7 +1737,7 @@ int rnpm_mbx_sdram_simm(struct rnpm_hw *hw, u32 flags, u32 offset,
 {
 	struct mbx_fw_cmd_reply reply;
 	struct mbx_fw_cmd_req req;
-	int err;
+	u64 address;
 
 	if (!dma_buf || dma_phy == 0) {
 		dev_err(&hw->pdev->dev, "%s: no memory:%d!", __func__,
@@ -1743,11 +1747,12 @@ int rnpm_mbx_sdram_simm(struct rnpm_hw *hw, u32 flags, u32 offset,
 
 	memset(&req, 0, sizeof(req));
 	memset(&reply, 0, sizeof(reply));
+	address = dma_phy;
 	build_comm_sdram_req(&req, NULL, flags, offset,
-			     dma_phy & 0xffffffff,
-			     (dma_phy >> 32) & 0xffffffff, len);
+			     address & 0xffffffff,
+			     (address >> 32) & 0xffffffff, len);
 
 	if (hw->mbx.irq_enabled)
 		rnpm_mbx_write_posted_locked(hw, &req);
-	return err ? -err : 0;
+	return 0;
 }

--- a/drivers/net/ethernet/mucse/rnpm/rnpm_mbx_fw.h
+++ b/drivers/net/ethernet/mucse/rnpm/rnpm_mbx_fw.h
@@ -1184,6 +1184,8 @@ static inline void build_ddr_csl(struct mbx_fw_cmd_req *req, void *cookie,
 				 bool enable, dma_addr_t dma_phy,
 				 int bytes)
 {
+	u64 address;
+
 	req->flags = 0;
 	req->opcode = SET_DDR_CSL;
 	req->datalen = sizeof(req->ddr_csl);
@@ -1191,10 +1193,11 @@ static inline void build_ddr_csl(struct mbx_fw_cmd_req *req, void *cookie,
 	req->reply_lo = 0;
 	req->reply_hi = 0;
 	req->ddr_csl.enable = enable;
+	address = dma_phy;
 	if (enable) {
 		req->ddr_csl.bytes = bytes;
-		req->ddr_csl.ddr_phy_hi = (dma_phy >> 32);
-		req->ddr_csl.ddr_phy_lo = dma_phy & 0xffffffff;
+		req->ddr_csl.ddr_phy_hi = (address >> 32);
+		req->ddr_csl.ddr_phy_lo = address & 0xffffffff;
 	} else {
 		req->ddr_csl.bytes = 0;
 	}


### PR DESCRIPTION
fix compiler error of rnpm for mucse N10/N400 4/8 ports ethernet card

## Summary by Sourcery

Fix compiler errors in the rnpm driver for mucse Ethernet cards by introducing a 64-bit temporary for DMA address handling, correcting a faulty conditional, and refactoring RX ring reinitialization.

Bug Fixes:
- Use a u64 `address` variable to split 64-bit DMA addresses consistently across mailbox commands.
- Fix the inverted logical check for `single_lane_link_evt_ctrl_ablity` in lane link change event enable.
- Correct the sdram simm function to return 0 unconditionally instead of using an unused error variable.

Enhancements:
- Refactor `rnpm_rx_ring_reinit` to allocate the temporary ring dynamically with vmalloc/vfree and streamline resource setup and teardown.