### PR TITLE
CI: check-config: add ACPI_DEBUG to generic whitelist

### DIFF
--- a/.github/workflows/generic_config_whitelist
+++ b/.github/workflows/generic_config_whitelist
@@ -17,3 +17,5 @@ CONFIG_FB_EFI
 CONFIG_CAN
 # driver for USB serial
 CONFIG_USB_SERIAL
+# compat for some ArrowLake laptop, see https://github.com/deepin-community/kernel/pull/870
+CONFIG_ACPI_DEBUG


### PR DESCRIPTION
Some x86 ArrowLake laptop device boot depends on the config. We have no device, but user says okay, so just enable it. DMI: LENOVO 21TU/LNVNB161216, BIOS RJCN20WW

Link:https://bbs.deepin.org/zh/post/288038?offset=0&postId=1722190 
Link:https://discourse.nixos.org/t/system-wont-boot-path-efi-stub/29212/30

## Summary by Sourcery

CI:
- Add CONFIG_ACPI_DEBUG to generic_config_whitelist in the check-config workflow