### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] Loongarch: optimize syscall reg save

### DIFF
--- a/arch/loongarch/kernel/entry.S
+++ b/arch/loongarch/kernel/entry.S
@@ -30,7 +30,8 @@ SYM_CODE_START(handle_syscall)
 	addi.d		sp, sp, -PT_SIZE
 	cfi_st		t2, PT_R3
 	cfi_rel_offset	sp, PT_R3
-	st.d		zero, sp, PT_R0
+	# Note it will be set in do_syscall regs->regs[0] = 0;
+	# st.d		zero, sp, PT_R0
 	csrrd		t2, LOONGARCH_CSR_PRMD
 	st.d		t2, sp, PT_PRMD
 	csrrd		t2, LOONGARCH_CSR_CRMD

--- a/arch/loongarch/kernel/syscall.c
+++ b/arch/loongarch/kernel/syscall.c
@@ -44,6 +44,8 @@ void noinstr do_syscall(struct pt_regs *regs)
 	sys_call_fn syscall_fn;
 
 	nr = regs->regs[11];
+	// Move from handle_syscall macro to save a memio
+	regs->regs[0] = 0;
 	/* Set for syscall restarting */
 	if (nr < NR_syscalls)
 		regs->regs[0] = nr + 1;


### PR DESCRIPTION
deepin inclusion
category: performance

It saves a st.d in the hot syscall path, and let
the compiler know to optimize it in asm,
and helps to improve the syscall performance little.

## Summary by Sourcery

Enhancements:
- Remove redundant zero-store in entry.S and initialize regs->regs[0] in do_syscall to save a memory write in the hot path