### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] Revert "drm/amd/display: more liberal vmin/vmax update for freesync"

### DIFF
--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
@@ -610,21 +610,15 @@ static void dm_crtc_high_irq(void *interrupt_params)
 	spin_lock_irqsave(&adev_to_drm(adev)->event_lock, flags);
 
 	if (acrtc->dm_irq_params.stream &&
-		acrtc->dm_irq_params.vrr_params.supported) {
-		bool replay_en = acrtc->dm_irq_params.stream->link->replay_settings.replay_feature_enabled;
-		bool psr_en = acrtc->dm_irq_params.stream->link->psr_settings.psr_feature_enabled;
-		bool fs_active_var_en = acrtc->dm_irq_params.freesync_config.state == VRR_STATE_ACTIVE_VARIABLE;
-
+	    acrtc->dm_irq_params.vrr_params.supported &&
+	    acrtc->dm_irq_params.freesync_config.state ==
+		    VRR_STATE_ACTIVE_VARIABLE) {
 		mod_freesync_handle_v_update(adev->dm.freesync_module,
 					     acrtc->dm_irq_params.stream,
 					     &acrtc->dm_irq_params.vrr_params);
 
-		/* update vmin_vmax only if freesync is enabled, or only if PSR and REPLAY are disabled */
-		if (fs_active_var_en || (!fs_active_var_en && !replay_en && !psr_en)) {
-			dc_stream_adjust_vmin_vmax(adev->dm.dc,
-					acrtc->dm_irq_params.stream,
-					&acrtc->dm_irq_params.vrr_params.adjust);
-		}
+		dc_stream_adjust_vmin_vmax(adev->dm.dc, acrtc->dm_irq_params.stream,
+					   &acrtc->dm_irq_params.vrr_params.adjust);
 	}
 
 	/*


### PR DESCRIPTION
This reverts commit cfb2d41831ee5647a4ae0ea7c24971a92d5dfa0d since it causes regressions on certain configs. Revert until the issue can be isolated and debugged.

Closes: https://gitlab.freedesktop.org/drm/amd/-/issues/4238

Acked-by: Alex Deucher <alexander.deucher@amd.com>

Cc: stable@vger.kernel.org
(cherry picked from commit 1b824eef269db44d068bbc0de74c94a8e8f9ce02)

## Summary by Sourcery

Revert the recent liberalized vmin/vmax update for Freesync to prevent regression issues

Bug Fixes:
- Revert commit cfb2d41831ee5647a4ae0ea7c24971a92d5dfa0d that altered vmin/vmax update conditions for Freesync
- Restore original conditional checks for VRR, PSR, and replay when adjusting vmin/vmax