### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] CI: use crosscompile for loongarch

### DIFF
--- a/.github/workflows/build-kernel-loong64.yml
+++ b/.github/workflows/build-kernel-loong64.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-kernel:
-    runs-on: [self-hosted, linux, loong64]
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v3
       - name: "Install Deps"
@@ -25,8 +25,8 @@ jobs:
       - name: "Compile kernel"
         run: |
           # .config
-          make deepin_loongarch_desktop_defconfig
-          make -j$(nproc)
+          time make ARCH=loongarch CROSS_COMPILE=loongarch64-linux-gnu- deepin_loongarch_desktop_defconfig
+          time make ARCH=loongarch CROSS_COMPILE=loongarch64-linux-gnu- -j$(nproc)
 
       - name: 'Upload Kernel Artifact'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
native build is very slow, use cross to check it for ci.

## Summary by Sourcery

Switch CI kernel build on LoongArch to cross-compilation on x64 runners for faster performance

Enhancements:
- Speed up CI by replacing slow native builds with cross-compiled builds

CI:
- Change runner from self-hosted loong64 to self-hosted x64
- Add ARCH=loongarch and CROSS_COMPILE=loongarch64-linux-gnu- flags to make commands to enable cross-compilation