### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] wifi: mt76: mt7925: fix fw download fail

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt76_connac_mcu.c
+++ b/drivers/net/wireless/mediatek/mt76/mt76_connac_mcu.c
@@ -66,7 +66,7 @@ int mt76_connac_mcu_init_download(struct mt76_dev *dev, u32 addr, u32 len,
 
 	if ((!is_connac_v1(dev) && addr == MCU_PATCH_ADDRESS) ||
 	    (is_mt7921(dev) && addr == 0x900000) ||
-	    (is_mt7925(dev) && addr == 0x900000) ||
+	    (is_mt7925(dev) && (addr == 0x900000 || addr == 0xe0002800)) ||
 	    (is_mt7996(dev) && addr == 0x900000))
 		cmd = MCU_CMD(PATCH_START_REQ);
 	else


### PR DESCRIPTION
stable inclusion
from stable-v6.8.2
category: bugfix

[ Upstream commit 6864bc734a48e90012cca8040cd0af72616666ca ]

Add an address of fw region for fw download.

Fixes: c948b5da6bbe ("wifi: mt76: mt7925: add Mediatek Wi-Fi7 driver for mt7925 chips")



(cherry picked from commit e46b6303e796d50ae9557f7e6b422dac9f098928) [Guan Wentao: skip the commit a63b75aac846 ("wifi: mt76: connac: add firmware support for mt7992") cause the context diff, but we don`t pick now for it takes more effect to pick more change for mt7996]

Conflicts:
	drivers/net/wireless/mediatek/mt76/mt76_connac_mcu.c

## Summary by Sourcery

Bug Fixes:
- Add 0xe0002800 firmware region address for mt7925 to resolve download failures