### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] platform/x86: ideapad-laptop: add missing Ideapad Pro 5 fn keys

### DIFF
--- a/drivers/platform/x86/ideapad-laptop.c
+++ b/drivers/platform/x86/ideapad-laptop.c
@@ -1102,6 +1102,9 @@ static const struct key_entry ideapad_keymap[] = {
 	{ KE_KEY,	0x27 | IDEAPAD_WMI_KEY, { KEY_HELP } },
 	/* Refresh Rate Toggle */
 	{ KE_KEY,	0x0a | IDEAPAD_WMI_KEY, { KEY_DISPLAYTOGGLE } },
+	/* Specific to some newer models */
+	{ KE_KEY,	0x3e | IDEAPAD_WMI_KEY, { KEY_MICMUTE } },
+	{ KE_KEY,	0x3f | IDEAPAD_WMI_KEY, { KEY_RFKILL } },
 	/* Touchpad Toggle */
 	{ KE_KEY,  0x29 | IDEAPAD_WMI_KEY, { KEY_TOUCHPAD_TOGGLE } },
 


### PR DESCRIPTION
[ Upsream commit 36e66be874a7ea9d28fb9757629899a8449b8748 ]

The scancodes for the Mic Mute and Airplane keys on the Ideapad Pro 5 (14AHP9 at least, probably the other variants too) are different and were not being picked up by the driver. This adds them to the keymap.

Apart from what is already supported, the remaining fn keys are unfortunately producing windows-specific key-combos.


Link: https://lore.kernel.org/r/20241102183116.30142-1-renato@calgera.com
Reviewed-by: Hans de Goede <hdegoede@redhat.com>

[ Backport from v6.12 ]
Reported-by: Qiongjie Wen <wenqiongjie@uniontech.com>

## Summary by Sourcery

Backport an upstream commit to map new scancodes for the Mic Mute and Airplane Fn keys on Ideapad Pro 5 models in the platform/x86 ideapad-laptop driver

New Features:
- Add missing Mic Mute and Airplane (RFKill) key mappings for Ideapad Pro 5 in the ideapad-laptop driver

Bug Fixes:
- Fix unrecognized scancodes for the Mic Mute and Airplane keys on newer Ideapad Pro 5 models