### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] docs: tproxy: fix formatting for nft code block

### DIFF
--- a/Documentation/networking/tproxy.rst
+++ b/Documentation/networking/tproxy.rst
@@ -69,9 +69,9 @@ add rules like this to the iptables ruleset above::
     # iptables -t mangle -A PREROUTING -p tcp --dport 80 -j TPROXY \
       --tproxy-mark 0x1/0x1 --on-port 50080
 
-Or the following rule to nft:
+Or the following rule to nft::
 
-# nft add rule filter divert tcp dport 80 tproxy to :50080 meta mark set 1 accept
+    # nft add rule filter divert tcp dport 80 tproxy to :50080 meta mark set 1 accept
 
 Note that for this to work you'll have to modify the proxy to enable (SOL_IP,
 IP_TRANSPARENT) for the listening socket.


### PR DESCRIPTION
[ Upstream commit 149a133a548158586058d14963b4e3a699d0de70 ]

The nft command snippet for redirecting traffic isn't formatted in a literal code block like the rest of snippets. Fix the formatting inconsistency.


Reviewed-by: Bagas Sanjaya <bagasdotme@gmail.com>

[ Backport from v6.16 ]

## Summary by Sourcery

Documentation:
- Format nft command snippet in a literal code block to match other examples