### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] CI: Add patch check by using build kernel riscv64

### DIFF
--- a/.github/workflows/build-kernel-riscv64.yml
+++ b/.github/workflows/build-kernel-riscv64.yml
@@ -1,0 +1,35 @@
+name: build kernel riscv64
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  KBUILD_BUILD_USER: deepin-kernel-sig
+  KBUILD_BUILD_HOST: deepin-kernel-builder
+  email: support@deepin.org
+
+permissions:
+  pull-requests: read
+
+jobs:
+  build-kernel:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Install Deps"
+        run: |
+          git config --global user.email $email
+          git config --global user.name $KBUILD_BUILD_USER
+
+      - name: "Compile kernel"
+        run: |
+          # .config
+          time make ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- deepin_riscv64_desktop_defconfig
+          time make ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- -j$(nproc)
+
+      - name: 'Upload Kernel Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Kernel-ABI-riscv64
+          path: "Module.symvers"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add GitHub Actions workflow 'build-kernel-riscv64' to compile the Linux kernel for riscv64 and upload the Kernel-ABI-riscv64 artifact