### PR TITLE
[6.6] HYGON: Optimization of TDM kernel driver and corresponding tdm_kernel_guard module

### DIFF
--- a/drivers/crypto/ccp/hygon/tdm-dev.c
+++ b/drivers/crypto/ccp/hygon/tdm-dev.c
@@ -24,6 +24,7 @@
 #include <linux/kallsyms.h>
 #include <linux/ftrace.h>
 #include "tdm-dev.h"
+#include "psp-dev.h"
 
 #ifdef pr_fmt
 #undef pr_fmt
@@ -533,8 +534,12 @@ int psp_check_tdm_support(void)
 {
 	int ret = 0;
 	struct tdm_version version;
+	struct psp_device *psp = psp_master;
 
-	if (boot_cpu_data.x86_vendor == X86_VENDOR_HYGON) {
+	if (!psp)
+		goto end;
+
+	if (is_vendor_hygon() && (psp->capability & PSP_CAPABILITY_SEV)) {
 		if (tdm_support)
 			goto end;
 

--- a/drivers/crypto/ccp/hygon/tdm-dev.c
+++ b/drivers/crypto/ccp/hygon/tdm-dev.c
@@ -676,8 +676,7 @@ int psp_create_measure_task(struct addr_range_info *range, struct measure_data *
 		}
 
 		paddr_range_info->count = info_index;
-		addr_range_info_len = paddr_range_info->count * sizeof(struct addr_info) +
-			sizeof(struct addr_range_info);
+		addr_range_info_len = paddr_range_info->count * sizeof(struct addr_info);
 	} else {
 		/*check if physics address valid*/
 		ret = tdm_verify_phy_addr_valid(range);
@@ -685,8 +684,7 @@ int psp_create_measure_task(struct addr_range_info *range, struct measure_data *
 			pr_err("range address is abnormal!\n");
 			goto end;
 		}
-		addr_range_info_len = range->count * sizeof(struct addr_info) +
-			sizeof(struct addr_range_info);
+		addr_range_info_len = range->count * sizeof(struct addr_info);
 	}
 
 	tdm_cmdresp_data = kzalloc(TDM_C2P_CMD_SIZE, GFP_KERNEL);
@@ -709,10 +707,14 @@ int psp_create_measure_task(struct addr_range_info *range, struct measure_data *
 		goto free_cmdresp;
 	}
 
-	if (flag & TASK_CREATE_VADDR)
-		memcpy(&create_cmd->range_info, paddr_range_info, addr_range_info_len);
-	else
-		memcpy(&create_cmd->range_info, range, addr_range_info_len);
+	if (flag & TASK_CREATE_VADDR) {
+		create_cmd->range_info.count = paddr_range_info->count;
+		memcpy(&create_cmd->range_info.addr[0], &paddr_range_info->addr[0],
+			addr_range_info_len);
+	} else {
+		create_cmd->range_info.count = range->count;
+		memcpy(&create_cmd->range_info.addr[0], &range->addr[0], addr_range_info_len);
+	}
 
 	ret = tdm_do_cmd(0, (void *)create_cmd, &error);
 	if (ret && ret != -EIO) {
@@ -1311,7 +1313,7 @@ int tdm_get_report(uint32_t task_id, struct task_selection_2b *selection,
 		*length = needed_length;
 		ret = -DYN_ERR_SIZE_SMALL;
 	} else {
-		memcpy(report_buffer, report_resp, needed_length);
+		memcpy(report_buffer, (uint8_t *)report_resp, needed_length);
 	}
 
 free_cmdresp:

--- a/drivers/crypto/ccp/hygon/tdm-kernel-guard.c
+++ b/drivers/crypto/ccp/hygon/tdm-kernel-guard.c
@@ -23,8 +23,33 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
 static int eh_obj = -1;
+static char *tdm_guard;
 module_param(eh_obj, int, 0644);
-MODULE_PARM_DESC(eh_obj, "security enhance object for TDM");
+MODULE_PARM_DESC(eh_obj,
+	"Bitmap of kernel targets protected by Hygon TDM(bit0: SCT, bit1: IDT, default: both)");
+module_param(tdm_guard, charp, 0644);
+MODULE_PARM_DESC(tdm_guard,
+	"Enable TDM protection for selected targets(on=enable, off=disable, default:off)");
+
+static bool tdm_guard_enabled;
+
+static int __init __maybe_unused parse_tdm_guard(char *str)
+{
+	if (!str)
+		return 0;
+
+	if (!strncmp(str, "off", 3)) {
+		tdm_guard_enabled = false;
+		pr_info("Hygon TDM Guard: Disabled(cmdline)\n");
+	} else if (!strncmp(str, "on", 2)) {
+		tdm_guard_enabled = true;
+		pr_info("Hygon TDM Guard: Enabled(cmdline)\n");
+	}
+
+	return 0;
+}
+
+__setup("tdm_guard=", parse_tdm_guard);
 
 /* Objects are protected by TDM now
  *   SCT: 0
@@ -292,6 +317,16 @@ static int __init kernel_security_enhance_init(void)
 		goto end;
 	}
 
+	if (tdm_guard) {
+		if (!strncmp(tdm_guard, "off", 3))
+			tdm_guard_enabled = false;
+		else if (!strncmp(tdm_guard, "on", 2))
+			tdm_guard_enabled = true;
+	}
+
+	if (tdm_guard_enabled == false)
+		goto end;
+
 	asm("sidt %0":"=m"(idtr));
 
 	if (!psp_check_tdm_support())
@@ -326,6 +361,9 @@ end:
 static void __exit kernel_security_enhance_exit(void)
 {
 	int i = 0;
+
+	if (tdm_guard_enabled == false)
+		return;
 
 	if (!psp_check_tdm_support())
 		return;


### PR DESCRIPTION
1. Fixed the problem that enabling the TDM driver will cause kernel initialization abnormality when the psp firmware is not loaded on the HYGON platform;
2. Add kernel boot parameter and module parameter for the tdm_kernel_guard module;
3. Fix the kernel warning that may be generated when running the tdm driver.

## Summary by Sourcery

Introduce configurable enablement for the Hygon TDM guard module, safeguard against missing PSP firmware during kernel init, and fix data copy logic to remove TDM driver warnings

New Features:
- Add tdm_guard module parameter and tdm_guard= boot parameter to enable or disable TDM protection

Bug Fixes:
- Add null check for PSP firmware device in psp_check_tdm_support to avoid kernel init failures when firmware is absent
- Correct address range length calculations and memcpy usage in psp_create_measure_task and tdm_get_report to eliminate kernel warnings