### PR TITLE
[bugfix][6.6] fix soft lockup warning in psp_mutex_lock_timeout()

### DIFF
--- a/drivers/crypto/ccp/hygon/psp-dev.c
+++ b/drivers/crypto/ccp/hygon/psp-dev.c
@@ -75,13 +75,20 @@ int psp_mutex_trylock(struct psp_mutex *mutex)
 int psp_mutex_lock_timeout(struct psp_mutex *mutex, uint64_t ms)
 {
 	int ret = 0;
-	unsigned long je;
+	unsigned long je, last_je;
 
+	last_je = jiffies;
 	je = jiffies + msecs_to_jiffies(ms);
 	do {
 		if (psp_mutex_trylock(mutex)) {
 			ret = 1;
 			break;
+		}
+
+		// avoid triggering soft lockup warning
+		if (time_after(jiffies, last_je + msecs_to_jiffies(100))) {
+			schedule();
+			last_je = jiffies;
 		}
 	} while ((ms == 0) || time_before(jiffies, je));
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add periodic schedule calls in psp_mutex_lock_timeout to avoid soft lockup warnings during extended waits