### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Linkdata] scsi: linkdata ps3stor compilation problem solved

### DIFF
--- a/drivers/scsi/linkdata/ps3_ioc_manager.c
+++ b/drivers/scsi/linkdata/ps3_ioc_manager.c
@@ -595,7 +595,7 @@ static void ps3_ioc_init_cmd_prepare(struct ps3_instance *instance)
 #endif
 
 	init_frame_msg->dumpDmaBufAddr = cpu_to_le64(dump_context->dump_dma_addr);
-	init_frame_msg->dumpDmaBufLen = cpu_to_le64(PS3_DUMP_DMA_BUF_SIZE);
+	init_frame_msg->dumpDmaBufLen = cpu_to_le32(PS3_DUMP_DMA_BUF_SIZE);
 	init_frame_msg->dumpIsrSN = cpu_to_le32(irq_context->dump_isrSN);
 #ifndef _WINDOWS
 	init_frame_msg->debugMemArrayNum =


### PR DESCRIPTION
Solve the compilation problem of turning on CPU_BIG_ENDIAN configuration

Link: https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel/pulls/425

## Summary by Sourcery

Bug Fixes:
- Fix compilation error in Linkdata PS3 storage driver under CPU_BIG_ENDIAN by using cpu_to_le32 for dumpDmaBufLen instead of cpu_to_le64.