### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Huawei] net/hinic3: drivers/new/ethernet/huawei: Modify the driver version

### DIFF
--- a/drivers/net/ethernet/huawei/hinic3/hinic3_crm.h
+++ b/drivers/net/ethernet/huawei/hinic3/hinic3_crm.h
@@ -8,7 +8,7 @@
 
 #include "mpu_cmd_base_defs.h"
 
-#define HINIC3_DRV_VERSION "17.7.8.1"
+#define HINIC3_DRV_VERSION "17.7.8.101"
 #define HINIC3_DRV_DESC "Intelligent Network Interface Card Driver"
 #define HIUDK_DRV_DESC "Intelligent Network Unified Driver"
 

--- a/drivers/net/ethernet/huawei/hinic3/hinic3_nic_dev.h
+++ b/drivers/net/ethernet/huawei/hinic3/hinic3_nic_dev.h
@@ -18,7 +18,7 @@
 #include "vram_common.h"
 
 #define HINIC3_NIC_DRV_NAME	"hinic3"
-#define HINIC3_NIC_DRV_VERSION	"17.7.8.1"
+#define HINIC3_NIC_DRV_VERSION	"17.7.8.101"
 
 #define HINIC3_FUNC_IS_VF(hwdev)	(hinic3_func_type(hwdev) == TYPE_VF)
 


### PR DESCRIPTION
Modify the driver version.

Link: https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel/pulls/422

## Summary by Sourcery

Bump the Huawei HINIC3 Ethernet driver version to reflect the latest release

Chores:
- Update HINIC3 driver version from 17.7.8.1 to 17.7.8.101 in CRM header
- Update HINIC3 NIC driver version from 17.7.8.1 to 17.7.8.101 in NIC device header