### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] tracing/selftests: Update kprobe args char/string to match new functions

### DIFF
--- a/tools/testing/selftests/ftrace/test.d/kprobe/kprobe_args_char.tc
+++ b/tools/testing/selftests/ftrace/test.d/kprobe/kprobe_args_char.tc
@@ -34,7 +34,9 @@ mips*)
 esac
 
 : "Test get argument (1)"
-if grep -q eventfs_add_dir available_filter_functions; then
+if grep -q eventfs_create_dir available_filter_functions; then
+  DIR_NAME="eventfs_create_dir"
+elif grep -q eventfs_add_dir available_filter_functions; then
   DIR_NAME="eventfs_add_dir"
 else
   DIR_NAME="tracefs_create_dir"

--- a/tools/testing/selftests/ftrace/test.d/kprobe/kprobe_args_string.tc
+++ b/tools/testing/selftests/ftrace/test.d/kprobe/kprobe_args_string.tc
@@ -40,7 +40,9 @@ sw_64)
 esac
 
 : "Test get argument (1)"
-if grep -q eventfs_add_dir available_filter_functions; then
+if grep -q eventfs_create_dir available_filter_functions; then
+  DIR_NAME="eventfs_create_dir"
+elif grep -q eventfs_add_dir available_filter_functions; then
   DIR_NAME="eventfs_add_dir"
 else
   DIR_NAME="tracefs_create_dir"


### PR DESCRIPTION
commit f5d9e8e08f81c9e7c723de7abcce106808f0770c upstream.

The function that the kprobe_args_char and kprobes_arg_string attaches to for its test has changed its name once again. Now we need to check for eventfs_create_dir(), and if it exists, use that, otherwise check for eventfs_add_dir() and if that exists use that, otherwise use the original tracefs_create_dir()!

Link: https://lore.kernel.org/linux-trace-kernel/20230914163535.487267410@goodmis.org

Cc: Mark Rutland <mark.rutland@arm.com>
Cc: Andrew Morton <akpm@linux-foundation.org>
Cc: Ajay Kaher <akaher@vmware.com>
Acked-by: Masami Hiramatsu (Google) <mhiramat@kernel.org>

[ Backport from v6.7 ]
Link: https://gitee.com/anolis/cloud-kernel/pulls/3974

Link: https://bugzilla.openanolis.cn/show_bug.cgi?id=11302

## Summary by Sourcery

Tests:
- Adapt kprobe_args_char.tc and kprobe_args_string.tc to first check for eventfs_create_dir(), then eventfs_add_dir(), or fall back to tracefs_create_dir()