### PR TITLE
symbols: Export symbols needed by Android Drivers

### DIFF
--- a/fs/file.c
+++ b/fs/file.c
@@ -807,6 +807,7 @@ struct file *file_close_fd(unsigned int fd)
 
 	return file;
 }
+EXPORT_SYMBOL_GPL(file_close_fd);
 
 void do_close_on_exec(struct files_struct *files)
 {

--- a/kernel/sched/syscalls.c
+++ b/kernel/sched/syscalls.c
@@ -140,6 +140,7 @@ int can_nice(const struct task_struct *p, const int nice)
 {
 	return is_nice_reduction(p, nice) || capable(CAP_SYS_NICE);
 }
+EXPORT_SYMBOL_GPL(can_nice);
 
 #ifdef __ARCH_WANT_SYS_NICE
 


### PR DESCRIPTION
Export the currently un-exported symbols to support some Android emulator such as kmre and so on.

## Summary by Sourcery

Export previously internal kernel functions to enable support for Android emulator drivers

Enhancements:
- Export file_close_fd symbol under GPL
- Export can_nice symbol under GPL