### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] merge pipe optimization from mainline v6.7

### DIFF
--- a/fs/pipe.c
+++ b/fs/pipe.c
@@ -512,16 +512,7 @@ pipe_write(struct kiocb *iocb, struct iov_iter *from)
 			 * it, either the reader will consume it or it'll still
 			 * be there for the next write.
 			 */
-			spin_lock_irq(&pipe->rd_wait.lock);
-
-			head = pipe->head;
-			if (pipe_full(head, pipe->tail, pipe->max_usage)) {
-				spin_unlock_irq(&pipe->rd_wait.lock);
-				continue;
-			}
-
 			pipe->head = head + 1;
-			spin_unlock_irq(&pipe->rd_wait.lock);
 
 			/* Insert it into the buffer array */
 			buf = &pipe->bufs[head & mask];

--- a/include/linux/pipe_fs_i.h
+++ b/include/linux/pipe_fs_i.h
@@ -62,9 +62,6 @@ struct pipe_inode_info {
 	unsigned int tail;
 	unsigned int max_usage;
 	unsigned int ring_size;
-#ifdef CONFIG_WATCH_QUEUE
-	bool note_loss;
-#endif
 	unsigned int nr_accounted;
 	unsigned int readers;
 	unsigned int writers;
@@ -72,6 +69,9 @@ struct pipe_inode_info {
 	unsigned int r_counter;
 	unsigned int w_counter;
 	bool poll_usage;
+#ifdef CONFIG_WATCH_QUEUE
+	bool note_loss;
+#endif
 	struct page *tmp_page;
 	struct fasync_struct *fasync_readers;
 	struct fasync_struct *fasync_writers;


### PR DESCRIPTION
https://lore.kernel.org/all/20230921075755.1378787-1-max.kellermann@ionos.com/
Merged:
[fs/pipe: move check to pipe_has_watch_queue()](https://lore.kernel.org/all/20230921075755.1378787-2-max.kellermann@ionos.com/#r)

## Summary by Sourcery

Integrate mainline v6.7 pipe performance optimizations by consolidating tail-update logic, reducing unnecessary locking, and reorganizing the note_loss flag.

Enhancements:
- Introduce pipe_update_tail() helper to centralize buffer release, tail increment, and conditional locking when a watch queue exists
- Refactor pipe_read() to use pipe_update_tail() for handling zero-length buffers and loss notifications
- Remove redundant spin-lock around head increment in pipe_write(), relying on existing synchronization
- Reposition note_loss field in pipe_inode_info to group watch-queue–related data together