### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] CI: Add patch check by using build kernel sw64 

### DIFF
--- a/.github/workflows/build-kernel-sw64.yml
+++ b/.github/workflows/build-kernel-sw64.yml
@@ -1,0 +1,35 @@
+name: build kernel sw6b
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  KBUILD_BUILD_USER: deepin-kernel-sig
+  KBUILD_BUILD_HOST: deepin-kernel-builder
+  email: support@deepin.org
+
+permissions:
+  pull-requests: read
+
+jobs:
+  build-kernel:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Install Deps"
+        run: |
+          git config --global user.email $email
+          git config --global user.name $KBUILD_BUILD_USER
+
+      - name: "Compile kernel"
+        run: |
+          # .config
+          time swmk1230 xuelang_defconfig
+          time swmk1230 -j`nproc`
+
+      - name: 'Upload Kernel Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Kernel-ABI-sw6b
+          path: "Module.symvers"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a GitHub Actions workflow to build the Linux kernel for the sw64 architecture and upload the Module.symvers artifact.