### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Uniontech] [AMD] Port some fixes of AMDGPU from UOS v20

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_connectors.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_connectors.c
@@ -614,6 +614,16 @@ static int amdgpu_connector_set_property(struct drm_connector *connector,
 		    (amdgpu_encoder->native_mode.clock == 0))
 			return 0;
 
+		/*
+		* Black screen when Oland GPU set scaling mode with Full/Full aspect/Center
+		* on 4K monitor, do not allow Oland GPU set scaling mode when native mode is 4K.
+		* FIXME: is there a new way to fix it?
+		*/
+		if(adev->asic_type == CHIP_OLAND &&
+			amdgpu_encoder->native_mode.hdisplay == 3840 &&
+			amdgpu_encoder->native_mode.vdisplay == 2160)
+			return 0;
+
 		amdgpu_encoder->rmx_type = rmx_type;
 
 		amdgpu_connector_property_change_mode(&amdgpu_encoder->base);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_connectors.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_connectors.c
@@ -864,11 +864,24 @@ static enum drm_mode_status amdgpu_connector_vga_mode_valid(struct drm_connector
 {
 	struct drm_device *dev = connector->dev;
 	struct amdgpu_device *adev = drm_to_adev(dev);
+	struct edid *edid = amdgpu_connector_edid(connector);
 
 	/* XXX check mode bandwidth */
 
 	if ((mode->clock / 10) > adev->clock.max_pixel_clock)
 		return MODE_CLOCK_HIGH;
+
+	/* Monitor ViewSonic include resolution 1600x1200 which is buggly,
+	 * GPU scaling with "Full" and "Full aspect" will cause screen flicker,
+	 * GPU scaling with "Center" will cause screen black,
+	 * FIXME: block it directly is ugly, is there a new way to fix it?
+	 */
+	if(edid != NULL && edid->mfg_id[0] == 0x5a && edid->mfg_id[1] == 0x63)
+	{
+		if (adev->asic_type == CHIP_OLAND && mode->hdisplay == 1600 && mode->vdisplay == 1200){
+			return MODE_BAD_WIDTH;
+		}
+	}
 
 	return MODE_OK;
 }
@@ -1211,6 +1224,7 @@ static enum drm_mode_status amdgpu_connector_dvi_mode_valid(struct drm_connector
 	struct drm_device *dev = connector->dev;
 	struct amdgpu_device *adev = drm_to_adev(dev);
 	struct amdgpu_connector *amdgpu_connector = to_amdgpu_connector(connector);
+	struct edid *edid = amdgpu_connector_edid(connector);
 
 	/* XXX check mode bandwidth */
 
@@ -1227,6 +1241,18 @@ static enum drm_mode_status amdgpu_connector_dvi_mode_valid(struct drm_connector
 				return MODE_OK;
 		} else {
 			return MODE_CLOCK_HIGH;
+		}
+	}
+
+	/* Monitor ViewSonic include resolution 1600x1200 which is buggly,
+	 * GPU scaling with "Full" and "Full aspect" will cause screen flicker,
+	 * GPU scaling with "Center" will cause screen black,
+	 * FIXME: block it directly is ugly, is there a new way to fix it?
+	 */
+	if(edid != NULL && edid->mfg_id[0] == 0x5a && edid->mfg_id[1] == 0x63)
+	{
+		if (adev->asic_type == CHIP_OLAND && mode->hdisplay == 1600 && mode->vdisplay == 1200){
+			return MODE_BAD_WIDTH;
 		}
 	}
 

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
@@ -583,7 +583,7 @@ module_param_named(timeout_period, amdgpu_watchdog_timer.period, uint, 0644);
 #ifdef CONFIG_DRM_AMDGPU_SI
 
 #if IS_ENABLED(CONFIG_DRM_RADEON) || IS_ENABLED(CONFIG_DRM_RADEON_MODULE)
-int amdgpu_si_support = 0;
+int amdgpu_si_support = 1;
 MODULE_PARM_DESC(si_support, "SI support (1 = enabled, 0 = disabled (default))");
 #else
 int amdgpu_si_support = 1;
@@ -602,7 +602,7 @@ module_param_named(si_support, amdgpu_si_support, int, 0444);
 #ifdef CONFIG_DRM_AMDGPU_CIK
 
 #if IS_ENABLED(CONFIG_DRM_RADEON) || IS_ENABLED(CONFIG_DRM_RADEON_MODULE)
-int amdgpu_cik_support = 0;
+int amdgpu_cik_support = 1;
 MODULE_PARM_DESC(cik_support, "CIK support (1 = enabled, 0 = disabled (default))");
 #else
 int amdgpu_cik_support = 1;

--- a/drivers/gpu/drm/amd/amdgpu/si.c
+++ b/drivers/gpu/drm/amd/amdgpu/si.c
@@ -25,9 +25,7 @@
 #include <linux/slab.h>
 #include <linux/module.h>
 #include <linux/pci.h>
-
-#include <drm/amdgpu_drm.h>
-
+#include <linux/suspend.h>
 #include "amdgpu.h"
 #include "amdgpu_atombios.h"
 #include "amdgpu_ih.h"
@@ -2750,7 +2748,8 @@ int si_set_ip_blocks(struct amdgpu_device *adev)
 #endif
 		else
 			amdgpu_device_ip_block_add(adev, &dce_v6_0_ip_block);
-		amdgpu_device_ip_block_add(adev, &uvd_v3_1_ip_block);
+		if (!pm_suspend_default_s2idle())
+			amdgpu_device_ip_block_add(adev, &uvd_v3_1_ip_block);
 		/* amdgpu_device_ip_block_add(adev, &vce_v1_0_ip_block); */
 		break;
 	case CHIP_OLAND:
@@ -2768,7 +2767,8 @@ int si_set_ip_blocks(struct amdgpu_device *adev)
 #endif
 		else
 			amdgpu_device_ip_block_add(adev, &dce_v6_4_ip_block);
-		amdgpu_device_ip_block_add(adev, &uvd_v3_1_ip_block);
+		if (!pm_suspend_default_s2idle())
+			amdgpu_device_ip_block_add(adev, &uvd_v3_1_ip_block);
 		/* amdgpu_device_ip_block_add(adev, &vce_v1_0_ip_block); */
 		break;
 	case CHIP_HAINAN:

--- a/drivers/gpu/drm/amd/display/dc/link/protocols/link_hpd.c
+++ b/drivers/gpu/drm/amd/display/dc/link/protocols/link_hpd.c
@@ -189,7 +189,7 @@ bool program_hpd_filter(const struct dc_link *link)
 	case SIGNAL_TYPE_HDMI_TYPE_A:
 		/* Program hpd filter */
 		delay_on_connect_in_ms = 500;
-		delay_on_disconnect_in_ms = 100;
+		delay_on_disconnect_in_ms = 700;
 		break;
 	case SIGNAL_TYPE_DISPLAY_PORT:
 	case SIGNAL_TYPE_DISPLAY_PORT_MST:

--- a/drivers/gpu/drm/radeon/radeon_connectors.c
+++ b/drivers/gpu/drm/radeon/radeon_connectors.c
@@ -984,11 +984,24 @@ static enum drm_mode_status radeon_vga_mode_valid(struct drm_connector *connecto
 {
 	struct drm_device *dev = connector->dev;
 	struct radeon_device *rdev = dev->dev_private;
+	struct edid *edid = radeon_connector_edid(connector);
 
 	/* XXX check mode bandwidth */
 
 	if ((mode->clock / 10) > rdev->clock.max_pixel_clock)
 		return MODE_CLOCK_HIGH;
+
+	/* Monitor ViewSonic include resolution 1600x1200 which is buggly,
+	 * GPU scaling with "Full" and "Full aspect" will cause screen flicker,
+	 * GPU scaling with "Center" will cause screen black,
+	 * FIXME: block it directly is ugly, is there a new way to fix it?
+	 */
+	if(edid != NULL && edid->mfg_id[0] == 0x5a && edid->mfg_id[1] == 0x63)
+	{
+		if (ASIC_IS_DCE64(rdev) && mode->hdisplay == 1600 && mode->vdisplay == 1200){
+			return MODE_BAD_WIDTH;
+		}
+	}
 
 	return MODE_OK;
 }
@@ -1464,6 +1477,7 @@ static enum drm_mode_status radeon_dvi_mode_valid(struct drm_connector *connecto
 	struct drm_device *dev = connector->dev;
 	struct radeon_device *rdev = dev->dev_private;
 	struct radeon_connector *radeon_connector = to_radeon_connector(connector);
+	struct edid *edid = radeon_connector_edid(connector);
 
 	/* XXX check mode bandwidth */
 
@@ -1492,6 +1506,18 @@ static enum drm_mode_status radeon_dvi_mode_valid(struct drm_connector *connecto
 	/* check against the max pixel clock */
 	if ((mode->clock / 10) > rdev->clock.max_pixel_clock)
 		return MODE_CLOCK_HIGH;
+
+	/* Monitor ViewSonic include resolution 1600x1200 which is buggly,
+	 * GPU scaling with "Full" and "Full aspect" will cause screen flicker,
+	 * GPU scaling with "Center" will cause screen black,
+	 * FIXME: block it directly is ugly, is there a new way to fix it?
+	 */
+	if(edid != NULL && edid->mfg_id[0] == 0x5a && edid->mfg_id[1] == 0x63)
+	{
+		if (ASIC_IS_DCE64(rdev) && mode->hdisplay == 1600 && mode->vdisplay == 1200){
+			return MODE_BAD_WIDTH;
+		}
+	}
 
 	return MODE_OK;
 }

--- a/drivers/gpu/drm/radeon/radeon_drv.c
+++ b/drivers/gpu/drm/radeon/radeon_drv.c
@@ -239,11 +239,11 @@ module_param_named(uvd, radeon_uvd, int, 0444);
 MODULE_PARM_DESC(vce, "vce enable/disable vce support (1 = enable, 0 = disable)");
 module_param_named(vce, radeon_vce, int, 0444);
 
-int radeon_si_support = 1;
+int radeon_si_support = 0;
 MODULE_PARM_DESC(si_support, "SI support (1 = enabled (default), 0 = disabled)");
 module_param_named(si_support, radeon_si_support, int, 0444);
 
-int radeon_cik_support = 1;
+int radeon_cik_support = 0;
 MODULE_PARM_DESC(cik_support, "CIK support (1 = enabled (default), 0 = disabled)");
 module_param_named(cik_support, radeon_cik_support, int, 0444);
 


### PR DESCRIPTION
## Summary by Sourcery

Port Uniontech AMDGPU fixes from UOS v20 to address display connector black screen issues, adjust IP block initialization based on suspend mode, update default SI/CIK support parameters, and tweak HDMI hotplug debounce timing

Bug Fixes:
- Skip scaling mode changes on Oland GPUs at native 4K resolution to avoid black screen
- Block 1600×1200 modes on ViewSonic monitors for Oland/DCE64 GPUs to prevent flicker or black screen
- Increase HDMI hotplug disconnect delay from 100 ms to 700 ms to reduce spurious disconnects

Enhancements:
- Load UVD IP block only when default s2idle suspend is not enabled
- Enable SI and CIK support by default for the AMDGPU driver and disable them by default for the Radeon driver