### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] mfd: syscon: fix device_syscon_regmap_lookup_by_property build error

### DIFF
--- a/include/linux/mfd/syscon.h
+++ b/include/linux/mfd/syscon.h
@@ -79,7 +79,7 @@ static inline int of_syscon_register_regmap(struct device_node *np,
 	return -EOPNOTSUPP;
 }
 
-extern struct regmap
+static inline struct regmap
 *device_syscon_regmap_lookup_by_property(struct device *dev,
 					 const char *property)
 {


### PR DESCRIPTION
fix build error which found on sw8a

Fixes: d76abc636f16 ("syscon: Add ACPI support for syscon")
Reported-by: wenlunpeng <wenlunpeng@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Convert device_syscon_regmap_lookup_by_property to a static inline function to resolve build errors.