### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] [Bugfix] fix test_offload

### DIFF
--- a/tools/bpf/bpftool/prog.c
+++ b/tools/bpf/bpftool/prog.c
@@ -442,7 +442,7 @@ static void print_prog_header_json(struct bpf_prog_info *info, int fd)
 		jsonw_uint_field(json_wtr, "recursion_misses", info->recursion_misses);
 }
 
-static void print_prog_json(struct bpf_prog_info *info, int fd)
+static void print_prog_json(struct bpf_prog_info *info, int fd, bool orphaned)
 {
 	char *memlock;
 
@@ -461,6 +461,7 @@ static void print_prog_json(struct bpf_prog_info *info, int fd)
 		jsonw_uint_field(json_wtr, "uid", info->created_by_uid);
 	}
 
+	jsonw_bool_field(json_wtr, "orphaned", orphaned);
 	jsonw_uint_field(json_wtr, "bytes_xlated", info->xlated_prog_len);
 
 	if (info->jited_prog_len) {
@@ -527,7 +528,7 @@ static void print_prog_header_plain(struct bpf_prog_info *info, int fd)
 	printf("\n");
 }
 
-static void print_prog_plain(struct bpf_prog_info *info, int fd)
+static void print_prog_plain(struct bpf_prog_info *info, int fd, bool orphaned)
 {
 	char *memlock;
 
@@ -553,6 +554,9 @@ static void print_prog_plain(struct bpf_prog_info *info, int fd)
 	if (memlock)
 		printf("  memlock %sB", memlock);
 	free(memlock);
+
+	if (orphaned)
+		printf("  orphaned");
 
 	if (info->nr_map_ids)
 		show_prog_maps(fd, info->nr_map_ids);
@@ -581,15 +585,15 @@ static int show_prog(int fd)
 	int err;
 
 	err = bpf_prog_get_info_by_fd(fd, &info, &len);
-	if (err) {
+	if (err && err != -ENODEV) {
 		p_err("can't get prog info: %s", strerror(errno));
 		return -1;
 	}
 
 	if (json_output)
-		print_prog_json(&info, fd);
+		print_prog_json(&info, fd, err == -ENODEV);
 	else
-		print_prog_plain(&info, fd);
+		print_prog_plain(&info, fd, err == -ENODEV);
 
 	return 0;
 }


### PR DESCRIPTION
Backport patchset from [1] to solve bpftool issues.

[1]. https://lore.kernel.org/netdev/20231127182057.1081138-1-sdf@google.com/

Link: https://bugzilla.openanolis.cn/show_bug.cgi?id=11330
Link: https://gitee.com/anolis/cloud-kernel/pulls/3980

## Summary by Sourcery

Backport upstream patch to improve bpftool’s handling of orphaned BPF programs and adjust selftests in test_offload accordingly.

Bug Fixes:
- Fix test_offload to correctly detect and fail on orphaned or removed-device program queries

Enhancements:
- Add an "orphaned" flag to bpftool JSON and plain outputs for BPF programs
- Treat ENODEV from prog show as an orphaned program instead of an error

Tests:
- Introduce exclude_orphaned parameter in bpftool_prog_list to filter orphaned programs by default
- Update test_offload assertions to expect failure (ret != 0) when querying orphaned or removed-device programs