### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] selftests: udpgro: no need to load xdp for gro

### DIFF
--- a/tools/testing/selftests/net/udpgro.sh
+++ b/tools/testing/selftests/net/udpgro.sh
@@ -7,8 +7,6 @@ source net_helper.sh
 
 readonly PEER_NS="ns-peer-$(mktemp -u XXXXXX)"
 
-BPF_FILE="xdp_dummy.o"
-
 # set global exit status, but never reset nonzero one.
 check_err()
 {
@@ -38,7 +36,7 @@ cfg_veth() {
 	ip -netns "${PEER_NS}" addr add dev veth1 192.168.1.1/24
 	ip -netns "${PEER_NS}" addr add dev veth1 2001:db8::1/64 nodad
 	ip -netns "${PEER_NS}" link set dev veth1 up
-	ip -n "${PEER_NS}" link set veth1 xdp object ${BPF_FILE} section xdp
+	ip netns exec "${PEER_NS}" ethtool -K veth1 gro on
 }
 
 run_one() {
@@ -205,11 +203,6 @@ run_all() {
 	check_err $?
 	return $ret
 }
-
-if [ ! -f ${BPF_FILE} ]; then
-	echo "Missing ${BPF_FILE}. Run 'make' first"
-	exit -1
-fi
 
 if [[ $# -eq 0 ]]; then
 	run_all


### PR DESCRIPTION
commit d7818402b1d80347c764001583f6d63fa68c2e1a upstream.

After commit d7db7775ea2e ("net: veth: do not manipulate GRO when using XDP"), there is no need to load XDP program to enable GRO. On the other hand, the current test is failed due to loading the XDP program. e.g.

 # selftests: net: udpgro.sh
 # ipv4
 #  no GRO              ok
 #  no GRO chk cmsg     ok
 #  GRO                 ./udpgso_bench_rx: recv: bad packet len, got 1472, expected 14720
 #
 # failed

 [...]

 #  bad GRO lookup      ok
 #  multiple GRO socks  ./udpgso_bench_rx: recv: bad packet len, got 1452, expected 14520
 #
 # ./udpgso_bench_rx: recv: bad packet len, got 1452, expected 14520
 #
 # failed
 ok 1 selftests: net: udpgro.sh

After fix, all the test passed.

 # ./udpgro.sh
 ipv4
  no GRO                                  ok
  [...]
  multiple GRO socks                      ok

Fixes: d7db7775ea2e ("net: veth: do not manipulate GRO when using XDP")
Reported-by: Yi Chen <yiche@redhat.com>
Closes: https://issues.redhat.com/browse/RHEL-53858
Reviewed-by: Toke Høiland-Jørgensen <toke@redhat.com>
Acked-by: Paolo Abeni <pabeni@redhat.com>


[ Backport from v6.12 ]

Link: https://bugzilla.openanolis.cn//show_bug.cgi?id=11339
Link: https://gitee.com/anolis/cloud-kernel/pulls/3982

## Summary by Sourcery

Update udpgro selftests to remove loading of an XDP dummy program and instead enable GRO via ethtool, fixing failures introduced by the upstream veth change.

Bug Fixes:
- Fix udpgro.sh test failures by removing mandatory XDP program loading

Enhancements:
- Enable GRO on the veth interface in the peer namespace via ethtool in the udpgro selftest

Tests:
- Adjust udpgro selftest script to align with the net:veth no-GRO-with-XDP change