### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] keys: Allow automatic module signature with SM3

### DIFF
--- a/kernel/module/Kconfig
+++ b/kernel/module/Kconfig
@@ -257,6 +257,10 @@ config MODULE_SIG_SHA512
 	bool "Sign modules with SHA-512"
 	select CRYPTO_SHA512
 
+config MODULE_SIG_SM3
+	bool "Sign modules with SM3"
+	select CRYPTO_SM3
+
 endchoice
 
 config MODULE_SIG_HASH
@@ -267,6 +271,7 @@ config MODULE_SIG_HASH
 	default "sha256" if MODULE_SIG_SHA256
 	default "sha384" if MODULE_SIG_SHA384
 	default "sha512" if MODULE_SIG_SHA512
+	default "sm3" if MODULE_SIG_SM3
 
 choice
 	prompt "Module compression mode"


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8JZPP

--------------------------------

Support SM3 algorithm for module automatic signature during "make modules_install" and "make modules_sign".


Reviewed-by: Xiu Jianfeng <xiujianfeng@huawei.com>
Reviewed-by: Chao Liu <liuchao173@huawei.com>

## Summary by Sourcery

Add SM3 algorithm support for automatic kernel module signing

New Features:
- Enable SM3 hashing algorithm in the module signing process during make modules_install and make modules_sign

Enhancements:
- Extend Kconfig configuration and build flow to integrate SM3 into module signature generation