### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] f2fs: fix potential deadloop in prepare_compress_overwrite()

### DIFF
--- a/fs/f2fs/compress.c
+++ b/fs/f2fs/compress.c
@@ -1118,6 +1118,7 @@ retry:
 		f2fs_compress_ctx_add_page(cc, page);
 
 		if (!PageUptodate(page)) {
+			f2fs_handle_page_eio(sbi, page->index, DATA);
 release_and_retry:
 			f2fs_put_rpages(cc);
 			f2fs_unlock_rpages(cc, i + 1);

--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -2157,6 +2157,12 @@ int f2fs_read_multi_pages(struct compress_ctx *cc, struct bio **bio_ret,
 	int i;
 	int ret = 0;
 
+	if (unlikely(f2fs_cp_error(sbi))) {
+		ret = -EIO;
+		from_dnode = false;
+		goto out_put_dnode;
+	}
+
 	f2fs_bug_on(sbi, f2fs_cluster_is_empty(cc));
 
 	last_block_in_file = bytes_to_blks(inode,
@@ -2197,10 +2203,6 @@ int f2fs_read_multi_pages(struct compress_ctx *cc, struct bio **bio_ret,
 	if (ret)
 		goto out;
 
-	if (unlikely(f2fs_cp_error(sbi))) {
-		ret = -EIO;
-		goto out_put_dnode;
-	}
 	f2fs_bug_on(sbi, dn.data_blkaddr != COMPRESS_ADDR);
 
 skip_reading_dnode:


### PR DESCRIPTION
mainline inclusion
from mainline-v6.15-rc1
commit 3147ee567dd9004a49826ddeaf0a4b12865d4409
category: bugfix
bugzilla: https://gitee.com/src-openeuler/kernel/issues/IC1QSJ CVE: CVE-2025-22127

Reference: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=3147ee567dd9004a49826ddeaf0a4b12865d4409

--------------------------------

Jan Prusakowski reported a kernel hang issue as below:

When running xfstests on linux-next kernel (6.14.0-rc3, 6.12) I encountered a problem in generic/475 test where fsstress process gets blocked in __f2fs_write_data_pages() and the test hangs. The options I used are:

MKFS_OPTIONS  -- -O compression -O extra_attr -O project_quota -O quota /dev/vdc MOUNT_OPTIONS -- -o acl,user_xattr -o discard,compress_extension=* /dev/vdc /vdc

INFO: task kworker/u8:0:11 blocked for more than 122 seconds.
      Not tainted 6.14.0-rc3-xfstests-lockdep #1
"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
task:kworker/u8:0    state:D stack:0     pid:11    tgid:11    ppid:2      task_flags:0x4208160 flags:0x00004000
Workqueue: writeback wb_workfn (flush-253:0)
Call Trace:
 <TASK>
 __schedule+0x309/0x8e0
 schedule+0x3a/0x100
 schedule_preempt_disabled+0x15/0x30
 __mutex_lock+0x59a/0xdb0
 __f2fs_write_data_pages+0x3ac/0x400
 do_writepages+0xe8/0x290
 __writeback_single_inode+0x5c/0x360
 writeback_sb_inodes+0x22f/0x570
 wb_writeback+0xb0/0x410
 wb_do_writeback+0x47/0x2f0
 wb_workfn+0x5a/0x1c0
 process_one_work+0x223/0x5b0
 worker_thread+0x1d5/0x3c0
 kthread+0xfd/0x230
 ret_from_fork+0x31/0x50
 ret_from_fork_asm+0x1a/0x30
 </TASK>

The root cause is: once generic/475 starts toload error table to dm device, f2fs_prepare_compress_overwrite() will loop reading compressed cluster pages due to IO error, meanwhile it has held .writepages lock, it can block all other writeback tasks.

Let's fix this issue w/ below changes:
- add f2fs_handle_page_eio() in prepare_compress_overwrite() to detect IO error.
- detect cp_error earler in f2fs_read_multi_pages().

Fixes: 4c8ff7095bef ("f2fs: support data compression")
Reported-by: Jan Prusakowski <jprusakowski@google.com>


(cherry picked from commit 3147ee567dd9004a49826ddeaf0a4b12865d4409) Conflicts:
        fs/f2fs/compress.c
[Wentao Guan: backport to 6.6.y]

## Summary by Sourcery

Backport upstream fixes to prevent hangs in F2FS compression overwrite by adding early IO‐error detection and handling in data read and overwrite routines.

Bug Fixes:
- Detect checkpoint errors early in f2fs_read_multi_pages and return -EIO to avoid infinite loops.
- Invoke f2fs_handle_page_eio in prepare_compress_overwrite when pages fail to load, breaking out on IO errors.