### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] selftests: fix some typos in tools/testing/selftests

### DIFF
--- a/tools/testing/selftests/mm/gup_longterm.c
+++ b/tools/testing/selftests/mm/gup_longterm.c
@@ -147,7 +147,7 @@ static void do_test(int fd, size_t size, enum test_type type, bool shared)
 		/*
 		 * R/O pinning or pinning in a private mapping is always
 		 * expected to work. Otherwise, we expect long-term R/W pinning
-		 * to only succeed for special fielesystems.
+		 * to only succeed for special filesystems.
 		 */
 		should_work = !shared || !rw ||
 			      fs_supports_writable_longterm_pinning(fs_type);

--- a/tools/testing/selftests/thermal/intel/power_floor/power_floor_test.c
+++ b/tools/testing/selftests/thermal/intel/power_floor/power_floor_test.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 	}
 
 	if (write(fd, "1\n", 2) < 0) {
-		perror("Can' enable power floor notifications\n");
+		perror("Can't enable power floor notifications\n");
 		exit(1);
 	}
 

--- a/tools/testing/selftests/thermal/intel/workload_hint/workload_hint_test.c
+++ b/tools/testing/selftests/thermal/intel/workload_hint/workload_hint_test.c
@@ -37,7 +37,7 @@ void workload_hint_exit(int signum)
 	}
 
 	if (write(fd, "0\n", 2) < 0) {
-		perror("Can' disable workload hints\n");
+		perror("Can't disable workload hints\n");
 		exit(1);
 	}
 
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 	}
 
 	if (write(fd, "1\n", 2) < 0) {
-		perror("Can' enable workload hints\n");
+		perror("Can't enable workload hints\n");
 		exit(1);
 	}
 


### PR DESCRIPTION
[ Upstream commit f11c1efe46ad84555a0948401c7bdb63d711088d ]

Fix multiple spelling errors:

 - "rougly" -> "roughly"
 - "fielesystems" -> "filesystems"
 - "Can'" -> "Can't"

Link: https://lkml.kernel.org/r/20250503211959.507815-1-chelsyratnawat2001@gmail.com

Cc: Christian Brauner <brauner@kernel.org>
Cc: Shuah Khan <shuah@kernel.org>

[ Backport from v6.16 ]
Link: https://github.com/deepin-community/kernel/pull/66

## Summary by Sourcery

Fix multiple spelling errors in kernel selftests

Enhancements:
- Replace erroneous "Can'" strings with "Can't" in several thermal selftests
- Correct typo "fielesystems" to "filesystems" in mm gup_longterm selftest
- Fix misspelling of "rougly" to "roughly" in selftests documentation