### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Loongson] crypto: loongson: fix sm3 engine while(true) problem

### DIFF
--- a/drivers/crypto/loongson/loongson_se_alg_1_1.c
+++ b/drivers/crypto/loongson/loongson_se_alg_1_1.c
@@ -182,13 +182,6 @@ static int loongson_sm3_one_request(struct crypto_engine *engine, void *areq)
 	if (!sae)
 		return -ENODEV;
 
-	if (sae->rctx && sae->rctx != rctx) {
-		/* Should wait last request done */
-		crypto_finalize_hash_request(sae->engine, req, -EINPROGRESS);
-		err = loongson_sm3_enqueue(req, rctx->op);
-		return err == -EINPROGRESS ? 0 : err;
-	}
-
 	sae->rctx = rctx;
 	rctx->req = req;
 


### PR DESCRIPTION
If the amount of data is relatively large, the crypto interface will use two different requests, then "sae->rctx && sae->rctx != rctx" will be true forever.

Tested-by: Yuan Feng <fengyuan@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Remove the stale rctx check in loongson_sm3_one_request to prevent perpetual retries and blocking on consecutive hash requests.