### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] x86/CPU/AMD: Clear virtualized VMLOAD/VMSAVE on Zen4 client

### DIFF
--- a/arch/x86/kernel/cpu/amd.c
+++ b/arch/x86/kernel/cpu/amd.c
@@ -1059,6 +1059,17 @@ static void init_amd_zen4(struct cpuinfo_x86 *c)
 {
 	if (!cpu_has(c, X86_FEATURE_HYPERVISOR))
 		msr_set_bit(MSR_ZEN4_BP_CFG, MSR_ZEN4_BP_CFG_SHARED_BTB_FIX_BIT);
+
+	/*
+	 * These Zen4 SoCs advertise support for virtualized VMLOAD/VMSAVE
+	 * in some BIOS versions but they can lead to random host reboots.
+	 */
+	switch (c->x86_model) {
+	case 0x18 ... 0x1f:
+	case 0x60 ... 0x7f:
+		clear_cpu_cap(c, X86_FEATURE_V_VMSAVE_VMLOAD);
+		break;
+	}
 }
 
 static void init_amd_zen5(struct cpuinfo_x86 *c)


### PR DESCRIPTION
mainline inclusion
from mainline-v6.12
commit a5ca1dc46a6b610dd4627d8b633d6c84f9724ef0
category: bugfix
bugzilla: https://gitee.com/src-openeuler/kernel/issues/IB8IUH CVE: CVE-2024-53114

A number of Zen4 client SoCs advertise the ability to use virtualized VMLOAD/VMSAVE, but using these instructions is reported to be a cause of a random host reboot.

These instructions aren't intended to be advertised on Zen4 client so clear the capability.



Cc: stable@vger.kernel.org
Link: https://bugzilla.kernel.org/show_bug.cgi?id=219009 (cherry picked from commit a5ca1dc46a6b610dd4627d8b633d6c84f9724ef0)

## Summary by Sourcery

Bug Fixes:
- Disable X86_FEATURE_V_VMSAVE_VMLOAD on AMD Zen4 client models 0x18–0x1f and 0x60–0x7f to avoid host reboots.