### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] NFSD: Force all NFSv4.2 COPY requests to be synchronous

### DIFF
--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -1794,6 +1794,13 @@ nfsd4_copy(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 	struct nfsd42_write_res *result;
 	__be32 status;
 
+	/*
+	 * Currently, async COPY is not reliable. Force all COPY
+	 * requests to be synchronous to avoid client application
+	 * hangs waiting for COPY completion.
+	 */
+	nfsd4_copy_set_sync(copy, true);
+
 	result = &copy->cp_res;
 	nfsd_copy_write_verifier((__be32 *)&result->wr_verifier.data, nn);
 


### PR DESCRIPTION
commit 8d915bbf39266bb66082c1e4980e123883f19830 upstream.

We've discovered that delivering a CB_OFFLOAD operation can be unreliable in some pretty unremarkable situations. Examples include:

 - The server dropped the connection because it lost a forechannel NFSv4 request and wishes to force the client to retransmit
 - The GSS sequence number window under-flowed
 - A network partition occurred

When that happens, all pending callback operations, including CB_OFFLOAD, are lost. NFSD does not retransmit them.

Moreover, the Linux NFS client does not yet support sending an OFFLOAD_STATUS operation to probe whether an asynchronous COPY operation has finished. Thus, on Linux NFS clients, when a CB_OFFLOAD is lost, asynchronous COPY can hang until manually interrupted.

I've tried a couple of remedies, but so far the side-effects are worse than the disease and they have had to be reverted. So temporarily force COPY operations to be synchronous so that the use of CB_OFFLOAD is avoided entirely. This is a fix that can easily be backported to LTS kernels. I am working on client patches that introduce an implementation of OFFLOAD_STATUS.

Note that NFSD arbitrarily limits the size of a copy_file_range to 4MB to avoid indefinitely blocking an nfsd thread. A short COPY result is returned in that case, and the client can present a fresh COPY request for the remainder.


[ Backport from v6.9 ]

## Summary by Sourcery

Force all NFSv4.2 COPY requests to be synchronous on the server to avoid client hangs caused by lost offload callbacks.

Bug Fixes:
- Prevent asynchronous COPY operations from hanging on Linux NFS clients when CB_OFFLOAD callbacks are lost.

Enhancements:
- Always set NFSv4.2 COPY requests to synchronous mode in nfsd4_copy to bypass unreliable offload behavior.

Chores:
- Backport the upstream v6.9 synchronous COPY workaround to the 6.6-y branch.