### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] Update kernel base to 6.6.98

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 6
-SUBLEVEL = 97
+SUBLEVEL = 98
 EXTRAVERSION =
 NAME = Pinguïn Aangedreven
 

--- a/arch/x86/kernel/cpu/amd.c
+++ b/arch/x86/kernel/cpu/amd.c
@@ -480,6 +480,7 @@ static bool amd_check_tsa_microcode(void)
 
 	p.ext_fam	= c->x86 - 0xf;
 	p.model		= c->x86_model;
+	p.ext_model	= c->x86_model >> 4;
 	p.stepping	= c->x86_stepping;
 
 	if (cpu_has(c, X86_FEATURE_ZEN3) ||


### PR DESCRIPTION
Update kernel base to 6.6.98.

## Summary by Sourcery

Update the kernel base to version 6.6.98 and improve AMD CPU microcode detection by initializing the ext_model field.

Enhancements:
- Bump kernel SUBLEVEL from 97 to 98 to track upstream 6.6.98
- Add ext_model assignment in amd_check_tsa_microcode for correct AMD CPU model handling