### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: firmware_loader: move log failed to load firmware to real failed

### DIFF
--- a/drivers/base/firmware_loader/main.c
+++ b/drivers/base/firmware_loader/main.c
@@ -585,10 +585,6 @@ fw_get_filesystem_firmware(struct device *device, struct fw_priv *fw_priv,
 	}
 	__putname(path);
 
-	if (rc)
-		dev_info(device, "firmware: failed to load %s (%d)\n",
-			 fw_priv->fw_name, rc);
-
 	return rc;
 }
 
@@ -930,6 +926,10 @@ _request_firmware(const struct firmware **firmware_p, const char *name,
 #endif
 	if (ret == -ENOENT && nondirect)
 		ret = firmware_fallback_platform(fw->priv);
+
+	if (ret)
+		dev_info(device, "firmware: failed to load %s (%d)\n",
+			 name, ret);
 
 	if (ret) {
 		if (!(opt_flags & FW_OPT_NO_WARN))


### PR DESCRIPTION
deepin inclusion

If we use the zstd compress firmware, cause the many report that said what the firmware load failed, but the truth is that the load failed log is not real.

Move it to the end of  fw_get_filesystem_firmware to check the real failed.

Link: https://bbs.deepin.org/zh/post/289309
Fixes: f081e61f3f1b ("debian: firmware_loader: Log direct loading failures as info for d-i")

## Summary by Sourcery

Move ineffective firmware load failure log to after the actual load attempt to avoid false failure messages when using compressed firmware.

Bug Fixes:
- Prevent premature "failed to load" logs in fw_get_filesystem_firmware to stop inaccurate error reporting for zstd-compressed firmware

Enhancements:
- Reposition dev_info logging into _request_firmware after real load failures are detected