### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] deepin: firmware_loader: move log failed to load firmware to real failed

### DIFF
--- a/drivers/base/firmware_loader/main.c
+++ b/drivers/base/firmware_loader/main.c
@@ -590,10 +590,6 @@ fw_get_filesystem_firmware(struct device *device, struct fw_priv *fw_priv,
 	}
 	__putname(path);
 
-	if (rc)
-		dev_info(device, "firmware: failed to load %s (%d)\n",
-			 fw_priv->fw_name, rc);
-
 	return rc;
 }
 
@@ -935,6 +931,10 @@ _request_firmware(const struct firmware **firmware_p, const char *name,
 #endif
 	if (ret == -ENOENT && nondirect)
 		ret = firmware_fallback_platform(fw->priv);
+
+	if (ret)
+		dev_info(device, "firmware: failed to load %s (%d)\n",
+			 name, ret);
 
 	if (ret) {
 		if (!(opt_flags & FW_OPT_NO_WARN))


### PR DESCRIPTION
deepin inclusion

If we use the zstd compress firmware, cause the many report that said what the firmware load failed, but the truth is that the load failed log is not real.

Move it to the end of  fw_get_filesystem_firmware to check the real failed.

Link: https://bbs.deepin.org/zh/post/289309
Fixes: f081e61f3f1b ("debian: firmware_loader: Log direct loading failures as info for d-i")

(cherry picked from commit e3ba77c964c394c822c69656e2fb5c4b3fd33eeb)

## Summary by Sourcery

Bug Fixes:
- Move failure dev_info log from fw_get_filesystem_firmware into _request_firmware after fallback to report only genuine failures