### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [AMD] drm/amd/display: Fix RISC-V FP configuration in Kconfig

### DIFF
--- a/drivers/gpu/drm/amd/display/Kconfig
+++ b/drivers/gpu/drm/amd/display/Kconfig
@@ -8,8 +8,7 @@ config DRM_AMD_DC
 	depends on BROKEN || !CC_IS_CLANG || ARM64 || RISCV || SPARC64 || X86_64
 	select SND_HDA_COMPONENT if SND_HDA_CORE
 	# !CC_IS_CLANG: https://github.com/ClangBuiltLinux/linux/issues/1752
-	select DRM_AMD_DC_FP if (X86 || LOONGARCH || (PPC64 && ALTIVEC) || (ARM64 && KERNEL_MODE_NEON && !CC_IS_CLANG))
-	select DRM_AMD_DC_DCN if RISCV && FPU
+	select DRM_AMD_DC_FP if (X86 || LOONGARCH || (PPC64 && ALTIVEC) || (ARM64 && KERNEL_MODE_NEON && !CC_IS_CLANG) || (RISCV && FPU))
 	help
 	  Choose this option if you want to use the new display engine
 	  support for AMDGPU. This adds required support for Vega and


### PR DESCRIPTION
Commit 4652ae7a51b7 ("drm/amd/display: Rename DCN config to FP") renamed DCN config to FP.

Consolidate DRM_AMD_DC_FP selection logic by moving RISCV && FPU condition from separate DRM_AMD_DC_DCN selection to the main DRM_AMD_DC_FP conditional statement.

Fixes: 75e7464c0707 ("drm/amd/display: Support DRM_AMD_DC_FP on RISC-V")
Reported-by: Yukari Chiba <i@0x7f.cc>
Suggested-by: Han Gao <gaohan@iscas.ac.cn>

## Summary by Sourcery

Consolidate and fix the Kconfig selection for DRM_AMD_DC_FP by moving the RISC-V and FPU prerequisites into its main conditional and removing the redundant check from the legacy DCN block

Bug Fixes:
- Correct the RISC-V FPU condition to properly enable DRM_AMD_DC_FP support

Enhancements:
- Merge RISC-V && FPU selection logic into the DRM_AMD_DC_FP Kconfig entry and eliminate it from DRM_AMD_DC_DCN