### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] [Intel] cpufreq: intel_pstate: Simplify spinlock locking

### DIFF
--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -1664,7 +1664,6 @@ ack_intr:
 
 static void intel_pstate_disable_hwp_interrupt(struct cpudata *cpudata)
 {
-	unsigned long flags;
 	bool cancel_work;
 
 	if (!cpu_feature_enabled(X86_FEATURE_HWP_NOTIFY))
@@ -1673,9 +1672,9 @@ static void intel_pstate_disable_hwp_interrupt(struct cpudata *cpudata)
 	/* wrmsrl_on_cpu has to be outside spinlock as this can result in IPC */
 	wrmsrl_on_cpu(cpudata->cpu, MSR_HWP_INTERRUPT, 0x00);
 
-	raw_spin_lock_irqsave(&hwp_notify_lock, flags);
+	raw_spin_lock_irqsave(&hwp_notify_lock);
 	cancel_work = cpumask_test_and_clear_cpu(cpudata->cpu, &hwp_intr_enable_mask);
-	raw_spin_unlock_irqrestore(&hwp_notify_lock, flags);
+	raw_spin_unlock_irqrestore(&hwp_notify_lock);
 
 	if (cancel_work)
 		cancel_delayed_work_sync(&cpudata->hwp_notify_work);
@@ -1689,12 +1688,11 @@ static void intel_pstate_enable_hwp_interrupt(struct cpudata *cpudata)
 	/* Enable HWP notification interrupt for performance change */
 	if (boot_cpu_has(X86_FEATURE_HWP_NOTIFY)) {
 		u64 interrupt_mask = HWP_GUARANTEED_PERF_CHANGE_REQ;
-		unsigned long flags;
 
-		raw_spin_lock_irqsave(&hwp_notify_lock, flags);
+		raw_spin_lock_irqsave(&hwp_notify_lock);
 		INIT_DELAYED_WORK(&cpudata->hwp_notify_work, intel_pstate_notify_work);
 		cpumask_set_cpu(cpudata->cpu, &hwp_intr_enable_mask);
-		raw_spin_unlock_irqrestore(&hwp_notify_lock, flags);
+		raw_spin_unlock_irqrestore(&hwp_notify_lock);
 
 		if (cpu_feature_enabled(X86_FEATURE_HWP_HIGHEST_PERF_CHANGE))
 			interrupt_mask |= HWP_HIGHEST_PERF_CHANGE_REQ;


### PR DESCRIPTION
commit 12ebba42d2f1eadc0f897ffeb6dbcfaf2449e107 upstream.

Because intel_pstate_enable/disable_hwp_interrupt() are only called from thread context, they need not save the IRQ flags when using a spinlock as interrupts are guaranteed to be enabled when they run, so make them use spin_lock/unlock_irq().

Intel-SIG: commit 12ebba42d2f1 cpufreq: intel_pstate: Simplify spinlock locking. Backport intel_pstate driver update for 6.6 from 6.11


[ Yingbao Jia: amend commit log ]

Link: https://bugzilla.openanolis.cn/show_bug.cgi?id=12074
Link: https://gitee.com/anolis/cloud-kernel/pulls/4164

## Summary by Sourcery

Enhancements:
- Simplify spinlock locking in intel_pstate by removing unnecessary IRQ flag saving in hwp interrupt enable/disable routines