### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Openeuler] cgroup: disable kernel memory accounting for all memory cgroups by de…

### DIFF
--- a/Documentation/admin-guide/cgroup-v1/memory.rst
+++ b/Documentation/admin-guide/cgroup-v1/memory.rst
@@ -320,9 +320,9 @@ the amount of kernel memory used by the system. Kernel memory is fundamentally
 different than user memory, since it can't be swapped out, which makes it
 possible to DoS the system by consuming too much of this precious resource.
 
-Kernel memory accounting is enabled for all memory cgroups by default. But
-it can be disabled system-wide by passing cgroup.memory=nokmem to the kernel
-at boot time. In this case, kernel memory will not be accounted at all.
+Kernel memory accounting is disabled for all memory cgroups by default. But
+it can be enabled system-wide by passing cgroup.memory=kmem to the kernel
+at boot time. In this case, kernel memory will all be accounted.
 
 Kernel memory limits are not imposed for the root cgroup. Usage for the root
 cgroup may or may not be accounted. The memory used is accumulated into

--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -589,6 +589,7 @@
 			Format: <string>
 			nosocket -- Disable socket memory accounting.
 			nokmem -- Disable kernel memory accounting.
+			kmem -- Enable kernel memory accounting.
 			nobpf -- Disable BPF memory accounting.
 
 	checkreqprot=	[SELINUX] Set initial checkreqprot flag value.

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -87,7 +87,7 @@ EXPORT_PER_CPU_SYMBOL_GPL(int_active_memcg);
 static bool cgroup_memory_nosocket __ro_after_init;
 
 /* Kernel memory accounting disabled? */
-static bool cgroup_memory_nokmem __ro_after_init;
+static bool cgroup_memory_nokmem __ro_after_init = true;
 
 /* BPF memory accounting disabled? */
 static bool cgroup_memory_nobpf __ro_after_init;
@@ -7618,6 +7618,8 @@ static int __init cgroup_memory(char *s)
 			cgroup_memory_nosocket = true;
 		if (!strcmp(token, "nokmem"))
 			cgroup_memory_nokmem = true;
+		else if (!strcmp(token, "kmem"))
+			cgroup_memory_nokmem = false;
 		if (!strcmp(token, "nobpf"))
 			cgroup_memory_nobpf = true;
 	}


### PR DESCRIPTION
…fault

hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I8QLND CVE: NA

----------------------------------------

The kernel memory accounting for all memory cgroups is not stable, and it will cause a 100% regression in hackbench compared with kernel-4.19, so disable it by default. We can use the following command line to enable or disable it:
cgroup.memory=kmem or cgroup.memory=nokmem.

## Summary by Sourcery

Disable kernel memory accounting for all memory cgroups by default to avoid performance regressions and introduce a command-line option to re-enable it.

New Features:
- Add cgroup.memory=kmem command-line token to explicitly enable kernel memory accounting

Bug Fixes:
- Disable unstable kernel memory accounting for all memory cgroups by default to prevent performance regressions in hackbench

Documentation:
- Update memory cgroup documentation to reflect default disabling of kernel memory accounting and the new kmem/nokmem options