### PR TITLE
drm/amd/display: dont subst v without RISCV_ISA_V

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dml/Makefile
+++ b/drivers/gpu/drm/amd/display/dc/dml/Makefile
@@ -45,8 +45,12 @@ endif
 
 ifdef CONFIG_RISCV
 include $(srctree)/arch/riscv/Makefile.isa
+ifdef CONFIG_RISCV_ISA_V
 # Remove V from the ISA string, like in arch/riscv/Makefile, but keep F and D.
 dml_ccflags := -march=$(subst v,,$(riscv-march-y))
+else
+dml_ccflags := -march=$(riscv-march-y)
+endif
 endif
 
 ifdef CONFIG_CC_IS_GCC


### PR DESCRIPTION
Prevent v in rv64 to be removed by subst.

## Summary by Sourcery

Bug Fixes:
- Prevent unconditional removal of the ‘v’ extension from the march string in rv64 builds