### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] drm/amd/display: Fix dc dml march cause riscv build failed 

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dml/Makefile
+++ b/drivers/gpu/drm/amd/display/dc/dml/Makefile
@@ -45,12 +45,7 @@ endif
 
 ifdef CONFIG_RISCV
 include $(srctree)/arch/riscv/Makefile.isa
-ifdef CONFIG_RISCV_ISA_V
-# Remove V from the ISA string, like in arch/riscv/Makefile, but keep F and D.
-dml_ccflags := -march=$(subst v,,$(riscv-march-y))
-else
-dml_ccflags := -march=$(riscv-march-y)
-endif
+dml_ccflags := -march=$(shell echo $(riscv-march-y) | sed -E 's/(rv32ima|rv64ima)([^v_]*)v?/\1\2/')
 endif
 
 ifdef CONFIG_CC_IS_GCC


### PR DESCRIPTION
We must carefully when remove the march substr.
otherwise it will cause build failed when CONFIG_RISCV_V

Log:
  CC [M]  drivers/gpu/drm/amd/amdgpu/../display/dc/dml/display_mode_lib.o
riscv64-linux-gnu-gcc: error: ‘-march=r64imafdc_zicsr_zifencei_zihintpause’: ISA string must begin with rv32 or rv64

## Summary by Sourcery

Bug Fixes:
- Remove CONFIG_RISCV_ISA_V branch and always set dml_ccflags to use the full riscv-march-y for the -march flag, preventing invalid ISA string errors on RISC-V builds.