### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Upstream] drm/amdkfd: enable kfd on RISC-V/LoongArch systems

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/Kconfig
+++ b/drivers/gpu/drm/amd/amdkfd/Kconfig
@@ -5,7 +5,7 @@
 
 config HSA_AMD
 	bool "HSA kernel driver for AMD GPU devices"
-	depends on DRM_AMDGPU && (X86_64 || ARM64 || PPC64)
+	depends on DRM_AMDGPU && (X86_64 || ARM64 || PPC64 || (RISCV && 64BIT))
 	select HMM_MIRROR
 	select MMU_NOTIFIER
 	select DRM_AMDGPU_USERPTR

--- a/drivers/gpu/drm/amd/amdkfd/Kconfig
+++ b/drivers/gpu/drm/amd/amdkfd/Kconfig
@@ -5,7 +5,7 @@
 
 config HSA_AMD
 	bool "HSA kernel driver for AMD GPU devices"
-	depends on DRM_AMDGPU && (X86_64 || ARM64 || PPC64 || (RISCV && 64BIT))
+	depends on DRM_AMDGPU && (X86_64 || ARM64 || PPC64 || (RISCV && 64BIT) || (LOONGARCH && 64BIT))
 	select HMM_MIRROR
 	select MMU_NOTIFIER
 	select DRM_AMDGPU_USERPTR


### PR DESCRIPTION
Author: Han Gao <rabenda.cn@gmail.com>
Date:   Wed Jul 9 14:51:38 2025 +0800

    drm/amdkfd: enable kfd on LoongArch systems
    
    mainline inclusion
    from mainline-v6.17-rc1
    category: feature
    
    KFD has been confirmed that can run on LoongArch systems.
    It's necessary to support CONFIG_HSA_AMD on LoongArch.
    
    Signed-off-by: Han Gao <rabenda.cn@gmail.com>
    Signed-off-by: Felix Kuehling <felix.kuehling@amd.com>
    Reviewed-by: Felix Kuehling <felix.kuehling@amd.com>
    Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
    (cherry picked from commit fa301127ba9a22f40b4261f569f1fc8b3d66e04e)
    Signed-off-by: Wentao Guan <guanwentao@uniontech.com>
Author: Xuemei Liu <liu.xuemei1@zte.com.cn>
Date:   Thu May 29 10:25:11 2025 +0800

    drm/amdkfd: enable kfd on RISCV systems
    
    mainline inclusion
    from mainline-v6.16-rc1
    category: feature
    
    KFD has been confirmed that can run on RISCV systems. It's necessary to
    support CONFIG_HSA_AMD on RISCV.
    
    Signed-off-by: Xuemei Liu <liu.xuemei1@zte.com.cn>
    Signed-off-by: Felix Kuehling <felix.kuehling@amd.com>
    Reviewed-by: Felix Kuehling <felix.kuehling@amd.com>
    Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
    (cherry picked from commit 4e696906e9a82d4cab75f3083fabd65433c77e20)
    Signed-off-by: Wentao Guan <guanwentao@uniontech.com>
