### PR TITLE
phytium: Add live migration for virtual machines and optimized huge page VM startup.

### DIFF
--- a/arch/arm64/kvm/hyp/pgtable.c
+++ b/arch/arm64/kvm/hyp/pgtable.c
@@ -1161,6 +1161,19 @@ struct stage2_attr_data {
 	u32				level;
 };
 
+static inline bool stage2_is_post_migration_huge(kvm_pte_t pte, kvm_pte_t old_pte, u32 level)
+{
+	/*
+	* Based on pagesize and PTE permissions(read, write and execute), determine whether it is a
+	* a huge pagesize VM live migration.
+	*/
+	return (kvm_granule_size(level) > PAGE_SIZE
+		&& (pte & KVM_PTE_LEAF_ATTR_LO_S2_S2AP_R)
+		&& (pte & KVM_PTE_LEAF_ATTR_LO_S2_S2AP_W)
+		&& stage2_pte_executable(pte)
+		&& !stage2_pte_executable(old_pte));
+}
+
 static int stage2_attr_walker(const struct kvm_pgtable_visit_ctx *ctx,
 			      enum kvm_pgtable_walk_flags visit)
 {
@@ -1182,6 +1195,17 @@ static int stage2_attr_walker(const struct kvm_pgtable_visit_ctx *ctx,
 	 * set on the next access instead.
 	 */
 	if (data->pte != pte) {
+		/*
+		* if it's a huge page VM after live migration, other vCPUs do not need to
+		* refresh icache because of the CMO mechanism.
+		*/
+		if(read_cpuid_implementor() == ARM_CPU_IMP_PHYTIUM) {
+			if (stage2_is_post_migration_huge(pte, ctx->old, ctx->level)) {
+				if (!stage2_try_set_pte(ctx, pte))
+					return -EAGAIN;
+			}
+		}
+
 		/*
 		 * Invalidate instruction cache before updating the guest
 		 * stage-2 PTE if we are going to add executable permission.

--- a/arch/arm64/kvm/mmu.c
+++ b/arch/arm64/kvm/mmu.c
@@ -2147,8 +2147,17 @@ void kvm_toggle_cache(struct kvm_vcpu *vcpu, bool was_enabled)
 	 * If switching it off, need to clean the caches.
 	 * Clean + invalidate does the trick always.
 	 */
-	if (now_enabled != was_enabled)
-		stage2_flush_vm(vcpu->kvm);
+	if (now_enabled != was_enabled) {
+		/*
+		 * Phytium CPU support cache consistency, so just
+		 * flush first vcpu dcache.
+		 */
+		if (read_cpuid_implementor() == ARM_CPU_IMP_PHYTIUM) {
+			if (vcpu->vcpu_id == 0)
+				stage2_flush_vm(vcpu->kvm);
+		} else
+			stage2_flush_vm(vcpu->kvm);
+	}
 
 	/* Caches are now on, stop trapping VM ops (until a S/W op) */
 	if (now_enabled)

--- a/arch/arm64/kvm/sys_regs.c
+++ b/arch/arm64/kvm/sys_regs.c
@@ -1256,6 +1256,7 @@ static int arm64_check_features(struct kvm_vcpu *vcpu,
 	u64 writable_mask = rd->val;
 	u64 limit = rd->reset(vcpu, rd);
 	u64 mask = 0;
+	u32 midr = read_cpuid_id();
 
 	/*
 	 * Hidden and unallocated ID registers may not have a corresponding
@@ -1276,8 +1277,11 @@ static int arm64_check_features(struct kvm_vcpu *vcpu,
 		u64 ftr_mask;
 
 		ftr_mask = arm64_ftr_mask(ftrp);
-		if ((ftr_mask & writable_mask) != ftr_mask)
-			continue;
+
+		if (MIDR_IMPLEMENTOR(midr) != ARM_CPU_IMP_PHYTIUM) {
+			if ((ftr_mask & writable_mask) != ftr_mask)
+				continue;
+		}
 
 		f_val = arm64_ftr_value(ftrp, val);
 		f_lim = arm64_ftr_value(ftrp, limit);


### PR DESCRIPTION
patch list:
1. KVM: uncheck writeable_mask in arm64_check_features
2. KVM: arm64: clean the first vcpu dcache
3. virt/kvm: Solved a soft lock problem after live migration of a VM with huge pages

## Summary by Sourcery

Add Phytium-specific optimizations and fixes to arm64 KVM, focusing on huge page VM live migration and cache management.

Enhancements:
- Bypass full VM stage2 flush on cache toggling by flushing only the first vCPU dcache on Phytium CPUs
- Skip I-cache invalidation for post-migration huge pages on Phytium implementors to avoid soft locks
- Relax writable_mask enforcement in arm64_check_features for Phytium CPUs