### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: KABI: KABI reservation for general block layer structures

### DIFF
--- a/include/linux/bio.h
+++ b/include/linux/bio.h
@@ -9,6 +9,7 @@
 /* struct bio, bio_vec and BIO_* flags are defined in blk_types.h */
 #include <linux/blk_types.h>
 #include <linux/uio.h>
+#include <linux/deepin_kabi.h>
 
 #define BIO_MAX_VECS		256U
 #define BIO_MAX_INLINE_VECS	UIO_MAXIOV
@@ -347,6 +348,12 @@ struct bio_integrity_payload {
 	struct work_struct	bip_work;	/* I/O completion */
 
 	struct bio_vec		*bip_vec;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+
 	struct bio_vec		bip_inline_vecs[];/* embedded bvec array */
 };
 
@@ -706,6 +713,10 @@ struct bio_set {
 	 * Hot un-plug notifier for the per-cpu cache, if used
 	 */
 	struct hlist_node cpuhp_dead;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 static inline bool bioset_initialized(struct bio_set *bs)

--- a/include/linux/blk-integrity.h
+++ b/include/linux/blk-integrity.h
@@ -33,6 +33,10 @@ struct blk_integrity_profile {
 	integrity_prepare_fn		*prepare_fn;
 	integrity_complete_fn		*complete_fn;
 	const char			*name;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 #ifdef CONFIG_BLK_DEV_INTEGRITY

--- a/include/linux/blk-mq.h
+++ b/include/linux/blk-mq.h
@@ -188,6 +188,15 @@ struct request {
 	 */
 	rq_end_io_fn *end_io;
 	void *end_io_data;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 static inline enum req_op req_op(const struct request *req)
@@ -429,6 +438,9 @@ struct blk_mq_hw_ctx {
 	 * q->unused_hctx_list.
 	 */
 	struct list_head	hctx_list;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -515,6 +527,18 @@ struct blk_mq_tag_set {
 	struct mutex		tag_list_lock;
 	struct list_head	tag_list;
 	struct srcu_struct	*srcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
+	DEEPIN_KABI_RESERVE(10)
+	DEEPIN_KABI_RESERVE(11)
 };
 
 /**
@@ -526,6 +550,9 @@ struct blk_mq_tag_set {
 struct blk_mq_queue_data {
 	struct request *rq;
 	bool last;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 typedef bool (busy_tag_iter_fn)(struct request *, void *);
@@ -645,6 +672,13 @@ struct blk_mq_ops {
 	 */
 	void (*show_rq)(struct seq_file *m, struct request *rq);
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 enum {
@@ -749,6 +783,16 @@ struct blk_mq_tags {
 	 * request pool
 	 */
 	spinlock_t lock;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
 };
 
 static inline struct request *blk_mq_tag_to_rq(struct blk_mq_tags *tags,

--- a/include/linux/blk_types.h
+++ b/include/linux/blk_types.h
@@ -75,6 +75,17 @@ struct block_device {
 	 * path
 	 */
 	struct device		bd_device;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
+	DEEPIN_KABI_RESERVE(10)
 } __randomize_layout;
 
 #define bdev_whole(_bdev) \
@@ -315,6 +326,16 @@ struct bio {
 	struct bio_vec		*bi_io_vec;	/* the actual vec list */
 
 	struct bio_set		*bi_pool;
+
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 
 	/*
 	 * We can inline a number of vecs at the end of the bio, to avoid

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -110,6 +110,9 @@ struct blk_integrity {
 	unsigned char				tuple_size;
 	unsigned char				interval_exp;
 	unsigned char				tag_size;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 typedef unsigned int __bitwise blk_mode_t;
@@ -207,6 +210,18 @@ struct gendisk {
 	 * devices that do not have multiple independent access ranges.
 	 */
 	struct blk_independent_access_ranges *ia_ranges;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
+	DEEPIN_KABI_RESERVE(10)
+	DEEPIN_KABI_RESERVE(11)
 };
 
 static inline bool disk_live(struct gendisk *disk)
@@ -337,6 +352,15 @@ struct queue_limits {
 	 * due to possible offsets.
 	 */
 	unsigned int		dma_alignment;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 typedef int (*report_zones_cb)(struct blk_zone *zone, unsigned int idx,
@@ -379,12 +403,20 @@ struct blk_independent_access_range {
 	struct kobject		kobj;
 	sector_t		sector;
 	sector_t		nr_sectors;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct blk_independent_access_ranges {
 	struct kobject				kobj;
 	bool					sysfs_registered;
 	unsigned int				nr_ia_ranges;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+
 	struct blk_independent_access_range	ia_range[];
 };
 
@@ -536,6 +568,15 @@ struct request_queue {
 	struct mutex		debugfs_mutex;
 
 	bool			mq_sysfs_init_done;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /* Keep blk_queue_flag_name[] in sync with the definitions below */
@@ -986,6 +1027,10 @@ struct blk_plug {
 	bool has_elevator;
 
 	struct list_head cb_list; /* md requires an unplug callback */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 struct blk_plug_cb;
@@ -1418,6 +1463,13 @@ struct block_device_operations {
 	 * driver.
 	 */
 	int (*alternative_gpt_sector)(struct gendisk *disk, sector_t *sector);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 #ifdef CONFIG_COMPAT
@@ -1481,6 +1533,13 @@ struct blk_holder_ops {
 	 * Sync the file system mounted on the block device.
 	 */
 	void (*sync)(struct block_device *bdev);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 extern const struct blk_holder_ops fs_holder_ops;
@@ -1560,6 +1619,8 @@ struct io_comp_batch {
 	struct request *req_list;
 	bool need_ts;
 	void (*complete)(struct io_comp_batch *);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 #define DEFINE_IO_COMP_BATCH(name)	struct io_comp_batch name = { }


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZW7Z CVE: NA

--------------------------------

| struture                      | size         | reserves |
| ----------------------------- | ------------ | -------- |
| bio_integrity_payload         | 96           | 4        |
| bio_set                       | 488          | 3        |
| blk_integrity_profile         | 40           | 3        |
| request                       | dynamic      | 8        |
| blk_mq_hw_ctx                 | 480 + 16对齐 | 2        |
| blk_mq_tag_set                | 168          | 11       |
| blk_mq_queue_data             | 16           | 2        |
| blk_mq_ops                    | 144          | 6        |
| blk_mq_tags                   | 184          | 9        |
| block_device                  | 1000          | 10       |
| bio                           | dynamic      | 8        |
| blk_integrity                 | 16           | 2        |
| gendisk                       | 872          | 11       |
| queue_limits                  | 120          | 8        |
| blk_independent_access_range  | 80           | 2        |
| blk_independent_access_ranges | 72           | 3        |
| request_queue                 | 936          | 8        |
| blk_plug                      | 40           | 3        |
| block_device_operations       | 144          | 6        |
| blk_holder_ops                | 16           | 6        |
| io_comp_batch                 | 24           | 1        |

## Summary by Sourcery

Reserve space in key block layer structures for future KABI compatibility

Enhancements:
- Add DEEPIN_KABI_RESERVE placeholders to core bio, bio_set, and bio_integrity_payload types
- Insert KABI reservation fields into block_device, gendisk, queue_limits, and request/request_queue structures
- Extend DEEPIN_KABI_RESERVE slots in blk_mq types, blk_plug, block_device_operations, blk_holder_ops, io_comp_batch, and blk_integrity_profile