### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: KABI: KABI reservation for fscache structures

### DIFF
--- a/include/linux/fscache-cache.h
+++ b/include/linux/fscache-cache.h
@@ -44,6 +44,11 @@ struct fscache_cache {
 	unsigned int		debug_id;
 	enum fscache_cache_state state;
 	char			*name;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*
@@ -78,6 +83,11 @@ struct fscache_cache_ops {
 
 	/* Prepare to write to a live cache object */
 	void (*prepare_to_write)(struct fscache_cookie *cookie);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 extern struct workqueue_struct *fscache_wq;

--- a/include/linux/fscache.h
+++ b/include/linux/fscache.h
@@ -89,6 +89,12 @@ struct fscache_volume {
 #define FSCACHE_VOLUME_ACQUIRE_PENDING	3	/* Volume is waiting to complete acquisition */
 #define FSCACHE_VOLUME_CREATING		4	/* Volume is being created on disk */
 	u8				coherency_len;	/* Length of the coherency data */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+
 	u8				coherency[];	/* Coherency data */
 };
 
@@ -145,6 +151,11 @@ struct fscache_cookie {
 		void			*aux;		/* Auxiliary data */
 		u8			inline_aux[8];	/* - If the aux data is short enough */
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I912AQ

--------------------------------

Reserve space for struct fscache_cache/fscache_cache_ops/fscache_volume/ fscache_cookie.

## Summary by Sourcery

New Features:
- Reserve KABI slots in fscache_volume, fscache_cookie, fscache_cache, and fscache_cache_ops structures for future compatibility