### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] x86/CPU/AMD: Always inline amd_clear_divider()

### DIFF
--- a/arch/x86/include/asm/processor.h
+++ b/arch/x86/include/asm/processor.h
@@ -698,7 +698,17 @@ extern u16 get_llc_id(unsigned int cpu);
 #ifdef CONFIG_CPU_SUP_AMD
 extern u32 amd_get_nodes_per_socket(void);
 extern u32 amd_get_highest_perf(void);
-extern void amd_clear_divider(void);
+
+/*
+ * Issue a DIV 0/1 insn to clear any division data from previous DIV
+ * operations.
+ */
+static __always_inline void amd_clear_divider(void)
+{
+	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
+		     :: "a" (0), "d" (0), "r" (1));
+}
+
 extern void amd_check_microcode(void);
 #else
 static inline u32 amd_get_nodes_per_socket(void)	{ return 0; }

--- a/arch/x86/kernel/cpu/amd.c
+++ b/arch/x86/kernel/cpu/amd.c
@@ -1427,14 +1427,3 @@ void amd_check_microcode(void)
 	if (cpu_feature_enabled(X86_FEATURE_ZEN2))
 		on_each_cpu(zenbleed_check_cpu, NULL, 1);
 }
-
-/*
- * Issue a DIV 0/1 insn to clear any division data from previous DIV
- * operations.
- */
-void noinstr amd_clear_divider(void)
-{
-	asm volatile(ALTERNATIVE("", "div %2\n\t", X86_BUG_DIV0)
-		     :: "a" (0), "d" (0), "r" (1));
-}
-EXPORT_SYMBOL_GPL(amd_clear_divider);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.11-rc1
category: performance

The routine is used on syscall exit and on non-AMD CPUs is guaranteed to be empty.

It probably does not need to be a function call even on CPUs which do need the mitigation.

  [ bp: Make sure it is always inlined so that noinstr marking works. ]



Link: https://lore.kernel.org/r/20240613082637.659133-1-mjguzik@gmail.com (cherry picked from commit 501bd734f933f4eb5c080b87936e9d43f471d723)

## Summary by Sourcery

Inline the amd_clear_divider routine for improved performance and ensure its implementation is defined directly in the header, removing the separate out-of-line version.

Enhancements:
- Move amd_clear_divider implementation into arch/x86/include/asm/processor.h as a static always_inline function
- Remove the out-of-line amd_clear_divider definition and its EXPORT_SYMBOL_GPL in amd.c