### PR TITLE
drm/amd/display: Remove wrong signal from vrr calculation

### DIFF
--- a/drivers/gpu/drm/amd/display/modules/freesync/freesync.c
+++ b/drivers/gpu/drm/amd/display/modules/freesync/freesync.c
@@ -1060,7 +1060,7 @@ void mod_freesync_build_vrr_params(struct mod_freesync *mod_freesync,
 			in_out_vrr->fixed_refresh_in_uhz = 0;
 
 		refresh_range = div_u64(in_out_vrr->max_refresh_in_uhz + 500000, 1000000) -
-+				div_u64(in_out_vrr->min_refresh_in_uhz + 500000, 1000000);
+				div_u64(in_out_vrr->min_refresh_in_uhz + 500000, 1000000);
 
 		in_out_vrr->supported = true;
 	}


### PR DESCRIPTION
In some of the merge conflict fixes, one '+' was accidentally left at the beginning of the line. Fortunately, this did not cause any major issues since it acted as a number signal. This commit addresses this issue by removing the extra '+'.

Acked-by: Wayne Lin <wayne.lin@amd.com>

Tested-by: Daniel Wheeler <daniel.wheeler@amd.com>

(cherry picked from commit bcebe44f6bb6d9a85e0710d0086bc3956e6887ba)

## Summary by Sourcery

Bug Fixes:
- Remove stray '+' operator from the VRR refresh range calculation in the AMD FreeSync module