### PR TITLE
deepin: KABI: kernfs: kabi: Reserve KABI slots for kernfs_* struct

### DIFF
--- a/fs/kernfs/file.c
+++ b/fs/kernfs/file.c
@@ -25,6 +25,10 @@ struct kernfs_open_node {
 	struct list_head	files; /* goes through kernfs_open_file.list */
 	unsigned int		nr_mmapped;
 	unsigned int		nr_to_release;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 /*

--- a/fs/kernfs/kernfs-internal.h
+++ b/fs/kernfs/kernfs-internal.h
@@ -51,6 +51,12 @@ struct kernfs_root {
 	struct rw_semaphore	kernfs_supers_rwsem;
 
 	struct rcu_head		rcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 };
 
 /* +1 to avoid triggering overflow warning when negating it */

--- a/include/linux/kernfs.h
+++ b/include/linux/kernfs.h
@@ -6,6 +6,7 @@
 #ifndef __LINUX_KERNFS_H
 #define __LINUX_KERNFS_H
 
+#include <linux/deepin_kabi.h>
 #include <linux/err.h>
 #include <linux/list.h>
 #include <linux/mutex.h>
@@ -244,6 +245,10 @@ struct kernfs_syscall_ops {
 		      const char *new_name);
 	int (*show_path)(struct seq_file *sf, struct kernfs_node *kn,
 			 struct kernfs_root *root);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 struct kernfs_node *kernfs_root_to_node(struct kernfs_root *root);
@@ -318,6 +323,11 @@ struct kernfs_ops {
 			 struct poll_table_struct *pt);
 
 	int (*mmap)(struct kernfs_open_file *of, struct vm_area_struct *vma);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in kernfs_* struct for future expansion.

struct			size(byte)	reserve(8*byte)	now(byte)
kernfs_syscall_ops	40		3		64
kernfs_root		216		5		256
kernfs_ops		96		4		128
kernfs_open_node	72		3		96

## Summary by Sourcery

Include the deepin_kabi interface and add reserved KABI slots to various kernfs structures to enable future ABI-safe expansion.

New Features:
- Reserve additional KABI slots in kernfs_syscall_ops, kernfs_ops, kernfs_root, and kernfs_open_node structures for future expansion.

Enhancements:
- Include deepin_kabi.h to provide DEEPIN_KABI_RESERVE macros.