### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] HAOC: CREDP: fix kernel boot panic without CONFIG_CREDP

### DIFF
--- a/kernel/cred.c
+++ b/kernel/cred.c
@@ -472,6 +472,8 @@ int copy_creds(struct task_struct *p, unsigned long clone_flags)
 		iee_init_copied_cred(p, get_cred(new));
 	else
 		p->cred = p->real_cred = get_cred(new);
+#else
+	p->cred = p->real_cred = get_cred(new);
 #endif
 	inc_rlimit_ucounts(task_ucounts(p), UCOUNT_RLIMIT_NPROC, 1);
 	return 0;


### PR DESCRIPTION
Log:
[09:22:50:784] [    4.205148] Kernel panic - not syncing: CRED: put_cred_rcu() sees (____ptrval____) with usage -5␍␊
[09:22:50:793] [    4.214015] CPU: 2 PID: 0 Comm: swapper/2 Not tainted 6.6.101-loong64-desktop-hwe #25.01.00.31  ␍␊
[09:22:50:800] [    4.222879] Hardware name: Loongson Loongson-3A6000-HV-7A2000-1w-V0.1-EVB/Loongson-3A6000-HV-7A2000-1w-EVB-V1.21, BIOS Loongson-UDK2018-V4.0.05756-prestab␍␊
[09:22:50:820] [    4.236884] Stack : 90000000044c1c48 9000000002755220 900000000023ff8c 9000000100474000␍␊
[09:22:50:823] [    4.244977]         9000000100263c40 0000000000000000 9000000100263c48 9000000002755220␍␊
[09:22:50:831] [    4.253067]         9000000008a319e0 9000000008a319d8 9000000100263b90 0000000000000001␍␊
[09:22:50:839] [    4.261155]         0000000000000001 a8fd0f104f1068ea 0000000008f40000 9000000100595a80␍␊
[09:22:50:847] [    4.269244]         0000000000000001 fffffffffffffffe 9000000100cba6f0 ffffffffffffffff␍␊
[09:22:50:856] [    4.277332]         0000000000000002 0000000000000003 0000000008f40000 90000000031a1000␍␊
[09:22:50:863] [    4.285421]         90000000031a1000 9000000002755220 0000000000000000 0000000000000000␍␊
[09:22:50:873] [    4.293508]         9000000002717a58 0000000000000000 0000000000000001 900000000a82c0f8␍␊
[09:22:50:880] [    4.301595]         9000000003490b48 9000000002755220 900000000024448c 00007ffff21aa2b3␍␊
[09:22:50:889] [    4.309684]         00000000000002b0 000000000000000c 0000000000000000 0000000000071c1d␍␊
[09:22:50:897] [    4.317773]         ...␍␊
[09:22:50:906] [    4.320327] Call Trace:␍␊
[09:22:50:906] [    4.320329] [<900000000024448c>] show_stack+0x3c/0x150␍␊
[09:22:50:906] [    4.328115] [<900000000023ff88>] dump_stack_lvl+0x5c/0x88␍␊
[09:22:50:914] [    4.333607] [<9000000000220c8c>] panic+0x13c/0x358␍␊
[09:22:50:923] [    4.338489] [<900000000029ff3c>] put_cred_rcu+0x134/0x138␍␊
[09:22:50:923] [    4.343976] [<9000000000331ff8>] rcu_do_batch+0x190/0x600␍␊
[09:22:50:930] [    4.347152] ata3: SATA link down (SStatus 0 SControl 300)␍␊
[09:22:50:939] [    4.354941] [<9000000000337ae8>] rcu_core+0x178/0x3c0␍␊
[09:22:50:939] [    4.360077] [<9000000000271ecc>] handle_softirqs+0x12c/0x3b0␍␊
[09:22:50:946] [    4.365815] [<90000000002722c8>] __irq_exit_rcu+0x120/0x158␍␊
[09:22:50:955] [    4.371465] [<9000000001787494>] do_vint+0x7c/0xd0␍␊
[09:22:50:955] [    4.376338] [<90000000002420cc>] __arch_cpu_idle+0xc/0x10␍␊
[09:22:50:962] [    4.381814] [<9000000001789c38>] arch_cpu_idle+0x8/0x30␍␊
[09:22:50:969] [    4.387117] [<9000000001789de0>] default_idle_call+0x20/0x130␍␊
[09:22:50:979] [    4.392938] [<90000000002da2f4>] do_idle+0xb4/0x130␍␊
[09:22:50:979] [    4.397892] [<90000000002da5c0>] cpu_startup_entry+0x38/0x40␍␊
[09:22:50:988] [    4.403624] [<9000000000252970>] start_secondary+0xa8/0xb8␍␊
[09:22:50:988] [    4.409184] [<900000000178a15c>] smpboot_entry+0x64/0x6c␍␊
[09:22:50:995] [    4.414571] ␍␊
[09:22:50:995] [    4.416157] ------------[ cut here ]------------␍␊
[09:22:51:003] [    4.420850] WARNING: CPU: 2 PID: 0 at kernel/smp.c:786 smp_call_function_many_cond+0x670/0x6e8␍␊
[09:22:51:013] [    4.429526] Modules linked in:␍␊
[09:22:51:013] [    4.432666] CPU: 2 PID: 0 Comm: swapper/2 Not tainted 6.6.101-loong64-desktop-hwe #25.01.00.31  ␍␊
[09:22:51:020] [    4.441511] Hardware name: Loongson Loongson-3A6000-HV-7A2000-1w-V0.1-EVB/Loongson-3A6000-HV-7A2000-1w-EVB-V1.21, BIOS Loongson-UDK2018-V4.0.05756-prestab␍␊
[09:22:51:033] [    4.455479] pc 9000000000373620 ra 90000000003736e0 tp 9000000100474000 sp 9000000100263ce0␍␊
[09:22:51:041] [    4.463892] a0 90000000033a49b0 a1 90000000002523d8 a2 0000000000000000 a3 0000000000000000␍␊
[09:22:51:051] [    4.472306] a4 0000000000000000 a5 90000001002639c0 a6 0000000000000001 a7 0000000000000001␍␊
[09:22:51:060] [    4.480719] t0 90000000033a49b0 t1 0000000000000100 t2 0000000000000001 t3 0000000000000103␍␊
[09:22:51:068] [    4.489132] t4 00000000000000ff t5 9000000100cba6e0 t6 ffffffffffffffff t7 0000000000000002␍␊
[09:22:51:077] [    4.497545] t8 0000000000000003 u0 9000000002755220 s9 90000000031a1000 s0 90000000044c17e8␍␊
[09:22:51:087] [    4.505958] s1 0000000000000000 s2 90000000002523d8 s3 90000000033a49b0 s4 9000000002717a58␍␊
[09:22:51:095] [    4.514372] s5 90000000033a5000 s6 0000000000000002 s7 0000000000000002 s8 0000000000000000␍␊
[09:22:51:104] [    4.522788]    ra: 90000000003736e0 smp_call_function+0x38/0x88␍␊
[09:22:51:112] [    4.528784]   ERA: 9000000000373620 smp_call_function_many_cond+0x670/0x6e8␍␊
[09:22:51:122] [    4.535818]  CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)␍␊
[09:22:51:122] [    4.542078]  PRMD: 00000008 (PPLV0 -PIE +PWE)␍␊
[09:22:51:130] [    4.546520]  EUEN: 00000000 (-FPE -SXE -ASXE -BTE)␍␊
[09:22:51:130] [    4.551395]  ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)␍␊
[09:22:51:139] [    4.556269] ESTAT: 000c1800 [BRK] (IS=11-12 ECode=12 EsubCode=0)␍␊
[09:22:51:147] [    4.562355]  PRID: 0014d000 (Loongson-64bit, Loongson-3A6000-HV)␍␊
[09:22:51:147] [    4.568439] CPU: 2 PID: 0 Comm: swapper/2 Not tainted 6.6.101-loong64-desktop-hwe #25.01.00.31  ␍␊
[09:22:51:156] [    4.577293] Hardware name: Loongson Loongson-3A6000-HV-7A2000-1w-V0.1-EVB/Loongson-3A6000-HV-7A2000-1w-EVB-V1.21, BIOS Loongson-UDK2018-V4.0.05756-prestab␍␊
[09:22:51:169] [    4.591283] Stack : 90000000044c1c48 9000000002755220 900000000023ff8c 9000000100474000␍␊
[09:22:51:184] [    4.599368]         9000000100263950 0000000000000000 9000000100263958 9000000002755220␍␊
[09:22:51:193] [    4.607453]         9000000008a319e0 9000000008a319d8 90000001002638a0 0000000000000001␍␊
[09:22:51:193] [    4.615538]         0000000000000001 a8fd0f104f1068ea 0000000008f40000 9000000100595a80␍␊
[09:22:51:210] [    4.623625]         0000000000000001 fffffffffffffffe 9000000100cba650 ffffffffffffffff␍␊
[09:22:51:210] [    4.631712]         0000000000000002 0000000000000003 0000000008f40000 90000000031a1000␍␊
[09:22:51:219] [    4.639801]         90000000031a1000 9000000002755220 0000000000000000 0000000000000009␍␊
[09:22:51:230] [    4.647889]         9000000000373620 0000000000000312 0000000000000002 0000000000000002␍␊
[09:22:51:239] [    4.651201] ata4: SATA link down (SStatus 0 SControl 300)␍␊
[09:22:51:239] [    4.661469]         0000000000000000 9000000002755220 900000000024448c 00007ffff21aa2b3␍␊
[09:22:51:256] [    4.669562]         00000000000002b0 0000000000000008 0000000000000000 0000000000071c1d␍␊
[09:22:51:256] [    4.677654]         ...␍␊
[09:22:51:263] [    4.680213] Call Trace:␍␊
[09:22:51:263] [    4.680214] [<900000000024448c>] show_stack+0x3c/0x150␍␊
[09:22:51:272] [    4.688001] [<900000000023ff88>] dump_stack_lvl+0x5c/0x88␍␊
[09:22:51:272] [    4.693492] [<9000000000268220>] __warn+0x88/0x188␍␊
[09:22:51:280] [    4.698376] [<9000000001752a3c>] report_bug+0x1d4/0x2e0␍␊
[09:22:51:289] [    4.703690] [<9000000001788220>] do_bp+0x1c8/0x408␍␊
[09:22:51:289] [    4.708570] ␍␊
[09:22:51:289] [    4.710159] ---[ end trace 0000000000000000 ]---␍␊
[09:22:51:296] [    4.714867] Rebooting in 30 seconds..␍␊

Fixes: a7369f49fb0a ("HAOC: CREDP: protect commit_creds() from ROP attack.")

## Summary by Sourcery

Bug Fixes:
- Initialize p->cred and p->real_cred in copy_creds when CONFIG_CREDP is disabled to prevent boot-time kernel panic.