### PR TITLE
deepin: KABI: dax: kabi: Reserve KABI slots for dax_* struct

### DIFF
--- a/drivers/dax/super.c
+++ b/drivers/dax/super.c
@@ -33,6 +33,15 @@ struct dax_device {
 	const struct dax_operations *ops;
 	void *holder_data;
 	const struct dax_holder_operations *holder_ops;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 static dev_t dax_devt;

--- a/include/linux/dax.h
+++ b/include/linux/dax.h
@@ -41,6 +41,11 @@ struct dax_operations {
 	 */
 	size_t (*recovery_write)(struct dax_device *dax_dev, pgoff_t pgoff,
 			void *addr, size_t bytes, struct iov_iter *iter);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct dax_holder_operations {
@@ -53,6 +58,10 @@ struct dax_holder_operations {
 	 */
 	int (*notify_failure)(struct dax_device *dax_dev, u64 offset,
 			u64 len, int mf_flags);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 #if IS_ENABLED(CONFIG_DAX)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in dax_* struct for future expansion.

struct			size(byte)	reserve(8*byte) now(byte)
dax_device		768		8		832
dax_operations		32		4		64
dax_holder_operations	8		3		32

## Summary by Sourcery

Reserve additional KABI slots in DAX-related structures to support future ABI compatibility extensions

Enhancements:
- Add KABI reserve slots to struct dax_device for future expansion
- Add KABI reserve slots to struct dax_operations for future expansion
- Add KABI reserve slots to struct dax_holder_operations for future expansion