### PR TITLE
deepin:KABI:nvme: kabi: KABI reservation for nvme_ctrl

### DIFF
--- a/drivers/nvme/host/nvme.h
+++ b/drivers/nvme/host/nvme.h
@@ -409,6 +409,11 @@ struct nvme_ctrl {
 
 	enum nvme_ctrl_type cntrltype;
 	enum nvme_dctype dctype;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static inline enum nvme_ctrl_state nvme_ctrl_state(struct nvme_ctrl *ctrl)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I91DNE

----------------------------------------------------------------------

Reserve KABI for struct nvme_ctrl.

## Summary by Sourcery

New Features:
- Reserve four KABI slots in struct nvme_ctrl to maintain ABI stability