### PR TITLE
deepin: KABI:kabi: reserve space for struct clocksource

### DIFF
--- a/include/linux/clocksource.h
+++ b/include/linux/clocksource.h
@@ -18,6 +18,7 @@
 #include <linux/init.h>
 #include <linux/of.h>
 #include <linux/clocksource_ids.h>
+#include <linux/deepin_kabi.h>
 #include <asm/div64.h>
 #include <asm/io.h>
 
@@ -127,6 +128,11 @@ struct clocksource {
 	u64			wd_last;
 #endif
 	struct module		*owner;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I907UN CVE: NA

-------------------------------

Reserve space for posix clock related structure.

## Summary by Sourcery

Reserve ABI space in struct clocksource for future POSIX clock fields by including deepin_kabi support and adding placeholder slots.

Enhancements:
- Include deepin_kabi.h in clocksource.h to enable ABI reservation macros
- Add four DEEPIN_KABI_RESERVE slots to struct clocksource for POSIX clock compatibility