### PR TITLE
deepin: KABI:kabi: bus_type, device_driver, dev_pm_ops reservation

### DIFF
--- a/include/linux/device/bus.h
+++ b/include/linux/device/bus.h
@@ -107,6 +107,11 @@ struct bus_type {
 	const struct iommu_ops *iommu_ops;
 
 	bool need_parent_lock;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 int __must_check bus_register(const struct bus_type *bus);

--- a/include/linux/pm.h
+++ b/include/linux/pm.h
@@ -308,6 +308,11 @@ struct dev_pm_ops {
 	int (*runtime_suspend)(struct device *dev);
 	int (*runtime_resume)(struct device *dev);
 	int (*runtime_idle)(struct device *dev);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define SYSTEM_SLEEP_PM_OPS(suspend_fn, resume_fn) \


### PR DESCRIPTION
Intel inclusion
category: feature
bugzilla: https://gitee.com/openeuler/intel-kernel/issues/I9193N CVE: NA

--------------------------------

Some base device layer data structures have impact on iommu kabi. Do some kabi reservation for bus_type, device_driver and dev_pm_ops.

## Summary by Sourcery

Add reserved fields to device layer structures to maintain KABI compatibility

Enhancements:
- Reserve four KABI slots in struct bus_type
- Reserve four KABI slots in struct dev_pm_ops