### PR TITLE
deepin: KABI:kabi: reserve space for efi.h

### DIFF
--- a/include/linux/efi.h
+++ b/include/linux/efi.h
@@ -24,6 +24,7 @@
 #include <linux/range.h>
 #include <linux/reboot.h>
 #include <linux/uuid.h>
+#include <linux/deepin_kabi.h>
 
 #include <asm/page.h>
 
@@ -670,6 +671,9 @@ extern struct efi {
 
 	struct efi_memory_map		memmap;
 	unsigned long			flags;
+	
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } efi;
 
 #define EFI_RT_SUPPORTED_GET_TIME				0x0001


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8X87C

--------------------------------

reserve space for efi.h

## Summary by Sourcery

New Features:
- Include deepin_kabi header and reserve KABI slots in efi.h for future compatibility