### PR TITLE
deepin: KABI:exportfs: kabi: Reserve KABI slots for export_operations…

### DIFF
--- a/include/linux/exportfs.h
+++ b/include/linux/exportfs.h
@@ -3,6 +3,7 @@
 #define LINUX_EXPORTFS_H 1
 
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 struct dentry;
 struct iattr;
@@ -225,6 +226,8 @@ struct export_operations {
 						*/
 #define EXPORT_OP_FLUSH_ON_CLOSE	(0x20) /* fs flushes file data on close */
 	unsigned long	flags;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern int exportfs_encode_inode_fh(struct inode *inode, struct fid *fid,


### PR DESCRIPTION
… structure

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZSV8

--------------------------------

export_operations is a structure for registering callback methods and has changed since version 5.10.

Reserve two KABI slots for export_operations by referring to the policy of version 5.10.

## Summary by Sourcery

Reserve two KABI slots in the export_operations structure to maintain ABI compatibility

Enhancements:
- Include deepin_kabi.h in exportfs.h to support KABI reservation
- Add two DEEPIN_KABI_RESERVE slots to export_operations struct for ABI compatibility