### PR TITLE
deepin: KABI:kabi: reserve space for fb.h

### DIFF
--- a/include/linux/fb.h
+++ b/include/linux/fb.h
@@ -17,6 +17,7 @@
 #include <linux/slab.h>
 
 #include <asm/fb.h>
+#include <linux/deepin_kabi.h>
 
 struct vm_area_struct;
 struct fb_info;
@@ -218,6 +219,8 @@ struct fb_deferred_io {
 	struct list_head pagereflist; /* list of pagerefs for touched pages */
 	/* callback */
 	void (*deferred_io)(struct fb_info *info, struct list_head *pagelist);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #endif
 
@@ -501,6 +504,10 @@ struct fb_info {
 	void *par;
 
 	bool skip_vt_switch; /* no VT switch on suspend/resume required */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* This will go away


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8X87C

--------------------------------

reserve space for fb.h

## Summary by Sourcery

Reserve additional space in framebuffer core structures and include deepin_kabi.h to maintain binary compatibility for deepin KABI

Enhancements:
- Include deepin_kabi.h in include/linux/fb.h
- Reserve extra fields in fb_deferred_io for deepin KABI compatibility
- Reserve extra fields in fb_info for deepin KABI compatibility