### PR TITLE
deepin: KABI:fscrypt: kabi: Reserve KABI slots for fscrypt_operations…

### DIFF
--- a/include/linux/fscrypt.h
+++ b/include/linux/fscrypt.h
@@ -176,6 +176,10 @@ struct fscrypt_operations {
 	 */
 	struct block_device **(*get_devices)(struct super_block *sb,
 					     unsigned int *num_devs);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 static inline struct fscrypt_info *fscrypt_get_info(const struct inode *inode)


### PR DESCRIPTION
… struct

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in fscrypt_operations struct for future expansion.

struct			size(byte)	reserve(8*byte) now(byte)
fscrypt_operations	72		3		96

## Summary by Sourcery

Enhancements:
- Reserve three Deepin KABI slots in fscrypt_operations struct for future extension