### PR TITLE
deepin: KABI:fanotify: kabi: Reserve KABI slots for fsnotify_* struct

### DIFF
--- a/include/linux/fsnotify_backend.h
+++ b/include/linux/fsnotify_backend.h
@@ -165,6 +165,9 @@ struct fsnotify_ops {
 	void (*free_event)(struct fsnotify_group *group, struct fsnotify_event *event);
 	/* called on final put+free to free memory */
 	void (*free_mark)(struct fsnotify_mark *mark);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*
@@ -174,6 +177,8 @@ struct fsnotify_ops {
  */
 struct fsnotify_event {
 	struct list_head list;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*
@@ -255,6 +260,15 @@ struct fsnotify_group {
 		} fanotify_data;
 #endif /* CONFIG_FANOTIFY */
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /*


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in fsnotify_* struct for future expansion.

struct			size(byte)	reserve(8*byte) now(byte)
fsnotify_ops		48		2		64
fsnotify_event		16		2		32
fsnotify_group		320		8		384

## Summary by Sourcery

Reserve additional KABI slots in fsnotify structures for future expansion

New Features:
- Reserve 2 KABI slots in fsnotify_ops struct
- Reserve 2 KABI slots in fsnotify_event struct
- Reserve 8 KABI slots in fsnotify_group struct