### PR TITLE
deepin: KABI:irq_desc: Add kabi_reserve in irq_desc

### DIFF
--- a/include/linux/irqdesc.h
+++ b/include/linux/irqdesc.h
@@ -5,7 +5,7 @@
 #include <linux/rcupdate.h>
 #include <linux/kobject.h>
 #include <linux/mutex.h>
-
+#include <linux/deepin_kabi.h>
 /*
  * Core internal functions to deal with irq descriptors
  */
@@ -105,6 +105,8 @@ struct irq_desc {
 #ifdef CONFIG_HARDIRQS_SW_RESEND
 	struct hlist_node	resend_node;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } ____cacheline_internodealigned_in_smp;
 
 #ifdef CONFIG_SPARSE_IRQ


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add DEEPIN_KABI_RESERVE in irq_desc



conflict:
	include/linux/irqdesc.h

## Summary by Sourcery

Add Deepin KABI reserve slots to the irq_desc structure and include the necessary header to support the macros

Enhancements:
- Include the deepin_kabi.h header in irqdesc for KABI support
- Add two DEEPIN_KABI_RESERVE slots in the irq_desc struct to maintain Deepin kernel ABI compatibility