### PR TITLE
deepin: KABI:kabi: reserve space for struct irq_work

### DIFF
--- a/include/linux/irq_work.h
+++ b/include/linux/irq_work.h
@@ -4,6 +4,7 @@
 
 #include <linux/smp_types.h>
 #include <linux/rcuwait.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * An entry can be in one of four states:
@@ -18,6 +19,10 @@ struct irq_work {
 	struct __call_single_node node;
 	void (*func)(struct irq_work *);
 	struct rcuwait irqwait;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define __IRQ_WORK_INIT(_func, _flags) (struct irq_work){	\


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8YRD2

--------------------------------

reserve space for struct irq_work

## Summary by Sourcery

Enhancements:
- Add DEEPIN_KABI_RESERVE(1-4) fields to struct irq_work for ABI compatibility