### PR TITLE
deepin: KABI:jbd2: kabi: KABI reservation for jbd2

### DIFF
--- a/include/linux/jbd2.h
+++ b/include/linux/jbd2.h
@@ -443,6 +443,9 @@ struct jbd2_inode {
 	 * ends. [j_list_lock]
 	 */
 	loff_t i_dirty_end;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct jbd2_revoke_table_s;
@@ -501,6 +504,8 @@ struct jbd2_journal_handle
 	unsigned int		h_requested_credits;
 
 	unsigned int		saved_alloc_context;
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 
@@ -512,6 +517,9 @@ struct transaction_chp_stats_s {
 	__u32			cs_forced_to_close;
 	__u32			cs_written;
 	__u32			cs_dropped;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* The transaction_t type is the guts of the journaling mechanism.  It
@@ -706,6 +714,11 @@ struct transaction_s
 	 * structures associated with the transaction
 	 */
 	struct list_head	t_private_list;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct transaction_run_stats_s {
@@ -1298,6 +1311,13 @@ struct journal_s
 	 * VFS bmap function.
 	 */
 	int (*j_bmap)(struct journal_s *journal, sector_t *block);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 #define jbd2_might_wait_for_commit(j) \
@@ -1474,6 +1494,9 @@ struct jbd2_buffer_trigger_type {
 	 */
 	void (*t_abort)(struct jbd2_buffer_trigger_type *type,
 			struct buffer_head *bh);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern void jbd2_buffer_frozen_trigger(struct journal_head *jh,

--- a/include/linux/journal-head.h
+++ b/include/linux/journal-head.h
@@ -109,6 +109,9 @@ struct journal_head {
 
 	/* Trigger type for the committing transaction's frozen data */
 	struct jbd2_buffer_trigger_type *b_frozen_triggers;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif		/* JOURNAL_HEAD_H_INCLUDED */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I918VT

----------------------------------------------------------------------

    structure                size reserves reserved

    jbd2_inode               64      2      80
    jbd2_journal_handle      56      1      64
    transaction_chp_stats_s  24      2      40
    transaction_s            208     4(+2)  256
    journal_s                1488    6      1536
    jbd2_buffer_trigger_type 16      2      32
    journal_head             112     2      128

## Summary by Sourcery

New Features:
- Add DEEPIN_KABI_RESERVE slots to jbd2_inode, jbd2_journal_handle, transaction_chp_stats_s, transaction_s, journal_s, jbd2_buffer_trigger_type, and journal_head structures