### PR TITLE
deepin: KABI:ata: libata: reserve space for structures in libata

### DIFF
--- a/include/linux/libata.h
+++ b/include/linux/libata.h
@@ -23,6 +23,7 @@
 #include <linux/cdrom.h>
 #include <linux/sched.h>
 #include <linux/async.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Define if arch has non-standard setup.  This is a _PCI_ standard
@@ -550,6 +551,11 @@ struct ata_taskfile {
 	u32			auxiliary;	/* auxiliary field */
 						/* from SATA 3.1 and */
 						/* ATA-8 ACS-3 */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #ifdef CONFIG_ATA_SFF
@@ -729,6 +735,14 @@ struct ata_device {
 	int			spdn_cnt;
 	/* ering is CLEAR_END, read comment above CLEAR_END */
 	struct ata_ering	ering;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
 };
 
 /* Fields between ATA_DEVICE_CLEAR_BEGIN and ATA_DEVICE_CLEAR_END are
@@ -800,6 +814,15 @@ struct ata_link {
 	struct ata_device	device[ATA_MAX_DEVICES];
 
 	unsigned long		last_lpm_change; /* when last LPM change happened */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+
 };
 #define ATA_LINK_CLEAR_BEGIN		offsetof(struct ata_link, active_tag)
 #define ATA_LINK_CLEAR_END		offsetof(struct ata_link, device[0])
@@ -878,6 +901,15 @@ struct ata_port {
 	/* owned by EH */
 	u8			*ncq_sense_buf;
 	u8			sector_buf[ATA_SECT_SIZE] ____cacheline_aligned;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /* The following initializer overrides a method to NULL whether one of
@@ -982,6 +1014,10 @@ struct ata_port_operations {
 	ssize_t (*transmit_led_message)(struct ata_port *ap, u32 state,
 					ssize_t size);
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 	/*
 	 * ->inherits must be the last field and all the preceding
 	 * fields must be pointers.
@@ -997,6 +1033,9 @@ struct ata_port_info {
 	unsigned int		udma_mask;
 	struct ata_port_operations *port_ops;
 	void 			*private_data;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct ata_timing {


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZUL1

--------------------------------

Reserve space for structure ata_taskfile/ata_device/ata_port/ ata_port_operations/ata_port_info.

## Summary by Sourcery

Import deepin_kabi header and insert DEEPIN_KABI_RESERVE slots into key libata structures for future ABI extension stability.

Enhancements:
- Add linux/deepin_kabi.h include to libata header
- Reserve padding fields in ata_taskfile, ata_device, ata_link, ata_port, ata_port_operations, and ata_port_info structures to maintain KABI compatibility