### PR TITLE
deepin: KABI:libnvdimm: reserve space for structures in libnvdimm

### DIFF
--- a/include/linux/libnvdimm.h
+++ b/include/linux/libnvdimm.h
@@ -12,6 +12,7 @@
 #include <linux/uuid.h>
 #include <linux/spinlock.h>
 #include <linux/bio.h>
+#include <linux/deepin_kabi.h>
 
 struct badrange_entry {
 	u64 start;
@@ -136,6 +137,9 @@ struct nd_region_desc {
 	int memregion;
 	struct device_node *of_node;
 	int (*flush)(struct nd_region *nd_region, struct bio *bio);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct device;
@@ -193,6 +197,11 @@ struct nvdimm_security_ops {
 	int (*query_overwrite)(struct nvdimm *nvdimm);
 	int (*disable_master)(struct nvdimm *nvdimm,
 			      const struct nvdimm_key_data *key_data);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 enum nvdimm_fwa_state {

--- a/include/linux/nd.h
+++ b/include/linux/nd.h
@@ -9,6 +9,7 @@
 #include <linux/device.h>
 #include <linux/badblocks.h>
 #include <linux/perf_event.h>
+#include <linux/deepin_kabi.h>
 
 enum nvdimm_event {
 	NVDIMM_REVALIDATE_POISON,
@@ -54,6 +55,12 @@ struct nvdimm_pmu {
 	enum cpuhp_state cpuhp_state;
 	/* cpumask provided by arch/platform specific code */
 	struct cpumask arch_cpumask;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 };
 
 struct platform_device;
@@ -82,6 +89,9 @@ struct nd_device_driver {
 	void (*remove)(struct device *dev);
 	void (*shutdown)(struct device *dev);
 	void (*notify)(struct device *dev, enum nvdimm_event event);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct nd_device_driver *to_nd_device_driver(
@@ -142,6 +152,9 @@ struct nd_namespace_pmem {
 	char *alt_name;
 	uuid_t *uuid;
 	int id;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct nd_namespace_io *to_nd_namespace_io(const struct device *dev)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZUL1

--------------------------------

Reserve space for structure nd_region_desc/nvdimm_security_ops/nvdimm_pmu/ nd_device_driver/nd_namespace_pmem.

## Summary by Sourcery

Reserve deepin KABI slots in various libnvdimm structures to maintain ABI compatibility

Enhancements:
- Include deepin_kabi.h in include/linux/nd.h and include/linux/libnvdimm.h
- Add DEEPIN_KABI_RESERVE fields to nvdimm_pmu, nd_device_driver, and nd_namespace_pmem structures
- Add DEEPIN_KABI_RESERVE fields to nd_region_desc and nvdimm_security_ops structures