### PR TITLE
deepin: KABI:mmc: kabi: KABI reservation for mmc

### DIFF
--- a/include/linux/mmc/card.h
+++ b/include/linux/mmc/card.h
@@ -9,6 +9,7 @@
 
 #include <linux/device.h>
 #include <linux/mod_devicetable.h>
+#include <linux/deepin_kabi.h>
 
 struct mmc_cid {
 	unsigned int		manfid;
@@ -126,6 +127,8 @@ struct mmc_ext_csd {
 	u8			device_life_time_est_typ_b;	/* 269 */
 
 	unsigned int            feature_support;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 #define MMC_DISCARD_FEATURE	BIT(0)                  /* CMD38 feature */
 };
 
@@ -343,6 +346,9 @@ struct mmc_card {
 	unsigned int    nr_parts;
 
 	struct workqueue_struct *complete_wq;	/* Private workqueue */
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline bool mmc_large_sector(struct mmc_card *card)

--- a/include/linux/mmc/host.h
+++ b/include/linux/mmc/host.h
@@ -16,6 +16,7 @@
 #include <linux/mmc/pm.h>
 #include <linux/dma-direction.h>
 #include <linux/blk-crypto-profile.h>
+#include <linux/deepin_kabi.h>
 
 struct mmc_ios {
 	unsigned int	clock;			/* clock rate */
@@ -78,6 +79,8 @@ struct mmc_ios {
 #define MMC_SET_DRIVER_TYPE_D	3
 
 	bool enhanced_strobe;			/* hs400es selection */
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct mmc_clk_phase {
@@ -218,6 +221,8 @@ struct mmc_host_ops {
 
 	/* Initialize an SD express card, mandatory for MMC_CAP2_SD_EXP. */
 	int	(*init_sd_express)(struct mmc_host *host, struct mmc_ios *ios);
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct mmc_cqe_ops {
@@ -528,6 +533,9 @@ struct mmc_host {
 	bool			hsq_enabled;
 
 	u32			err_stats[MMC_ERR_MAX];
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	unsigned long		private[] ____cacheline_aligned;
 };
 


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8T231

--------------------------------

Reserve space for mmc module in advance to prepare for merging new feature in the future.

## Summary by Sourcery

Enhancements:
- Add DEEPIN_KABI_RESERVE placeholders to mmc_ios, mmc_host_ops, mmc_host, mmc_ext_csd, and mmc_card structures for KABI compatibility