### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: KABI: reserve space for cpu cgroup and cpuset cgroup related …

### DIFF
--- a/kernel/cgroup/cpuset.c
+++ b/kernel/cgroup/cpuset.c
@@ -44,6 +44,7 @@
 #include <linux/sched/isolation.h>
 #include <linux/cgroup.h>
 #include <linux/wait.h>
+#include <linux/deepin_kabi.h>
 
 DEFINE_STATIC_KEY_FALSE(cpusets_pre_enable_key);
 DEFINE_STATIC_KEY_FALSE(cpusets_enabled_key);
@@ -184,6 +185,11 @@ struct cpuset {
 
 	/* Handle for cpuset.cpus.partition */
 	struct cgroup_file partition_file;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -68,6 +68,7 @@
 #include <linux/wait_api.h>
 #include <linux/wait_bit.h>
 #include <linux/workqueue_api.h>
+#include <linux/deepin_kabi.h>
 
 #include <trace/events/power.h>
 #include <trace/events/sched.h>
@@ -422,6 +423,14 @@ struct task_group {
 	struct uclamp_se	uclamp[UCLAMP_CNT];
 #endif
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 #ifdef CONFIG_FAIR_GROUP_SCHED


### PR DESCRIPTION
…structures

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8SWPP

---------------------------------------------

We reserve some fields beforehand for cpu cgroup and cpuset related structures prone to change, therefore, we can hot add/change features of cpu cgroup cpuset and cgroup with this enhancement.

After reserving, normally cache does not matter as the reserved fields are not accessed at all.

## Summary by Sourcery

Reserve KABI-compatible placeholder fields in task_group and cpuset structures to support hot-adding or changing cpu cgroup and cpuset features without ABI breaks

Enhancements:
- Add DEEPIN_KABI_RESERVE slots to task_group for future cpu cgroup feature extensions
- Add DEEPIN_KABI_RESERVE slots to cpuset struct for future cpuset feature extensions
- Include linux/deepin_kabi.h in sched.h and cpuset.c