### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: KABI: writeback: kabi: KABI reservation for writeback

### DIFF
--- a/include/linux/backing-dev-defs.h
+++ b/include/linux/backing-dev-defs.h
@@ -63,6 +63,9 @@ enum wb_reason {
 struct wb_completion {
 	atomic_t		cnt;
 	wait_queue_head_t	*waitq;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define __WB_COMPLETION_INIT(_waitq)	\
@@ -158,6 +161,13 @@ struct bdi_writeback {
 		struct rcu_head rcu;
 	};
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
 };
 
 struct backing_dev_info {
@@ -201,6 +211,11 @@ struct backing_dev_info {
 #ifdef CONFIG_DEBUG_FS
 	struct dentry *debug_dir;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 struct wb_lock_cookie {

--- a/include/linux/writeback.h
+++ b/include/linux/writeback.h
@@ -89,6 +89,10 @@ struct writeback_control {
 	size_t wb_lcand_bytes;		/* bytes written by last candidate */
 	size_t wb_tcand_bytes;		/* bytes written by this candidate */
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 static inline blk_opf_t wbc_to_write_flags(struct writeback_control *wbc)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I9170A

----------------------------------------------------------------------

    structure            size reserves reserved

    wb_completion        16      2      32
    bdi_writeback        784     6      832
    backing_dev_info     1184    4      1216
    writeback_control    104     3      128

## Summary by Sourcery

New Features:
- Add DEEPIN_KABI_RESERVE slots to wb_completion, bdi_writeback, backing_dev_info, and writeback_control structs