### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: KABI: tty: KABI reservation for tty

### DIFF
--- a/include/linux/tty.h
+++ b/include/linux/tty.h
@@ -15,6 +15,7 @@
 #include <uapi/linux/tty.h>
 #include <linux/rwsem.h>
 #include <linux/llist.h>
+#include <linux/deepin_kabi.h>
 
 
 /*
@@ -248,6 +249,12 @@ struct tty_struct {
 
 #define N_TTY_BUF_SIZE 4096
 	struct work_struct SAK_work;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 } __randomize_layout;
 
 /* Each of a tty's open files has private_data pointing to tty_file_private */

--- a/include/linux/tty_buffer.h
+++ b/include/linux/tty_buffer.h
@@ -6,6 +6,7 @@
 #include <linux/llist.h>
 #include <linux/mutex.h>
 #include <linux/workqueue.h>
+#include <linux/deepin_kabi.h>
 
 struct tty_buffer {
 	union {
@@ -18,6 +19,8 @@ struct tty_buffer {
 	unsigned int lookahead;		/* Lazy update on recv, can become less than "read" */
 	unsigned int read;
 	bool flags;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 	/* Data points here */
 	u8 data[] __aligned(sizeof(unsigned long));
 };
@@ -42,6 +45,8 @@ struct tty_bufhead {
 	atomic_t	   mem_used;    /* In-use buffers excluding free list */
 	int		   mem_limit;
 	struct tty_buffer *tail;	/* Active buffer */
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /*

--- a/include/linux/tty_driver.h
+++ b/include/linux/tty_driver.h
@@ -10,6 +10,7 @@
 #include <linux/uaccess.h>
 #include <linux/termios.h>
 #include <linux/seq_file.h>
+#include <linux/deepin_kabi.h>
 
 struct tty_struct;
 struct tty_driver;
@@ -399,6 +400,8 @@ struct tty_operations {
 	void (*poll_put_char)(struct tty_driver *driver, int line, char ch);
 #endif
 	int (*proc_show)(struct seq_file *m, void *driver);
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 } __randomize_layout;
 
 /**

--- a/include/linux/tty_ldisc.h
+++ b/include/linux/tty_ldisc.h
@@ -10,6 +10,7 @@ struct tty_struct;
 #include <linux/list.h>
 #include <linux/lockdep.h>
 #include <linux/seq_file.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * the semaphore definition
@@ -264,6 +265,8 @@ struct tty_ldisc_ops {
 				 const u8 *fp, size_t count);
 
 	struct  module *owner;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct tty_ldisc {

--- a/include/linux/tty_port.h
+++ b/include/linux/tty_port.h
@@ -7,6 +7,7 @@
 #include <linux/mutex.h>
 #include <linux/tty_buffer.h>
 #include <linux/wait.h>
+#include <linux/deepin_kabi.h>
 
 struct attribute_group;
 struct tty_driver;
@@ -121,6 +122,8 @@ struct tty_port {
 	int			drain_delay;
 	struct kref		kref;
 	void			*client_data;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /* tty_port::iflags bits -- use atomic bit ops */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8T231

--------------------------------

Reserve space for tty module in advance to prepare for merging new feature in the future.

## Summary by Sourcery

Reserve KABI padding in tty core structures by adding DEEPIN_KABI_RESERVE fields and including the deepin_kabi.h header to ensure ABI compatibility for future enhancements

Enhancements:
- Reserve DEEPIN_KABI slots in various tty-related structs to prep for future feature additions
- Include deepin_kabi.h in tty headers to enable KABI reservations