### PR TITLE
deepin: KABI:KABI: Reserve space for struct module

### DIFF
--- a/include/linux/module.h
+++ b/include/linux/module.h
@@ -590,6 +590,10 @@ struct module {
 #ifdef CONFIG_DYNAMIC_DEBUG_CORE
 	struct _ddebug_info dyndbg_info;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } ____cacheline_aligned __randomize_layout;
 #ifndef MODULE_ARCH_INIT
 #define MODULE_ARCH_INIT {}


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZJI8 CVE: NA

-------------------------------

Reserve space for struct module.

## Summary by Sourcery

Enhancements:
- Add four DEEPIN_KABI_RESERVE slots to struct module for future KABI extensions.