### PR TITLE
deepin: KABI:kabi: reserve space for hrtimer related structures

### DIFF
--- a/include/linux/hrtimer.h
+++ b/include/linux/hrtimer.h
@@ -20,6 +20,7 @@
 #include <linux/seqlock.h>
 #include <linux/timer.h>
 #include <linux/timerqueue.h>
+#include <linux/deepin_kabi.h>
 
 struct hrtimer_clock_base;
 struct hrtimer_cpu_base;
@@ -124,6 +125,9 @@ struct hrtimer {
 	u8				is_rel;
 	u8				is_soft;
 	u8				is_hard;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -165,6 +169,9 @@ struct hrtimer_clock_base {
 	struct timerqueue_head	active;
 	ktime_t			(*get_time)(void);
 	ktime_t			offset;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } __hrtimer_clock_base_align;
 
 enum  hrtimer_base_type {
@@ -238,6 +245,9 @@ struct hrtimer_cpu_base {
 	struct hrtimer			*softirq_next_timer;
 	struct hrtimer_clock_base	clock_base[HRTIMER_MAX_CLOCK_BASES];
 	call_single_data_t		csd;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } ____cacheline_aligned;
 
 static inline void hrtimer_set_expires(struct hrtimer *timer, ktime_t time)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I9083Y CVE: NA

-------------------------------

Reserve space for hrtimer related structures.

## Summary by Sourcery

Reserve space in high-resolution timer structures to maintain deepin KABI compatibility by including the deepin_kabi header and inserting reserved fields.

Enhancements:
- Add DEEPIN_KABI_RESERVE fields to hrtimer, hrtimer_clock_base, and hrtimer_cpu_base structures for KABI compatibility
- Include <linux/deepin_kabi.h> in hrtimer.h