### PR TITLE
TEST

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,7 @@
+
+
+
+
 The Linux Kernel is provided under:
 
 	SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note


### PR DESCRIPTION
Fixes: 1026392d10af ("selftests: ALSA: Cover userspace-driven timers with test")
Reported-by: Jun Zhan <zhanjun@uniontech.com>

Link: https://patch.msgid.link/DE4D931FCF54F3DB+20250731100222.65748-1-wangyuli@uniontech.com

## Summary by Sourcery

Documentation:
- Refresh license text in COPYING file