### PR TITLE
deepin: KABI:scsi: scsi_transport_fc: kabi: KABI reservation for scsi…

### DIFF
--- a/include/scsi/scsi_transport_fc.h
+++ b/include/scsi/scsi_transport_fc.h
@@ -383,6 +383,27 @@ struct fc_rport {	/* aka fc_starget_attrs */
  	struct work_struct stgt_delete_work;
 	struct work_struct rport_delete_work;
 	struct request_queue *rqst_q;	/* bsg support */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
+	DEEPIN_KABI_RESERVE(10)
+	DEEPIN_KABI_RESERVE(11)
+	DEEPIN_KABI_RESERVE(12)
+	DEEPIN_KABI_RESERVE(13)
+	DEEPIN_KABI_RESERVE(14)
+	DEEPIN_KABI_RESERVE(15)
+	DEEPIN_KABI_RESERVE(16)
+	DEEPIN_KABI_RESERVE(17)
+	DEEPIN_KABI_RESERVE(18)
+	DEEPIN_KABI_RESERVE(19)
+	DEEPIN_KABI_RESERVE(20)
 } __attribute__((aligned(sizeof(unsigned long))));
 
 /* bit field values for struct fc_rport "flags" field: */
@@ -765,6 +786,15 @@ struct fc_function_template {
 	unsigned long	show_host_system_hostname:1;
 
 	unsigned long	disable_target_scan:1;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 /**


### PR DESCRIPTION
…_transport_fc

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I910BZ

--------------------------------

Reserve KABI for file scsi_transport_fc.h.

## Summary by Sourcery

Reserve KABI slots in scsi_transport_fc to maintain ABI compatibility for deepin

Enhancements:
- Add 20 DEEPIN_KABI_RESERVE entries to the fc_rport structure
- Add 8 DEEPIN_KABI_RESERVE entries to the fc_function_template structure