### PR TITLE
deepin: KABI:tlb: reserve fields for struct mmu_gather

### DIFF
--- a/include/asm-generic/tlb.h
+++ b/include/asm-generic/tlb.h
@@ -14,6 +14,7 @@
 #include <linux/mmu_notifier.h>
 #include <linux/swap.h>
 #include <linux/hugetlb_inline.h>
+#include <linux/deepin_kabi.h>
 #include <asm/tlbflush.h>
 #include <asm/cacheflush.h>
 
@@ -348,6 +349,8 @@ struct mmu_gather {
 	unsigned int page_size;
 #endif
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 void tlb_flush_mmu(struct mmu_gather *tlb);


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8YJQK

--------------------------------

reserve fields for struct mmu_gather.

## Summary by Sourcery

Reserve two KABI fields in the mmu_gather structure to maintain ABI stability by including the deekabi header and adding DEEPIN_KABI_RESERVE slots.

Enhancements:
- Include the linux/deekabi header to support KABI reserve macros
- Add two DEEPIN_KABI_RESERVE fields to struct mmu_gather for future API compatibility