### PR TITLE
deepin: KABI:scsi: reserve space for structures in scsi

### DIFF
--- a/include/scsi/libfc.h
+++ b/include/scsi/libfc.h
@@ -12,6 +12,7 @@
 #include <linux/if.h>
 #include <linux/percpu.h>
 #include <linux/refcount.h>
+#include <linux/deepin_kabi.h>
 
 #include <scsi/scsi_transport.h>
 #include <scsi/scsi_transport_fc.h>
@@ -358,6 +359,9 @@ struct libfc_cmd_priv {
 	struct fc_fcp_pkt *fsp;
 	u32 resid_len;
 	u8 status;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*

--- a/include/scsi/libfcoe.h
+++ b/include/scsi/libfcoe.h
@@ -16,6 +16,7 @@
 #include <linux/workqueue.h>
 #include <linux/local_lock.h>
 #include <linux/random.h>
+#include <linux/deepin_kabi.h>
 #include <scsi/fc/fc_fcoe.h>
 #include <scsi/libfc.h>
 #include <scsi/fcoe_sysfs.h>
@@ -329,6 +330,9 @@ struct fcoe_percpu_s {
 	struct page *crc_eof_page;
 	int crc_eof_offset;
 	local_lock_t lock;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**

--- a/include/scsi/libiscsi.h
+++ b/include/scsi/libiscsi.h
@@ -17,6 +17,7 @@
 #include <linux/workqueue.h>
 #include <linux/kfifo.h>
 #include <linux/refcount.h>
+#include <linux/deepin_kabi.h>
 #include <scsi/iscsi_proto.h>
 #include <scsi/iscsi_if.h>
 #include <scsi/scsi_cmnd.h>
@@ -133,6 +134,12 @@ struct iscsi_task {
 	refcount_t		refcount;
 	struct list_head	running;	/* running cmd list */
 	void			*dd_data;	/* driver/transport data */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 };
 
 static inline int iscsi_task_has_unsol_data(struct iscsi_task *task)
@@ -156,6 +163,9 @@ static inline bool iscsi_task_is_completed(struct iscsi_task *task)
 struct iscsi_cmd {
 	struct iscsi_task	*task;
 	int			age;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct iscsi_cmd *iscsi_cmd(struct scsi_cmnd *cmd)
@@ -256,6 +266,17 @@ struct iscsi_conn {
 	/* custom statistics */
 	uint32_t		eh_abort_cnt;
 	uint32_t		fmr_unalign_cnt;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
+	DEEPIN_KABI_RESERVE(10)
 };
 
 struct iscsi_pool {
@@ -363,6 +384,15 @@ struct iscsi_session {
 	struct iscsi_task	**cmds;		/* Original Cmds arr */
 	struct iscsi_pool	cmdpool;	/* PDU's pool */
 	void			*dd_data;	/* LLD private data */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 enum {
@@ -383,6 +413,10 @@ struct iscsi_host {
 	int			state;
 
 	struct workqueue_struct	*workq;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 /*

--- a/include/scsi/scsi_cmnd.h
+++ b/include/scsi/scsi_cmnd.h
@@ -9,6 +9,7 @@
 #include <linux/types.h>
 #include <linux/timer.h>
 #include <linux/scatterlist.h>
+#include <linux/deepin_kabi.h>
 #include <scsi/scsi_device.h>
 
 struct Scsi_Host;
@@ -141,6 +142,9 @@ struct scsi_cmnd {
 					 * to be at an address < 16Mb). */
 
 	int result;		/* Status code from lower level driver */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* Variant of blk_mq_rq_from_pdu() that verifies the type of its argument. */

--- a/include/scsi/scsi_device.h
+++ b/include/scsi/scsi_device.h
@@ -9,6 +9,7 @@
 #include <scsi/scsi.h>
 #include <linux/atomic.h>
 #include <linux/sbitmap.h>
+#include <linux/deepin_kabi.h>
 
 struct bsg_device;
 struct device;
@@ -280,6 +281,15 @@ struct scsi_device {
 	struct mutex		state_mutex;
 	enum scsi_device_state sdev_state;
 	struct task_struct	*quiesced_by;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 	unsigned long		sdev_data[];
 } __attribute__((aligned(sizeof(unsigned long))));
 
@@ -366,6 +376,17 @@ struct scsi_target {
 	char			scsi_level;
 	enum scsi_target_state	state;
 	void 			*hostdata; /* available to low-level driver */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
+
 	unsigned long		starget_data[]; /* for the transport */
 	/* starget_data must be the last element!!!! */
 } __attribute__((aligned(sizeof(unsigned long))));
@@ -494,6 +515,8 @@ struct scsi_exec_args {
 	blk_mq_req_flags_t req_flags;	/* BLK_MQ_REQ flags */
 	int scmd_flags;			/* SCMD flags */
 	int *resid;			/* residual length */
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 int scsi_execute_cmd(struct scsi_device *sdev, const unsigned char *cmd,

--- a/include/scsi/scsi_dh.h
+++ b/include/scsi/scsi_dh.h
@@ -11,6 +11,7 @@
  */
 
 #include <scsi/scsi_device.h>
+#include <linux/deepin_kabi.h>
 
 enum {
 	SCSI_DH_OK = 0,
@@ -60,6 +61,9 @@ struct scsi_device_handler {
 	blk_status_t (*prep_fn)(struct scsi_device *, struct request *);
 	int (*set_params)(struct scsi_device *, const char *);
 	void (*rescan)(struct scsi_device *);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #ifdef CONFIG_SCSI_DH

--- a/include/scsi/scsi_driver.h
+++ b/include/scsi/scsi_driver.h
@@ -4,6 +4,7 @@
 
 #include <linux/blk_types.h>
 #include <linux/device.h>
+#include <linux/deepin_kabi.h>
 #include <scsi/scsi_cmnd.h>
 
 struct module;
@@ -19,6 +20,9 @@ struct scsi_driver {
 	int (*done)(struct scsi_cmnd *);
 	int (*eh_action)(struct scsi_cmnd *, int);
 	void (*eh_reset)(struct scsi_cmnd *);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #define to_scsi_driver(drv) \
 	container_of((drv), struct scsi_driver, gendrv)

--- a/include/scsi/scsi_eh.h
+++ b/include/scsi/scsi_eh.h
@@ -3,6 +3,7 @@
 #define _SCSI_SCSI_EH_H
 
 #include <linux/scatterlist.h>
+#include <linux/deepin_kabi.h>
 
 #include <scsi/scsi_cmnd.h>
 #include <scsi/scsi_common.h>
@@ -41,6 +42,9 @@ struct scsi_eh_save {
 	unsigned char cmnd[32];
 	struct scsi_data_buffer sdb;
 	struct scatterlist sense_sgl;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern void scsi_eh_prep_cmnd(struct scsi_cmnd *scmd,

--- a/include/scsi/scsi_host.h
+++ b/include/scsi/scsi_host.h
@@ -9,6 +9,7 @@
 #include <linux/mutex.h>
 #include <linux/seq_file.h>
 #include <linux/blk-mq.h>
+#include <linux/deepin_kabi.h>
 #include <scsi/scsi.h>
 
 struct block_device;
@@ -497,6 +498,11 @@ struct scsi_host_template {
 
 	/* Delay for runtime autosuspend */
 	int rpm_autosuspend_delay;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*
@@ -710,6 +716,15 @@ struct Scsi_Host {
 	 */
 	struct device *dma_dev;
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
+	DEEPIN_KABI_RESERVE(9)
 	/*
 	 * We should ensure that this is aligned, both for better performance
 	 * and also because some compilers (m68k) don't automatically force


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZUL1

--------------------------------

Reserve space for structure libfc_cmd_priv/fcoe_percpu_s/iscsi_task/ iscsi_cmd/iscsi_conn/iscsi_session/iscsi_host/scsi_cmnd/scsi_device/ scsi_exec_args/scsi_device_handler/scsi_driver/scsi_eh_save/ scsi_host_template/Scsi_Host/scsi_target.

## Summary by Sourcery

Introduce KABI compatibility padding to the SCSI subsystem by reserving fields in core scsi, iscsi, libfc, and libfcoe structures

New Features:
- Add DEEPIN_KABI_RESERVE padding fields to scsi, iscsi, libfc, libfcoe, and related structures to maintain kernel binary interface

Enhancements:
- Include linux/deepin_kabi.h in relevant SCSI header files