### PR TITLE
deepin: KABI:fs: kabi: Reserve KABI slots for nameidata struct

### DIFF
--- a/fs/namei.c
+++ b/fs/namei.c
@@ -587,6 +587,8 @@ struct nameidata {
 	int		dfd;
 	vfsuid_t	dir_vfsuid;
 	umode_t		dir_mode;
+
+	DEEPIN_KABI_RESERVE(1)
 } __randomize_layout;
 
 #define ND_ROOT_PRESET 1


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in nameidata struct for future expansion.

struct			size(byte)	reserve(8*byte)	now(byte)
nameidata		232		1		240

## Summary by Sourcery

New Features:
- Reserve an 8-byte KABI slot in the nameidata struct for future expansion