### PR TITLE
deepin: KABI:elevator: reserve space for structures in elevator

### DIFF
--- a/block/elevator.h
+++ b/block/elevator.h
@@ -4,6 +4,7 @@
 
 #include <linux/percpu.h>
 #include <linux/hashtable.h>
+#include <linux/deepin_kabi.h>
 #include "blk-mq.h"
 
 struct io_cq;
@@ -48,6 +49,15 @@ struct elevator_mq_ops {
 	struct request *(*next_request)(struct request_queue *, struct request *);
 	void (*init_icq)(struct io_cq *);
 	void (*exit_icq)(struct io_cq *);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 #define ELV_NAME_MAX	(16)
@@ -84,6 +94,11 @@ struct elevator_type
 	/* managed by elevator core */
 	char icq_cache_name[ELV_NAME_MAX + 6];	/* elvname + "_io_cq" */
 	struct list_head list;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static inline bool elevator_tryget(struct elevator_type *e)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZUL1

--------------------------------

Reserve space for struct elevator_mq_ops/elevator_type.

## Summary by Sourcery

Reserve deepin KABI compatibility slots in elevator structures to allow future expansion without ABI breakage.

Enhancements:
- Include linux/deepin_kabi.h in the elevator header
- Add DEEPIN_KABI_RESERVE fields to struct elevator_mq_ops and struct elevator_type