### PR TITLE
deepin: KABI:net/kabi: reserve space for net related structures

### DIFF
--- a/include/linux/inetdevice.h
+++ b/include/linux/inetdevice.h
@@ -163,6 +163,8 @@ struct in_ifaddr {
 	__u32			ifa_preferred_lft;
 	unsigned long		ifa_cstamp; /* created timestamp */
 	unsigned long		ifa_tstamp; /* updated timestamp */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct in_validator_info {

--- a/include/net/if_inet6.h
+++ b/include/net/if_inet6.h
@@ -107,6 +107,8 @@ struct ip6_sf_list {
 	unsigned char		sf_oldin;	/* change state */
 	unsigned char		sf_crcount;	/* retrans. left to send */
 	struct rcu_head		rcu;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define MAF_TIMER_RUNNING	0x01
@@ -131,6 +133,10 @@ struct ifmcaddr6 {
 	unsigned long		mca_cstamp;
 	unsigned long		mca_tstamp;
 	struct rcu_head		rcu;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* Anycast stuff */
@@ -219,6 +225,8 @@ struct inet6_dev {
 	struct rcu_head		rcu;
 
 	unsigned int		ra_mtu;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline void ipv6_eth_mc_map(const struct in6_addr *addr, char *buf)

--- a/include/net/netns/sctp.h
+++ b/include/net/netns/sctp.h
@@ -179,6 +179,8 @@ struct netns_sctp {
 #ifdef CONFIG_NET_L3_MASTER_DEV
 	int l3mdev_accept;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif /* __NETNS_SCTP_H__ */

--- a/include/net/sock_reuseport.h
+++ b/include/net/sock_reuseport.h
@@ -26,6 +26,8 @@ struct sock_reuseport {
 	unsigned int		bind_inany:1;
 	unsigned int		has_conns:1;
 	struct bpf_prog __rcu	*prog;		/* optional BPF sock selector */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct sock		*socks[];	/* array of sock pointers */
 };
 

--- a/include/rdma/ib_verbs.h
+++ b/include/rdma/ib_verbs.h
@@ -450,6 +450,8 @@ struct ib_device_attr {
 	u64			max_dm_size;
 	/* Max entries for sgl for optimized performance per READ */
 	u32			max_sgl_rd;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum ib_mtu {
@@ -608,6 +610,8 @@ struct rdma_hw_stats {
 	const struct rdma_stat_desc *descs;
 	unsigned long	*is_disabled;
 	int		num_counters;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	u64		value[];
 };
 
@@ -1644,6 +1648,8 @@ struct ib_srq {
 	 * Implementation details of the RDMA core, don't use in drivers:
 	 */
 	struct rdma_restrack_entry res;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum ib_raw_packet_caps {
@@ -2219,6 +2225,8 @@ struct ib_port_data {
 	struct hlist_node ndev_hash_link;
 	struct rdma_port_counter port_counter;
 	struct ib_port *sysfs;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* rdma netdev type - specifies protocol type */
@@ -2686,6 +2694,8 @@ struct ib_device_ops {
 	DECLARE_RDMA_OBJ_SIZE(ib_srq);
 	DECLARE_RDMA_OBJ_SIZE(ib_ucontext);
 	DECLARE_RDMA_OBJ_SIZE(ib_xrcd);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct ib_core_device {
@@ -2787,6 +2797,8 @@ struct ib_device {
 	char iw_ifname[IFNAMSIZ];
 	u32 iw_driver_flags;
 	u32 lag_flags;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline void *rdma_zalloc_obj(struct ib_device *dev, size_t size,


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I903T2

--------------------------------

## Summary by Sourcery

Add KABI reservation space to various network and RDMA core structures

Enhancements:
- Insert DEEPIN_KABI_RESERVE placeholders in ib_verbs, rdma_hw_stats, ib_srq, ib_port_data and ib_device_ops structures
- Add DEEPIN_KABI_RESERVE entries to IPv6 multicast, unicast, SCTP and reuseport socket structures for future ABI compatibility