### PR TITLE
deepin: KABI:sysfs: kabi: Reserve KABI slots for bin_attribute struct

### DIFF
--- a/include/linux/sysfs.h
+++ b/include/linux/sysfs.h
@@ -183,6 +183,8 @@ struct bin_attribute {
 			 char *, loff_t, size_t);
 	int (*mmap)(struct file *, struct kobject *, struct bin_attribute *attr,
 		    struct vm_area_struct *vma);
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in bin_attribute struct for future expansion.

struct			size(byte)	reserve(8*byte) now(byte)
bin_attribute		64		1		72

## Summary by Sourcery

New Features:
- Add a reserved KABI slot to the bin_attribute struct for future expansion