### PR TITLE
deepin: KABI:energy_model: Add DEEPIN_KABI_RESERVE

### DIFF
--- a/include/linux/energy_model.h
+++ b/include/linux/energy_model.h
@@ -9,6 +9,7 @@
 #include <linux/sched/cpufreq.h>
 #include <linux/sched/topology.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 /**
  * struct em_perf_state - Performance state of a performance domain
@@ -24,6 +25,8 @@ struct em_perf_state {
 	unsigned long power;
 	unsigned long cost;
 	unsigned long flags;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*
@@ -56,6 +59,8 @@ struct em_perf_domain {
 	struct em_perf_state *table;
 	int nr_perf_states;
 	unsigned long flags;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	unsigned long cpus[];
 };
 


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add DEEPIN_KABI_RESERVE in energy_model.h

## Summary by Sourcery

Add DEEPIN_KABI_RESERVE markers to energy model structures to ensure KABI compatibility for Deepin.

Enhancements:
- Include linux/deepin_kabi.h in energy_model.h
- Insert DEEPIN_KABI_RESERVE fields into em_perf_state and em_perf_domain structs to reserve space for future ABI changes