### PR TITLE
deepin: KABI:net/kabi: Reserve space for net structures

### DIFF
--- a/include/linux/netpoll.h
+++ b/include/linux/netpoll.h
@@ -32,6 +32,9 @@ struct netpoll {
 	bool ipv6;
 	u16 local_port, remote_port;
 	u8 remote_mac[ETH_ALEN];
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct netpoll_info {

--- a/include/net/nexthop.h
+++ b/include/net/nexthop.h
@@ -114,6 +114,9 @@ struct nh_grp_entry {
 
 	struct list_head nh_list;
 	struct nexthop	*nh_parent;  /* nexthop of group with this entry */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct nh_group {
@@ -150,6 +153,9 @@ struct nexthop {
 		struct nh_info	__rcu *nh_info;
 		struct nh_group __rcu *nh_grp;
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum nexthop_event_type {


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I914DA

--------------------------------

Reserve some fields beforehand for net subsystem related structures prone to change.

## Summary by Sourcery

Enhancements:
- Add DEEPIN_KABI_RESERVE slots to nh_grp_entry, nexthop, and netpoll structures for ABI stability