### PR TITLE
deepin: KABI:kabi: net: reserve space for net subsystem related struc…

### DIFF
--- a/include/linux/ethtool.h
+++ b/include/linux/ethtool.h
@@ -87,6 +87,9 @@ struct kernel_ethtool_ringparam {
 	u32	cqe_size;
 	u32	tx_push_buf_len;
 	u32	tx_push_buf_max_len;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -977,6 +980,9 @@ struct ethtool_phy_ops {
 	int (*start_cable_test_tdr)(struct phy_device *phydev,
 				    struct netlink_ext_ack *extack,
 				    const struct phy_tdr_config *config);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**

--- a/include/linux/phy.h
+++ b/include/linux/phy.h
@@ -433,6 +433,9 @@ struct mii_bus {
 
 	/** @shared: shared state across different PHYs */
 	struct phy_package_shared *shared[PHY_MAX_ADDR];
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #define to_mii_bus(d) container_of(d, struct mii_bus, dev)
 
@@ -761,6 +764,11 @@ struct phy_device {
 	/* MACsec management functions */
 	const struct macsec_ops *macsec_ops;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* Generic phy_device::dev_flags */
@@ -1139,6 +1147,10 @@ struct phy_driver {
 	int (*led_hw_control_get)(struct phy_device *dev, u8 index,
 				  unsigned long *rules);
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 #define to_phy_driver(d) container_of(to_mdio_common_driver(d),		\
 				      struct phy_driver, mdiodrv)

--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -332,6 +332,9 @@ struct tc_skb_ext {
 	u8 post_ct_dnat:1;
 	u8 act_miss:1; /* Set if act_miss_cookie is used */
 	u8 l2_miss:1; /* Set by bridge upon FDB or MDB miss */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #endif
 

--- a/include/net/tls.h
+++ b/include/net/tls.h
@@ -117,6 +117,9 @@ struct tls_strparser {
 
 	struct sk_buff *anchor;
 	struct work_struct work;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct tls_sw_context_rx {

--- a/include/rdma/rdma_cm.h
+++ b/include/rdma/rdma_cm.h
@@ -64,6 +64,9 @@ struct rdma_route {
 	 * 2 - Both primary and alternate path are available
 	 */
 	int num_pri_alt_paths;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rdma_conn_param {


### PR DESCRIPTION
…ture

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for net subsystem related structures prone to change.

## Summary by Sourcery

New Features:
- Reserve additional fields in multiple network subsystem structures using DEEPIN_KABI_RESERVE to ensure future KABI compatibility