### PR TITLE
deepin: KABI:pipe: kabi: Reserve KABI slots for pipe_inode_info struc…

### DIFF
--- a/include/linux/pipe_fs_i.h
+++ b/include/linux/pipe_fs_i.h
@@ -2,6 +2,8 @@
 #ifndef _LINUX_PIPE_FS_I_H
 #define _LINUX_PIPE_FS_I_H
 
+#include <linux/deepin_kabi.h>
+
 #define PIPE_DEF_BUFFERS	16
 
 #define PIPE_BUF_FLAG_LRU	0x01	/* page is on the LRU */
@@ -116,6 +118,9 @@ struct pipe_inode_info {
 #ifdef CONFIG_WATCH_QUEUE
 	struct watch_queue *watch_queue;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 /*


### PR DESCRIPTION
…ture

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZTLZ

--------------------------------

pipe_inode_info is a structure widely used in the kernel and occupies 168 bytes. In the three cache lines, three KABI slots can be reserved for future expansion.

## Summary by Sourcery

Reserve KABI slots in the pipe_inode_info structure and add the deepin_kabi header to enable future ABI expansion

New Features:
- Reserve three KABI slots in the pipe_inode_info structure for future expansion

Enhancements:
- Include deepin_kabi header in pipe_fs_i.h to support KABI slot macros