### PR TITLE
deepin: KABI:namespace: kabi: reserve for future namespace development

### DIFF
--- a/include/linux/pid_namespace.h
+++ b/include/linux/pid_namespace.h
@@ -10,6 +10,7 @@
 #include <linux/nsproxy.h>
 #include <linux/ns_common.h>
 #include <linux/idr.h>
+#include <linux/deepin_kabi.h>
 
 /* MAX_PID_NS_LEVEL is needed for limiting size of 'struct pid' */
 #define MAX_PID_NS_LEVEL 32
@@ -41,6 +42,9 @@ struct pid_namespace {
 #if defined(CONFIG_SYSCTL) && defined(CONFIG_MEMFD_CREATE)
 	int memfd_noexec_scope;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 } __randomize_layout;
 
 extern struct pid_namespace init_pid_ns;

--- a/include/linux/user_namespace.h
+++ b/include/linux/user_namespace.h
@@ -10,6 +10,7 @@
 #include <linux/rwsem.h>
 #include <linux/sysctl.h>
 #include <linux/err.h>
+#include <linux/deepin_kabi.h>
 
 #define UID_GID_MAP_MAX_BASE_EXTENTS 5
 #define UID_GID_MAP_MAX_EXTENTS 340
@@ -53,6 +54,11 @@ enum ucount_type {
 #ifdef CONFIG_FANOTIFY
 	UCOUNT_FANOTIFY_GROUPS,
 	UCOUNT_FANOTIFY_MARKS,
+#endif
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
+	UCOUNT_DEEPIN_KABI_RESERVE1,
+	UCOUNT_DEEPIN_KABI_RESERVE2,
+	UCOUNT_DEEPIN_KABI_RESERVE3,
 #endif
 	UCOUNT_COUNTS,
 };
@@ -102,6 +108,9 @@ struct user_namespace {
 	struct ucounts		*ucounts;
 	long ucount_max[UCOUNT_COUNTS];
 	long rlimit_max[UCOUNT_RLIMIT_COUNTS];
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 } __randomize_layout;
 
 struct ucounts {

--- a/kernel/ucount.c
+++ b/kernel/ucount.c
@@ -87,6 +87,12 @@ static struct ctl_table user_table[] = {
 	UCOUNT_ENTRY("max_fanotify_groups"),
 	UCOUNT_ENTRY("max_fanotify_marks"),
 #endif
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
+	/* These corresponds to the reservation in enum ucount_type */
+	{ }, // UCOUNT_DEEPIN_KABI_RESERVE1
+	{ }, // UCOUNT_DEEPIN_KABI_RESERVE2
+	{ }, // UCOUNT_DEEPIN_KABI_RESERVE3
+#endif
 	{ }
 };
 #endif /* CONFIG_SYSCTL */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8SA3O

----------------------------------------------------------------------

Reserve KABI for future namespace development.

## Summary by Sourcery

Reserve deepin KABI slots for future namespace development by adding DEEPIN_KABI_RESERVE placeholders and UCOUNT_DEEPIN_KABI_RESERVE entries in user and pid namespace headers and corresponding sysctl table entries.

New Features:
- Include deepin_kabi.h and add three DEEPIN_KABI_RESERVE placeholders in struct user_namespace.
- Include deepin_kabi.h and add three DEEPIN_KABI_RESERVE placeholders in struct pid_namespace.
- Add three UCOUNT_DEEPIN_KABI_RESERVE enumeration entries and matching empty sysctl table entries for future use.