### PR TITLE
deepin: KABI:cgroup_bpf/kabi: reserve space for cgroup_bpf related st…

### DIFF
--- a/include/linux/bpf-cgroup-defs.h
+++ b/include/linux/bpf-cgroup-defs.h
@@ -7,6 +7,7 @@
 #include <linux/list.h>
 #include <linux/percpu-refcount.h>
 #include <linux/workqueue.h>
+#include <linux/deepin_kabi.h>
 
 struct bpf_prog_array;
 
@@ -70,6 +71,15 @@ struct cgroup_bpf {
 
 	/* cgroup_bpf is released using a work queue */
 	struct work_struct release_work;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 #else /* CONFIG_CGROUP_BPF */


### PR DESCRIPTION
…ructures

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8TP4Z

--------------------------------

We reserve some fields beforehand for cgroup_bpf_attach_type bpf_cgroup_storage_type prone and struct cgroup_bpf to change, therefore, we can hot add/change features of bpf cgroup with this enhancement.

After reserving, normally cache does not matter as the reserved fields are not accessed at all.

## Summary by Sourcery

Reserve ABI-compatible space in cgroup_bpf structures to enable future BPF cgroup feature additions without breaking the kernel ABI

Enhancements:
- Include deepin_kabi.h to support KABI reservation macros
- Add eight DEEPIN_KABI_RESERVE placeholders into struct cgroup_bpf to reserve fields for future BPF cgroup enhancements