### PR TITLE
deepin: KABI:interrupt: Add DEEPIN_KABI_RESERVE in interrupt.h

### DIFF
--- a/include/linux/interrupt.h
+++ b/include/linux/interrupt.h
@@ -13,6 +13,8 @@
 #include <linux/hrtimer.h>
 #include <linux/kref.h>
 #include <linux/workqueue.h>
+#include <linux/deepin_kabi.h>
+
 #include <linux/jump_label.h>
 
 #include <linux/atomic.h>
@@ -289,6 +291,8 @@ struct irq_affinity {
 	unsigned int	set_size[IRQ_AFFINITY_MAX_SETS];
 	void		(*calc_sets)(struct irq_affinity *, unsigned int nvecs);
 	void		*priv;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -650,6 +654,8 @@ struct tasklet_struct
 		void (*callback)(struct tasklet_struct *t);
 	};
 	unsigned long data;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define DECLARE_TASKLET(name, _callback)		\


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add DEEPIN_KABI_RESERVE tasklet_struct and irq_affinity in interrupt.h



conflict:
	include/linux/interrupt.h

## Summary by Sourcery

Reserve KABI slots in interrupt structures by adding DEEPIN_KABI_RESERVE fields and including deepin_kabi.h

Enhancements:
- Include deepin_kabi.h in interrupt.h to enable DEEPIN_KABI_RESERVE macros
- Add DEEPIN_KABI_RESERVE slots in irq_affinity structure
- Add DEEPIN_KABI_RESERVE slots in tasklet_struct structure