### PR TITLE
deepin: KABI:irqdomain: Add DEEPIN_KABI_RESERVE in irqdomain

### DIFF
--- a/include/linux/irqdomain.h
+++ b/include/linux/irqdomain.h
@@ -36,6 +36,7 @@
 #include <linux/of.h>
 #include <linux/mutex.h>
 #include <linux/radix-tree.h>
+#include <linux/deepin_kabi.h>
 
 struct device_node;
 struct fwnode_handle;
@@ -174,6 +175,8 @@ struct irq_domain {
 	irq_hw_number_t			hwirq_max;
 	unsigned int			revmap_size;
 	struct radix_tree_root		revmap_tree;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct irq_data __rcu		*revmap[];
 };
 


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add DEEPIN_KABI_RESERVE in irqdomain.h



conflict:
	include/linux/irqdomain.h

## Summary by Sourcery

Include the deepin_kabi.h header and reserve two KABI slots in the irq_domain structure to maintain Deepin kernel ABI compatibility

Enhancements:
- Add inclusion of linux/deepin_kabi.h in irqdomain.h
- Insert two DEEPIN_KABI_RESERVE entries in the irq_domain struct for ABI reservation