### PR TITLE
deepin: KABI:cgroup/misc: reserve kabi for future misc development

### DIFF
--- a/include/linux/misc_cgroup.h
+++ b/include/linux/misc_cgroup.h
@@ -7,6 +7,7 @@
  */
 #ifndef _MISC_CGROUP_H_
 #define _MISC_CGROUP_H_
+#include <linux/deepin_kabi.h>
 
 /**
  * Types of misc cgroup entries supported by the host.
@@ -17,6 +18,13 @@ enum misc_res_type {
 	MISC_CG_RES_SEV,
 	/* AMD SEV-ES ASIDs resource */
 	MISC_CG_RES_SEV_ES,
+#endif
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
+	MISC_RES_TYPE_RESERVE1,
+	MISC_RES_TYPE_RESERVE2,
+	MISC_RES_TYPE_RESERVE3,
+	MISC_RES_TYPE_RESERVE4,
+	MISC_RES_TYPE_RESERVE5,
 #endif
 	MISC_CG_RES_TYPES
 };
@@ -37,6 +45,9 @@ struct misc_res {
 	u64 max;
 	atomic64_t usage;
 	atomic64_t events;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 /**
@@ -52,6 +63,9 @@ struct misc_cg {
 	struct cgroup_file events_file;
 
 	struct misc_res res[MISC_CG_RES_TYPES];
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 u64 misc_cg_res_total_usage(enum misc_res_type type);


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8SA3O

----------------------------------------------------------------------

cgroup/misc: reserve kabi for future misc development

## Summary by Sourcery

Reserve kernel ABI slots in misc cgroup interfaces for future development by including the deepin KABI header and adding placeholder enum entries and struct fields.

Enhancements:
- Include <linux/deepin_kabi.h> to enable DEEPIN_KABI_RESERVE macros
- Add five reserved values to the misc_res_type enum
- Add DEEPIN_KABI_RESERVE fields to misc_res and misc_cg structs to maintain ABI compatibility