### PR TITLE
deepin: KABI:nvmet-fc: kabi: KABI reservation for nvme_fc_port_template

### DIFF
--- a/include/linux/nvme-fc-driver.h
+++ b/include/linux/nvme-fc-driver.h
@@ -511,6 +511,15 @@ struct nvme_fc_port_template {
 	u32	remote_priv_sz;
 	u32	lsrqst_priv_sz;
 	u32	fcprqst_priv_sz;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
+	DEEPIN_KABI_RESERVE(6)
+	DEEPIN_KABI_RESERVE(7)
+	DEEPIN_KABI_RESERVE(8)
 };
 
 


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I913YJ

----------------------------------------------------------------------

Reserve KABI for struct 'nvme_fc_port_template'.

## Summary by Sourcery

New Features:
- Add eight DEEPIN_KABI_RESERVE slots to struct nvme_fc_port_template