### PR TITLE
deepin: KABI:kabi: reserve space for struct mfd_cell

### DIFF
--- a/include/linux/mfd/core.h
+++ b/include/linux/mfd/core.h
@@ -11,6 +11,7 @@
 #define MFD_CORE_H
 
 #include <linux/platform_device.h>
+#include <linux/deepin_kabi.h>
 
 #define MFD_RES_SIZE(arr) (sizeof(arr) / sizeof(struct resource))
 
@@ -118,6 +119,11 @@ struct mfd_cell {
 	 */
 	int			num_parent_supplies;
 	const char * const	*parent_supplies;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /*


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8YRD2

--------------------------------

reserve space for struct mfd_cell

## Summary by Sourcery

Reserve KABI space in the mfd_cell structure to ensure future binary compatibility.

Enhancements:
- Include deepin_kabi header in mfd/core.h
- Add four DEEPIN_KABI_RESERVE fields to struct mfd_cell for ABI padding