### PR TITLE
deepin: KABI:quota: kabi: KABI reservation for quota

### DIFF
--- a/include/linux/quota.h
+++ b/include/linux/quota.h
@@ -318,6 +318,9 @@ struct quota_format_ops {
 	int (*commit_dqblk)(struct dquot *dquot);	/* Write structure for one user */
 	int (*release_dqblk)(struct dquot *dquot);	/* Called when last reference to dquot is being dropped */
 	int (*get_next_id)(struct super_block *sb, struct kqid *qid);	/* Get next ID with existing structure in the quota file */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* Operations working with dquots */
@@ -337,6 +340,9 @@ struct dquot_operations {
 	int (*get_inode_usage) (struct inode *, qsize_t *);
 	/* Get next ID with active quota structure */
 	int (*get_next_id) (struct super_block *sb, struct kqid *qid);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct path;


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I91COK

----------------------------------------------------------------------

    structure                size reserves reserved

    quota_format_ops         64      2      80
    dquot_operations         88      2      104

## Summary by Sourcery

Reserve KABI slots in quota_format_ops and dquot_operations for deepin kernel ABI compatibility

Enhancements:
- Add two DEEPIN_KABI_RESERVE entries to quota_format_ops
- Add two DEEPIN_KABI_RESERVE entries to dquot_operations