### PR TITLE
deepin: KABI:iov_iter: kabi: KABI reservation for iov_iter

### DIFF
--- a/include/linux/uio.h
+++ b/include/linux/uio.h
@@ -81,6 +81,10 @@ struct iov_iter {
 		unsigned long nr_segs;
 		loff_t xarray_start;
 	};
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 static inline const struct iovec *iter_iov(const struct iov_iter *iter)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I918ZJ

----------------------------------------------------------------------

    structure     size reserves reserved

    iov_iter       40      3      64

## Summary by Sourcery

New Features:
- Introduce three DEEPIN_KABI_RESERVE entries into the iov_iter struct