### PR TITLE
deepin: KABI:kabi: reserve space for struct timer_list

### DIFF
--- a/include/linux/timer.h
+++ b/include/linux/timer.h
@@ -7,6 +7,7 @@
 #include <linux/stddef.h>
 #include <linux/debugobjects.h>
 #include <linux/stringify.h>
+#include <linux/deepin_kabi.h>
 
 struct timer_list {
 	/*
@@ -21,6 +22,9 @@ struct timer_list {
 #ifdef CONFIG_LOCKDEP
 	struct lockdep_map	lockdep_map;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #ifdef CONFIG_LOCKDEP


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I908BC

--------------------------------

reserve space for struct timer_list.

## Summary by Sourcery

Enhancements:
- Reserve two padding fields in struct timer_list for deepin KABI compatibility