### PR TITLE
deepin: KABI:kabi: net: reserve space for net related structure

### DIFF
--- a/include/linux/netlink.h
+++ b/include/linux/netlink.h
@@ -8,6 +8,7 @@
 #include <linux/export.h>
 #include <net/scm.h>
 #include <uapi/linux/netlink.h>
+#include <linux/deepin_kabi.h>
 
 struct net;
 
@@ -88,6 +89,10 @@ struct netlink_ext_ack {
 	u8 cookie[NETLINK_MAX_COOKIE_LEN];
 	u8 cookie_len;
 	char _msg_buf[NETLINK_MAX_FMTMSG_LEN];
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* Always use this macro, this allows later putting the

--- a/include/net/cfg802154.h
+++ b/include/net/cfg802154.h
@@ -16,6 +16,8 @@
 
 #include <net/nl802154.h>
 
+#include <linux/deepin_kabi.h>
+
 struct wpan_phy;
 struct wpan_phy_cca;
 struct cfg802154_scan_request;
@@ -241,6 +243,9 @@ struct wpan_phy {
 	 * Only allowed to be changed if phy is not operational.
 	 */
 	enum ieee802154_filtering_level filtering;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	char priv[] __aligned(NETDEV_ALIGN);
 };

--- a/include/net/inet_frag.h
+++ b/include/net/inet_frag.h
@@ -8,6 +8,7 @@
 #include <linux/rbtree_types.h>
 #include <linux/refcount.h>
 #include <net/dropreason-core.h>
+#include <linux/deepin_kabi.h>
 
 /* Per netns frag queues directory */
 struct fqdir {
@@ -102,6 +103,9 @@ struct inet_frag_queue {
 	u16			max_size;
 	struct fqdir		*fqdir;
 	struct rcu_head		rcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct inet_frags {

--- a/include/net/ip_fib.h
+++ b/include/net/ip_fib.h
@@ -22,6 +22,7 @@
 #include <linux/percpu.h>
 #include <linux/notifier.h>
 #include <linux/refcount.h>
+#include <linux/deepin_kabi.h>
 
 struct fib_config {
 	u8			fc_dst_len;
@@ -100,6 +101,9 @@ struct fib_nh_common {
 	struct rtable __rcu * __percpu *nhc_pcpu_rth_output;
 	struct rtable __rcu     *nhc_rth_input;
 	struct fnhe_hash_bucket	__rcu *nhc_exceptions;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct fib_nh {
@@ -157,6 +161,10 @@ struct fib_info {
 	bool			pfsrc_removed;
 	struct nexthop		*nh;
 	struct rcu_head		rcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+
 	struct fib_nh		fib_nh[];
 };
 

--- a/include/net/ipv6_stubs.h
+++ b/include/net/ipv6_stubs.h
@@ -9,6 +9,7 @@
 #include <net/flow.h>
 #include <net/neighbour.h>
 #include <net/sock.h>
+#include <linux/deepin_kabi.h>
 
 /* structs from net/ip6_fib.h */
 struct fib6_info;
@@ -69,6 +70,9 @@ struct ipv6_stub {
 			     int (*output)(struct net *, struct sock *, struct sk_buff *));
 	struct net_device *(*ipv6_dev_find)(struct net *net, const struct in6_addr *addr,
 					    struct net_device *dev);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 extern const struct ipv6_stub *ipv6_stub __read_mostly;
 

--- a/include/net/netns/conntrack.h
+++ b/include/net/netns/conntrack.h
@@ -14,6 +14,7 @@
 #include <linux/netfilter/nf_conntrack_sctp.h>
 #endif
 #include <linux/seqlock.h>
+#include <linux/deepin_kabi.h>
 
 struct ctl_table_header;
 struct nf_conntrack_ecache;
@@ -31,6 +32,9 @@ struct nf_tcp_net {
 #if IS_ENABLED(CONFIG_NF_FLOW_TABLE)
 	unsigned int offload_timeout;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum udp_conntrack {

--- a/include/net/netns/core.h
+++ b/include/net/netns/core.h
@@ -3,6 +3,7 @@
 #define __NETNS_CORE_H__
 
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 struct ctl_table_header;
 struct prot_inuse;
@@ -22,6 +23,11 @@ struct netns_core {
 #if IS_ENABLED(CONFIG_RPS) && IS_ENABLED(CONFIG_SYSCTL)
 	struct cpumask *rps_default_mask;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #endif

--- a/include/net/xfrm.h
+++ b/include/net/xfrm.h
@@ -33,6 +33,8 @@
 #include <net/snmp.h>
 #endif
 
+#include <linux/deepin_kabi.h>
+
 #define XFRM_PROTO_ESP		50
 #define XFRM_PROTO_AH		51
 #define XFRM_PROTO_COMP		108
@@ -297,6 +299,9 @@ struct xfrm_state {
 	/* Private data of this transformer, format is opaque,
 	 * interpreted by xfrm_type methods. */
 	void			*data;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct net *xs_net(struct xfrm_state *x)
@@ -562,6 +567,9 @@ struct xfrm_policy {
 	struct rcu_head		rcu;
 
 	struct xfrm_dev_offload xdo;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct net *xp_net(const struct xfrm_policy *xp)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZMS7

----------------------------------------------------

Reserve some fields beforehand for net related structures prone to change.

## Summary by Sourcery

Reserve padding fields in multiple network headers by including deepin_kabi.h and inserting DEEPIN_KABI_RESERVE placeholders to maintain binary ABI compatibility for future kernel changes.

New Features:
- Reserve future KABI extension slots in various network subsystem structures using DEEPIN_KABI_RESERVE
- Include deepin_kabi.h in network headers to support the reserve macro