### PR TITLE
deepin: KABI:ixarray: Reserve kabi for xa_state

### DIFF
--- a/include/linux/xarray.h
+++ b/include/linux/xarray.h
@@ -19,6 +19,7 @@
 #include <linux/sched/mm.h>
 #include <linux/spinlock.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * The bottom two bits of the entry determine how the XArray interprets
@@ -1352,6 +1353,8 @@ struct xa_state {
 	struct xa_node *xa_alloc;
 	xa_update_node_t xa_update;
 	struct list_lru *xa_lru;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for xa_state in xarray.h.

## Summary by Sourcery

Reserve two KABI slots in struct xa_state to maintain ABI compatibility

Bug Fixes:
- Include deepin_kabi.h in xarray.h
- Add two DEEPIN_KABI_RESERVE entries to struct xa_state