### PR TITLE
deepin: KABI:delayacct: Reserve kabi for task_delay_info

### DIFF
--- a/include/linux/delayacct.h
+++ b/include/linux/delayacct.h
@@ -8,6 +8,7 @@
 #define _LINUX_DELAYACCT_H
 
 #include <uapi/linux/taskstats.h>
+#include <linux/deepin_kabi.h>
 
 #ifdef CONFIG_TASK_DELAY_ACCT
 struct task_delay_info {
@@ -55,6 +56,8 @@ struct task_delay_info {
 	u32 compact_count;	/* total count of memory compact */
 	u32 wpcopy_count;	/* total count of write-protect copy */
 	u32 irq_count;	/* total count of IRQ/SOFTIRQ */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #endif
 


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for task_delay_info in delayacct.h.

## Summary by Sourcery

Reserve Deepin KABI slots in task_delay_info to support ABI compatibility

Bug Fixes:
- Add DEEPIN_KABI_RESERVE entries to task_delay_info to reserve space for future fields
- Include deepin_kabi.h in delayacct.h to enable reservation macros