### PR TITLE
deepin: KABI:block: kabi: KABI reservation for iocontext

### DIFF
--- a/include/linux/iocontext.h
+++ b/include/linux/iocontext.h
@@ -112,6 +112,8 @@ struct io_context {
 
 	struct work_struct release_work;
 #endif /* CONFIG_BLK_ICQ */
+
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct task_struct;


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I9118F

----------------------------------------------------------------------

Reserve KABI for struct 'iocontext'.

## Summary by Sourcery

New Features:
- Add a KABI reservation placeholder to io_context structure