### PR TITLE
deepin: KABI:kabi: reserve space for struct cpu_stop_work

### DIFF
--- a/include/linux/stop_machine.h
+++ b/include/linux/stop_machine.h
@@ -6,6 +6,7 @@
 #include <linux/cpumask.h>
 #include <linux/smp.h>
 #include <linux/list.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * stop_cpu[s]() is simplistic per-cpu maximum priority cpu
@@ -27,6 +28,8 @@ struct cpu_stop_work {
 	unsigned long		caller;
 	void			*arg;
 	struct cpu_stop_done	*done;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 int stop_one_cpu(unsigned int cpu, cpu_stop_fn_t fn, void *arg);


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I4JBL0 CVE: NA

-------------------------------

Reserve space for struct cpu_stop_work. Changing this struct will affect set_cpus_allowed_ptr(), so reserve one kabi field.


conflicts:
	include/linux/stop_machine.h

## Summary by Sourcery

Enhancements:
- Include deepin_kabi.h and reserve two KABI slots in struct cpu_stop_work