### PR TITLE
deepin: KABI:xattr: kabi: Reserve KABI slots for xattr_handler struct

### DIFF
--- a/include/linux/xattr.h
+++ b/include/linux/xattr.h
@@ -11,7 +11,7 @@
 #ifndef _LINUX_XATTR_H
 #define _LINUX_XATTR_H
 
-
+#include <linux/deepin_kabi.h>
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/spinlock.h>
@@ -45,6 +45,9 @@ struct xattr_handler {
 		   struct mnt_idmap *idmap, struct dentry *dentry,
 		   struct inode *inode, const char *name, const void *buffer,
 		   size_t size, int flags);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in xattr_handler struct for future expansion.

struct			size(byte)	reserve(8*byte)	now(byte)
xattr_handler		48		2		64

## Summary by Sourcery

Reserve two future KABI slots in the xattr_handler struct by including deepin_kabi.h and invoking the DEEPIN_KABI_RESERVE macros

New Features:
- Add two 8-byte reserved slots in xattr_handler for future KABI-compatible expansion

Enhancements:
- Include linux/deepin_kabi.h in xattr.h to enable KABI reservation macros