### PR TITLE
deepin: KABI:ipmi: kabi: KABI reservation for ipmi

### DIFF
--- a/drivers/char/ipmi/ipmi_msghandler.c
+++ b/drivers/char/ipmi/ipmi_msghandler.c
@@ -36,6 +36,7 @@
 #include <linux/nospec.h>
 #include <linux/vmalloc.h>
 #include <linux/delay.h>
+#include <linux/deepin_kabi.h>
 
 #define IPMI_DRIVER_VERSION "39.2"
 
@@ -203,6 +204,7 @@ struct ipmi_user {
 
 	/* Free must run in process context for RCU cleanup. */
 	struct work_struct remove_work;
+	DEEPIN_KABI_RESERVE(0)
 };
 
 static struct workqueue_struct *remove_work_wq;
@@ -603,6 +605,10 @@ struct ipmi_smi {
 	 * parameters passed by "low" level IPMI code.
 	 */
 	int run_to_completion;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 #define to_si_intf_from_dev(device) container_of(device, struct ipmi_smi, dev)
 

--- a/include/linux/ipmi.h
+++ b/include/linux/ipmi.h
@@ -19,6 +19,7 @@
 #include <linux/list.h>
 #include <linux/proc_fs.h>
 #include <linux/acpi.h> /* For acpi_handle */
+#include <linux/deepin_kabi.h>
 
 struct module;
 struct device;
@@ -70,6 +71,7 @@ struct ipmi_recv_msg {
 	 * the size or existence of this, since it may change.
 	 */
 	unsigned char   msg_data[IPMI_MAX_MSG_LENGTH];
+	DEEPIN_KABI_RESERVE(0)
 };
 
 #define INIT_IPMI_RECV_MSG(done_handler) \

--- a/include/linux/ipmi_smi.h
+++ b/include/linux/ipmi_smi.h
@@ -19,6 +19,7 @@
 #include <linux/proc_fs.h>
 #include <linux/platform_device.h>
 #include <linux/ipmi.h>
+#include <linux/deepin_kabi.h>
 
 struct device;
 
@@ -123,6 +124,7 @@ struct ipmi_smi_msg {
 	 * (presumably to free it).
 	 */
 	void (*done)(struct ipmi_smi_msg *msg);
+	DEEPIN_KABI_RESERVE(0)
 };
 
 #define INIT_IPMI_SMI_MSG(done_handler) \
@@ -218,6 +220,7 @@ struct ipmi_smi_handlers {
 	 * block.
 	 */
 	void (*set_maintenance_mode)(void *send_info, bool enable);
+	DEEPIN_KABI_RESERVE(0)
 };
 
 struct ipmi_device_id {


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8T231

--------------------------------

Reserve space for ipmi module in advance to prepare for merging new feature in the future.

## Summary by Sourcery

Reserve binary interface compatibility slots in the IPMI driver to prepare for future feature additions.

Enhancements:
- Include deepin_kabi.h in IPMI source and header files.
- Insert DEEPIN_KABI_RESERVE markers in ipmi_user, ipmi_smi, ipmi_smi_msg, ipmi_smi_handlers, and ipmi_recv_msg structures to allocate KABI reservation slots.