### PR TITLE
deepin: KABI:cgroup/psi: reserve kabi for future psi development

### DIFF
--- a/include/linux/psi_types.h
+++ b/include/linux/psi_types.h
@@ -7,6 +7,7 @@
 #include <linux/types.h>
 #include <linux/kref.h>
 #include <linux/wait.h>
+#include <linux/deepin_kabi.h>
 
 #ifdef CONFIG_PSI
 
@@ -104,6 +105,11 @@ struct psi_group_cpu {
 	/* Delta detection against the sampling buckets */
 	u32 times_prev[NR_PSI_AGGREGATORS][NR_PSI_STATES]
 			____cacheline_aligned_in_smp;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
+	DEEPIN_KABI_RESERVE(5)
 };
 
 /* PSI growth tracking window */
@@ -119,6 +125,9 @@ struct psi_window {
 
 	/* Value growth in the previous window */
 	u64 prev_growth;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 struct psi_trigger {
@@ -157,6 +166,9 @@ struct psi_trigger {
 
 	/* Trigger type - PSI_AVGS for unprivileged, PSI_POLL for RT */
 	enum psi_aggregators aggregator;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 struct psi_group {


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8SA3O

----------------------------------------------------------------------

cgroup/psi: reserve kabi for future psi development

## Summary by Sourcery

Reserve deepin KABI slots in PSI data structures to accommodate future PSI feature expansions

Enhancements:
- Include deepin_kabi.h in psi_types.h
- Add DEEPIN_KABI_RESERVE entries to struct psi_group_cpu
- Add DEEPIN_KABI_RESERVE entries to struct psi_window
- Add DEEPIN_KABI_RESERVE entries to struct psi_trigger