### PR TITLE
deepin: KABI:statx: kabi: KABI reservation for kstat

### DIFF
--- a/include/linux/stat.h
+++ b/include/linux/stat.h
@@ -18,6 +18,7 @@
 #include <linux/types.h>
 #include <linux/time.h>
 #include <linux/uidgid.h>
+#include <linux/deepin_kabi.h>
 
 struct kstat {
 	u32		result_mask;	/* What fields the user got */
@@ -53,6 +54,11 @@ struct kstat {
 	u32		dio_mem_align;
 	u32		dio_offset_align;
 	u64		change_cookie;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /* These definitions are internal to the kernel for now. Mainly used by nfsd. */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/IBC24E

----------------------------------------------------------------------

    structure                size reserves reserved  mainline
    kstat                    160     4       192       184

## Summary by Sourcery

Reserve additional deepin KABI slots in the kstat structure to maintain ABI compatibility

New Features:
- Add four DEEPIN_KABI_RESERVE entries to struct kstat

Enhancements:
- Include deepin_kabi.h header in linux/stat.h for KABI support