### PR TITLE
deepin: KABI:profs: kabi: Reserve KABI slots for proc_ops struct

### DIFF
--- a/include/linux/proc_fs.h
+++ b/include/linux/proc_fs.h
@@ -45,6 +45,11 @@ struct proc_ops {
 #endif
 	int	(*proc_mmap)(struct file *, struct vm_area_struct *);
 	unsigned long (*proc_get_unmapped_area)(struct file *, unsigned long, unsigned long, unsigned long, unsigned long);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } __randomize_layout;
 
 /* definitions for hide_pid field */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I905SE CVE: NA

--------------------------------

Add kabi slots in proc_ops struct for future expansion.

struct			size(byte)	reserve(8*byte) now(byte)
proc_ops		96		4		128

## Summary by Sourcery

New Features:
- Reserve four KABI slots in proc_ops struct for future extension