### PR TITLE
deepin: KABI:crypto: kabi: KABI reservation for crypto

### DIFF
--- a/include/crypto/aead.h
+++ b/include/crypto/aead.h
@@ -13,6 +13,7 @@
 #include <linux/crypto.h>
 #include <linux/slab.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 /**
  * DOC: Authenticated Encryption With Associated Data (AEAD) Cipher API
@@ -97,6 +98,8 @@ struct aead_request {
 
 	struct scatterlist *src;
 	struct scatterlist *dst;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	void *__ctx[] CRYPTO_MINALIGN_ATTR;
 };
@@ -169,6 +172,8 @@ struct aead_alg {
 	unsigned int ivsize;
 	unsigned int maxauthsize;
 	unsigned int chunksize;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	struct crypto_alg base;
 };
@@ -177,6 +182,8 @@ struct crypto_aead {
 	unsigned int authsize;
 	unsigned int reqsize;
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_tfm base;
 };
 

--- a/include/crypto/akcipher.h
+++ b/include/crypto/akcipher.h
@@ -39,6 +39,8 @@ struct akcipher_request {
 	struct scatterlist *dst;
 	unsigned int src_len;
 	unsigned int dst_len;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	void *__ctx[] CRYPTO_MINALIGN_ATTR;
 };
 
@@ -52,6 +54,8 @@ struct akcipher_request {
 struct crypto_akcipher {
 	unsigned int reqsize;
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_tfm base;
 };
 
@@ -135,6 +139,8 @@ struct akcipher_alg {
 #ifdef CONFIG_CRYPTO_STATS
 	struct crypto_istat_akcipher stat;
 #endif
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	struct crypto_alg base;
 };

--- a/include/crypto/algapi.h
+++ b/include/crypto/algapi.h
@@ -13,6 +13,7 @@
 #include <linux/crypto.h>
 #include <linux/types.h>
 #include <linux/workqueue.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Maximum values for blocksize and alignmask, used to allocate
@@ -69,6 +70,8 @@ struct crypto_type {
 	unsigned int maskclear;
 	unsigned int maskset;
 	unsigned int tfmsize;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct crypto_instance {
@@ -84,6 +87,8 @@ struct crypto_instance {
 	};
 
 	struct work_struct free_work;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	void *__ctx[] CRYPTO_MINALIGN_ATTR;
 };
@@ -111,6 +116,8 @@ struct crypto_spawn {
 	u32 mask;
 	bool dead;
 	bool registered;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct crypto_queue {

--- a/include/crypto/hash.h
+++ b/include/crypto/hash.h
@@ -11,6 +11,7 @@
 #include <linux/atomic.h>
 #include <linux/crypto.h>
 #include <linux/string.h>
+#include <linux/deepin_kabi.h>
 
 struct crypto_ahash;
 
@@ -78,6 +79,8 @@ struct ahash_request {
 
 	/* This field may only be used by the ahash API code. */
 	void *priv;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	void *__ctx[] CRYPTO_MINALIGN_ATTR;
 };
@@ -176,6 +179,8 @@ struct ahash_alg {
 };
 
 struct shash_desc {
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_shash *tfm;
 	void *__ctx[] __aligned(ARCH_SLAB_MINALIGN);
 };
@@ -265,11 +270,15 @@ struct crypto_ahash {
 
 	unsigned int statesize;
 	unsigned int reqsize;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_tfm base;
 };
 
 struct crypto_shash {
 	unsigned int descsize;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_tfm base;
 };
 

--- a/include/crypto/public_key.h
+++ b/include/crypto/public_key.h
@@ -30,6 +30,8 @@ struct public_key {
 	const char *id_type;
 	const char *pkey_algo;
 	unsigned long key_eflags;	/* key extension flags */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 #define KEY_EFLAG_CA		0	/* set if the CA basic constraints is set */
 #define KEY_EFLAG_DIGITALSIG	1	/* set if the digitalSignature usage is set */
 #define KEY_EFLAG_KEYCERTSIGN	2	/* set if the keyCertSign usage is set */
@@ -53,6 +55,8 @@ struct public_key_signature {
 	const char *pkey_algo;
 	const char *hash_algo;
 	const char *encoding;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 extern void public_key_signature_free(struct public_key_signature *sig);

--- a/include/crypto/rng.h
+++ b/include/crypto/rng.h
@@ -12,6 +12,7 @@
 #include <linux/atomic.h>
 #include <linux/container_of.h>
 #include <linux/crypto.h>
+#include <linux/deepin_kabi.h>
 
 struct crypto_rng;
 
@@ -68,6 +69,8 @@ struct rng_alg {
 #endif
 
 	unsigned int seedsize;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	struct crypto_alg base;
 };

--- a/include/crypto/skcipher.h
+++ b/include/crypto/skcipher.h
@@ -14,6 +14,7 @@
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 struct scatterlist;
 
@@ -35,6 +36,8 @@ struct skcipher_request {
 	struct scatterlist *dst;
 
 	struct crypto_async_request base;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	void *__ctx[] CRYPTO_MINALIGN_ATTR;
 };
@@ -42,6 +45,8 @@ struct skcipher_request {
 struct crypto_skcipher {
 	unsigned int reqsize;
 
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_tfm base;
 };
 
@@ -142,6 +147,8 @@ struct skcipher_alg {
 #endif
 
 	struct crypto_alg base;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define MAX_SYNC_SKCIPHER_REQSIZE      384

--- a/include/linux/crypto.h
+++ b/include/linux/crypto.h
@@ -16,6 +16,7 @@
 #include <linux/refcount.h>
 #include <linux/slab.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * Algorithm masks and types.
@@ -367,6 +368,8 @@ struct crypto_alg {
 	void (*cra_destroy)(struct crypto_alg *alg);
 	
 	struct module *cra_module;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 } CRYPTO_MINALIGN_ATTR;
 
 /*
@@ -429,6 +432,8 @@ struct crypto_tfm {
 	void (*exit)(struct crypto_tfm *tfm);
 	
 	struct crypto_alg *__crt_alg;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	void *__crt_ctx[] CRYPTO_MINALIGN_ATTR;
 };

--- a/include/linux/kernel_read_file.h
+++ b/include/linux/kernel_read_file.h
@@ -14,6 +14,9 @@
 	id(KEXEC_INITRAMFS, kexec-initramfs)	\
 	id(POLICY, security-policy)		\
 	id(X509_CERTIFICATE, x509-certificate)	\
+	id(DEEPIN_KABI_RESERVE1, DEEPIN_KABI_RESERVE1)	\
+	id(DEEPIN_KABI_RESERVE2, DEEPIN_KABI_RESERVE2)	\
+	id(DEEPIN_KABI_RESERVE3, DEEPIN_KABI_RESERVE3)	\
 	id(MAX_ID, )
 
 #define __fid_enumify(ENUM, dummy) READING_ ## ENUM,

--- a/include/linux/kexec.h
+++ b/include/linux/kexec.h
@@ -21,6 +21,7 @@
 
 #include <uapi/linux/kexec.h>
 #include <linux/verification.h>
+#include <linux/deepin_kabi.h>
 
 /* Location of a reserved region to hold the crash kernel.
  */
@@ -368,6 +369,10 @@ struct kimage {
 	void *elf_headers;
 	unsigned long elf_headers_sz;
 	unsigned long elf_load_addr;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 /* kexec interface functions */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8RI9L

--------------------------------

Reserve KABI for future crypto development.

## Summary by Sourcery

Reserve KABI slots across the crypto framework and related subsystems to maintain binary compatibility for future enhancements

Enhancements:
- Add linux/deepin_kabi.h includes in crypto and kexec headers
- Insert DEEPIN_KABI_RESERVE placeholders into various crypto structs (hash, aead, skcipher, akcipher, rng, algapi, public_key, cryptd)
- Extend kimage struct and kernel_read_file IDs with DEEPIN_KABI_RESERVE entries for future ABI stability