### PR TITLE
deepin: KABI:kabi: reserve space for workqueue subsystem related stru…

### DIFF
--- a/include/linux/workqueue.h
+++ b/include/linux/workqueue.h
@@ -6,6 +6,7 @@
 #ifndef _LINUX_WORKQUEUE_H
 #define _LINUX_WORKQUEUE_H
 
+#include <linux/deepin_kabi.h>
 #include <linux/timer.h>
 #include <linux/linkage.h>
 #include <linux/bitops.h>
@@ -102,6 +103,9 @@ struct work_struct {
 #ifdef CONFIG_LOCKDEP
 	struct lockdep_map lockdep_map;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define WORK_DATA_INIT()	ATOMIC_LONG_INIT((unsigned long)WORK_STRUCT_NO_POOL)
@@ -201,6 +205,11 @@ struct workqueue_attrs {
 	 * @ordered: work items must be executed one by one in queueing order
 	 */
 	bool ordered;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static inline struct delayed_work *to_delayed_work(struct work_struct *work)


### PR DESCRIPTION
…cture

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I9089C CVE: NA

-------------------------------

Reserve space for workqueue subsystem.

## Summary by Sourcery

Add reserved KABI space to workqueue subsystem structures for deepin kernel compatibility.

Enhancements:
- Include deepin_kabi header in workqueue.h
- Add DEEPIN_KABI_RESERVE fields to work_struct
- Add DEEPIN_KABI_RESERVE fields to workqueue_attrs