### PR TITLE
deepin: KABI:mtd: kabi: KABI reservation for mtd

### DIFF
--- a/include/linux/mtd/mtd.h
+++ b/include/linux/mtd/mtd.h
@@ -77,6 +77,8 @@ struct mtd_oob_ops {
 	uint8_t		*datbuf;
 	uint8_t		*oobbuf;
 	struct mtd_req_stats *stats;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /**
@@ -215,6 +217,8 @@ struct mtd_part {
 	u64 offset;
 	u64 size;
 	u32 flags;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 /**
@@ -233,6 +237,8 @@ struct mtd_master {
 	struct mutex partitions_lock;
 	struct mutex chrdev_lock;
 	unsigned int suspended : 1;
+	DEEPIN_KABI_RESERVE(0)
+	DEEPIN_KABI_RESERVE(1)
 };
 
 struct mtd_info {


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8T231

--------------------------------

Reserve space for mtd module in advance to prepare for merging new feature in the future.

## Summary by Sourcery

Enhancements:
- Add two DEEPIN_KABI_RESERVE slots to mtd_oob_ops, mtd_part, and mtd_master structures to maintain ABI compatibility for future expansions