### PR TITLE
deepin: KABI:mtd: kabi: Reserve KABI slots for mtd_device_xxx_registe…

### DIFF
--- a/include/linux/mtd/mtd.h
+++ b/include/linux/mtd/mtd.h
@@ -13,6 +13,7 @@
 #include <linux/device.h>
 #include <linux/of.h>
 #include <linux/nvmem-provider.h>
+#include <linux/deepin_kabi.h>
 
 #include <mtd/mtd-abi.h>
 
@@ -398,6 +399,10 @@ struct mtd_info {
 
 	struct mtd_part part;
 	struct mtd_master master;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static inline struct mtd_info *mtd_get_master(struct mtd_info *mtd)

--- a/include/linux/mtd/partitions.h
+++ b/include/linux/mtd/partitions.h
@@ -10,7 +10,7 @@
 #define MTD_PARTITIONS_H
 
 #include <linux/types.h>
-
+#include <linux/deepin_kabi.h>
 
 /*
  * Partition definition structure:
@@ -71,6 +71,9 @@ struct hwnode_handle;
  */
 struct mtd_part_parser_data {
 	unsigned long origin;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
 };
 
 


### PR DESCRIPTION
…r() related structures

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZUFD

--------------------------------

The mtd_device_parse_register() and mtd_device_unregister() APIs are in the kabi trustlist. The involved structures are 'struct mtd_info', 'struct mtd_part_parser_data', and 'struct mtd_partition'.

These structures may still be changed. To prevent KABI incompatibility caused by CVE fixes in the future, these structures are reserved.

mtd_info:
 Important structure with a size of 1408 bytes. In the 2 slab objects,
 four KABI slots can be reserved for future expansion.

mtd_partition:
 Important structure with a size of 48 bytes. In 1 cache line space,
 two KABI slots can be reserved for future expansion.

mtd_part_parser_data:
 The size is 8 bytes. Three KABI slots can be reserved for future
 expansion.

## Summary by Sourcery

Reserve future KABI slots in MTD core structures to safeguard against ABI changes.

Enhancements:
- Include deepin_kabi.h in MTD headers.
- Add four DEEPIN_KABI_RESERVE slots to struct mtd_info.
- Add three DEEPIN_KABI_RESERVE slots to struct mtd_part_parser_data.