### PR TITLE
deepin: KABI:kabi: net: reserve space for net base subsystem related …

### DIFF
--- a/include/linux/device.h
+++ b/include/linux/device.h
@@ -32,6 +32,7 @@
 #include <linux/device/class.h>
 #include <linux/device/driver.h>
 #include <linux/cleanup.h>
+#include <linux/deepin_kabi.h>
 #include <asm/device.h>
 
 struct device;

--- a/include/net/flow_dissector.h
+++ b/include/net/flow_dissector.h
@@ -7,6 +7,7 @@
 #include <linux/siphash.h>
 #include <linux/string.h>
 #include <uapi/linux/if_ether.h>
+#include <linux/deepin_kabi.h>
 
 struct bpf_prog;
 struct net;
@@ -401,6 +402,11 @@ struct flow_keys {
 	struct flow_dissector_key_icmp icmp;
 	/* 'addrs' must be the last member */
 	struct flow_dissector_key_addrs addrs;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define FLOW_KEYS_HASH_OFFSET		\

--- a/include/net/genetlink.h
+++ b/include/net/genetlink.h
@@ -92,6 +92,7 @@ struct genl_family {
 	unsigned int		mcgrp_offset;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -118,6 +119,7 @@ struct genl_info {
 	struct netlink_ext_ack *extack;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct net *genl_info_net(const struct genl_info *info)

--- a/include/net/inet_connection_sock.h
+++ b/include/net/inet_connection_sock.h
@@ -55,6 +55,7 @@ struct inet_connection_sock_af_ops {
 	void	    (*mtu_reduced)(struct sock *sk);
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /** inet_connection_sock - INET connection oriented sock
@@ -143,6 +144,7 @@ struct inet_connection_sock {
 	u32			  icsk_user_timeout;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	u64			  icsk_ca_priv[104 / sizeof(u64)];
 #define ICSK_CA_PRIV_SIZE	  sizeof_field(struct inet_connection_sock, icsk_ca_priv)

--- a/include/net/ip6_fib.h
+++ b/include/net/ip6_fib.h
@@ -70,6 +70,7 @@ struct fib6_config {
 	bool		fc_is_fdb;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct fib6_node {
@@ -88,6 +89,7 @@ struct fib6_node {
 	struct rcu_head		rcu;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct fib6_gc_args {
@@ -209,6 +211,7 @@ struct fib6_info {
 	struct nexthop			*nh;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	struct fib6_nh			fib6_nh[];
 };
@@ -228,6 +231,7 @@ struct rt6_info {
 	unsigned short			rt6i_nfheader_len;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct fib6_result {

--- a/include/net/neighbour.h
+++ b/include/net/neighbour.h
@@ -89,6 +89,7 @@ struct neigh_parms {
 	DECLARE_BITMAP(data_state, NEIGH_VAR_DATA_MAX);
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline void neigh_var_set(struct neigh_parms *p, int index, int val)
@@ -165,6 +166,10 @@ struct neighbour {
 	struct rcu_head		rcu;
 	struct net_device	*dev;
 	netdevice_tracker	dev_tracker;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+
 	u8			primary_key[];
 } __randomize_layout;
 
@@ -239,6 +244,7 @@ struct neigh_table {
 	struct pneigh_entry	**phash_buckets;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum {

--- a/include/net/netdev_rx_queue.h
+++ b/include/net/netdev_rx_queue.h
@@ -21,6 +21,11 @@ struct netdev_rx_queue {
 #ifdef CONFIG_XDP_SOCKETS
 	struct xsk_buff_pool            *pool;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 } ____cacheline_aligned_in_smp;
 
 /*

--- a/include/net/netns/ipv6.h
+++ b/include/net/netns/ipv6.h
@@ -122,6 +122,7 @@ struct netns_ipv6 {
 	struct ioam6_pernet_data *ioam6_data;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #if IS_ENABLED(CONFIG_NF_DEFRAG_IPV6)

--- a/include/net/netns/nftables.h
+++ b/include/net/netns/nftables.h
@@ -7,6 +7,7 @@
 struct netns_nftables {
 	u8			gencursor;
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif

--- a/include/net/netns/xfrm.h
+++ b/include/net/netns/xfrm.h
@@ -86,6 +86,7 @@ struct netns_xfrm {
 	struct mutex xfrm_cfg_mutex;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif

--- a/include/net/page_pool/types.h
+++ b/include/net/page_pool/types.h
@@ -5,6 +5,7 @@
 
 #include <linux/dma-direction.h>
 #include <linux/ptr_ring.h>
+#include <linux/deepin_kabi.h>
 
 #define PP_FLAG_DMA_MAP		BIT(0) /* Should page_pool do the DMA
 					* map/unmap
@@ -180,6 +181,9 @@ struct page_pool {
 	refcount_t user_cnt;
 
 	u64 destroy_cnt;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct page *page_pool_alloc_pages(struct page_pool *pool, gfp_t gfp);

--- a/include/net/sch_generic.h
+++ b/include/net/sch_generic.h
@@ -286,6 +286,7 @@ struct Qdisc_class_ops {
 					struct gnet_dump *);
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* Qdisc_class_ops flag values */
@@ -333,6 +334,7 @@ struct Qdisc_ops {
 	struct module		*owner;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct tcf_result {

--- a/include/net/tls.h
+++ b/include/net/tls.h
@@ -48,6 +48,7 @@
 #include <net/strparser.h>
 #include <crypto/aead.h>
 #include <uapi/linux/tls.h>
+#include <linux/deepin_kabi.h>
 
 struct tls_rec;
 
@@ -142,6 +143,10 @@ struct tls_record_info {
 	u32 end_seq;
 	int len;
 	int num_frags;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+
 	skb_frag_t frags[MAX_SKB_FRAGS];
 };
 
@@ -191,6 +196,11 @@ enum tls_context_flags {
 struct cipher_context {
 	char *iv;
 	char *rec_seq;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 union tls_crypto_context {
@@ -261,6 +271,11 @@ struct tls_context {
 	struct list_head list;
 	refcount_t refcount;
 	struct rcu_head rcu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 enum tls_offload_ctx_dir {

--- a/include/net/xsk_buff_pool.h
+++ b/include/net/xsk_buff_pool.h
@@ -9,6 +9,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/bpf.h>
 #include <net/xdp.h>
+#include <linux/deepin_kabi.h>
 
 struct xsk_buff_pool;
 struct xdp_rxq_info;
@@ -87,6 +88,8 @@ struct xsk_buff_pool {
 	 * sockets share a single cq when the same netdev and queue id is shared.
 	 */
 	spinlock_t cq_lock;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct xdp_buff_xsk *free_heads[];
 };
 

--- a/net/devlink/devl_internal.h
+++ b/net/devlink/devl_internal.h
@@ -14,6 +14,7 @@
 #include <net/net_namespace.h>
 #include <net/rtnetlink.h>
 #include <rdma/ib_verbs.h>
+#include <linux/deepin_kabi.h>
 
 #include "netlink_gen.h"
 
@@ -55,6 +56,10 @@ struct devlink {
 	u8 reload_failed:1;
 	refcount_t refcount;
 	struct rcu_work rwork;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+
 	char priv[] __aligned(NETDEV_ALIGN);
 };
 


### PR DESCRIPTION
…structure

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for net base framework related structures prone to change.

## Summary by Sourcery

Introduce reserved KABI fields in core network subsystem structures for future API compatibility.

New Features:
- Reserve placeholder fields in multiple net base framework structures via DEEPIN_KABI_RESERVE macros.

Enhancements:
- Include deepin_kabi.h in various network headers and insert reserve macros in TLS, Generic Netlink, Flow Dissector, Neighbour, netdev_rx_queue, Devlink, IPv6 FIB, page_pool, XSK buff pool, inet_connection_sock, Qdisc, device, and netns modules.