### PR TITLE
deepin: KABI:kabi: reserve space for struct acpi_device and acpi_scan…

### DIFF
--- a/include/acpi/acpi_bus.h
+++ b/include/acpi/acpi_bus.h
@@ -11,6 +11,7 @@
 
 #include <linux/device.h>
 #include <linux/property.h>
+#include <linux/deepin_kabi.h>
 
 /* TBD: Make dynamic */
 #define ACPI_MAX_HANDLES	10
@@ -130,6 +131,8 @@ struct acpi_scan_handler {
 	void (*bind)(struct device *phys_dev);
 	void (*unbind)(struct device *phys_dev);
 	struct acpi_hotplug_profile hotplug;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /*
@@ -282,6 +285,8 @@ struct acpi_device_power {
 	struct acpi_device_power_flags flags;
 	struct acpi_device_power_state states[ACPI_D_STATE_COUNT];	/* Power states (D0-D3Cold) */
 	u8 state_for_enumeration; /* Deepest power state for enumeration */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct acpi_dep_data {
@@ -389,6 +394,8 @@ struct acpi_device {
 	struct list_head physical_node_list;
 	struct mutex physical_node_lock;
 	void (*remove)(struct acpi_device *);
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* Non-device subnode */


### PR DESCRIPTION
…_handler

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8ZCY9 CVE: NA

-------------------------------

reserve space for struct acpi_device, struct acpi_device_power and struct acpi_scan_handler

## Summary by Sourcery

Reserve reserved KABI slots in ACPI structures for future binary compatibility

Enhancements:
- Include deepin_kabi.h in acpi_bus.h
- Add DEEPIN_KABI_RESERVE entries to struct acpi_scan_handler
- Add DEEPIN_KABI_RESERVE entries to struct acpi_device_power
- Add DEEPIN_KABI_RESERVE entries to struct acpi_device