### PR TITLE
deepin: KABI:kabi: reserve space for struct rate_sample

### DIFF
--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -26,6 +26,7 @@
 #include <linux/kref.h>
 #include <linux/ktime.h>
 #include <linux/indirect_call_wrapper.h>
+#include <linux/deepin_kabi.h>
 
 #include <net/inet_connection_sock.h>
 #include <net/inet_timewait_sock.h>
@@ -1080,6 +1081,8 @@ struct rate_sample {
 	bool is_app_limited;	/* is sample from packet with bubble in pipe? */
 	bool is_retrans;	/* is sample from retransmission? */
 	bool is_ack_delayed;	/* is this (likely) a delayed ACK? */
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct tcp_congestion_ops {


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I908BZ CVE: NA

-------------------------------

Reserve space for struct rate_sample in tcp.h.

## Summary by Sourcery

Reserve padding in the TCP rate_sample structure for deepin kernel ABI compatibility

Enhancements:
- Include the linux/deepin_kabi.h header in net/tcp.h
- Add two DEEPIN_KABI_RESERVE entries to struct rate_sample to reserve space for future KABI extensions