### PR TITLE
deepin: KABI:kabi: net: reserve space for net netfilter subsystem rel…

### DIFF
--- a/include/linux/netfilter/ipset/ip_set.h
+++ b/include/linux/netfilter/ipset/ip_set.h
@@ -193,6 +193,7 @@ struct ip_set_type_variant {
 	bool region_lock;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct ip_set_region {
@@ -241,6 +242,7 @@ struct ip_set_type {
 	struct module *me;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /* register and unregister set type */
@@ -287,6 +289,7 @@ struct ip_set {
 	void *data;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline void

--- a/include/linux/netfilter/nfnetlink.h
+++ b/include/linux/netfilter/nfnetlink.h
@@ -31,6 +31,7 @@ struct nfnl_callback {
 	__u16			attr_count;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum nfnl_abort_action {
@@ -51,6 +52,7 @@ struct nfnetlink_subsystem {
 	bool (*valid_genid)(struct net *net, u32 genid);
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 int nfnetlink_subsys_register(const struct nfnetlink_subsystem *n);

--- a/include/net/netns/netfilter.h
+++ b/include/net/netns/netfilter.h
@@ -36,5 +36,6 @@ struct netns_nf {
 #endif
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 #endif


### PR DESCRIPTION
…ated structure

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for net netfilter framework related structures prone to change.

## Summary by Sourcery

Reserve additional DEEPIN_KABI_RESERVE slots in netfilter-related structures to future-proof the kernel ABI.

Enhancements:
- Add a second DEEPIN_KABI_RESERVE slot to ip_set_type_variant, ip_set_type, and ip_set structs
- Add a second DEEPIN_KABI_RESERVE slot to nfnl_callback and nfnetlink_subsystem structs
- Add a second DEEPIN_KABI_RESERVE slot to netns_nf struct