### PR TITLE
deepin: KABI:kabi: net: reserve space for net can subsystem related s…

### DIFF
--- a/include/net/netns/can.h
+++ b/include/net/netns/can.h
@@ -39,6 +39,7 @@ struct netns_can {
 	struct hlist_head cgw_list;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif /* __NETNS_CAN_H__ */


### PR DESCRIPTION
…tructure

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for net can framework related structures prone to change.

## Summary by Sourcery

Enhancements:
- Add a second DEEPIN_KABI_RESERVE entry in the netns_can struct