### PR TITLE
deepin: KABI:drm: Add kabi reserve in drm_mode_config.h

### DIFF
--- a/include/drm/drm_mode_config.h
+++ b/include/drm/drm_mode_config.h
@@ -28,6 +28,7 @@
 #include <linux/idr.h>
 #include <linux/workqueue.h>
 #include <linux/llist.h>
+#include <linux/deepin_kabi.h>
 
 #include <drm/drm_modeset_lock.h>
 
@@ -955,6 +956,10 @@ struct drm_mode_config {
 	struct drm_atomic_state *suspend_state;
 
 	const struct drm_mode_config_helper_funcs *helper_private;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 int __must_check drmm_mode_config_init(struct drm_device *dev);


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for drm_mode_config in drm_mode_config.h.

## Summary by Sourcery

Add reserved KABI space in drm_mode_config struct to maintain deepin kernel ABI compatibility.

Bug Fixes:
- Add four DEEPIN_KABI_RESERVE fields in drm_mode_config struct to reserve space for ABI stability.

Enhancements:
- Include linux/deepin_kabi.h header in drm_mode_config.h.