### PR TITLE
deepin: KABI:drm: drm_fb_helper.h: Add DEEPIN_KABI_RESERVE

### DIFF
--- a/include/drm/drm_fb_helper.h
+++ b/include/drm/drm_fb_helper.h
@@ -37,6 +37,8 @@ struct drm_fb_helper;
 
 #include <drm/drm_client.h>
 
+#include <linux/deepin_kabi.h>
+
 /**
  * struct drm_fb_helper_surface_size - describes fbdev size and scanout surface size
  * @fb_width: fbdev width
@@ -99,6 +101,9 @@ struct drm_fb_helper_funcs {
 	 * 0 on success, or an error code otherwise.
 	 */
 	int (*fb_dirty)(struct drm_fb_helper *helper, struct drm_clip_rect *clip);
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -206,6 +211,9 @@ struct drm_fb_helper {
 	 */
 	struct fb_deferred_io fbdefio;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static inline struct drm_fb_helper *


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add DEEPIN_KABI_RESERVE in drm_fb_helper.h

## Summary by Sourcery

Add DEEPIN_KABI_RESERVE placeholders to drm_fb_helper header to support Deepin KABI compatibility.

Enhancements:
- Include linux/deepin_kabi.h in drm_fb_helper.h
- Insert DEEPIN_KABI_RESERVE(1) and DEEPIN_KABI_RESERVE(2) in drm_fb_helper_funcs and drm_fb_helper structures