### PR TITLE
deepin: KABI:drm: drm_device.h: Add DEEPIN_KABI_RESERVE

### DIFF
--- a/include/drm/drm_device.h
+++ b/include/drm/drm_device.h
@@ -8,6 +8,7 @@
 
 #include <drm/drm_legacy.h>
 #include <drm/drm_mode_config.h>
+#include <linux/deepin_kabi.h>
 
 struct drm_driver;
 struct drm_minor;
@@ -391,6 +392,9 @@ struct drm_device {
 	bool irq_enabled;
 	int irq;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #endif


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add DEEPIN_KABI_RESERVE in drm_device.h

## Summary by Sourcery

Add reserved slots for Deepin kernel ABI stability in the DRM device structure

Enhancements:
- Include linux/deepin_kabi.h in drm_device.h
- Insert two DEEPIN_KABI_RESERVE entries into struct drm_device