### PR TITLE
deepin: KABI:drm/ttm: Add kabi reserve in ttm_bo.h

### DIFF
--- a/include/drm/ttm/ttm_bo.h
+++ b/include/drm/ttm/ttm_bo.h
@@ -35,6 +35,7 @@
 
 #include <linux/kref.h>
 #include <linux/list.h>
+#include <linux/deepin_kabi.h>
 
 #include "ttm_device.h"
 
@@ -133,6 +134,10 @@ struct ttm_buffer_object {
 	 * either of these locks held.
 	 */
 	struct sg_table *sg;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 /**
@@ -183,6 +188,8 @@ struct ttm_operation_ctx {
 	bool force_alloc;
 	struct dma_resv *resv;
 	uint64_t bytes_moved;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for ttm_buffer_object and ttm_operation_ctx in ttm_bo.h

## Summary by Sourcery

Bug Fixes:
- Include deepin_kabi.h and insert DEEPIN_KABI_RESERVE slots in ttm_buffer_object and ttm_operation_ctx to prevent ABI breakage