### PR TITLE
deepin: KABI:kabi: net: reserve space for xdp subsystem related struc…

### DIFF
--- a/include/net/xdp.h
+++ b/include/net/xdp.h
@@ -54,6 +54,9 @@ enum xdp_mem_type {
 struct xdp_mem_info {
 	u32 type; /* enum xdp_mem_type, but known size type */
 	u32 id;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct page_pool;
@@ -74,6 +77,9 @@ struct xdp_rxq_info {
 
 struct xdp_txq_info {
 	struct net_device *dev;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 enum xdp_buff_flags {
@@ -92,6 +98,11 @@ struct xdp_buff {
 	struct xdp_txq_info *txq;
 	u32 frame_sz; /* frame size to deduce data_hard_end/reserved tailroom*/
 	u32 flags; /* supported values defined in xdp_buff_flags */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static __always_inline bool xdp_buff_has_frags(struct xdp_buff *xdp)
@@ -181,6 +192,11 @@ struct xdp_frame {
 	struct net_device *dev_rx; /* used by cpumap */
 	u32 frame_sz;
 	u32 flags; /* supported values defined in xdp_buff_flags */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 static __always_inline bool xdp_frame_has_frags(struct xdp_frame *frame)
@@ -198,6 +214,9 @@ struct xdp_frame_bulk {
 	int count;
 	void *xa;
 	void *q[XDP_BULK_QUEUE_SIZE];
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 static __always_inline void xdp_frame_bulk_init(struct xdp_frame_bulk *bq)


### PR DESCRIPTION
…ture

hulk inclusion
category: other
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for xdp framework related structures prone to change.

## Summary by Sourcery

Enhancements:
- Add DEEPIN_KABI_RESERVE padding fields to xdp_mem_info, xdp_txq_info, xdp_buff, xdp_frame, and xdp_frame_bulk to maintain KABI compatibility.