### PR TITLE
deepin: KABI:drm/ttm: Add kabi reserve in ttm_tt.h

### DIFF
--- a/include/drm/ttm/ttm_tt.h
+++ b/include/drm/ttm/ttm_tt.h
@@ -29,6 +29,7 @@
 
 #include <linux/pagemap.h>
 #include <linux/types.h>
+#include <linux/deepin_kabi.h>
 #include <drm/ttm/ttm_caching.h>
 #include <drm/ttm/ttm_kmap_iter.h>
 
@@ -110,6 +111,8 @@ struct ttm_tt {
 	 * ttm_caching.
 	 */
 	enum ttm_caching caching;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for ttm_tt in ttm_tt.h

## Summary by Sourcery

Add deepin KABI reservation in ttm_tt.h to maintain ABI compatibility

Bug Fixes:
- Reserve space in ttm_tt struct to maintain KABI compatibility

Enhancements:
- Include linux/deepin_kabi.h for KABI reservation