### PR TITLE
deepin: KABI:drm: Add kabi reserve in drm_modeset_lock.h

### DIFF
--- a/include/drm/drm_modeset_lock.h
+++ b/include/drm/drm_modeset_lock.h
@@ -27,6 +27,7 @@
 #include <linux/types.h> /* stackdepot.h is not self-contained */
 #include <linux/stackdepot.h>
 #include <linux/ww_mutex.h>
+#include <linux/deepin_kabi.h>
 
 struct drm_modeset_lock;
 
@@ -72,6 +73,8 @@ struct drm_modeset_acquire_ctx {
 
 	/* Perform interruptible waits on this context. */
 	bool interruptible;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for drm_modeset_acquire_ctx in drm_modeset_lock.h.

## Summary by Sourcery

Bug Fixes:
- Include linux/deepin_kabi.h and add DEEPIN_KABI_RESERVE slots in drm_modeset_acquire_ctx for stable KABI compatibility.