### PR TITLE
deepin: KABI:kabi: net: reserve space for net rdma subsystem related …

### DIFF
--- a/include/rdma/ib_addr.h
+++ b/include/rdma/ib_addr.h
@@ -47,6 +47,7 @@ struct rdma_dev_addr {
 	int hoplimit;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**

--- a/include/rdma/rdma_cm.h
+++ b/include/rdma/rdma_cm.h
@@ -104,6 +104,7 @@ struct rdma_cm_event {
 	struct rdma_ucm_ece ece;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rdma_cm_id;
@@ -130,6 +131,7 @@ struct rdma_cm_id {
 	struct work_struct net_work;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rdma_cm_id *

--- a/include/rdma/rdma_counter.h
+++ b/include/rdma/rdma_counter.h
@@ -44,6 +44,7 @@ struct rdma_counter {
 	u32				port;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 void rdma_counter_init(struct ib_device *dev);

--- a/include/rdma/rdma_vt.h
+++ b/include/rdma/rdma_vt.h
@@ -108,6 +108,7 @@ struct rvt_ibport {
 	struct timer_list trap_timer;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define RVT_CQN_MAX 16 /* maximum length of cq name */


### PR DESCRIPTION
…structure

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for net rdma framework related structures prone to change.

## Summary by Sourcery

Enhancements:
- Add a second DEEPIN_KABI_RESERVE slot to rdma_cm_event, rdma_cm_id, rdma_dev_addr, rdma_counter, and rvt_ibport structures for future ABI compatibility