### PR TITLE
deepin: KABI:kabi: reserve space for struct ptp_clock

### DIFF
--- a/drivers/ptp/ptp_private.h
+++ b/drivers/ptp/ptp_private.h
@@ -15,6 +15,7 @@
 #include <linux/ptp_clock.h>
 #include <linux/ptp_clock_kernel.h>
 #include <linux/time.h>
+#include <linux/deepin_kabi.h>
 
 #define PTP_MAX_TIMESTAMPS 128
 #define PTP_BUF_TIMESTAMPS 30
@@ -53,6 +54,10 @@ struct ptp_clock {
 	struct mutex n_vclocks_mux; /* protect concurrent n_vclocks access */
 	bool is_virtual_clock;
 	bool has_cycles;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #define info_to_vclock(d) container_of((d), struct ptp_vclock, info)


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8Z2NU CVE: NA

-------------------------------

reserve space for struct ptp_clock.

## Summary by Sourcery

Reserve additional deepin KABI compatibility space in the ptp_clock structure by adding reserved fields and including the deepin_kabi header

Enhancements:
- Include linux/deepin_kabi.h in ptp_private.h
- Add four DEEPIN_KABI_RESERVE entries to struct ptp_clock