### PR TITLE
deepin: KABI:cgroup/psi: reserve kabi for future psi development

### DIFF
--- a/include/linux/psi_types.h
+++ b/include/linux/psi_types.h
@@ -217,6 +217,10 @@ struct psi_group {
 	u64 rtpoll_total[NR_PSI_STATES - 1];
 	u64 rtpoll_next_update;
 	u64 rtpoll_until;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_RESERVE(3)
+	DEEPIN_KABI_RESERVE(4)
 };
 
 #else /* CONFIG_PSI */


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8SA3O

----------------------------------------------------------------------

cgroup/psi: reserve kabi for future psi development

## Summary by Sourcery

Enhancements:
- Reserve four KABI slots in psi_group struct to ensure ABI stability for future PSI enhancements