### PR TITLE
deepin: KABI:kabi: reserve space for thread_info structure

### DIFF
--- a/arch/arm64/include/asm/thread_info.h
+++ b/arch/arm64/include/asm/thread_info.h
@@ -17,6 +17,7 @@ struct task_struct;
 #include <asm/memory.h>
 #include <asm/stack_pointer.h>
 #include <asm/types.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * low level task data that entry.S needs immediate access to.
@@ -43,6 +44,9 @@ struct thread_info {
 	void			*scs_sp;
 #endif
 	u32			cpu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 #define thread_saved_pc(tsk)	\

--- a/arch/x86/include/asm/thread_info.h
+++ b/arch/x86/include/asm/thread_info.h
@@ -13,6 +13,7 @@
 #include <asm/page.h>
 #include <asm/percpu.h>
 #include <asm/types.h>
+#include <linux/deepin_kabi.h>
 
 /*
  * TOP_OF_KERNEL_STACK_PADDING is a number of unused bytes that we


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I90MTG

-------------------------------

Reserve space for arm64 and x86 thread_info structure

## Summary by Sourcery

Reserve space for the thread_info structure on arm64 by inserting KABI padding macros and include the deepin_kabi header in both arm64 and x86 to enable future thread_info ABI reservations

New Features:
- Add DEEPIN_KABI_RESERVE slots in the arm64 thread_info struct to reserve future ABI space
- Include the deepin_kabi header in both arm64 and x86 thread_info definitions for KABI support