### PR TITLE
deepin: KABI:drm: Add kabi reserve in drm_syncobj.h

### DIFF
--- a/include/drm/drm_syncobj.h
+++ b/include/drm/drm_syncobj.h
@@ -28,6 +28,7 @@
 
 #include <linux/dma-fence.h>
 #include <linux/dma-fence-chain.h>
+#include <linux/deepin_kabi.h>
 
 struct drm_file;
 
@@ -65,6 +66,8 @@ struct drm_syncobj {
 	 * @file: A file backing for this syncobj.
 	 */
 	struct file *file;
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 void drm_syncobj_free(struct kref *kref);


### PR DESCRIPTION
hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I9244H

---------------------------

Reserve space for drm_syncobj in drm_syncobj.h.

## Summary by Sourcery

Reserve KABI space in the DRM sync object to maintain stable deepin kernel ABI.

Bug Fixes:
- Add DEEPIN_KABI_RESERVE entries to the drm_syncobj struct to fix KABI compatibility.

Enhancements:
- Include deepin_kabi.h and insert reserve macros in drm_syncobj.h.