### PR TITLE
deepin: KABI:drm: drm_drv.h: Add kabi_reserve

### DIFF
--- a/include/drm/drm_drv.h
+++ b/include/drm/drm_drv.h
@@ -34,6 +34,8 @@
 
 #include <drm/drm_device.h>
 
+#include <linux/deepin_kabi.h>
+
 struct drm_file;
 struct drm_gem_object;
 struct drm_master;
@@ -461,6 +463,9 @@ struct drm_driver {
 	void (*disable_vblank)(struct drm_device *dev, unsigned int pipe);
 	int dev_priv_size;
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 void *__devm_drm_dev_alloc(struct device *parent,


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add kabi_reserve in drm_drv.h

## Summary by Sourcery

Add deepin KABI reservation slots to the drm_driver struct by including the deepin KABI header and inserting DEEPIN_KABI_RESERVE entries to maintain ABI compatibility.

Enhancements:
- Include deepin_kabi.h in drm_drv.h
- Add two DEEPIN_KABI_RESERVE slots to the drm_driver struct