### PR TITLE
deepin: KABI:drm: drm_fourcc.h: Add kabi_reserve

### DIFF
--- a/include/drm/drm_fourcc.h
+++ b/include/drm/drm_fourcc.h
@@ -25,6 +25,8 @@
 #include <linux/types.h>
 #include <uapi/drm/drm_fourcc.h>
 
+#include <linux/deepin_kabi.h>
+
 /**
  * DRM_FORMAT_MAX_PLANES - maximum number of planes a DRM format can have
  */
@@ -141,6 +143,9 @@ struct drm_format_info {
 
 	/** @is_color_indexed: Is it a color-indexed format? */
 	bool is_color_indexed;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add kabi_reserve in drm_fourcc.h

## Summary by Sourcery

Add deepin KABI reservation slots to drm_fourcc.h to preserve binary compatibility

Enhancements:
- Include linux/deepin_kabi.h in drm_fourcc.h
- Add two DEEPIN_KABI_RESERVE entries in the drm_format_info struct