### PR TITLE
deepin: KABI:drm: drm_file.h: Add kabi_reserve

### DIFF
--- a/include/drm/drm_file.h
+++ b/include/drm/drm_file.h
@@ -38,6 +38,8 @@
 
 #include <drm/drm_prime.h>
 
+#include <linux/deepin_kabi.h>
+
 struct dma_fence;
 struct drm_file;
 struct drm_device;
@@ -85,6 +87,9 @@ struct drm_minor {
 
 	struct list_head debugfs_list;
 	struct mutex debugfs_lock; /* Protects debugfs_list. */
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**
@@ -398,6 +403,9 @@ struct drm_file {
 #if IS_ENABLED(CONFIG_DRM_LEGACY)
 	unsigned long lock_count; /* DRI1 legacy lock count */
 #endif
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 /**


### PR DESCRIPTION
hulk inclusion
bugzilla: https://gitee.com/openeuler/kernel/issues/I8PS7G CVE: NA

---------------------------------------------

Add kabi_reserve in drm_file.h

## Summary by Sourcery

Add deepin KABI reservation slots to DRM file and minor structures for ABI stability

Enhancements:
- Include <linux/deepin_kabi.h> in drm_file.h
- Add two DEEPIN_KABI_RESERVE entries to struct drm_minor
- Add two DEEPIN_KABI_RESERVE entries to struct drm_file