### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] sched/psi: Bail out early from irq time accounting

### DIFF
--- a/kernel/sched/psi.c
+++ b/kernel/sched/psi.c
@@ -1009,6 +1009,9 @@ void psi_account_irqtime(struct rq *rq, struct task_struct *curr, struct task_st
 	s64 delta;
 	u64 irq;
 
+	if (static_branch_likely(&psi_disabled))
+		return;
+
 	if (!curr->pid)
 		return;
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
category: bugfix

We could bail out early when psi was disabled.



Reviewed-by: Chengming Zhou <zhouchengming@bytedance.com>
Link: https://lore.kernel.org/r/20230926115722.467833-1-haifeng.xu@shopee.com (cherry picked from commit 0c2924079f5a83ed715630680e338b3685a0bf7d)

[Because commit ddae0ca2a8fe ("sched: Move psi_account_irqtime() out of update_rq_clock_task() hotpath") merged before]
Conflicts:
	kernel/sched/psi.c

## Summary by Sourcery

Bug Fixes:
- Skip irq time accounting early when psi is disabled to prevent unnecessary work.