### PR TITLE
deepin: KABI:kabi: reserve space for workqueue subsystem related stru…

### DIFF
--- a/include/linux/workqueue.h
+++ b/include/linux/workqueue.h
@@ -119,6 +119,9 @@ struct delayed_work {
 	/* target workqueue and CPU ->timer uses to queue ->work */
 	struct workqueue_struct *wq;
 	int cpu;
+
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rcu_work {


### PR DESCRIPTION
…cture

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I9089C CVE: NA

-------------------------------

Reserve space for workqueue subsystem.

## Summary by Sourcery

Enhancements:
- Reserve space for KABI compatibility in the delayed_work struct of the workqueue subsystem