### PR TITLE
deepin: KABI:kabi: net: reserve space for net sunrpc subsystem relate…

### DIFF
--- a/include/linux/sunrpc/clnt.h
+++ b/include/linux/sunrpc/clnt.h
@@ -114,6 +114,7 @@ struct rpc_program {
 	const char *		pipe_dir_name;	/* path to rpc_pipefs dir */
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rpc_version {

--- a/include/linux/sunrpc/sched.h
+++ b/include/linux/sunrpc/sched.h
@@ -30,6 +30,7 @@ struct rpc_message {
 	const struct cred *	rpc_cred;	/* Credentials */
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct rpc_call_ops;

--- a/include/linux/sunrpc/stats.h
+++ b/include/linux/sunrpc/stats.h
@@ -27,6 +27,7 @@ struct rpc_stat {
 				rpcgarbage;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct svc_stat {
@@ -42,6 +43,7 @@ struct svc_stat {
 				rpcbadclnt;
 
 	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 };
 
 struct net;


### PR DESCRIPTION
…d structure

hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8OWRC

----------------------------------------------------

Reserve some fields beforehand for net sunrpc framework related structures prone to change.

## Summary by Sourcery

Enhancements:
- Add extra DEEPIN_KABI_RESERVE slots to rpc_stat, svc_stat, rpc_program, and rpc_message structures for KABI stability.