### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] sched/fair: Remove unused parameter from sched_asym()

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -9752,7 +9752,6 @@ static bool sched_use_asym_prio(struct sched_domain *sd, int cpu)
 /**
  * sched_asym - Check if the destination CPU can do asym_packing load balance
  * @env:	The load balancing environment
- * @sds:	Load-balancing data with statistics of the local group
  * @sgs:	Load-balancing statistics of the candidate busiest group
  * @group:	The candidate busiest group
  *
@@ -9771,8 +9770,7 @@ static bool sched_use_asym_prio(struct sched_domain *sd, int cpu)
  * otherwise.
  */
 static inline bool
-sched_asym(struct lb_env *env, struct sd_lb_stats *sds,  struct sg_lb_stats *sgs,
-	   struct sched_group *group)
+sched_asym(struct lb_env *env, struct sg_lb_stats *sgs, struct sched_group *group)
 {
 	/* Ensure that the whole local core is idle, if applicable. */
 	if (!sched_use_asym_prio(env->sd, env->dst_cpu))
@@ -9943,7 +9941,7 @@ static inline void update_sg_lb_stats(struct lb_env *env,
 	/* Check if dst CPU is idle and preferred to this group */
 	if (!local_group && env->sd->flags & SD_ASYM_PACKING &&
 	    env->idle != CPU_NOT_IDLE && sgs->sum_h_nr_running &&
-	    sched_asym(env, sds, sgs, group)) {
+	    sched_asym(env, sgs, group)) {
 		sgs->group_asym_packing = 1;
 	}
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.9-rc1
category: bugfix

The 'sds' argument is not used in the sched_asym() function anymore, remove it.

Fixes: c9ca07886aaa ("sched/fair: Do not even the number of busy CPUs via asym_packing")


Reviewed-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
Reviewed-by: Valentin Schneider <vschneid@redhat.com>
Reviewed-by: Vincent Guittot <vincent.guittot@linaro.org>
Link: https://lore.kernel.org/r/20240210113924.1130448-2-alexs@kernel.org (cherry picked from commit 5a64983731566f3b102b4ed12445b8a1b2f46a46)

## Summary by Sourcery

Remove the unused 'sds' parameter from the sched_asym function in the fair scheduler and adjust its invocations accordingly

Bug Fixes:
- Update sched_asym signature and all call sites to drop the redundant 'sds' argument

Enhancements:
- Simplify sched_asym function by removing the unused 'sds' parameter