### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Deepin] Loongarch: optimize syscall_enter_audit 

### DIFF
--- a/arch/loongarch/include/asm/syscall.h
+++ b/arch/loongarch/include/asm/syscall.h
@@ -58,7 +58,11 @@ static inline void syscall_get_arguments(struct task_struct *task,
 					 unsigned long *args)
 {
 	args[0] = regs->orig_a0;
-	memcpy(&args[1], &regs->regs[5], 5 * sizeof(long));
+	args[1] = regs->regs[5];
+	args[2] = regs->regs[6];
+	args[3] = regs->regs[7];
+	args[4] = regs->regs[8];
+	args[5] = regs->regs[9];
 }
 
 static inline int syscall_get_arch(struct task_struct *task)


### PR DESCRIPTION
deepin inclusion
category: performance

Loongarch use -fno-builtin-memcpy in Makefile,
so cause a extra memcpy in syscall hot path:

syscall_enter_audit
->syscall_get_arguments->memcpy
->audit_syscall_entry

Just avoid memcpy() altogether and write the copying of args from regs manually, which shows 5% multi core score up in UnixBench syscall.


(cherry picked from commit e3e32c894c0f2e5357b614e75cceb08ce6e8aa5b)

## Summary by Sourcery

Enhancements:
- Replace memcpy in syscall_get_arguments with direct register assignments to avoid extra copy on Loongarch