### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] Merge mm: page_alloc: fixes for high atomic reserve caluculations from v6.8-rc1

### DIFF
--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -1911,10 +1911,11 @@ static void reserve_highatomic_pageblock(struct page *page, struct zone *zone)
 	unsigned long max_managed, flags;
 
 	/*
-	 * Limit the number reserved to 1 pageblock or roughly 1% of a zone.
+	 * The number reserved as: minimum is 1 pageblock, maximum is
+	 * roughly 1% of a zone.
 	 * Check is race-prone but harmless.
 	 */
-	max_managed = (zone_managed_pages(zone) / 100) + pageblock_nr_pages;
+	max_managed = ALIGN((zone_managed_pages(zone) / 100), pageblock_nr_pages);
 	if (zone->nr_reserved_highatomic >= max_managed)
 		return;
 

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -1912,9 +1912,12 @@ static void reserve_highatomic_pageblock(struct page *page, struct zone *zone)
 
 	/*
 	 * The number reserved as: minimum is 1 pageblock, maximum is
-	 * roughly 1% of a zone.
+	 * roughly 1% of a zone. But if 1% of a zone falls below a
+	 * pageblock size, then don't reserve any pageblocks.
 	 * Check is race-prone but harmless.
 	 */
+	if ((zone_managed_pages(zone) / 100) < pageblock_nr_pages)
+		return;
 	max_managed = ALIGN((zone_managed_pages(zone) / 100), pageblock_nr_pages);
 	if (zone->nr_reserved_highatomic >= max_managed)
 		return;


### PR DESCRIPTION
Link: https://lore.kernel.org/all/1660034138397b82a0a8b6ae51cbe96bd583d89e.1700821416.git.quic_charante@quicinc.com/T/#u

## Summary by Sourcery

Fix highatomic pageblock reservation logic to correctly calculate maximum reserved pageblocks and avoid reservations for zones smaller than one pageblock

Bug Fixes:
- Return early when 1% of zone is smaller than a pageblock to prevent erroneous highatomic reservations
- Align maximum reserved pages to pageblock boundary instead of adding a fixed pageblock size