### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] mm/vmalloc: fix return value of vb_alloc if size is 0

### DIFF
--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -2198,7 +2198,7 @@ static void *vb_alloc(unsigned long size, gfp_t gfp_mask)
 		 * get_order(0) returns funny result. Just warn and terminate
 		 * early.
 		 */
-		return NULL;
+		return ERR_PTR(-EINVAL);
 	}
 	order = get_order(size);
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.9
category: bugfix

vm_map_ram() uses IS_ERR() to validate the return value of vb_alloc().  If vm_map_ram(page, 0, 0) is executed, vb_alloc(0, GFP_KERNEL) would return NULL.  In such a case, IS_ERR() cannot handle the return value and lead to kernel panic by vmap_pages_range_noflush() at last.  To resolve this issue, return ERR_PTR(-EINVAL) if the size is 0.

Link: https://lkml.kernel.org/r/20240426024149.21176-1-hailong.liu@oppo.com
Reviewed-by: Barry Song <baohua@kernel.org>
Reviewed-by: Uladzislau Rezki (Sony) <urezki@gmail.com>

Reviewed-by: Christoph Hellwig <hch@lst.de>
Cc: Lorenzo Stoakes <lstoakes@gmail.com>

(cherry picked from commit ac0476e8ca2e4125c0886d7d8d418b8e7cb17139)

## Summary by Sourcery

Bug Fixes:
- Return ERR_PTR(-EINVAL) from vb_alloc when size is zero instead of NULL to ensure IS_ERR handles it and avoid vmap_pages_range_noflush panics