### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] PM: runtime: Simplify pm_runtime_get_if_active() usage (Fix 6.6.103 build)

### DIFF
--- a/drivers/accel/ivpu/ivpu_pm.c
+++ b/drivers/accel/ivpu/ivpu_pm.c
@@ -307,7 +307,7 @@ int ivpu_rpm_get_if_active(struct ivpu_device *vdev)
 {
 	int ret;
 
-	ret = pm_runtime_get_if_active(vdev->drm.dev, false);
+	ret = pm_runtime_get_if_in_use(vdev->drm.dev);
 	drm_WARN_ON(&vdev->drm, ret < 0);
 
 	return ret;


### PR DESCRIPTION
#1135 

mainline inclusion
from mainline-v6.9-rc1
category: bugfix

There are two ways to opportunistically increment a device's runtime PM usage count, calling either pm_runtime_get_if_active() or pm_runtime_get_if_in_use(). The former has an argument to tell whether to ignore the usage count or not, and the latter simply calls the former with ign_usage_count set to false. The other users that want to ignore the usage_count will have to explicitly set that argument to true which is a bit cumbersome.

To make this function more practical to use, remove the ign_usage_count argument from the function. The main implementation is in a static function called pm_runtime_get_conditional() and implementations of pm_runtime_get_if_active() and pm_runtime_get_if_in_use() are moved to runtime.c.


Reviewed-by: Alex Elder <elder@linaro.org>
Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
Acked-by: Takashi Iwai <tiwai@suse.de> # sound/
Reviewed-by: Jacek Lawrynowicz <jacek.lawrynowicz@linux.intel.com> # drivers/accel/ivpu/
Acked-by: Rodrigo Vivi <rodrigo.vivi@intel.com> # drivers/gpu/drm/i915/
Reviewed-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
Acked-by: Bjorn Helgaas <bhelgaas@google.com> # drivers/pci/


[We must modified drivers/accel/ivpu/ivpu_pm.c which drop by stable tree] Fixes: 8d4d26d65e4f ("PM: runtime: Simplify pm_runtime_get_if_active() usage")

## Summary by Sourcery

Bug Fixes:
- Replace pm_runtime_get_if_active(vdev->drm.dev, false) with pm_runtime_get_if_in_use(vdev->drm.dev) in ivpu_pm.c to align with the simplified PM runtime API