### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] Revert "drm/amdgpu: Avoid extra evict-restore process." for verion

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
@@ -1115,9 +1115,6 @@ static int amdgpu_cs_vm_handling(struct amdgpu_cs_parser *p)
 		}
 	}
 
-	if (!amdgpu_vm_ready(vm))
-		return -EINVAL;
-
 	r = amdgpu_vm_clear_freed(adev, vm, NULL);
 	if (r)
 		return r;

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_vm.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_vm.c
@@ -2125,11 +2125,13 @@ void amdgpu_vm_adjust_size(struct amdgpu_device *adev, uint32_t min_vm_size,
  */
 long amdgpu_vm_wait_idle(struct amdgpu_vm *vm, long timeout)
 {
-	timeout = drm_sched_entity_flush(&vm->immediate, timeout);
+	timeout = dma_resv_wait_timeout(vm->root.bo->tbo.base.resv,
+					DMA_RESV_USAGE_BOOKKEEP,
+					true, timeout);
 	if (timeout <= 0)
 		return timeout;
 
-	return drm_sched_entity_flush(&vm->delayed, timeout);
+	return dma_fence_wait_timeout(vm->last_unlocked, true, timeout);
 }
 
 /**

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_vm.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_vm.c
@@ -502,10 +502,11 @@ int amdgpu_vm_validate_pt_bos(struct amdgpu_device *adev, struct amdgpu_vm *vm,
  * Check if all VM PDs/PTs are ready for updates
  *
  * Returns:
- * True if VM is not evicting and all VM entities are not stopped
+ * True if VM is not evicting.
  */
 bool amdgpu_vm_ready(struct amdgpu_vm *vm)
 {
+	bool empty;
 	bool ret;
 
 	amdgpu_vm_eviction_lock(vm);
@@ -513,18 +514,10 @@ bool amdgpu_vm_ready(struct amdgpu_vm *vm)
 	amdgpu_vm_eviction_unlock(vm);
 
 	spin_lock(&vm->status_lock);
-	ret &= list_empty(&vm->evicted);
+	empty = list_empty(&vm->evicted);
 	spin_unlock(&vm->status_lock);
 
-	spin_lock(&vm->immediate.lock);
-	ret &= !vm->immediate.stopped;
-	spin_unlock(&vm->immediate.lock);
-
-	spin_lock(&vm->delayed.lock);
-	ret &= !vm->delayed.stopped;
-	spin_unlock(&vm->delayed.lock);
-
-	return ret;
+	return ret && empty;
 }
 
 /**


### PR DESCRIPTION
Fixes: https://gitlab.freedesktop.org/drm/amd/-/issues/2950

## Summary by Sourcery

Revert previous amdgpu VM eviction optimizations to restore the original eviction and idle-wait logic to address VM eviction issues

Bug Fixes:
- Simplify amdgpu_vm_ready to only check the eviction list again
- Restore amdgpu_vm_wait_idle to use dma_resv_wait_timeout and dma_fence_wait_timeout instead of drm_sched_entity_flush
- Remove the amdgpu_vm_ready check from the command submission path