### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] FROMLIST: ACPICA: add more parameter validation for acpi_walk_namespa…

### DIFF
--- a/drivers/acpi/acpica/nsxfeval.c
+++ b/drivers/acpi/acpica/nsxfeval.c
@@ -564,7 +564,7 @@ acpi_walk_namespace(acpi_object_type type,
 
 	/* Parameter validation */
 
-	if ((type > ACPI_TYPE_LOCAL_MAX) ||
+	if ((type > ACPI_TYPE_LOCAL_MAX) || (start_object == NULL) ||
 	    (!max_depth) || (!descending_callback && !ascending_callback)) {
 		return_ACPI_STATUS(AE_BAD_PARAMETER);
 	}


### PR DESCRIPTION
…ce()

maillist inclusion
category: bugfix

On the Honor FMB-P-PCB laptop, an incorrect ACPI table causes sdw_intel_acpi_scan to pass a NULL pointer as start_object to acpi_walk_namespace() when calling it, which eventually causes the kernel to report a NULL pointer dereference[1].

1. https://gist.github.com/Cryolitia/a860ffc97437dcd2cd988371d5b73ed7

## Summary by Sourcery

Bug Fixes:
- Validate that start_object is not NULL in acpi_walk_namespace to avoid NULL pointer dereference