### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Upstream] wifi: iwlwifi: bump FW API to 96 for BZ/SC devices

### DIFF
--- a/drivers/net/wireless/intel/iwlwifi/cfg/bz.c
+++ b/drivers/net/wireless/intel/iwlwifi/cfg/bz.c
@@ -10,7 +10,7 @@
 #include "fw/api/txq.h"
 
 /* Highest firmware API version supported */
-#define IWL_BZ_UCODE_API_MAX	93
+#define IWL_BZ_UCODE_API_MAX	94
 
 /* Lowest firmware API version supported */
 #define IWL_BZ_UCODE_API_MIN	90

--- a/drivers/net/wireless/intel/iwlwifi/cfg/bz.c
+++ b/drivers/net/wireless/intel/iwlwifi/cfg/bz.c
@@ -10,7 +10,7 @@
 #include "fw/api/txq.h"
 
 /* Highest firmware API version supported */
-#define IWL_BZ_UCODE_API_MAX	94
+#define IWL_BZ_UCODE_API_MAX	95
 
 /* Lowest firmware API version supported */
 #define IWL_BZ_UCODE_API_MIN	90

--- a/drivers/net/wireless/intel/iwlwifi/cfg/bz.c
+++ b/drivers/net/wireless/intel/iwlwifi/cfg/bz.c
@@ -10,7 +10,7 @@
 #include "fw/api/txq.h"
 
 /* Highest firmware API version supported */
-#define IWL_BZ_UCODE_API_MAX	95
+#define IWL_BZ_UCODE_API_MAX	96
 
 /* Lowest firmware API version supported */
 #define IWL_BZ_UCODE_API_MIN	90

--- a/drivers/net/wireless/intel/iwlwifi/cfg/sc.c
+++ b/drivers/net/wireless/intel/iwlwifi/cfg/sc.c
@@ -10,7 +10,7 @@
 #include "fw/api/txq.h"
 
 /* Highest firmware API version supported */
-#define IWL_SC_UCODE_API_MAX	93
+#define IWL_SC_UCODE_API_MAX	94
 
 /* Lowest firmware API version supported */
 #define IWL_SC_UCODE_API_MIN	90

--- a/drivers/net/wireless/intel/iwlwifi/cfg/sc.c
+++ b/drivers/net/wireless/intel/iwlwifi/cfg/sc.c
@@ -10,7 +10,7 @@
 #include "fw/api/txq.h"
 
 /* Highest firmware API version supported */
-#define IWL_SC_UCODE_API_MAX	94
+#define IWL_SC_UCODE_API_MAX	95
 
 /* Lowest firmware API version supported */
 #define IWL_SC_UCODE_API_MIN	90

--- a/drivers/net/wireless/intel/iwlwifi/cfg/sc.c
+++ b/drivers/net/wireless/intel/iwlwifi/cfg/sc.c
@@ -10,7 +10,7 @@
 #include "fw/api/txq.h"
 
 /* Highest firmware API version supported */
-#define IWL_SC_UCODE_API_MAX	95
+#define IWL_SC_UCODE_API_MAX	96
 
 /* Lowest firmware API version supported */
 #define IWL_SC_UCODE_API_MIN	90


### PR DESCRIPTION
Test ok on magicbook pro 14 2025 with firmware
https://github.com/deepin-community/linux-firmware/pull/20

## Summary by Sourcery

Bump the supported firmware API version for Intel BZ and SC iwlwifi devices to 96

Enhancements:
- Increase IWL_BZ_UCODE_API_MAX from 93 to 96
- Increase IWL_SC_UCODE_API_MAX from 93 to 96