### PR TITLE
deepin: KABI:crypto: kabi: KABI reservation for crypto

### DIFF
--- a/include/crypto/cryptd.h
+++ b/include/crypto/cryptd.h
@@ -18,6 +18,7 @@
 #include <crypto/aead.h>
 #include <crypto/hash.h>
 #include <crypto/skcipher.h>
+#include <linux/deepin_kabi.h>
 
 struct cryptd_skcipher {
 	struct crypto_skcipher base;
@@ -32,6 +33,8 @@ bool cryptd_skcipher_queued(struct cryptd_skcipher *tfm);
 void cryptd_free_skcipher(struct cryptd_skcipher *tfm);
 
 struct cryptd_ahash {
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_ahash base;
 };
 

--- a/include/crypto/rng.h
+++ b/include/crypto/rng.h
@@ -76,6 +76,8 @@ struct rng_alg {
 };
 
 struct crypto_rng {
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 	struct crypto_tfm base;
 };
 


### PR DESCRIPTION
hulk inclusion
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8RI9L

--------------------------------

Reserve KABI for future crypto development.

## Summary by Sourcery

Reserve KABI fields across various crypto and related kernel structures to maintain future binary compatibility.

New Features:
- Add DEEPIN_KABI_RESERVE placeholders to crypto hash, cipher, AEAD, and RNG API structures
- Extend crypto_tfm, crypto_alg, public_key, cryptd, kexec, and kernel_read_file definitions with KABI reservation slots