### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] sched/fair: Remove unused 'curr' argument from pick_next_entity()

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -5440,7 +5440,7 @@ set_next_entity(struct cfs_rq *cfs_rq, struct sched_entity *se)
  * 4) do not run the "skip" process, if something else is available
  */
 static struct sched_entity *
-pick_next_entity(struct cfs_rq *cfs_rq, struct sched_entity *curr)
+pick_next_entity(struct cfs_rq *cfs_rq)
 {
 	/*
 	 * Enabling NEXT_BUDDY will affect latency but not fairness.
@@ -8366,7 +8366,7 @@ again:
 				goto again;
 		}
 
-		se = pick_next_entity(cfs_rq, curr);
+		se = pick_next_entity(cfs_rq);
 		cfs_rq = group_cfs_rq(se);
 	} while (cfs_rq);
 
@@ -8429,7 +8429,7 @@ again:
 			}
 		}
 
-		se = pick_next_entity(cfs_rq, curr);
+		se = pick_next_entity(cfs_rq);
 		cfs_rq = group_cfs_rq(se);
 	} while (cfs_rq);
 
@@ -8468,7 +8468,7 @@ simple:
 		put_prev_task(rq, prev);
 
 	do {
-		se = pick_next_entity(cfs_rq, NULL);
+		se = pick_next_entity(cfs_rq);
 		set_next_entity(cfs_rq, se);
 		cfs_rq = group_cfs_rq(se);
 	} while (cfs_rq);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
category: misc

The 'curr' argument of pick_next_entity() has become unused after the EEVDF changes.

[ mingo: Updated the changelog. ]



Link: https://lore.kernel.org/r/20231020055617.42064-1-s921975628@gmail.com (cherry picked from commit 4c456c9ad334a940e354da1002184bc19f4493ef)

## Summary by Sourcery

Remove the unused 'curr' argument from pick_next_entity in the fair scheduler and update all its call sites accordingly.

Enhancements:
- Remove the now-unused 'curr' parameter from the pick_next_entity function signature.
- Update all invocations of pick_next_entity to match the new signature without the 'curr' argument.