### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Upstream] sched/fair: optimize the PLACE_LAG when se->vlag is zero

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -5311,7 +5311,7 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
 	 *
 	 * EEVDF: placement strategy #1 / #2
 	 */
-	if (sched_feat(PLACE_LAG) && cfs_rq->nr_running) {
+	if (sched_feat(PLACE_LAG) && cfs_rq->nr_running && se->vlag) {
 		struct sched_entity *curr = cfs_rq->curr;
 		unsigned long load;
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.13-rc1
category: performance

When PLACE_LAG is enabled, from the relationship:
            vl_i = (W + w_i)*vl'_i / W
we know that if vl'_i(se->vlag) is zero, the vl_i is zero too.

So if se->vlag is zero, there is no need to waste cycles to do the calculation.



Reviewed-by: Christoph Lameter (Ampere) <cl@linux.com>
Link: https://lkml.kernel.org/r/20241001070021.10626-1-shijie@os.amperecomputing.com (cherry picked from commit 4423af84b29794a9bd2bd07188d8e71083e54c61)

## Summary by Sourcery

Enhancements:
- Skip PLACE_LAG calculations when a sched_entity's vlag is zero to avoid redundant work