### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] mm/mincore: improve performance by adding an unlikely hint

### DIFF
--- a/mm/mincore.c
+++ b/mm/mincore.c
@@ -239,7 +239,7 @@ SYSCALL_DEFINE3(mincore, unsigned long, start, size_t, len,
 	start = untagged_addr(start);
 
 	/* Check the start address: needs to be page-aligned.. */
-	if (start & ~PAGE_MASK)
+	if (unlikely(start & ~PAGE_MASK))
 		return -EINVAL;
 
 	/* ..and we need to be passed a valid user-space range */


### PR DESCRIPTION
mainline inclusion
from mainline-v6.16-rc1
category: performance

Adding an unlikely() hint on the masked start comparison error return path improves run-time performance of the mincore system call.

Benchmarking on an i9-12900 shows an improvement of 7ns on mincore calls on a 256KB mmap'd region where 50% of the pages we resident.  Improvement was from ~970 ns down to 963 ns, so a small ~0.7% improvement.

Results based on running 20 tests with turbo disabled (to reduce clock freq turbo changes), with 10 second run per test and comparing the number of mincores calls per second.  The % standard deviation of the 20 tests was ~0.10%, so results are reliable.

Link: https://lkml.kernel.org/r/20250219083607.5183-1-colin.i.king@gmail.com

Cc: Matthew Wilcow <willy@infradead.org>

(cherry picked from commit 9fa26fb554baaf71826814804749f5cff130c4d6)

## Summary by Sourcery

Enhancements:
- Introduce unlikely() hint on the PAGE_MASK comparison in mm/mincore to reduce misprediction overhead and boost runtime by ~0.7%