### PR TITLE
[linux-6.6.y] LoongArch fix data sequence dislocation

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
@@ -1279,6 +1279,11 @@ static int amdgpu_cs_submit(struct amdgpu_cs_parser *p,
 	uint64_t seq;
 	int r;
 
+#ifdef CONFIG_LOONGARCH
+	while (amdgpu_ih_fix_is_busy(p->adev))
+		msleep(20);
+#endif
+
 	for (i = 0; i < p->gang_size; ++i)
 		drm_sched_job_arm(&p->jobs[i]->base);
 

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ih.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ih.c
@@ -192,13 +192,13 @@ restart_check:
 		msleep(20);
 
 	for (i = rptr; i < wptr; i += 1) {
-		if (le32_to_cpu(ih->ring[i]) == 0xDEADBEFF)
+		if (le32_to_cpu(ih->ring[i]) == 0xDEADBEFF && (i % 4) != 3)
 			goto restart_check;
 	}
 
 	if (rptr > wptr) {
 		for (i = 0; i < wptr; i += 1) {
-			if (le32_to_cpu(ih->ring[i]) == 0xDEADBEFF)
+			if (le32_to_cpu(ih->ring[i]) == 0xDEADBEFF && (i % 4) != 3)
 				goto restart_check;
 		}
 	}
@@ -363,7 +363,8 @@ restart_ih:
 	old_rptr = adev->irq.ih.rptr;
 	r = amdgpu_ih_fix_loongarch_pcie_order_start(&adev->irq.ih, old_rptr, wptr, false);
 	if (r) {
-		if (old_rptr == ((wptr + 16) & adev->irq.ih.ptr_mask))
+		if (old_rptr == ((wptr + 16) & adev->irq.ih.ptr_mask) ||
+		    old_rptr == ((wptr + 32) & adev->irq.ih.ptr_mask))
 			return IRQ_NONE;
 
 		atomic_xchg(&adev->irq.cs_lock, 1);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ih.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ih.c
@@ -26,6 +26,10 @@
 #include "amdgpu.h"
 #include "amdgpu_ih.h"
 
+#ifdef CONFIG_LOONGARCH
+static void amdgpu_ih_handle_fix_work(struct work_struct *work);
+#endif
+
 /**
  * amdgpu_ih_ring_init - initialize the IH state
  *
@@ -71,6 +75,15 @@ int amdgpu_ih_ring_init(struct amdgpu_device *adev, struct amdgpu_ih_ring *ih,
 		ih->wptr_cpu = &ih->ring[ih->ring_size / 4];
 		ih->rptr_addr = dma_addr + ih->ring_size + 4;
 		ih->rptr_cpu = &ih->ring[(ih->ring_size / 4) + 1];
+
+	#ifdef CONFIG_LOONGARCH
+		INIT_WORK(&adev->irq.ih.fix_work, amdgpu_ih_handle_fix_work);
+		for (r = 0; r < (adev->irq.ih.ring_size >> 2); r++)
+			adev->irq.ih.ring[r] = 0xDEADBEFF;
+		/* memory barrier for writing into ih ring */
+		mb();
+	#endif
+
 	} else {
 		unsigned wptr_offs, rptr_offs;
 
@@ -98,6 +111,15 @@ int amdgpu_ih_ring_init(struct amdgpu_device *adev, struct amdgpu_ih_ring *ih,
 		ih->wptr_cpu = &adev->wb.wb[wptr_offs];
 		ih->rptr_addr = adev->wb.gpu_addr + rptr_offs * 4;
 		ih->rptr_cpu = &adev->wb.wb[rptr_offs];
+
+	#ifdef CONFIG_LOONGARCH
+		INIT_WORK(&adev->irq.ih.fix_work, amdgpu_ih_handle_fix_work);
+		for (r = 0; r < (adev->irq.ih.ring_size >> 2); r++)
+			adev->irq.ih.ring[r] = 0xDEADBEFF;
+		/* memory barrier for writing into ih ring */
+		mb();
+	#endif
+
 	}
 
 	init_waitqueue_head(&ih->wait_process);
@@ -119,6 +141,10 @@ void amdgpu_ih_ring_fini(struct amdgpu_device *adev, struct amdgpu_ih_ring *ih)
 	if (!ih->ring)
 		return;
 
+#ifdef CONFIG_LOONGARCH
+	cancel_work_sync(&adev->irq.ih.fix_work);
+#endif
+
 	if (ih->use_bus_addr) {
 
 		/* add 8 bytes for the rptr/wptr shadows and
@@ -134,6 +160,113 @@ void amdgpu_ih_ring_fini(struct amdgpu_device *adev, struct amdgpu_ih_ring *ih)
 		amdgpu_device_wb_free(adev, (ih->rptr_addr - ih->gpu_addr) / 4);
 	}
 }
+
+#ifdef CONFIG_LOONGARCH
+
+int amdgpu_ih_fix_is_busy(struct amdgpu_device *adev)
+{
+	return atomic_read(&adev->irq.cs_lock);
+}
+
+static int amdgpu_ih_fix_loongarch_pcie_order_start(struct amdgpu_ih_ring *ih,
+						u32 rptr, u32 wptr,
+						bool forever)
+{
+	int i;
+	int check_cnt = 0;
+	u32 ring_end = ih->ring_size >> 2;
+
+	if (rptr == wptr)
+		return 0;
+
+	rptr = rptr >> 2;
+	wptr = wptr >> 2;
+
+	wptr = (rptr > wptr) ? ring_end : wptr;
+
+restart_check:
+	if (!forever && ++check_cnt > 1)
+		return -ENAVAIL;
+
+	if (forever)
+		msleep(20);
+
+	for (i = rptr; i < wptr; i += 1) {
+		if (le32_to_cpu(ih->ring[i]) == 0xDEADBEFF)
+			goto restart_check;
+	}
+
+	if (rptr > wptr) {
+		for (i = 0; i < wptr; i += 1) {
+			if (le32_to_cpu(ih->ring[i]) == 0xDEADBEFF)
+				goto restart_check;
+		}
+	}
+
+	return 0;
+}
+
+static int amdgpu_ih_fix_loongarch_pcie_order_end(struct amdgpu_ih_ring *ih,
+						u32 rptr, u32 wptr)
+{
+	int i;
+	u32 ring_end = ih->ring_size >> 2;
+
+	if (rptr == wptr)
+		return 0;
+
+	rptr = rptr >> 2;
+	wptr = wptr >> 2;
+
+	wptr = (rptr > wptr) ? ring_end : wptr;
+
+	for (i = rptr; i < wptr; i += 1)
+		ih->ring[i] = 0xDEADBEFF;
+
+	if (rptr > wptr) {
+		for (i = 0; i < wptr; i += 1)
+			ih->ring[i] = 0xDEADBEFF;
+	}
+	/* memory barrier for writing into ih ring */
+	mb();
+	return 0;
+}
+
+static void amdgpu_ih_handle_fix_work(struct work_struct *work)
+{
+	struct amdgpu_device *adev =
+		container_of(work, struct amdgpu_device, irq.ih.fix_work);
+	struct amdgpu_ih_ring *ih = &adev->irq.ih;
+
+	u32 wptr;
+	u32 old_rptr;
+
+restart:
+
+	wptr = amdgpu_ih_get_wptr(adev, ih);
+	/* Order reading of wptr vs. reading of IH ring data */
+	rmb();
+
+	old_rptr = ih->rptr;
+	amdgpu_ih_fix_loongarch_pcie_order_start(&adev->irq.ih, old_rptr, wptr, true);
+
+	while (adev->irq.ih.rptr != wptr) {
+		amdgpu_irq_dispatch(adev, ih);
+		ih->rptr &= ih->ptr_mask;
+	}
+
+	amdgpu_ih_fix_loongarch_pcie_order_end(&adev->irq.ih, old_rptr, adev->irq.ih.rptr);
+
+	amdgpu_ih_set_rptr(adev, ih);
+	/* memory barrier for setting rptr */
+	mb();
+
+	if (ih->rptr != amdgpu_ih_get_wptr(adev, ih))
+		goto restart;
+
+	atomic_set(&adev->irq.cs_lock, 0);
+}
+#endif
 
 /**
  * amdgpu_ih_ring_write - write IV to the ring buffer
@@ -209,6 +342,10 @@ int amdgpu_ih_process(struct amdgpu_device *adev, struct amdgpu_ih_ring *ih)
 {
 	unsigned int count;
 	u32 wptr;
+#ifdef CONFIG_LOONGARCH
+	u32 old_rptr;
+	int r;
+#endif
 
 	if (!ih->enabled || adev->shutdown)
 		return IRQ_NONE;
@@ -222,10 +359,27 @@ restart_ih:
 	/* Order reading of wptr vs. reading of IH ring data */
 	rmb();
 
+#ifdef CONFIG_LOONGARCH
+	old_rptr = adev->irq.ih.rptr;
+	r = amdgpu_ih_fix_loongarch_pcie_order_start(&adev->irq.ih, old_rptr, wptr, false);
+	if (r) {
+		if (old_rptr == ((wptr + 16) & adev->irq.ih.ptr_mask))
+			return IRQ_NONE;
+
+		atomic_xchg(&adev->irq.cs_lock, 1);
+		schedule_work(&adev->irq.ih.fix_work);
+		return IRQ_NONE;
+	}
+#endif
+
 	while (ih->rptr != wptr && --count) {
 		amdgpu_irq_dispatch(adev, ih);
 		ih->rptr &= ih->ptr_mask;
 	}
+
+#ifdef CONFIG_LOONGARCH
+	amdgpu_ih_fix_loongarch_pcie_order_end(&adev->irq.ih, old_rptr, adev->irq.ih.rptr);
+#endif
 
 	amdgpu_ih_set_rptr(adev, ih);
 	wake_up_all(&ih->wait_process);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ih.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ih.h
@@ -72,6 +72,9 @@ struct amdgpu_ih_ring {
 	/* For waiting on IH processing at checkpoint. */
 	wait_queue_head_t wait_process;
 	uint64_t		processed_timestamp;
+#ifdef CONFIG_LOONGARCH
+	struct work_struct      fix_work;
+#endif
 };
 
 /* return true if time stamp t2 is after t1 with 48bit wrap around */
@@ -110,4 +113,7 @@ void amdgpu_ih_decode_iv_helper(struct amdgpu_device *adev,
 				struct amdgpu_iv_entry *entry);
 uint64_t amdgpu_ih_decode_iv_ts_helper(struct amdgpu_ih_ring *ih, u32 rptr,
 				       signed int offset);
+#ifdef CONFIG_LOONGARCH
+int amdgpu_ih_fix_is_busy(struct amdgpu_device *adev);
+#endif
 #endif

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_irq.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_irq.c
@@ -275,6 +275,10 @@ int amdgpu_irq_init(struct amdgpu_device *adev)
 
 	spin_lock_init(&adev->irq.lock);
 
+#ifdef CONFIG_LOONGARCH
+	atomic_set(&adev->irq.cs_lock, 0);
+#endif
+
 	/* Enable MSI if not disabled by module parameter */
 	adev->irq.msi_enabled = false;
 

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_irq.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_irq.h
@@ -100,6 +100,9 @@ struct amdgpu_irq {
 	uint32_t                        srbm_soft_reset;
 	u32                             retry_cam_doorbell_index;
 	bool                            retry_cam_enabled;
+#ifdef CONFIG_LOONGARCH
+	atomic_t                        cs_lock;
+#endif
 };
 
 enum interrupt_node_id_per_aid {

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v6_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v6_0.c
@@ -1818,6 +1818,17 @@ static void gfx_v6_0_ring_emit_fence(struct amdgpu_ring *ring, u64 addr,
 	amdgpu_ring_write(ring, 0xFFFFFFFF);
 	amdgpu_ring_write(ring, 0);
 	amdgpu_ring_write(ring, 10); /* poll interval */
+#ifdef CONFIG_LOONGARCH
+	/* EVENT_WRITE_EOP - flush caches, no send int */
+	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
+	amdgpu_ring_write(ring, EVENT_TYPE(CACHE_FLUSH_AND_INV_TS_EVENT) | EVENT_INDEX(5));
+	amdgpu_ring_write(ring, addr & 0xfffffffc);
+	amdgpu_ring_write(ring, (upper_32_bits(addr) & 0xffff) |
+				((write64bit ? 2 : 1) << CP_EOP_DONE_DATA_CNTL__DATA_SEL__SHIFT) |
+				(0 << CP_EOP_DONE_DATA_CNTL__INT_SEL__SHIFT));
+	amdgpu_ring_write(ring, lower_32_bits(seq));
+	amdgpu_ring_write(ring, upper_32_bits(seq));
+#endif
 	/* EVENT_WRITE_EOP - flush caches, send int */
 	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 	amdgpu_ring_write(ring, EVENT_TYPE(CACHE_FLUSH_AND_INV_TS_EVENT) | EVENT_INDEX(5));
@@ -3469,7 +3480,11 @@ static const struct amdgpu_ring_funcs gfx_v6_0_ring_funcs_gfx = {
 	.set_wptr = gfx_v6_0_ring_set_wptr_gfx,
 	.emit_frame_size =
 		5 + 5 + /* hdp flush / invalidate */
+#ifdef CONFIG_LOONGARCH
+		20 + 20 + 20 + /* gfx_v6_0_ring_emit_fence x3 for user fence, vm fence */
+#else
 		14 + 14 + 14 + /* gfx_v6_0_ring_emit_fence x3 for user fence, vm fence */
+#endif
 		7 + 4 + /* gfx_v6_0_ring_emit_pipeline_sync */
 		SI_FLUSH_GPU_TLB_NUM_WREG * 5 + 7 + 6 + /* gfx_v6_0_ring_emit_vm_flush */
 		3 + 2 + /* gfx_v6_ring_emit_cntxcntl including vgt flush */
@@ -3498,7 +3513,11 @@ static const struct amdgpu_ring_funcs gfx_v6_0_ring_funcs_compute = {
 		5 + 5 + /* hdp flush / invalidate */
 		7 + /* gfx_v6_0_ring_emit_pipeline_sync */
 		SI_FLUSH_GPU_TLB_NUM_WREG * 5 + 7 + /* gfx_v6_0_ring_emit_vm_flush */
+#ifdef CONFIG_LOONGARCH
+		20 + 20 + 20 + /* gfx_v6_0_ring_emit_fence x3 for user fence, vm fence */
+#else
 		14 + 14 + 14 + /* gfx_v6_0_ring_emit_fence x3 for user fence, vm fence */
+#endif
 		5, /* SURFACE_SYNC */
 	.emit_ib_size = 6, /* gfx_v6_0_ring_emit_ib */
 	.emit_ib = gfx_v6_0_ring_emit_ib,

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
@@ -2127,11 +2127,17 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 				 EVENT_INDEX(5)));
 	amdgpu_ring_write(ring, addr & 0xfffffffc);
 	amdgpu_ring_write(ring, (upper_32_bits(addr) & 0xffff) |
+#ifdef CONFIG_LOONGARCH
+				DATA_SEL(write64bit ? 2 : 1) | INT_SEL(0));
+	amdgpu_ring_write(ring, lower_32_bits(seq));
+	amdgpu_ring_write(ring, upper_32_bits(seq));
+#else
 				DATA_SEL(1) | INT_SEL(0));
 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
 
 	/* Then send the real EOP event down the pipe. */
+#endif
 	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 	amdgpu_ring_write(ring, (EOP_TCL1_ACTION_EN |
 				 EOP_TC_ACTION_EN |

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
@@ -2117,14 +2117,6 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 {
 	bool write64bit = flags & AMDGPU_FENCE_FLAG_64BIT;
 	bool int_sel = flags & AMDGPU_FENCE_FLAG_INT;
-
-/* This workaround causes instability for LoongArch/Loongson (MIPS)
- * devices based on the 7A1000/2000 chipset under heavy I/O load.
- *
- * FIXME: Disable this workaround until we find a better fix (possibly in
- * the platform-specific PCI code).
- */
-#ifndef CONFIG_MACH_LOONGSON64
 	/* Workaround for cache flush problems. First send a dummy EOP
 	 * event down the pipe with seq one below.
 	 */
@@ -2138,7 +2130,6 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 				DATA_SEL(1) | INT_SEL(0));
 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
-#endif
 
 	/* Then send the real EOP event down the pipe. */
 	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
@@ -6195,12 +6195,18 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 				 EVENT_INDEX(5)));
 	amdgpu_ring_write(ring, addr & 0xfffffffc);
 	amdgpu_ring_write(ring, (upper_32_bits(addr) & 0xffff) |
+#ifdef CONFIG_LOONGARCH
+				DATA_SEL(write64bit ? 2 : 1) | INT_SEL(0));
+	amdgpu_ring_write(ring, lower_32_bits(seq));
+	amdgpu_ring_write(ring, upper_32_bits(seq));
+#else
 				DATA_SEL(1) | INT_SEL(0));
 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
 
 	/* Then send the real EOP event down the pipe:
 	 * EVENT_WRITE_EOP - flush caches, send int */
+#endif
 	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 	amdgpu_ring_write(ring, (EOP_TCL1_ACTION_EN |
 				 EOP_TC_ACTION_EN |

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
@@ -6184,13 +6184,6 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 	bool write64bit = flags & AMDGPU_FENCE_FLAG_64BIT;
 	bool int_sel = flags & AMDGPU_FENCE_FLAG_INT;
 
-/* This workaround causes instability for LoongArch/Loongson (MIPS)
- * devices based on the 7A1000/2000 chipset under heavy I/O load.
- *
- * FIXME: Disable this workaround until we find a better fix (possibly in
- * the platform-specific PCI code).
- */
-#ifndef CONFIG_MACH_LOONGSON64
 	/* Workaround for cache flush problems. First send a dummy EOP
 	 * event down the pipe with seq one below.
 	 */
@@ -6205,7 +6198,6 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
 				DATA_SEL(1) | INT_SEL(0));
 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
-#endif
 
 	/* Then send the real EOP event down the pipe:
 	 * EVENT_WRITE_EOP - flush caches, send int */

--- a/drivers/gpu/drm/radeon/cik.c
+++ b/drivers/gpu/drm/radeon/cik.c
@@ -3554,7 +3554,11 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
 	radeon_ring_write(ring, addr & 0xfffffffc);
 	radeon_ring_write(ring, (upper_32_bits(addr) & 0xffff) |
 				DATA_SEL(1) | INT_SEL(0));
+#ifdef CONFIG_LOONGARCH
+	radeon_ring_write(ring, fence->seq);
+#else
 	radeon_ring_write(ring, fence->seq - 1);
+#endif
 	radeon_ring_write(ring, 0);
 
 	/* Then send the real EOP event down the pipe. */

--- a/drivers/gpu/drm/radeon/cik.c
+++ b/drivers/gpu/drm/radeon/cik.c
@@ -3543,13 +3543,6 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
 	struct radeon_ring *ring = &rdev->ring[fence->ring];
 	u64 addr = rdev->fence_drv[fence->ring].gpu_addr;
 
-/* This workaround causes instability for LoongArch/Loongson (MIPS)
- * devices based on the 7A1000/2000 chipset under heavy I/O load.
- *
- * FIXME: Disable this workaround until we find a better fix (possibly in
- * the platform-specific PCI code).
- */
-#ifndef CONFIG_MACH_LOONGSON64
 	/* Workaround for cache flush problems. First send a dummy EOP
 	 * event down the pipe with seq one below.
 	 */
@@ -3563,7 +3556,6 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
 				DATA_SEL(1) | INT_SEL(0));
 	radeon_ring_write(ring, fence->seq - 1);
 	radeon_ring_write(ring, 0);
-#endif
 
 	/* Then send the real EOP event down the pipe. */
 	radeon_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -10,6 +10,9 @@
 #include <linux/blk-mq.h>
 #include <linux/blk-mq-pci.h>
 #include <linux/blk-integrity.h>
+#ifdef CONFIG_LOONGARCH
+#include <linux/delay.h>
+#endif
 #include <linux/dmi.h>
 #include <linux/init.h>
 #include <linux/interrupt.h>
@@ -1078,6 +1081,14 @@ static irqreturn_t nvme_irq(int irq, void *data)
 {
 	struct nvme_queue *nvmeq = data;
 	DEFINE_IO_COMP_BATCH(iob);
+
+#ifdef CONFIG_LOONGARCH
+	/*
+	 * There is no guarantee of sequence between DMA
+	 * and interrupts on the Loongson platform.
+	 */
+	udelay(30);
+#endif
 
 	if (nvme_poll_cq(nvmeq, &iob)) {
 		if (!rq_list_empty(iob.req_list))

--- a/drivers/scsi/megaraid/megaraid_sas_fusion.c
+++ b/drivers/scsi/megaraid/megaraid_sas_fusion.c
@@ -3884,7 +3884,13 @@ static irqreturn_t megasas_isr_fusion(int irq, void *devp)
 		instance->instancet->clear_intr(instance);
 		return IRQ_HANDLED;
 	}
-
+#ifdef CONFIG_LOONGARCH
+	/*
+	 * There is no guarantee of sequence between DMA
+	 * and interrupts on the Loongson platform.
+	 */
+	udelay(30);
+#endif
 	return complete_cmd_fusion(instance, irq_context->MSIxIndex, irq_context)
 			? IRQ_HANDLED : IRQ_NONE;
 }


### PR DESCRIPTION
Introduction to the patchset:

Ptach 1-6: Workaround for cache flush problems in radeon and amdgpu;

Ptach 7-8: Fix data error caused by dma sequence. 
This issue occurs on the 3c6000. After a PCIe device receives an interrupt, it must wait for DMA to complete (as there is a probability that DMA has not yet finished) before reading data; otherwise, data errors will occur.

## Summary by Sourcery

Add LoongArch-specific workarounds to ensure correct PCIe DMA ordering and cache flush semantics across GPU, NVMe, and SAS drivers.

Bug Fixes:
- Fix data corruption caused by out-of-order DMA and interrupt sequences on LoongArch by inserting delays and memory barriers in amdgpu_ih, NVMe PCIe IRQ handler, and megaraid SAS ISR.

Enhancements:
- Implement LoongArch-specific IH ring fix in AMDGPU by initializing ring entries with sentinel values, adding memory barriers, and scheduling a workqueue that enforces PCIe DMA ordering via new amdgpu_ih_fix_loongarch_pcie_order functions.
- Update AMDGPU and Radeon fence emit routines to use proper EOP event packets under CONFIG_LOONGARCH and remove unstable cache flush workarounds.
- Introduce atomic cs_lock and synchronize command submission with the IH fix workqueue in amdgpu_irq and amdgpu_cs.