### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] CI: disable KABI upload for networking

### DIFF
--- a/.github/workflows/build-kernel-arm64.yml
+++ b/.github/workflows/build-kernel-arm64.yml
@@ -28,12 +28,6 @@ jobs:
           make deepin_arm64_desktop_defconfig
           make -j$(nproc)
 
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-arm64
-          path: "Module.symvers"
-
       - name: 'Clang build kernel'
         run: |
           # .config

--- a/.github/workflows/build-kernel-loong64.yml
+++ b/.github/workflows/build-kernel-loong64.yml
@@ -27,9 +27,3 @@ jobs:
           # .config
           time make ARCH=loongarch CROSS_COMPILE=loongarch64-linux-gnu- deepin_loongarch_desktop_defconfig
           time make ARCH=loongarch CROSS_COMPILE=loongarch64-linux-gnu- -j$(nproc)
-
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-loong64
-          path: "Module.symvers"

--- a/.github/workflows/build-kernel-riscv64.yml
+++ b/.github/workflows/build-kernel-riscv64.yml
@@ -27,9 +27,3 @@ jobs:
           # .config
           time make ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- deepin_riscv64_desktop_defconfig
           time make ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- -j$(nproc)
-
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-riscv64
-          path: "Module.symvers"

--- a/.github/workflows/build-kernel-s390.yml
+++ b/.github/workflows/build-kernel-s390.yml
@@ -27,9 +27,3 @@ jobs:
           # .config
           make deepin_s390x_z13_defconfig
           make -j$(nproc)
-
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-s390
-          path: "Module.symvers"

--- a/.github/workflows/build-kernel-sw64.yml
+++ b/.github/workflows/build-kernel-sw64.yml
@@ -28,12 +28,6 @@ jobs:
           time swmk1230 xuelang_defconfig
           time swmk1230 -j`nproc`
 
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-sw6b
-          path: "Module.symvers"
-
   build-kernel-sw8a:
     runs-on: [self-hosted, linux, x64]
     steps:
@@ -42,9 +36,3 @@ jobs:
           # .config
           time swmk8a1230 junzhang_defconfig
           time swmk8a1230 -j`nproc`
-
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-sw8a
-          path: "Module.symvers"

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -28,12 +28,6 @@ jobs:
           make deepin_x86_desktop_defconfig
           make -j$(nproc)
 
-      - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Kernel-ABI-x86-64
-          path: "Module.symvers"
-
       - name: "Clang build kernel"
         run: |
           # .config


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove actions/upload-artifact steps for KABI artifacts from kernel build workflows.