### PR TITLE
[linux-6.6.y] iommu/vt-d: fix NULL pointer issue in acpi_rmrr_andd_probe

### DIFF
--- a/drivers/iommu/dma-iommu.c
+++ b/drivers/iommu/dma-iommu.c
@@ -485,6 +485,12 @@ int iova_reserve_domain_addr(struct iommu_domain *domain, dma_addr_t start, dma_
 
 	unsigned long lo, hi;
 
+	if (!iovad->granule) {
+		unsigned long order = __ffs(domain->pgsize_bitmap);
+
+		iovad->granule = 1UL << order;
+	}
+
 	lo = iova_pfn(iovad, start);
 	hi = iova_pfn(iovad, end);
 

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -3787,6 +3787,10 @@ static inline int acpi_rmrr_andd_probe(struct device *dev)
 		pr_info("dpoint-- cannot get acpi devie corresponding pci_device\n");
 		return -EINVAL;
 	}
+
+	if (!dev->iommu)
+		dev->iommu = (&pci_device->dev)->iommu;
+
 	ret = acpi_rmrr_device_create_direct_mappings(iommu_get_domain_for_dev(&pci_device->dev),
 			dev);
 


### PR DESCRIPTION
zhaoxin inclusion
category: feature

-------------------

When the dev->iommu was NULL for the RMRR ANDD device, the corresponding (&pci_device->dev)->iommu could be used instead.

## Summary by Sourcery

Ensure proper initialization and avoid NULL pointer dereferences in IOMMU domain handling and ACPI RMRR ANDD probing

Bug Fixes:
- Initialize iovad->granule from domain->pgsize_bitmap when it’s unset in iova_reserve_domain_addr
- Assign dev->iommu from the corresponding PCI device when dev->iommu is NULL in acpi_rmrr_andd_probe