### PR TITLE
[linux-6.6.y] Optimize Zhaoxin CPU Temp Monitoring During Suspend/Resume

### DIFF
--- a/drivers/hwmon/via-cputemp.c
+++ b/drivers/hwmon/via-cputemp.c
@@ -216,6 +216,13 @@ static int via_cputemp_online(unsigned int cpu)
 	struct platform_device *pdev;
 	struct pdev_entry *pdev_entry;
 
+	/*
+	 * Don't execute this on suspend as the device remove locks
+	 * up the machine.
+	 */
+	if (cpuhp_tasks_frozen)
+		return 0;
+
 	pdev = platform_device_alloc(DRVNAME, cpu);
 	if (!pdev) {
 		err = -ENOMEM;
@@ -254,6 +261,13 @@ exit:
 static int via_cputemp_down_prep(unsigned int cpu)
 {
 	struct pdev_entry *p;
+
+	/*
+	 * Don't execute this on suspend as the device remove locks
+	 * up the machine.
+	 */
+	if (cpuhp_tasks_frozen)
+		return 0;
 
 	mutex_lock(&pdev_list_mutex);
 	list_for_each_entry(p, &pdev_list, list) {

--- a/drivers/hwmon/zhaoxin-cputemp.c
+++ b/drivers/hwmon/zhaoxin-cputemp.c
@@ -216,6 +216,13 @@ static int zhaoxin_cputemp_online(unsigned int cpu)
 	struct platform_device *pdev;
 	struct pdev_entry *pdev_entry;
 
+	/*
+	 * Don't execute this on suspend as the device remove locks
+	 * up the machine.
+	 */
+	if (cpuhp_tasks_frozen)
+		return 0;
+
 	pdev = platform_device_alloc(DRVNAME, cpu);
 	if (!pdev) {
 		err = -ENOMEM;
@@ -254,6 +261,13 @@ exit:
 static int zhaoxin_cputemp_down_prep(unsigned int cpu)
 {
 	struct pdev_entry *p;
+
+	/*
+	 * Don't execute this on suspend as the device remove locks
+	 * up the machine.
+	 */
+	if (cpuhp_tasks_frozen)
+		return 0;
 
 	mutex_lock(&pdev_list_mutex);
 	list_for_each_entry(p, &pdev_list, list) {


### PR DESCRIPTION
This patch improves the VIA CPU temperature driver's behavior during suspend and resume.
It adds conditions in 'via_cputemp_online' and 'via_cputemp_down_prep' functions to skip processes
when the system is suspending or resuming, using 'cpuhp_tasks_frozen'. 
This prevents potential lock-ups and ensures smoother temperature monitoring during power state transitions.

Modified 'zhaoxin_cputemp_down_prep' to avoid system freezes during suspend by skipping device removal when 'cpuhp_tasks_frozen' is true.

## Summary by Sourcery

Bug Fixes:
- Add cpuhp_tasks_frozen checks in via_cputemp_online, via_cputemp_down_prep, zhaoxin_cputemp_online, and zhaoxin_cputemp_down_prep to return early and avoid deadlocks during suspend/resume