### PR TITLE
[linux-6.6.y] i2c: zhaoxin: Enhancements and Modifications to SMBus Driver

### DIFF
--- a/drivers/i2c/busses/i2c-zhaoxin-smbus.c
+++ b/drivers/i2c/busses/i2c-zhaoxin-smbus.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /*
- * Zhaoxin SMBus controller driver
+ *  i2c-zhaoxin-smbus.c - Zhaoxin SMBus controller driver
  *
- * Copyright(c) 2023 Shanghai Zhaoxin Semiconductor Corporation.
- * All rights reserved.
+ *  Copyright(c) 2023 Shanghai Zhaoxin Semiconductor Corporation.
+ *                    All rights reserved.
  */
 
 #include <linux/acpi.h>
@@ -15,7 +15,7 @@
 #include <linux/module.h>
 #include <linux/platform_device.h>
 
-#define DRIVER_VERSION "3.1.0"
+#define DRIVER_VERSION "3.4.0"
 
 #define ZXSMB_NAME "smbus_zhaoxin"
 
@@ -23,7 +23,7 @@
  * registers
  */
 /* SMBus MMIO address offsets */
-#define ZXSMB_STS		0x00
+#define ZXSMB_STS	0x00
 #define   ZXSMB_BUSY		BIT(0)
 #define   ZXSMB_CMD_CMPLET	BIT(1)
 #define   ZXSMB_DEV_ERR		BIT(2)
@@ -31,32 +31,32 @@
 #define   ZXSMB_FAIL_TRANS	BIT(4)
 #define   ZXSMB_STS_MASK 		GENMASK(4, 0)
 #define   ZXSMB_NSMBSRST	BIT(5)
-#define ZXSMB_CTL		0x02
+#define ZXSMB_CTL	0x02
 #define   ZXSMB_CMPLT_EN	BIT(0)
 #define   ZXSMB_KILL_PRG	BIT(1)
 #define   ZXSMB_START		BIT(6)
 #define   ZXSMB_PEC_EN		BIT(7)
-#define ZXSMB_CMD		0x03
-#define ZXSMB_ADD		0x04
-#define ZXSMB_DAT0		0x05
-#define ZXSMB_DAT1		0x06
+#define ZXSMB_CMD	0x03
+#define ZXSMB_ADD	0x04
+#define ZXSMB_DAT0	0x05
+#define ZXSMB_DAT1	0x06
 #define ZXSMB_BLKDAT	0x07
 
 /*
  * platform related informations
  */
- /* protocol cmd constants */
-#define ZXSMB_QUICK				0x00
-#define ZXSMB_BYTE				0x04
-#define ZXSMB_BYTE_DATA			0x08
-#define ZXSMB_WORD_DATA			0x0C
-#define ZXSMB_PROC_CALL			0x10
-#define ZXSMB_BLOCK_DATA		0x14
+/* protocol cmd constants */
+#define ZXSMB_QUICK		0x00
+#define ZXSMB_BYTE		0x04
+#define ZXSMB_BYTE_DATA		0x08
+#define ZXSMB_WORD_DATA		0x0C
+#define ZXSMB_PROC_CALL		0x10
+#define ZXSMB_BLOCK_DATA	0x14
 #define ZXSMB_I2C_10_BIT_ADDR	0x18
-#define ZXSMB_I2C_PROC_CALL		0x30
+#define ZXSMB_I2C_PROC_CALL	0x30
 #define ZXSMB_I2C_BLOCK_DATA	0x34
 #define ZXSMB_I2C_7_BIT_ADDR	0x38
-#define ZXSMB_UNIVERSAL			0x3C
+#define ZXSMB_UNIVERSAL		0x3C
 
 #define ZXSMB_TIMEOUT 500
 
@@ -74,11 +74,13 @@ struct zxsmb {
 static irqreturn_t zxsmb_irq_handle(int irq, void *dev_id)
 {
 	struct zxsmb *smb = (struct zxsmb *)dev_id;
+	u8 status;
 
-	smb->status = inb(smb->base + ZXSMB_STS);
-	if ((smb->status & ZXSMB_STS_MASK) == 0)
+	status = inb(smb->base + ZXSMB_STS);
+	if ((status & ZXSMB_STS_MASK) == 0 || (status & ZXSMB_BUSY))
 		return IRQ_NONE;
 
+	smb->status = status;
 	/* clear status */
 	outb(smb->status, smb->base + ZXSMB_STS);
 	complete(&smb->complete);
@@ -138,7 +140,14 @@ static int zxsmb_wait_polling_finish(struct zxsmb *smb)
 	} while ((status & ZXSMB_BUSY) && (--time_left));
 
 	if (time_left == 0) {
-		dev_dbg(smb->dev, "polling timeout\n");
+		if (status & ZXSMB_BUSY) {
+			/* kill process and try again */
+			outb(ZXSMB_KILL_PRG, smb->base + ZXSMB_CTL);
+			outb(status, smb->base + ZXSMB_STS);
+			dev_err(smb->dev, "timeout and Bus still busy\n");
+			return -EAGAIN;
+		}
+		dev_err(smb->dev, "polling timeout\n");
 		return -EIO;
 	}
 
@@ -155,10 +164,12 @@ static int zxsmb_trans_start(struct zxsmb *smb)
 	int tmp;
 
 	/* Make sure the SMBus host is ready to start transmitting */
-	if ((tmp = inb(base + ZXSMB_STS)) & ZXSMB_BUSY) {
+	tmp = inb(base + ZXSMB_STS);
+	if (tmp & ZXSMB_BUSY) {
 		outb(tmp, base + ZXSMB_STS);
 		usleep_range(1000, 5000);
-		if ((tmp = inb(base + ZXSMB_STS)) & ZXSMB_BUSY) {
+		tmp = inb(base + ZXSMB_STS);
+		if (tmp & ZXSMB_BUSY) {
 			dev_err(smb->dev, "SMBus reset failed! (0x%02x)\n", tmp);
 			return -EIO;
 		}
@@ -198,7 +209,7 @@ static int zxsmb_transaction(struct zxsmb *smb)
 }
 
 static int zxsmb_smbus_xfer(struct i2c_adapter *adap, u16 addr, u16 flags, char read, u8 command,
-				int size, union i2c_smbus_data *data)
+			    int size, union i2c_smbus_data *data)
 {
 	int i;
 	int err;
@@ -230,25 +241,20 @@ static int zxsmb_smbus_xfer(struct i2c_adapter *adap, u16 addr, u16 flags, char 
 			outb(data->word & 0xff, base + ZXSMB_DAT0);
 			outb((data->word & 0xff00) >> 8, base + ZXSMB_DAT1);
 		}
-		size = (size == I2C_SMBUS_PROC_CALL) ?
-			ZXSMB_PROC_CALL : ZXSMB_WORD_DATA;
+		size = (size == I2C_SMBUS_PROC_CALL) ? ZXSMB_PROC_CALL : ZXSMB_WORD_DATA;
 		break;
 	case I2C_SMBUS_I2C_BLOCK_DATA:
 	case I2C_SMBUS_BLOCK_DATA:
 		len = data->block[0];
-		if (read && size == I2C_SMBUS_I2C_BLOCK_DATA)
-			outb(len, base + ZXSMB_DAT1);
+		outb(len, base + ZXSMB_DAT0);
 		outb(command, base + ZXSMB_CMD);
 		/* Reset ZXSMB_BLKDAT */
 		inb(base + ZXSMB_CTL);
 		if (!read) {
-			outb(len, base + ZXSMB_DAT0);
-			outb(0, base + ZXSMB_DAT1);
 			for (i = 1; i <= len; i++)
 				outb(data->block[i], base + ZXSMB_BLKDAT);
 		}
-		size = (size == I2C_SMBUS_I2C_BLOCK_DATA) ?
-			ZXSMB_I2C_BLOCK_DATA : ZXSMB_BLOCK_DATA;
+		size = (size == I2C_SMBUS_I2C_BLOCK_DATA) ? ZXSMB_I2C_BLOCK_DATA : ZXSMB_BLOCK_DATA;
 		break;
 	default:
 		goto exit_unsupported;
@@ -278,6 +284,11 @@ prepare_read:
 		data->word = inb(base + ZXSMB_DAT0) + (inb(base + ZXSMB_DAT1) << 8);
 		break;
 	case ZXSMB_I2C_BLOCK_DATA:
+		inb(base + ZXSMB_CTL);
+		data->block[0] = len;
+		for (i = 1; i <= len; i++)
+			data->block[i] = inb(base + ZXSMB_BLKDAT);
+		break;
 	case ZXSMB_BLOCK_DATA:
 		data->block[0] = inb(base + ZXSMB_DAT0);
 		if (data->block[0] > I2C_SMBUS_BLOCK_MAX)
@@ -298,12 +309,12 @@ exit_unsupported:
 
 static u32 zxsmb_func(struct i2c_adapter *adapter)
 {
-	return I2C_FUNC_SMBUS_EMUL;
+	return I2C_FUNC_SMBUS_EMUL | I2C_FUNC_SMBUS_READ_BLOCK_DATA;
 }
 
 static const struct i2c_algorithm smbus_algorithm = {
 	.smbus_xfer = zxsmb_smbus_xfer,
-	.functionality  = zxsmb_func,
+	.functionality = zxsmb_func,
 };
 
 static int zxsmb_probe(struct platform_device *pdev)
@@ -311,6 +322,7 @@ static int zxsmb_probe(struct platform_device *pdev)
 	struct zxsmb *smb;
 	struct resource *res;
 	struct i2c_adapter *adap;
+	int err;
 
 	smb = devm_kzalloc(&pdev->dev, sizeof(*smb), GFP_KERNEL);
 	if (!smb)
@@ -327,11 +339,12 @@ static int zxsmb_probe(struct platform_device *pdev)
 
 	smb->irq = platform_get_irq(pdev, 0);
 	if (smb->irq < 0 || devm_request_irq(&pdev->dev, smb->irq, zxsmb_irq_handle, IRQF_SHARED,
-			pdev->name, smb)) {
+					     pdev->name, smb)) {
 		dev_warn(&pdev->dev, "failed to request irq %d\n", smb->irq);
 		smb->irq = 0;
-	} else
+	} else {
 		init_completion(&smb->complete);
+	}
 
 	smb->dev = &pdev->dev;
 	platform_set_drvdata(pdev, (void *)smb);
@@ -343,10 +356,16 @@ static int zxsmb_probe(struct platform_device *pdev)
 	adap->dev.parent = &pdev->dev;
 	ACPI_COMPANION_SET(&adap->dev, ACPI_COMPANION(&pdev->dev));
 	snprintf(adap->name, sizeof(adap->name), "zhaoxin-%s-%s", dev_name(pdev->dev.parent),
-		dev_name(smb->dev));
+		 dev_name(smb->dev));
 	i2c_set_adapdata(&smb->adap, smb);
 
-	return i2c_add_adapter(&smb->adap);
+	err = i2c_add_adapter(&smb->adap);
+	if (err)
+		return err;
+
+	dev_info(smb->dev, "adapter /dev/i2c-%d registered. version %s\n", adap->nr,
+		 DRIVER_VERSION);
+	return 0;
 }
 
 static int zxsmb_remove(struct platform_device *pdev)
@@ -371,7 +390,7 @@ static struct platform_driver zxsmb_driver = {
 	.remove = zxsmb_remove,
 	.driver = {
 		.name = ZXSMB_NAME,
-		.acpi_match_table = ACPI_PTR(zxsmb_acpi_match),
+		.acpi_match_table = zxsmb_acpi_match,
 	},
 };
 


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

1. Remove IIC access.
2. Enablement of I2C Block Read/Write Function.
3. Returning IRQ_NONE When Host is Busy.

## Summary by Sourcery

Add I2C block read/write functionality and strengthen busy/timeout handling in the Zhaoxin SMBus driver, along with metadata updates and improved logging.

New Features:
- Enable I2C block read/write support in the Zhaoxin SMBus driver

Bug Fixes:
- Return IRQ_NONE from the IRQ handler when the SMBus host is busy

Enhancements:
- Improve timeout recovery by resetting the controller on busy timeouts
- Bump driver version to 3.4.0 and add an informational log on adapter registration
- Simplify ACPI match table handling and update the module description