### PR TITLE
[linux-6.6.y] PCI: Supplement ACS quirk for more Zhaoxin Root Ports

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -4902,7 +4902,7 @@ static int pci_quirk_zhaoxin_pcie_ports_acs(struct pci_dev *dev, u16 acs_flags)
 	switch (dev->device) {
 	case 0x0710 ... 0x071e:
 	case 0x0721:
-	case 0x0723 ... 0x0752:
+	case 0x0723 ... 0x075e:
 		return pci_acs_ctrl_enabled(acs_flags,
 			PCI_ACS_SV | PCI_ACS_RR | PCI_ACS_CR | PCI_ACS_UF);
 	}


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

To adapt to more new Zhaoxin platforms, further supplement more Root Port Device IDs to the pci_quirk_zhaoxin_pcie_ports_acs() function.

## Summary by Sourcery

New Features:
- Expand the supported device ID range in pci_quirk_zhaoxin_pcie_ports_acs from 0x0752 to 0x075e