### PR TITLE
[linux-6.6.y] perf/zhaoxin/uncore: Enhance uncore support and fix related bugs

### DIFF
--- a/arch/x86/events/zhaoxin/core.c
+++ b/arch/x86/events/zhaoxin/core.c
@@ -22,21 +22,19 @@
  * Zhaoxin PerfMon, used on Lujiazui and later.
  */
 static u64 zx_pmon_event_map[PERF_COUNT_HW_MAX] __read_mostly = {
-	[PERF_COUNT_HW_CPU_CYCLES]		= 0x0082,
-	[PERF_COUNT_HW_INSTRUCTIONS]		= 0x00c0,
-	[PERF_COUNT_HW_BUS_CYCLES]		= 0x0083,
-	[PERF_COUNT_HW_BRANCH_INSTRUCTIONS]	= 0x0028,
-	[PERF_COUNT_HW_BRANCH_MISSES]		= 0x0029,
+	[PERF_COUNT_HW_CPU_CYCLES] = 0x0082,
+	[PERF_COUNT_HW_INSTRUCTIONS] = 0x00c0,
+	[PERF_COUNT_HW_BUS_CYCLES] = 0x0083,
+	[PERF_COUNT_HW_BRANCH_INSTRUCTIONS] = 0x0028,
+	[PERF_COUNT_HW_BRANCH_MISSES] = 0x0029,
 };
 
 static struct event_constraint zxc_event_constraints[] __read_mostly = {
-
 	FIXED_EVENT_CONSTRAINT(0x0082, 1), /* unhalted core clock cycles */
 	EVENT_CONSTRAINT_END
 };
 
 static struct event_constraint wudaokou_event_constraints[] __read_mostly = {
-
 	FIXED_EVENT_CONSTRAINT(0x00c0, 0), /* retired instructions */
 	FIXED_EVENT_CONSTRAINT(0x0082, 1), /* unhalted core clock cycles */
 	FIXED_EVENT_CONSTRAINT(0x0083, 2), /* unhalted bus clock cycles */
@@ -445,9 +443,8 @@ static u64 zhaoxin_pmu_event_map(int hw_event)
 	return zx_pmon_event_map[hw_event];
 }
 
-static struct event_constraint *
-zhaoxin_get_event_constraints(struct cpu_hw_events *cpuc, int idx,
-			struct perf_event *event)
+static struct event_constraint *zhaoxin_get_event_constraints(struct cpu_hw_events *cpuc, int idx,
+							      struct perf_event *event)
 {
 	struct event_constraint *c;
 
@@ -461,11 +458,11 @@ zhaoxin_get_event_constraints(struct cpu_hw_events *cpuc, int idx,
 	return &unconstrained;
 }
 
-PMU_FORMAT_ATTR(event,	"config:0-7");
-PMU_FORMAT_ATTR(umask,	"config:8-15");
-PMU_FORMAT_ATTR(edge,	"config:18");
-PMU_FORMAT_ATTR(inv,	"config:23");
-PMU_FORMAT_ATTR(cmask,	"config:24-31");
+PMU_FORMAT_ATTR(event, "config:0-7");
+PMU_FORMAT_ATTR(umask, "config:8-15");
+PMU_FORMAT_ATTR(edge, "config:18");
+PMU_FORMAT_ATTR(inv, "config:23");
+PMU_FORMAT_ATTR(cmask, "config:24-31");
 
 static struct attribute *zx_arch_formats_attr[] = {
 	&format_attr_event.attr,
@@ -497,32 +494,34 @@ static struct perf_guest_switch_msr *zhaoxin_guest_get_msrs(int *nr, void *data)
 }
 
 static const struct x86_pmu zhaoxin_pmu __initconst = {
-	.name			= "zhaoxin",
-	.handle_irq		= zhaoxin_pmu_handle_irq,
-	.disable_all		= zhaoxin_pmu_disable_all,
-	.enable_all		= zhaoxin_pmu_enable_all,
-	.enable			= zhaoxin_pmu_enable_event,
-	.disable		= zhaoxin_pmu_disable_event,
-	.hw_config		= x86_pmu_hw_config,
-	.schedule_events	= x86_schedule_events,
-	.eventsel		= MSR_ARCH_PERFMON_EVENTSEL0,
-	.perfctr		= MSR_ARCH_PERFMON_PERFCTR0,
-	.event_map		= zhaoxin_pmu_event_map,
-	.max_events		= ARRAY_SIZE(zx_pmon_event_map),
-	.apic			= 1,
+	.name = "zhaoxin",
+	.handle_irq = zhaoxin_pmu_handle_irq,
+	.disable_all = zhaoxin_pmu_disable_all,
+	.enable_all = zhaoxin_pmu_enable_all,
+	.enable = zhaoxin_pmu_enable_event,
+	.disable = zhaoxin_pmu_disable_event,
+	.hw_config = x86_pmu_hw_config,
+	.schedule_events = x86_schedule_events,
+	.eventsel = MSR_ARCH_PERFMON_EVENTSEL0,
+	.perfctr = MSR_ARCH_PERFMON_PERFCTR0,
+	.event_map = zhaoxin_pmu_event_map,
+	.max_events = ARRAY_SIZE(zx_pmon_event_map),
+	.apic = 1,
 	/*
 	 * For wudaokou/lujiazui, read/write operation for PMCx MSR is 48 bits.
 	 */
-	.max_period		= (1ULL << 47) - 1,
-	.get_event_constraints	= zhaoxin_get_event_constraints,
+	.max_period = (1ULL << 47) - 1,
+	.get_event_constraints = zhaoxin_get_event_constraints,
 
-	.format_attrs		= zx_arch_formats_attr,
-	.events_sysfs_show	= zhaoxin_event_sysfs_show,
-
-	.guest_get_msrs		= zhaoxin_guest_get_msrs,
+	.format_attrs = zx_arch_formats_attr,
+	.events_sysfs_show = zhaoxin_event_sysfs_show,
+	.guest_get_msrs = zhaoxin_guest_get_msrs,
 };
 
-static const struct { int id; char *name; } zx_arch_events_map[] __initconst = {
+static  struct {
+	int id;
+	char *name;
+} const zx_arch_events_map[] __initconst = {
 	{ PERF_COUNT_HW_CPU_CYCLES, "cpu cycles" },
 	{ PERF_COUNT_HW_INSTRUCTIONS, "instructions" },
 	{ PERF_COUNT_HW_BUS_CYCLES, "bus cycles" },
@@ -539,8 +538,7 @@ static __init void zhaoxin_arch_events_quirk(void)
 	/* disable event that reported as not present by cpuid */
 	for_each_set_bit(bit, x86_pmu.events_mask, ARRAY_SIZE(zx_arch_events_map)) {
 		zx_pmon_event_map[zx_arch_events_map[bit].id] = 0;
-		pr_warn("CPUID marked event: \'%s\' unavailable\n",
-			zx_arch_events_map[bit].name);
+		pr_warn("CPUID marked event: \'%s\' unavailable\n", zx_arch_events_map[bit].name);
 	}
 }
 
@@ -571,12 +569,12 @@ __init int zhaoxin_pmu_init(void)
 	x86_pmu = zhaoxin_pmu;
 	pr_info("Version check pass!\n");
 
-	x86_pmu.version			= version;
-	x86_pmu.num_counters		= eax.split.num_counters;
-	x86_pmu.cntval_bits		= eax.split.bit_width;
-	x86_pmu.cntval_mask		= (1ULL << eax.split.bit_width) - 1;
-	x86_pmu.events_maskl		= ebx.full;
-	x86_pmu.events_mask_len		= eax.split.mask_length;
+	x86_pmu.version = version;
+	x86_pmu.num_counters = eax.split.num_counters;
+	x86_pmu.cntval_bits = eax.split.bit_width;
+	x86_pmu.cntval_mask = (1ULL << eax.split.bit_width) - 1;
+	x86_pmu.events_maskl = ebx.full;
+	x86_pmu.events_mask_len = eax.split.mask_length;
 
 	x86_pmu.num_counters_fixed = edx.split.num_counters_fixed;
 	x86_add_quirk(zhaoxin_arch_events_quirk);
@@ -589,8 +587,7 @@ __init int zhaoxin_pmu_init(void)
 		 * ZXC FMS: Family=6, Model=F, Stepping=E-F OR Family=6, Model=0x19, Stepping=0-3
 		 */
 		if ((boot_cpu_data.x86_model == 0x0f && boot_cpu_data.x86_stepping >= 0x0e) ||
-			boot_cpu_data.x86_model == 0x19) {
-
+		    boot_cpu_data.x86_model == 0x19) {
 			x86_pmu.max_period = x86_pmu.cntval_mask >> 1;
 
 			/* Clearing status works only if the global control is enable on zxc. */
@@ -644,6 +641,7 @@ __init int zhaoxin_pmu_init(void)
 			break;
 		case 0x5b:
 		case 0x6b:
+		case 0x7b:
 			zx_pmon_event_map[PERF_COUNT_HW_STALLED_CYCLES_FRONTEND] =
 				X86_CONFIG(.event = 0x02, .umask = 0x01, .inv = 0x01,
 					   .cmask = 0x01);
@@ -659,7 +657,7 @@ __init int zhaoxin_pmu_init(void)
 			if (boot_cpu_data.x86_model == 0x5b)
 				pr_cont("Yongfeng events, ");
 
-			if (boot_cpu_data.x86_model == 0x6b)
+			if (boot_cpu_data.x86_model == 0x6b || boot_cpu_data.x86_model == 0x7b)
 				pr_cont("Shijidadao events, ");
 
 			break;
@@ -673,7 +671,7 @@ __init int zhaoxin_pmu_init(void)
 	}
 
 	x86_pmu.intel_ctrl = (1 << (x86_pmu.num_counters)) - 1;
-	x86_pmu.intel_ctrl |= ((1LL << x86_pmu.num_counters_fixed)-1) << INTEL_PMC_IDX_FIXED;
+	x86_pmu.intel_ctrl |= ((1LL << x86_pmu.num_counters_fixed) - 1) << INTEL_PMC_IDX_FIXED;
 
 	if (x86_pmu.event_constraints) {
 		for_each_event_constraint(c, x86_pmu.event_constraints) {

--- a/arch/x86/events/zhaoxin/uncore.c
+++ b/arch/x86/events/zhaoxin/uncore.c
@@ -2,13 +2,17 @@
 #include <asm/cpu_device_id.h>
 #include "uncore.h"
 
-static struct zhaoxin_uncore_type *empty_uncore[] = { NULL, };
+static int uncore_enabled;
+
+static struct zhaoxin_uncore_type *empty_uncore[] = {
+	NULL,
+};
 static struct zhaoxin_uncore_type **uncore_msr_uncores = empty_uncore;
 static struct zhaoxin_uncore_type **uncore_pci_uncores = empty_uncore;
 static struct zhaoxin_uncore_type **uncore_mmio_uncores = empty_uncore;
 
 static bool pcidrv_registered;
-static struct pci_driver *uncore_pci_driver;
+static const struct pci_device_id *uncore_pci_ids;
 
 /* mask of cpus that collect uncore events */
 static cpumask_t uncore_cpu_mask;
@@ -24,203 +28,206 @@ static int clusters_per_subnode;
 static int subnodes_per_die;
 static int dies_per_socket;
 
-#define KH40000_MAX_SUBNODE_NUMBER    8
+#define KH40000_MAX_SUBNODE_NUMBER 8
 static int kh40000_pcibus_limit[KH40000_MAX_SUBNODE_NUMBER];
 
 /* get CPU topology register */
-#define BJ_GLOBAL_STATUS_MSR	0x1610
-#define BJ_HDW_CONFIG_MSR	0X1628
+#define BJ_GLOBAL_STATUS_MSR 0x1610
+#define BJ_HDW_CONFIG_MSR 0X1628
 
 /* KX5000/KX6000 event control */
-#define KX5000_UNC_CTL_EV_SEL_MASK		0x000000ff
-#define KX5000_UNC_CTL_UMASK_MASK		0x0000ff00
-#define KX5000_UNC_CTL_EDGE_DET			(1 << 18)
-#define KX5000_UNC_CTL_EN			(1 << 22)
-#define KX5000_UNC_CTL_INVERT			(1 << 23)
-#define KX5000_UNC_CTL_CMASK_MASK		0x7000000
-#define KX5000_UNC_FIXED_CTR_CTL_EN		(1 << 0)
+#define KX5000_UNC_CTL_EV_SEL_MASK 0x000000ff
+#define KX5000_UNC_CTL_UMASK_MASK 0x0000ff00
+#define KX5000_UNC_CTL_EDGE_DET (1 << 18)
+#define KX5000_UNC_CTL_EN (1 << 22)
+#define KX5000_UNC_CTL_INVERT (1 << 23)
+#define KX5000_UNC_CTL_CMASK_MASK 0x7000000
+#define KX5000_UNC_FIXED_CTR_CTL_EN (1 << 0)
 
-#define KX5000_UNC_RAW_EVENT_MASK		(KX5000_UNC_CTL_EV_SEL_MASK | \
-						KX5000_UNC_CTL_UMASK_MASK | \
-						KX5000_UNC_CTL_EDGE_DET | \
-						KX5000_UNC_CTL_INVERT | \
-						KX5000_UNC_CTL_CMASK_MASK)
+#define KX5000_UNC_RAW_EVENT_MASK	\
+	(KX5000_UNC_CTL_EV_SEL_MASK |	\
+	 KX5000_UNC_CTL_UMASK_MASK |	\
+	 KX5000_UNC_CTL_EDGE_DET |	\
+	 KX5000_UNC_CTL_INVERT |	\
+	 KX5000_UNC_CTL_CMASK_MASK)
 
 /* KX5000/KX6000 uncore global register */
-#define KX5000_UNC_PERF_GLOBAL_CTL		0x391
-#define KX5000_UNC_FIXED_CTR			0x394
-#define KX5000_UNC_FIXED_CTR_CTRL		0x395
+#define KX5000_UNC_PERF_GLOBAL_CTL 0x391
+#define KX5000_UNC_FIXED_CTR 0x394
+#define KX5000_UNC_FIXED_CTR_CTRL 0x395
 
 /* KX5000/KX6000 uncore global control */
-#define KX5000_UNC_GLOBAL_CTL_EN_PC_ALL		((1ULL << 4) - 1)
-#define KX5000_UNC_GLOBAL_CTL_EN_FC		(1ULL << 32)
+#define KX5000_UNC_GLOBAL_CTL_EN_PC_ALL ((1ULL << 4) - 1)
+#define KX5000_UNC_GLOBAL_CTL_EN_FC (1ULL << 32)
 
 /* KX5000/KX6000 uncore register */
-#define KX5000_UNC_PERFEVTSEL0		0x3c0
-#define KX5000_UNC_UNCORE_PMC0		0x3b0
+#define KX5000_UNC_PERFEVTSEL0 0x3c0
+#define KX5000_UNC_UNCORE_PMC0 0x3b0
 
 /* KH40000 event control */
-#define KH40000_PMON_CTL_EV_SEL_MASK		0x000000ff
-#define KH40000_PMON_CTL_UMASK_MASK		0x0000ff00
-#define KH40000_PMON_CTL_RST			(1 << 17)
-#define KH40000_PMON_CTL_EDGE_DET		(1 << 18)
-#define KH40000_PMON_CTL_EN			(1 << 22)
-#define KH40000_PMON_CTL_INVERT			(1 << 23)
-#define KH40000_PMON_CTL_THRESH_MASK		0xff000000
-#define KH40000_PMON_RAW_EVENT_MASK		(KH40000_PMON_CTL_EV_SEL_MASK | \
-						KH40000_PMON_CTL_UMASK_MASK | \
-						KH40000_PMON_CTL_EDGE_DET | \
-						KH40000_PMON_CTL_INVERT | \
-						KH40000_PMON_CTL_THRESH_MASK)
+#define KH40000_PMON_CTL_EV_SEL_MASK 0x000000ff
+#define KH40000_PMON_CTL_UMASK_MASK 0x0000ff00
+#define KH40000_PMON_CTL_RST (1 << 17)
+#define KH40000_PMON_CTL_EDGE_DET (1 << 18)
+#define KH40000_PMON_CTL_EN (1 << 22)
+#define KH40000_PMON_CTL_INVERT (1 << 23)
+#define KH40000_PMON_CTL_THRESH_MASK 0xff000000
+#define KH40000_PMON_RAW_EVENT_MASK	\
+	(KH40000_PMON_CTL_EV_SEL_MASK |	\
+	 KH40000_PMON_CTL_UMASK_MASK |	\
+	 KH40000_PMON_CTL_EDGE_DET |	\
+	 KH40000_PMON_CTL_INVERT |	\
+	 KH40000_PMON_CTL_THRESH_MASK)
 
 /* KH40000 LLC register*/
-#define KH40000_LLC_MSR_PMON_CTL0		0x1660
-#define KH40000_LLC_MSR_PMON_CTR0		0x165c
-#define KH40000_LLC_MSR_PMON_BLK_CTL		0x1665
+#define KH40000_LLC_MSR_PMON_CTL0 0x1660
+#define KH40000_LLC_MSR_PMON_CTR0 0x165c
+#define KH40000_LLC_MSR_PMON_BLK_CTL 0x1665
 
 /* KH40000 HIF register*/
-#define KH40000_HIF_MSR_PMON_CTL0		0x1656
-#define KH40000_HIF_MSR_PMON_CTR0		0x1651
-#define KH40000_HIF_MSR_PMON_FIXED_CTL		0x1655
-#define KH40000_HIF_MSR_PMON_FIXED_CTR		0x1650
-#define KH40000_HIF_MSR_PMON_BLK_CTL		0x165b
+#define KH40000_HIF_MSR_PMON_CTL0 0x1656
+#define KH40000_HIF_MSR_PMON_CTR0 0x1651
+#define KH40000_HIF_MSR_PMON_FIXED_CTL 0x1655
+#define KH40000_HIF_MSR_PMON_FIXED_CTR 0x1650
+#define KH40000_HIF_MSR_PMON_BLK_CTL 0x165b
 
 /* KH40000 ZZI(ZPI+ZOI+INI) register*/
-#define KH40000_ZZI_MSR_PMON_CTL0		0x166A
-#define KH40000_ZZI_MSR_PMON_CTR0		0x1666
-#define KH40000_ZZI_MSR_PMON_BLK_CTL		0x166f
+#define KH40000_ZZI_MSR_PMON_CTL0 0x166A
+#define KH40000_ZZI_MSR_PMON_CTR0 0x1666
+#define KH40000_ZZI_MSR_PMON_BLK_CTL 0x166f
 
 /* KH40000 MC register*/
-#define KH40000_MC0_CHy_PMON_FIXED_CTL		0xf40
-#define KH40000_MC0_CHy_PMON_FIXED_CTR		0xf20
-#define KH40000_MC0_CHy_PMON_CTR0		0xf00
-#define KH40000_MC0_CHy_PMON_CTL0		0xf28
-#define KH40000_MC0_CHy_PMON_BLK_CTL		0xf44
+#define KH40000_MC0_CHy_PMON_FIXED_CTL 0xf40
+#define KH40000_MC0_CHy_PMON_FIXED_CTR 0xf20
+#define KH40000_MC0_CHy_PMON_CTR0 0xf00
+#define KH40000_MC0_CHy_PMON_CTL0 0xf28
+#define KH40000_MC0_CHy_PMON_BLK_CTL 0xf44
 
-#define KH40000_MC1_CHy_PMON_FIXED_CTL		0xf90
-#define KH40000_MC1_CHy_PMON_FIXED_CTR		0xf70
-#define KH40000_MC1_CHy_PMON_CTR0		0xf50
-#define KH40000_MC1_CHy_PMON_CTL0		0xf78
-#define KH40000_MC1_CHy_PMON_BLK_CTL		0xf94
+#define KH40000_MC1_CHy_PMON_FIXED_CTL 0xf90
+#define KH40000_MC1_CHy_PMON_FIXED_CTR 0xf70
+#define KH40000_MC1_CHy_PMON_CTR0 0xf50
+#define KH40000_MC1_CHy_PMON_CTL0 0xf78
+#define KH40000_MC1_CHy_PMON_BLK_CTL 0xf94
 
 /* KH40000 PCI register*/
-#define KH40000_PCI_PMON_CTR0			0xf00
-#define KH40000_PCI_PMON_CTL0			0xf28
-#define KH40000_PCI_PMON_BLK_CTL		0xf44
+#define KH40000_PCI_PMON_CTR0 0xf00
+#define KH40000_PCI_PMON_CTL0 0xf28
+#define KH40000_PCI_PMON_BLK_CTL 0xf44
 
 /* KH40000 ZPI_DLL register*/
-#define KH40000_ZPI_DLL_PMON_FIXED_CTL		0xf40
-#define KH40000_ZPI_DLL_PMON_FIXED_CTR		0xf20
-#define KH40000_ZPI_DLL_PMON_CTR0		0xf00
-#define KH40000_ZPI_DLL_PMON_CTL0		0xf28
-#define KH40000_ZPI_DLL_PMON_BLK_CTL		0xf44
+#define KH40000_ZPI_DLL_PMON_FIXED_CTL 0xf40
+#define KH40000_ZPI_DLL_PMON_FIXED_CTR 0xf20
+#define KH40000_ZPI_DLL_PMON_CTR0 0xf00
+#define KH40000_ZPI_DLL_PMON_CTL0 0xf28
+#define KH40000_ZPI_DLL_PMON_BLK_CTL 0xf44
 
 /* KH40000 ZDI_DLL register*/
-#define KH40000_ZDI_DLL_PMON_FIXED_CTL		0xf40
-#define KH40000_ZDI_DLL_PMON_FIXED_CTR		0xf20
-#define KH40000_ZDI_DLL_PMON_CTR0		0xf00
-#define KH40000_ZDI_DLL_PMON_CTL0		0xf28
-#define KH40000_ZDI_DLL_PMON_BLK_CTL		0xf44
+#define KH40000_ZDI_DLL_PMON_FIXED_CTL 0xf40
+#define KH40000_ZDI_DLL_PMON_FIXED_CTR 0xf20
+#define KH40000_ZDI_DLL_PMON_CTR0 0xf00
+#define KH40000_ZDI_DLL_PMON_CTL0 0xf28
+#define KH40000_ZDI_DLL_PMON_BLK_CTL 0xf44
 
 /* KH40000 PXPTRF register*/
-#define KH40000_PXPTRF_PMON_CTR0		0xf00
-#define KH40000_PXPTRF_PMON_CTL0		0xf28
-#define KH40000_PXPTRF_PMON_BLK_CTL		0xf44
+#define KH40000_PXPTRF_PMON_CTR0 0xf00
+#define KH40000_PXPTRF_PMON_CTL0 0xf28
+#define KH40000_PXPTRF_PMON_BLK_CTL 0xf44
 
 /* KH40000 Box level control */
-#define KH40000_PMON_BOX_CTL_RST_CTRL		(1 << 0)
-#define KH40000_PMON_BOX_CTL_RST_CTRS		(1 << 1)
-#define KH40000_PMON_BOX_CTL_FRZ		(1 << 8)
-#define KH40000_PMON_PCI_BOX_PMON_EN		(1 << 31)
+#define KH40000_PMON_BOX_CTL_RST_CTRL (1 << 0)
+#define KH40000_PMON_BOX_CTL_RST_CTRS (1 << 1)
+#define KH40000_PMON_BOX_CTL_FRZ (1 << 8)
+#define KH40000_PMON_PCI_BOX_PMON_EN (1 << 31)
 
-#define KH40000_PMON_BOX_CTL_INT		(KH40000_PMON_BOX_CTL_RST_CTRL | \
-						KH40000_PMON_BOX_CTL_RST_CTRS)
+#define KH40000_PMON_BOX_CTL_INT (KH40000_PMON_BOX_CTL_RST_CTRL | KH40000_PMON_BOX_CTL_RST_CTRS)
 
-#define KH40000_PMON_PCI_BOX_CTL_INT		(KH40000_PMON_BOX_CTL_RST_CTRL | \
-						KH40000_PMON_BOX_CTL_RST_CTRS | \
-						KH40000_PMON_PCI_BOX_PMON_EN)
+#define KH40000_PMON_PCI_BOX_CTL_INT		\
+	(KH40000_PMON_BOX_CTL_RST_CTRL |	\
+	 KH40000_PMON_BOX_CTL_RST_CTRS |	\
+	 KH40000_PMON_PCI_BOX_PMON_EN)
 
 /* KX7000 event control */
-#define KX7000_PMON_CTL_EV_SEL_MASK		0x000000ff
-#define KX7000_PMON_CTL_UMASK_MASK		0x0000ff00
-#define KX7000_PMON_CTL_RST			(1 << 17)
-#define KX7000_PMON_CTL_EDGE_DET		(1 << 18)
-#define KX7000_PMON_CTL_LOGIC_OP0		(1 << 19)
-#define KX7000_PMON_CTL_LOGIC_OP1		(1 << 21)
-#define KX7000_PMON_CTL_EN			(1 << 22)
-#define KX7000_PMON_CTL_INVERT			(1 << 23)
-#define KX7000_PMON_CTL_THRESH_MASK		0xff000000
-#define KX7000_PMON_RAW_EVENT_MASK		(KX7000_PMON_CTL_EV_SEL_MASK | \
-						KX7000_PMON_CTL_UMASK_MASK | \
-						KX7000_PMON_CTL_EDGE_DET | \
-						KX7000_PMON_CTL_LOGIC_OP0 | \
-						KX7000_PMON_CTL_LOGIC_OP1 | \
-						KX7000_PMON_CTL_INVERT | \
-						KX7000_PMON_CTL_THRESH_MASK)
+#define KX7000_PMON_CTL_EV_SEL_MASK 0x000000ff
+#define KX7000_PMON_CTL_UMASK_MASK 0x0000ff00
+#define KX7000_PMON_CTL_RST (1 << 17)
+#define KX7000_PMON_CTL_EDGE_DET (1 << 18)
+#define KX7000_PMON_CTL_LOGIC_OP0 (1 << 19)
+#define KX7000_PMON_CTL_LOGIC_OP1 (1 << 21)
+#define KX7000_PMON_CTL_EN (1 << 22)
+#define KX7000_PMON_CTL_INVERT (1 << 23)
+#define KX7000_PMON_CTL_THRESH_MASK 0xff000000
+#define KX7000_PMON_RAW_EVENT_MASK	\
+	(KX7000_PMON_CTL_EV_SEL_MASK |	\
+	 KX7000_PMON_CTL_UMASK_MASK |	\
+	 KX7000_PMON_CTL_EDGE_DET |	\
+	 KX7000_PMON_CTL_LOGIC_OP0 |	\
+	 KX7000_PMON_CTL_LOGIC_OP1 |	\
+	 KX7000_PMON_CTL_INVERT |	\
+	 KX7000_PMON_CTL_THRESH_MASK)
 
 /* KX7000 LLC register*/
-#define KX7000_LLC_MSR_PMON_CTL0		0x1979
-#define KX7000_LLC_MSR_PMON_CTR0		0x1975
-#define KX7000_LLC_MSR_PMON_BLK_CTL		0x197e
+#define KX7000_LLC_MSR_PMON_CTL0 0x1979
+#define KX7000_LLC_MSR_PMON_CTR0 0x1975
+#define KX7000_LLC_MSR_PMON_BLK_CTL 0x197e
 
 /* KX7000 MESH register*/
-#define KX7000_MESH_MSR_PMON_CTL0		0x1983
-#define KX7000_MESH_MSR_PMON_CTR0		0x197f
-#define KX7000_MESH_MSR_PMON_BLK_CTL		0x1987
+#define KX7000_MESH_MSR_PMON_CTL0 0x1983
+#define KX7000_MESH_MSR_PMON_CTR0 0x197f
+#define KX7000_MESH_MSR_PMON_BLK_CTL 0x1987
 
 /* KX7000 HOMESTOP register*/
-#define KX7000_HOMESTOP_MSR_PMON_CTL0		0x196a
-#define KX7000_HOMESTOP_MSR_PMON_CTR0		0x1966
-#define KX7000_HOMESTOP_MSR_PMON_BLK_CTL	0x196e
-#define KX7000_HOMESTOP_MSR_PMON_FIXED_CTR	0x1970
-#define KX7000_HOMESTOP_MSR_PMON_FIXED_CTL	0x1971
+#define KX7000_HOMESTOP_MSR_PMON_CTL0 0x196a
+#define KX7000_HOMESTOP_MSR_PMON_CTR0 0x1966
+#define KX7000_HOMESTOP_MSR_PMON_BLK_CTL 0x196e
+#define KX7000_HOMESTOP_MSR_PMON_FIXED_CTR 0x1970
+#define KX7000_HOMESTOP_MSR_PMON_FIXED_CTL 0x1971
 
 /* KX7000 CCDie ZDI_PL register*/
-#define KX7000_CCD_ZDI_PL_MSR_PMON_CTL0		0x1960
-#define KX7000_CCD_ZDI_PL_MSR_PMON_CTR0		0x195c
-#define KX7000_CCD_ZDI_PL_MSR_PMON_BLK_CTL	0x1964
+#define KX7000_CCD_ZDI_PL_MSR_PMON_CTL0 0x1960
+#define KX7000_CCD_ZDI_PL_MSR_PMON_CTR0 0x195c
+#define KX7000_CCD_ZDI_PL_MSR_PMON_BLK_CTL 0x1964
 
 /* KX7000 cIODie ZDI_PL register*/
-#define KX7000_IOD_ZDI_PL_MSR_PMON_CTL0		0x1894
-#define KX7000_IOD_ZDI_PL_MSR_PMON_CTR0		0x1890
-#define KX7000_IOD_ZDI_PL_MSR_PMON_BLK_CTL	0x1898
-#define KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTR	0x189A
-#define KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTL	0x189B
+#define KX7000_IOD_ZDI_PL_MSR_PMON_CTL0 0x1894
+#define KX7000_IOD_ZDI_PL_MSR_PMON_CTR0 0x1890
+#define KX7000_IOD_ZDI_PL_MSR_PMON_BLK_CTL 0x1898
+#define KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTR 0x189A
+#define KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTL 0x189B
 
 /* KX7000 MC register*/
-#define KX7000_MC_A0_CHy_PMON_FIXED_CTL		0xe30
-#define KX7000_MC_A0_CHy_PMON_FIXED_CTR		0xe08
-#define KX7000_MC_A0_CHy_PMON_CTR0		0xe00
-#define KX7000_MC_A0_CHy_PMON_CTL0		0xe20
-#define KX7000_MC_A0_CHy_PMON_BLK_CTL		0xe34
+#define KX7000_MC_A0_CHy_PMON_FIXED_CTL 0xe30
+#define KX7000_MC_A0_CHy_PMON_FIXED_CTR 0xe08
+#define KX7000_MC_A0_CHy_PMON_CTR0 0xe00
+#define KX7000_MC_A0_CHy_PMON_CTL0 0xe20
+#define KX7000_MC_A0_CHy_PMON_BLK_CTL 0xe34
 
-#define KX7000_MC_A1_CHy_PMON_FIXED_CTL		0xe70
-#define KX7000_MC_A1_CHy_PMON_FIXED_CTR		0xe48
-#define KX7000_MC_A1_CHy_PMON_CTR0		0xe40
-#define KX7000_MC_A1_CHy_PMON_CTL0		0xe60
-#define KX7000_MC_A1_CHy_PMON_BLK_CTL		0xe74
+#define KX7000_MC_A1_CHy_PMON_FIXED_CTL 0xe70
+#define KX7000_MC_A1_CHy_PMON_FIXED_CTR 0xe48
+#define KX7000_MC_A1_CHy_PMON_CTR0 0xe40
+#define KX7000_MC_A1_CHy_PMON_CTL0 0xe60
+#define KX7000_MC_A1_CHy_PMON_BLK_CTL 0xe74
 
-#define KX7000_MC_B0_CHy_PMON_FIXED_CTL		0xeb0
-#define KX7000_MC_B0_CHy_PMON_FIXED_CTR		0xe88
-#define KX7000_MC_B0_CHy_PMON_CTR0		0xe80
-#define KX7000_MC_B0_CHy_PMON_CTL0		0xea0
-#define KX7000_MC_B0_CHy_PMON_BLK_CTL		0xeb4
+#define KX7000_MC_B0_CHy_PMON_FIXED_CTL 0xeb0
+#define KX7000_MC_B0_CHy_PMON_FIXED_CTR 0xe88
+#define KX7000_MC_B0_CHy_PMON_CTR0 0xe80
+#define KX7000_MC_B0_CHy_PMON_CTL0 0xea0
+#define KX7000_MC_B0_CHy_PMON_BLK_CTL 0xeb4
 
-#define KX7000_MC_B1_CHy_PMON_FIXED_CTL		0xef0
-#define KX7000_MC_B1_CHy_PMON_FIXED_CTR		0xec8
-#define KX7000_MC_B1_CHy_PMON_CTR0		0xec0
-#define KX7000_MC_B1_CHy_PMON_CTL0		0xee0
-#define KX7000_MC_B1_CHy_PMON_BLK_CTL		0xef4
+#define KX7000_MC_B1_CHy_PMON_FIXED_CTL 0xef0
+#define KX7000_MC_B1_CHy_PMON_FIXED_CTR 0xec8
+#define KX7000_MC_B1_CHy_PMON_CTR0 0xec0
+#define KX7000_MC_B1_CHy_PMON_CTL0 0xee0
+#define KX7000_MC_B1_CHy_PMON_BLK_CTL 0xef4
 
-#define	KX7000_ZDI_DL_MMIO_PMON_CTR0		0xf00
-#define KX7000_ZDI_DL_MMIO_PMON_CTL0		0xf28
-#define KX7000_ZDI_DL_MMIO_PMON_BLK_CTL		0xf44
-#define KX7000_IOD_ZDI_DL_MMIO_BASE_OFFSET	0x168
-#define KX7000_CCD_ZDI_DL_MMIO_BASE_OFFSET	0x170
-#define KX7000_ZDI_DL_MMIO_BASE_MASK		0x3fff
-#define KX7000_ZDI_DL_MMIO_BASE_MASK		0x3fff
-#define KX7000_ZDI_DL_MMIO_MEM0_MASK		0xfffff000
-#define KX7000_ZDI_DL_MMIO_SIZE			0x1000
+#define KX7000_ZDI_DL_MMIO_PMON_CTR0 0xf00
+#define KX7000_ZDI_DL_MMIO_PMON_CTL0 0xf28
+#define KX7000_ZDI_DL_MMIO_PMON_BLK_CTL 0xf44
+#define KX7000_IOD_ZDI_DL_MMIO_BASE_OFFSET 0x168
+#define KX7000_CCD_ZDI_DL_MMIO_BASE_OFFSET 0x170
+#define KX7000_ZDI_DL_MMIO_BASE_MASK 0x3fff
+#define KX7000_ZDI_DL_MMIO_BASE_MASK 0x3fff
+#define KX7000_ZDI_DL_MMIO_MEM0_MASK 0xfffff000
+#define KX7000_ZDI_DL_MMIO_SIZE 0x1000
 
 DEFINE_UNCORE_FORMAT_ATTR(event, event, "config:0-7");
 DEFINE_UNCORE_FORMAT_ATTR(umask, umask, "config:8-15");
@@ -248,8 +255,6 @@ static void get_global_status_msr(void *status)
 /*topology number : get max packages/subnode/clusters number*/
 static void get_topology_number(void)
 {
-	int clusters;
-	int subnodes;
 	int dies;
 	int packages;
 	u64 data;
@@ -275,18 +280,10 @@ static void get_topology_number(void)
 		dies_per_socket = 1;
 
 	/* check subnodes_per_die */
-	subnodes = (data >> 32) & 0x3;
-	if (subnodes == 0x3)
-		subnodes_per_die = 2;
-	else
-		subnodes_per_die = 1;
+	subnodes_per_die = 2;
 
 	/* check clusters_per_subnode */
-	clusters = (data >> 6) & 0x3;
-	if (clusters == 0x3)
-		clusters_per_subnode = 2;
-	else
-		clusters_per_subnode = 1;
+	clusters_per_subnode = 2;
 
 	max_subnodes = max_packages * dies_per_socket * subnodes_per_die;
 	max_clusters = clusters_per_subnode * max_subnodes;
@@ -319,6 +316,8 @@ static int get_pcibus_limit(void)
 			kh40000_pcibus_limit[i++] = (val >> 24 & 0x1f) << 3 | 0x7;
 		}
 	}
+
+	pci_dev_put(dev);
 
 	return 0;
 }
@@ -397,7 +396,7 @@ DEFINE_PER_CPU(cpumask_t, zx_subnode_core_bits);
 
 static void zx_gen_core_map(void)
 {
-	int cpu, i;
+	int i, cpu;
 	int cluster_id, subnode_id;
 
 	for_each_present_cpu(cpu) {
@@ -429,20 +428,10 @@ static struct cpumask *topology_subnode_core_cpumask(int cpu)
 	return &per_cpu(zx_subnode_core_bits, cpu);
 }
 
-static void uncore_free_pcibus_map(void)
+ssize_t zx_uncore_event_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
+	struct uncore_event_desc *event = container_of(attr, struct uncore_event_desc, attr);
 
-}
-
-static int kh40000_pci2node_map_init(void)
-{
-	return 0;
-}
-
-ssize_t zx_uncore_event_show(struct device *dev, struct device_attribute *attr,  char *buf)
-{
-	struct uncore_event_desc *event =
-		container_of(attr, struct uncore_event_desc, attr);
 	return sprintf(buf, "%s", event->config);
 }
 
@@ -482,7 +471,7 @@ static void uncore_assign_hw_event(struct zhaoxin_uncore_box *box, struct perf_e
 	}
 
 	hwc->config_base = uncore_event_ctl(box, hwc->idx);
-	hwc->event_base  = uncore_perf_ctr(box, hwc->idx);
+	hwc->event_base = uncore_perf_ctr(box, hwc->idx);
 }
 
 void uncore_perf_event_update(struct zhaoxin_uncore_box *box, struct perf_event *event)
@@ -555,27 +544,27 @@ static struct uncore_event_desc kx5000_uncore_events[] = {
 };
 
 static struct zhaoxin_uncore_ops kx5000_uncore_msr_ops = {
-	.disable_box	= kx5000_uncore_msr_disable_box,
-	.enable_box	= kx5000_uncore_msr_enable_box,
-	.disable_event	= kx5000_uncore_msr_disable_event,
-	.enable_event	= kx5000_uncore_msr_enable_event,
-	.read_counter	= uncore_msr_read_counter,
+	.disable_box = kx5000_uncore_msr_disable_box,
+	.enable_box = kx5000_uncore_msr_enable_box,
+	.disable_event = kx5000_uncore_msr_disable_event,
+	.enable_event = kx5000_uncore_msr_enable_event,
+	.read_counter = uncore_msr_read_counter,
 };
 
 static struct zhaoxin_uncore_type kx5000_uncore_box = {
-	.name		= "",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.event_ctl	= KX5000_UNC_PERFEVTSEL0,
-	.perf_ctr	= KX5000_UNC_UNCORE_PMC0,
-	.fixed_ctr	= KX5000_UNC_FIXED_CTR,
-	.fixed_ctl	= KX5000_UNC_FIXED_CTR_CTRL,
-	.event_mask	= KX5000_UNC_RAW_EVENT_MASK,
-	.event_descs	= kx5000_uncore_events,
-	.ops		= &kx5000_uncore_msr_ops,
-	.format_group	= &kx5000_uncore_format_group,
+	.name = "",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.event_ctl = KX5000_UNC_PERFEVTSEL0,
+	.perf_ctr = KX5000_UNC_UNCORE_PMC0,
+	.fixed_ctr = KX5000_UNC_FIXED_CTR,
+	.fixed_ctl = KX5000_UNC_FIXED_CTR_CTRL,
+	.event_mask = KX5000_UNC_RAW_EVENT_MASK,
+	.event_descs = kx5000_uncore_events,
+	.ops = &kx5000_uncore_msr_ops,
+	.format_group = &kx5000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type *kx5000_msr_uncores[] = {
@@ -664,57 +653,57 @@ static struct uncore_event_desc kh40000_uncore_zzi_box_events[] = {
 };
 
 static struct zhaoxin_uncore_ops kh40000_uncore_msr_ops = {
-	.init_box	= kh40000_uncore_msr_init_box,
-	.disable_box	= kh40000_uncore_msr_disable_box,
-	.enable_box	= kh40000_uncore_msr_enable_box,
-	.disable_event	= kh40000_uncore_msr_disable_event,
-	.enable_event	= kh40000_uncore_msr_enable_event,
-	.read_counter	= uncore_msr_read_counter,
+	.init_box = kh40000_uncore_msr_init_box,
+	.disable_box = kh40000_uncore_msr_disable_box,
+	.enable_box = kh40000_uncore_msr_enable_box,
+	.disable_event = kh40000_uncore_msr_disable_event,
+	.enable_event = kh40000_uncore_msr_enable_event,
+	.read_counter = uncore_msr_read_counter,
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_llc_box = {
-	.name		= "llc",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.event_ctl	= KH40000_LLC_MSR_PMON_CTL0,
-	.perf_ctr	= KH40000_LLC_MSR_PMON_CTR0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_LLC_MSR_PMON_BLK_CTL,
-	.event_descs	= kh40000_uncore_llc_box_events,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kh40000_uncore_format_group,
+	.name = "llc",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.event_ctl = KH40000_LLC_MSR_PMON_CTL0,
+	.perf_ctr = KH40000_LLC_MSR_PMON_CTR0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_LLC_MSR_PMON_BLK_CTL,
+	.event_descs = kh40000_uncore_llc_box_events,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kh40000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_hif_box = {
-	.name		= "hif",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
+	.name = "hif",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
 	.fixed_ctr_bits = 48,
-	.event_ctl	= KH40000_HIF_MSR_PMON_CTL0,
-	.perf_ctr	= KH40000_HIF_MSR_PMON_CTR0,
-	.fixed_ctr	= KH40000_HIF_MSR_PMON_FIXED_CTR,
-	.fixed_ctl	= KH40000_HIF_MSR_PMON_FIXED_CTL,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_HIF_MSR_PMON_BLK_CTL,
-	.event_descs	= kh40000_uncore_hif_box_events,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kh40000_uncore_format_group,
+	.event_ctl = KH40000_HIF_MSR_PMON_CTL0,
+	.perf_ctr = KH40000_HIF_MSR_PMON_CTR0,
+	.fixed_ctr = KH40000_HIF_MSR_PMON_FIXED_CTR,
+	.fixed_ctl = KH40000_HIF_MSR_PMON_FIXED_CTL,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_HIF_MSR_PMON_BLK_CTL,
+	.event_descs = kh40000_uncore_hif_box_events,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kh40000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_zzi_box = {
-	.name		= "zzi",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.event_ctl	= KH40000_ZZI_MSR_PMON_CTL0,
-	.perf_ctr	= KH40000_ZZI_MSR_PMON_CTR0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_ZZI_MSR_PMON_BLK_CTL,
-	.event_descs	= kh40000_uncore_zzi_box_events,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kh40000_uncore_format_group,
+	.name = "zzi",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.event_ctl = KH40000_ZZI_MSR_PMON_CTL0,
+	.perf_ctr = KH40000_ZZI_MSR_PMON_CTR0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_ZZI_MSR_PMON_BLK_CTL,
+	.event_descs = kh40000_uncore_zzi_box_events,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kh40000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type *kh40000_msr_uncores[] = {
@@ -809,102 +798,102 @@ static struct uncore_event_desc kh40000_uncore_pxptrf_events[] = {
 };
 
 static struct zhaoxin_uncore_ops kh40000_uncore_pci_ops = {
-	.init_box	= kh40000_uncore_pci_init_box,
-	.disable_box	= kh40000_uncore_pci_disable_box,
-	.enable_box	= kh40000_uncore_pci_enable_box,
-	.disable_event	= kh40000_uncore_pci_disable_event,
-	.enable_event	= kh40000_uncore_pci_enable_event,
-	.read_counter	= kh40000_uncore_pci_read_counter
+	.init_box = kh40000_uncore_pci_init_box,
+	.disable_box = kh40000_uncore_pci_disable_box,
+	.enable_box = kh40000_uncore_pci_enable_box,
+	.disable_event = kh40000_uncore_pci_disable_event,
+	.enable_event = kh40000_uncore_pci_enable_event,
+	.read_counter = kh40000_uncore_pci_read_counter
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_mc0 = {
-	.name		= "mc0",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.fixed_ctr	= KH40000_MC0_CHy_PMON_FIXED_CTR,
-	.fixed_ctl	= KH40000_MC0_CHy_PMON_FIXED_CTL,
-	.event_descs	= kh40000_uncore_imc_events,
-	.perf_ctr	= KH40000_MC0_CHy_PMON_CTR0,
-	.event_ctl	= KH40000_MC0_CHy_PMON_CTL0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_MC0_CHy_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kh40000_uncore_format_group
+	.name = "mc0",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.fixed_ctr = KH40000_MC0_CHy_PMON_FIXED_CTR,
+	.fixed_ctl = KH40000_MC0_CHy_PMON_FIXED_CTL,
+	.event_descs = kh40000_uncore_imc_events,
+	.perf_ctr = KH40000_MC0_CHy_PMON_CTR0,
+	.event_ctl = KH40000_MC0_CHy_PMON_CTL0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_MC0_CHy_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kh40000_uncore_format_group
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_mc1 = {
-	.name		= "mc1",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.fixed_ctr	= KH40000_MC1_CHy_PMON_FIXED_CTR,
-	.fixed_ctl	= KH40000_MC1_CHy_PMON_FIXED_CTL,
-	.event_descs	= kh40000_uncore_imc_events,
-	.perf_ctr	= KH40000_MC1_CHy_PMON_CTR0,
-	.event_ctl	= KH40000_MC1_CHy_PMON_CTL0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_MC1_CHy_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kh40000_uncore_format_group
+	.name = "mc1",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.fixed_ctr = KH40000_MC1_CHy_PMON_FIXED_CTR,
+	.fixed_ctl = KH40000_MC1_CHy_PMON_FIXED_CTL,
+	.event_descs = kh40000_uncore_imc_events,
+	.perf_ctr = KH40000_MC1_CHy_PMON_CTR0,
+	.event_ctl = KH40000_MC1_CHy_PMON_CTL0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_MC1_CHy_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kh40000_uncore_format_group
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_pci = {
-	.name		= "pci",
-	.num_counters	= 4,
-	.num_boxes	= 10,
-	.perf_ctr_bits	= 48,
-	.event_descs	= kh40000_uncore_pci_events,
-	.perf_ctr	= KH40000_PCI_PMON_CTR0,
-	.event_ctl	= KH40000_PCI_PMON_CTL0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_PCI_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kh40000_uncore_format_group
+	.name = "pci",
+	.num_counters = 4,
+	.num_boxes = 2,
+	.perf_ctr_bits = 48,
+	.event_descs = kh40000_uncore_pci_events,
+	.perf_ctr = KH40000_PCI_PMON_CTR0,
+	.event_ctl = KH40000_PCI_PMON_CTL0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_PCI_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kh40000_uncore_format_group
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_zpi_dll = {
-	.name		= "zpi_dll",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.event_descs	= kh40000_uncore_zpi_dll_events,
-	.perf_ctr	= KH40000_ZPI_DLL_PMON_CTR0,
-	.event_ctl	= KH40000_ZPI_DLL_PMON_CTL0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_ZPI_DLL_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kh40000_uncore_format_group
+	.name = "zpi_dll",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.event_descs = kh40000_uncore_zpi_dll_events,
+	.perf_ctr = KH40000_ZPI_DLL_PMON_CTR0,
+	.event_ctl = KH40000_ZPI_DLL_PMON_CTL0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_ZPI_DLL_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kh40000_uncore_format_group
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_zdi_dll = {
-	.name		= "zdi_dll",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.event_descs	= kh40000_uncore_zdi_dll_events,
-	.perf_ctr	= KH40000_ZDI_DLL_PMON_CTR0,
-	.event_ctl	= KH40000_ZDI_DLL_PMON_CTL0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_ZDI_DLL_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kh40000_uncore_format_group
+	.name = "zdi_dll",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.event_descs = kh40000_uncore_zdi_dll_events,
+	.perf_ctr = KH40000_ZDI_DLL_PMON_CTR0,
+	.event_ctl = KH40000_ZDI_DLL_PMON_CTL0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_ZDI_DLL_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kh40000_uncore_format_group
 };
 
 static struct zhaoxin_uncore_type kh40000_uncore_pxptrf = {
-	.name		= "pxptrf",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.event_descs	= kh40000_uncore_pxptrf_events,
-	.perf_ctr	= KH40000_PXPTRF_PMON_CTR0,
-	.event_ctl	= KH40000_PXPTRF_PMON_CTL0,
-	.event_mask	= KH40000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_PXPTRF_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kh40000_uncore_format_group
+	.name = "pxptrf",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.event_descs = kh40000_uncore_pxptrf_events,
+	.perf_ctr = KH40000_PXPTRF_PMON_CTR0,
+	.event_ctl = KH40000_PXPTRF_PMON_CTL0,
+	.event_mask = KH40000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_PXPTRF_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kh40000_uncore_format_group
 };
 
 enum {
@@ -917,59 +906,72 @@ enum {
 };
 
 static struct zhaoxin_uncore_type *kh40000_pci_uncores[] = {
-	[KH40000_PCI_UNCORE_MC0]	= &kh40000_uncore_mc0,
-	[KH40000_PCI_UNCORE_MC1]	= &kh40000_uncore_mc1,
-	[KH40000_PCI_UNCORE_PCI]	= &kh40000_uncore_pci,
-	[KH40000_PCI_UNCORE_ZPI_DLL]	= &kh40000_uncore_zpi_dll,
-	[KH40000_PCI_UNCORE_ZDI_DLL]	= &kh40000_uncore_zdi_dll,
-	[KH40000_PCI_UNCORE_PXPTRF]	= &kh40000_uncore_pxptrf,
+	[KH40000_PCI_UNCORE_MC0] = &kh40000_uncore_mc0,
+	[KH40000_PCI_UNCORE_MC1] = &kh40000_uncore_mc1,
+	[KH40000_PCI_UNCORE_PCI] = &kh40000_uncore_pci,
+	[KH40000_PCI_UNCORE_ZPI_DLL] = &kh40000_uncore_zpi_dll,
+	[KH40000_PCI_UNCORE_ZDI_DLL] = &kh40000_uncore_zdi_dll,
+	[KH40000_PCI_UNCORE_PXPTRF] = &kh40000_uncore_pxptrf,
 	NULL,
 };
 
 static const struct pci_device_id kh40000_uncore_pci_ids[] = {
-	{ /* MC Channe0/1 */
+	{
+		/* MC Channe0/1 */
 		PCI_DEVICE(0x1D17, 0x31b2),
 		.driver_data = UNCORE_PCI_DEV_DATA(KH40000_PCI_UNCORE_MC0, 0),
 	},
 
-	{ /* ZPI_DLL */
+	/*
+	 * PEXC_A: D2F0 D2F1 D3F0 D3F1 D3F2 all use D2F0 to access,
+	 * with different eventcode.
+	 */
+	{
+		/* PCIE D2F0 */
+		PCI_DEVICE(0x1D17, 0x0717),
+		.driver_data = UNCORE_PCI_DEV_DATA(KH40000_PCI_UNCORE_PCI, 0),
+	},
+
+	/*
+	 * PEXC_B: D4F0 D4F1 D5F0 D5F1 D5F2 all use D4F0 to access,
+	 * with different eventcode.
+	 */
+	{
+		/* PCIE D4F0 */
+		PCI_DEVICE(0x1D17, 0x071C),
+		.driver_data = UNCORE_PCI_DEV_DATA(KH40000_PCI_UNCORE_PCI, 1),
+	},
+
+	{
+		/* ZPI_DLL */
 		PCI_DEVICE(0x1D17, 0x91c1),
 		.driver_data = UNCORE_PCI_DEV_DATA(KH40000_PCI_UNCORE_ZPI_DLL, 0),
 	},
 
-	{ /* ZDI_DLL */
+	{
+		/* ZDI_DLL */
 		PCI_DEVICE(0x1D17, 0x3b03),
 		.driver_data = UNCORE_PCI_DEV_DATA(KH40000_PCI_UNCORE_ZDI_DLL, 0),
 	},
 
-	{ /* PXPTRF */
+	{
+		/* PXPTRF */
 		PCI_DEVICE(0x1D17, 0x31B4),
 		.driver_data = UNCORE_PCI_DEV_DATA(KH40000_PCI_UNCORE_PXPTRF, 0),
 	},
 
 	{ /* end: all zeroes */ }
 };
-
-static struct pci_driver kh40000_uncore_pci_driver = {
-	.name = "kh40000_uncore",
-	.id_table = kh40000_uncore_pci_ids,
-};
 /*KH40000 pci ops end*/
 
 /*KX7000 msr ops start*/
-static unsigned int kx7000_uncore_msr_offsets[] = {
-	0x0, 0x13, 0x27, 0x3b, 0x4f, 0x63, 0x77, 0x8b
-};
+static unsigned int kx7000_uncore_msr_offsets[] = { 0x0, 0x13, 0x27, 0x3b, 0x4f, 0x63, 0x77, 0x8b };
 
 static struct attribute *kx7000_uncore_formats_attr[] = {
-	&format_attr_event.attr,
-	&format_attr_umask.attr,
-	&format_attr_edge.attr,
-	&format_attr_logic_op0.attr,
-	&format_attr_logic_op1.attr,
-	&format_attr_inv.attr,
-	&format_attr_thresh8.attr,
-	NULL,
+	&format_attr_event.attr,     &format_attr_umask.attr,
+	&format_attr_edge.attr,	     &format_attr_logic_op0.attr,
+	&format_attr_logic_op1.attr, &format_attr_inv.attr,
+	&format_attr_thresh8.attr,   NULL,
 };
 
 static struct attribute_group kx7000_uncore_format_group = {
@@ -978,93 +980,93 @@ static struct attribute_group kx7000_uncore_format_group = {
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_mesh_box = {
-	.name		= "mesh",
-	.num_counters	= 4,
-	.num_boxes	= 8,
-	.perf_ctr_bits	= 48,
-	.event_ctl	= KX7000_MESH_MSR_PMON_CTL0,
-	.perf_ctr	= KX7000_MESH_MSR_PMON_CTR0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_MESH_MSR_PMON_BLK_CTL,
-	.msr_offsets	= kx7000_uncore_msr_offsets,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "mesh",
+	.num_counters = 4,
+	.num_boxes = 8,
+	.perf_ctr_bits = 48,
+	.event_ctl = KX7000_MESH_MSR_PMON_CTL0,
+	.perf_ctr = KX7000_MESH_MSR_PMON_CTR0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_MESH_MSR_PMON_BLK_CTL,
+	.msr_offsets = kx7000_uncore_msr_offsets,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_llc_box = {
-	.name		= "llc",
-	.num_counters	= 4,
-	.num_boxes	= 8,
-	.perf_ctr_bits	= 48,
-	.event_ctl	= KX7000_LLC_MSR_PMON_CTL0,
-	.perf_ctr	= KX7000_LLC_MSR_PMON_CTR0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_LLC_MSR_PMON_BLK_CTL,
-	.msr_offsets	= kx7000_uncore_msr_offsets,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "llc",
+	.num_counters = 4,
+	.num_boxes = 8,
+	.perf_ctr_bits = 48,
+	.event_ctl = KX7000_LLC_MSR_PMON_CTL0,
+	.perf_ctr = KX7000_LLC_MSR_PMON_CTR0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_LLC_MSR_PMON_BLK_CTL,
+	.msr_offsets = kx7000_uncore_msr_offsets,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_hif_box = {
-	.name		= "hif",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.event_ctl	= KH40000_HIF_MSR_PMON_CTL0,
-	.perf_ctr	= KH40000_HIF_MSR_PMON_CTR0,
-	.fixed_ctr	= KH40000_HIF_MSR_PMON_FIXED_CTR,
-	.fixed_ctl	= KH40000_HIF_MSR_PMON_FIXED_CTL,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_HIF_MSR_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "hif",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.event_ctl = KH40000_HIF_MSR_PMON_CTL0,
+	.perf_ctr = KH40000_HIF_MSR_PMON_CTR0,
+	.fixed_ctr = KH40000_HIF_MSR_PMON_FIXED_CTR,
+	.fixed_ctl = KH40000_HIF_MSR_PMON_FIXED_CTL,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_HIF_MSR_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_homestop = {
-	.name		= "homestop",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.event_ctl	= KX7000_HOMESTOP_MSR_PMON_CTL0,
-	.perf_ctr	= KX7000_HOMESTOP_MSR_PMON_CTR0,
-	.fixed_ctr	= KX7000_HOMESTOP_MSR_PMON_FIXED_CTR,
-	.fixed_ctl	= KX7000_HOMESTOP_MSR_PMON_FIXED_CTL,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_HOMESTOP_MSR_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "homestop",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.event_ctl = KX7000_HOMESTOP_MSR_PMON_CTL0,
+	.perf_ctr = KX7000_HOMESTOP_MSR_PMON_CTR0,
+	.fixed_ctr = KX7000_HOMESTOP_MSR_PMON_FIXED_CTR,
+	.fixed_ctl = KX7000_HOMESTOP_MSR_PMON_FIXED_CTL,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_HOMESTOP_MSR_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_ccd_zdi_pl = {
-	.name		= "ccd_zdi_pl",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.event_ctl	= KX7000_CCD_ZDI_PL_MSR_PMON_CTL0,
-	.perf_ctr	= KX7000_CCD_ZDI_PL_MSR_PMON_CTR0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_CCD_ZDI_PL_MSR_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "ccd_zdi_pl",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.event_ctl = KX7000_CCD_ZDI_PL_MSR_PMON_CTL0,
+	.perf_ctr = KX7000_CCD_ZDI_PL_MSR_PMON_CTR0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_CCD_ZDI_PL_MSR_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_iod_zdi_pl = {
-	.name		= "iod_zdi_pl",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.event_ctl	= KX7000_IOD_ZDI_PL_MSR_PMON_CTL0,
-	.perf_ctr	= KX7000_IOD_ZDI_PL_MSR_PMON_CTR0,
-	.fixed_ctr	= KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTR,
-	.fixed_ctl	= KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTL,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_IOD_ZDI_PL_MSR_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_msr_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "iod_zdi_pl",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.event_ctl = KX7000_IOD_ZDI_PL_MSR_PMON_CTL0,
+	.perf_ctr = KX7000_IOD_ZDI_PL_MSR_PMON_CTR0,
+	.fixed_ctr = KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTR,
+	.fixed_ctl = KX7000_IOD_ZDI_PL_MSR_PMON_FIXED_CTL,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_IOD_ZDI_PL_MSR_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_msr_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type *kx7000_msr_uncores[] = {
@@ -1079,9 +1081,7 @@ static struct zhaoxin_uncore_type *kx7000_msr_uncores[] = {
 /*KX7000 msr ops end*/
 
 /*KX7000 pci ops start*/
-static unsigned int kx7000_mc_ctr_lh_offsets[] = {
-	0xc, 0xe, 0x10, 0x12, 0x14
-};
+static unsigned int kx7000_mc_ctr_lh_offsets[] = { 0xc, 0xe, 0x10, 0x12, 0x14 };
 
 static u64 kx7000_uncore_pci_mc_read_counter(struct zhaoxin_uncore_box *box,
 					     struct perf_event *event)
@@ -1090,7 +1090,7 @@ static u64 kx7000_uncore_pci_mc_read_counter(struct zhaoxin_uncore_box *box,
 	struct hw_perf_event *hwc = &event->hw;
 	u64 count = 0;
 
-	pci_read_config_word(pdev, hwc->event_base, (u16 *)&count + 3);
+	pci_read_config_word(pdev, hwc->event_base, (u16 *)&count + 2);
 	pci_read_config_dword(pdev, hwc->event_base + kx7000_mc_ctr_lh_offsets[hwc->idx],
 			      (u32 *)&count);
 
@@ -1098,103 +1098,103 @@ static u64 kx7000_uncore_pci_mc_read_counter(struct zhaoxin_uncore_box *box,
 }
 
 static struct zhaoxin_uncore_ops kx7000_uncore_pci_mc_ops = {
-	.init_box	= kh40000_uncore_pci_init_box,
-	.disable_box	= kh40000_uncore_pci_disable_box,
-	.enable_box	= kh40000_uncore_pci_enable_box,
-	.disable_event	= kh40000_uncore_pci_disable_event,
-	.enable_event	= kh40000_uncore_pci_enable_event,
-	.read_counter	= kx7000_uncore_pci_mc_read_counter
+	.init_box = kh40000_uncore_pci_init_box,
+	.disable_box = kh40000_uncore_pci_disable_box,
+	.enable_box = kh40000_uncore_pci_enable_box,
+	.disable_event = kh40000_uncore_pci_disable_event,
+	.enable_event = kh40000_uncore_pci_enable_event,
+	.read_counter = kx7000_uncore_pci_mc_read_counter
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_mc_a0 = {
-	.name		= "mc_a0",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.fixed_ctr	= KX7000_MC_A0_CHy_PMON_FIXED_CTR,
-	.fixed_ctl	= KX7000_MC_A0_CHy_PMON_FIXED_CTL,
-	.perf_ctr	= KX7000_MC_A0_CHy_PMON_CTR0,
-	.event_ctl	= KX7000_MC_A0_CHy_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_MC_A0_CHy_PMON_BLK_CTL,
-	.ops		= &kx7000_uncore_pci_mc_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "mc_a0",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.fixed_ctr = KX7000_MC_A0_CHy_PMON_FIXED_CTR,
+	.fixed_ctl = KX7000_MC_A0_CHy_PMON_FIXED_CTL,
+	.perf_ctr = KX7000_MC_A0_CHy_PMON_CTR0,
+	.event_ctl = KX7000_MC_A0_CHy_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_MC_A0_CHy_PMON_BLK_CTL,
+	.ops = &kx7000_uncore_pci_mc_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_mc_a1 = {
-	.name		= "mc_a1",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.fixed_ctr	= KX7000_MC_A1_CHy_PMON_FIXED_CTR,
-	.fixed_ctl	= KX7000_MC_A1_CHy_PMON_FIXED_CTL,
-	.perf_ctr	= KX7000_MC_A1_CHy_PMON_CTR0,
-	.event_ctl	= KX7000_MC_A1_CHy_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_MC_A1_CHy_PMON_BLK_CTL,
-	.ops		= &kx7000_uncore_pci_mc_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "mc_a1",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.fixed_ctr = KX7000_MC_A1_CHy_PMON_FIXED_CTR,
+	.fixed_ctl = KX7000_MC_A1_CHy_PMON_FIXED_CTL,
+	.perf_ctr = KX7000_MC_A1_CHy_PMON_CTR0,
+	.event_ctl = KX7000_MC_A1_CHy_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_MC_A1_CHy_PMON_BLK_CTL,
+	.ops = &kx7000_uncore_pci_mc_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_mc_b0 = {
-	.name		= "mc_b0",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.fixed_ctr	= KX7000_MC_B0_CHy_PMON_FIXED_CTR,
-	.fixed_ctl	= KX7000_MC_B0_CHy_PMON_FIXED_CTL,
-	.perf_ctr	= KX7000_MC_B0_CHy_PMON_CTR0,
-	.event_ctl	= KX7000_MC_B0_CHy_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_MC_B0_CHy_PMON_BLK_CTL,
-	.ops		= &kx7000_uncore_pci_mc_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "mc_b0",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.fixed_ctr = KX7000_MC_B0_CHy_PMON_FIXED_CTR,
+	.fixed_ctl = KX7000_MC_B0_CHy_PMON_FIXED_CTL,
+	.perf_ctr = KX7000_MC_B0_CHy_PMON_CTR0,
+	.event_ctl = KX7000_MC_B0_CHy_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_MC_B0_CHy_PMON_BLK_CTL,
+	.ops = &kx7000_uncore_pci_mc_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_mc_b1 = {
-	.name		= "mc_b1",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.fixed_ctr	= KX7000_MC_B1_CHy_PMON_FIXED_CTR,
-	.fixed_ctl	= KX7000_MC_B1_CHy_PMON_FIXED_CTL,
-	.perf_ctr	= KX7000_MC_B1_CHy_PMON_CTR0,
-	.event_ctl	= KX7000_MC_B1_CHy_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_MC_B1_CHy_PMON_BLK_CTL,
-	.ops		= &kx7000_uncore_pci_mc_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "mc_b1",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.fixed_ctr = KX7000_MC_B1_CHy_PMON_FIXED_CTR,
+	.fixed_ctl = KX7000_MC_B1_CHy_PMON_FIXED_CTL,
+	.perf_ctr = KX7000_MC_B1_CHy_PMON_CTR0,
+	.event_ctl = KX7000_MC_B1_CHy_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_MC_B1_CHy_PMON_BLK_CTL,
+	.ops = &kx7000_uncore_pci_mc_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_pci = {
-	.name		= "pci",
-	.num_counters	= 4,
-	.num_boxes	= 17,
-	.perf_ctr_bits	= 48,
-	.perf_ctr	= KH40000_PCI_PMON_CTR0,
-	.event_ctl	= KH40000_PCI_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_PCI_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "pci",
+	.num_counters = 4,
+	.num_boxes = 2,
+	.perf_ctr_bits = 48,
+	.perf_ctr = KH40000_PCI_PMON_CTR0,
+	.event_ctl = KH40000_PCI_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_PCI_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_pxptrf = {
-	.name		= "pxptrf",
-	.num_counters	= 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.event_descs	= kh40000_uncore_pxptrf_events,
-	.perf_ctr	= KH40000_PXPTRF_PMON_CTR0,
-	.event_ctl	= KH40000_PXPTRF_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KH40000_PXPTRF_PMON_BLK_CTL,
-	.ops		= &kh40000_uncore_pci_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "pxptrf",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.event_descs = kh40000_uncore_pxptrf_events,
+	.perf_ctr = KH40000_PXPTRF_PMON_CTR0,
+	.event_ctl = KH40000_PXPTRF_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KH40000_PXPTRF_PMON_BLK_CTL,
+	.ops = &kh40000_uncore_pci_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 enum {
@@ -1207,32 +1207,49 @@ enum {
 };
 
 static struct zhaoxin_uncore_type *kx7000_pci_uncores[] = {
-	[KX7000_PCI_UNCORE_MC_A0]	= &kx7000_uncore_mc_a0,
-	[KX7000_PCI_UNCORE_MC_A1]	= &kx7000_uncore_mc_a1,
-	[KX7000_PCI_UNCORE_MC_B0]	= &kx7000_uncore_mc_b0,
-	[KX7000_PCI_UNCORE_MC_B1]	= &kx7000_uncore_mc_b1,
-	[KX7000_PCI_UNCORE_PCI]		= &kx7000_uncore_pci,
-	[KX7000_PCI_UNCORE_PXPTRF]	= &kx7000_uncore_pxptrf,
+	[KX7000_PCI_UNCORE_MC_A0] = &kx7000_uncore_mc_a0,
+	[KX7000_PCI_UNCORE_MC_A1] = &kx7000_uncore_mc_a1,
+	[KX7000_PCI_UNCORE_MC_B0] = &kx7000_uncore_mc_b0,
+	[KX7000_PCI_UNCORE_MC_B1] = &kx7000_uncore_mc_b1,
+	[KX7000_PCI_UNCORE_PCI] = &kx7000_uncore_pci,
+	[KX7000_PCI_UNCORE_PXPTRF] = &kx7000_uncore_pxptrf,
 	NULL,
 };
 
 static const struct pci_device_id kx7000_uncore_pci_ids[] = {
-	{ /* MC Channe A0/A1/B0/B1 */
+	{
+		/* MC Channe A0/A1/B0/B1 */
 		PCI_DEVICE(0x1D17, 0x31B2),
 		.driver_data = UNCORE_PCI_DEV_DATA(KX7000_PCI_UNCORE_MC_A0, 0),
 	},
 
-	{ /* PXPTRF */
+	/*
+	 * PEXC_A: D2F0 D2F1 D2F2 D2F3 D2F4 D3F0 D3F1 D3F2 D3F3 all
+	 * use D2F0 to access, with different eventcode
+	 */
+	{
+		/* PCIE D2F0 */
+		PCI_DEVICE(0x1D17, 0x0717),
+		.driver_data = UNCORE_PCI_DEV_DATA(KX7000_PCI_UNCORE_PCI, 0),
+	},
+
+	/*
+	 * PEXC_B: D4F0 D4F1 D4F2 D4F3 D4F4 D5F0 D5F1 D5F2 D5F3 all
+	 * use D4F0 to access, with different eventcode
+	 */
+	{
+		/* PCIE D4F0 */
+		PCI_DEVICE(0x1D17, 0x071B),
+		.driver_data = UNCORE_PCI_DEV_DATA(KX7000_PCI_UNCORE_PCI, 1),
+	},
+
+	{
+		/* PXPTRF */
 		PCI_DEVICE(0x1D17, 0x31B4),
 		.driver_data = UNCORE_PCI_DEV_DATA(KX7000_PCI_UNCORE_PXPTRF, 0),
 	},
 
 	{ /* end: all zeroes */ }
-};
-
-static struct pci_driver kx7000_uncore_pci_driver = {
-	.name           = "kx7000_uncore",
-	.id_table       = kx7000_uncore_pci_ids,
 };
 /*KX7000 pci ops end*/
 
@@ -1259,6 +1276,8 @@ static void kx7000_uncore_mmio_init_box(struct zhaoxin_uncore_box *box)
 
 	pci_read_config_dword(pdev, mmio_base_offset + 4, &pci_dword);
 	addr |= pci_dword & KX7000_ZDI_DL_MMIO_MEM0_MASK;
+
+	pci_dev_put(pdev);
 
 	box->io_addr = ioremap(addr, KX7000_ZDI_DL_MMIO_SIZE);
 	if (!box->io_addr)
@@ -1338,41 +1357,41 @@ static u64 uncore_mmio_read_counter(struct zhaoxin_uncore_box *box, struct perf_
 }
 
 static struct zhaoxin_uncore_ops kx7000_uncore_mmio_ops = {
-	.init_box	= kx7000_uncore_mmio_init_box,
-	.exit_box	= uncore_mmio_exit_box,
-	.disable_box	= kx7000_uncore_mmio_disable_box,
-	.enable_box	= kx7000_uncore_mmio_enable_box,
-	.disable_event	= kx7000_uncore_mmio_disable_event,
-	.enable_event	= kx7000_uncore_mmio_enable_event,
-	.read_counter	= uncore_mmio_read_counter,
+	.init_box = kx7000_uncore_mmio_init_box,
+	.exit_box = uncore_mmio_exit_box,
+	.disable_box = kx7000_uncore_mmio_disable_box,
+	.enable_box = kx7000_uncore_mmio_enable_box,
+	.disable_event = kx7000_uncore_mmio_disable_event,
+	.enable_event = kx7000_uncore_mmio_enable_event,
+	.read_counter = uncore_mmio_read_counter,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_iod_zdi_dl = {
-	.name		= "iod_zdi_dl",
-	.num_counters   = 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.perf_ctr	= KX7000_ZDI_DL_MMIO_PMON_CTR0,
-	.event_ctl	= KX7000_ZDI_DL_MMIO_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_ZDI_DL_MMIO_PMON_BLK_CTL,
-	.ops		= &kx7000_uncore_mmio_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "iod_zdi_dl",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.perf_ctr = KX7000_ZDI_DL_MMIO_PMON_CTR0,
+	.event_ctl = KX7000_ZDI_DL_MMIO_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_ZDI_DL_MMIO_PMON_BLK_CTL,
+	.ops = &kx7000_uncore_mmio_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type kx7000_uncore_ccd_zdi_dl = {
-	.name		= "ccd_zdi_dl",
-	.num_counters   = 4,
-	.num_boxes	= 1,
-	.perf_ctr_bits	= 48,
-	.fixed_ctr_bits	= 48,
-	.perf_ctr	= KX7000_ZDI_DL_MMIO_PMON_CTR0,
-	.event_ctl	= KX7000_ZDI_DL_MMIO_PMON_CTL0,
-	.event_mask	= KX7000_PMON_RAW_EVENT_MASK,
-	.box_ctl	= KX7000_ZDI_DL_MMIO_PMON_BLK_CTL,
-	.ops		= &kx7000_uncore_mmio_ops,
-	.format_group	= &kx7000_uncore_format_group,
+	.name = "ccd_zdi_dl",
+	.num_counters = 4,
+	.num_boxes = 1,
+	.perf_ctr_bits = 48,
+	.fixed_ctr_bits = 48,
+	.perf_ctr = KX7000_ZDI_DL_MMIO_PMON_CTR0,
+	.event_ctl = KX7000_ZDI_DL_MMIO_PMON_CTL0,
+	.event_mask = KX7000_PMON_RAW_EVENT_MASK,
+	.box_ctl = KX7000_ZDI_DL_MMIO_PMON_BLK_CTL,
+	.ops = &kx7000_uncore_mmio_ops,
+	.format_group = &kx7000_uncore_format_group,
 };
 
 static struct zhaoxin_uncore_type *kx7000_mmio_uncores[] = {
@@ -1488,8 +1507,7 @@ static int uncore_collect_events(struct zhaoxin_uncore_box *box, struct perf_eve
 		return n;
 
 	for_each_sibling_event(event, leader) {
-		if (!is_box_event(box, event) ||
-			event->state <= PERF_EVENT_STATE_OFF)
+		if (!is_box_event(box, event) || event->state <= PERF_EVENT_STATE_OFF)
 			continue;
 
 		if (n >= max_count)
@@ -1571,8 +1589,7 @@ static int uncore_assign_events(struct zhaoxin_uncore_box *box, int assign[], in
 	}
 	/* slow path */
 	if (i != n)
-		ret = perf_assign_events(box->event_constraint, n,
-					wmin, wmax, n, assign);
+		ret = perf_assign_events(box->event_constraint, n, wmin, wmax, n, assign);
 
 	if (!assign || ret) {
 		for (i = 0; i < n; i++)
@@ -1585,7 +1602,6 @@ static void uncore_pmu_event_start(struct perf_event *event, int flags)
 {
 	struct zhaoxin_uncore_box *box = uncore_event_to_box(event);
 	int idx = event->hw.idx;
-
 
 	if (WARN_ON_ONCE(idx == -1 || idx >= UNCORE_PMC_IDX_MAX))
 		return;
@@ -1659,8 +1675,7 @@ static int uncore_pmu_event_add(struct perf_event *event, int flags)
 		event = box->event_list[i];
 		hwc = &event->hw;
 
-		if (hwc->idx == assign[i] &&
-			hwc->last_tag == box->tags[assign[i]])
+		if (hwc->idx == assign[i] && hwc->last_tag == box->tags[assign[i]])
 			continue;
 		/*
 		 * Ensure we don't accidentally enable a stopped
@@ -1677,8 +1692,7 @@ static int uncore_pmu_event_add(struct perf_event *event, int flags)
 		event = box->event_list[i];
 		hwc = &event->hw;
 
-		if (hwc->idx != assign[i] ||
-			hwc->last_tag != box->tags[assign[i]])
+		if (hwc->idx != assign[i] || hwc->last_tag != box->tags[assign[i]])
 			uncore_assign_hw_event(box, event, assign[i]);
 		else if (i < box->n_events)
 			continue;
@@ -1895,19 +1909,19 @@ static int uncore_pmu_register(struct zhaoxin_uncore_pmu *pmu)
 	int ret;
 
 	if (!pmu->type->pmu) {
-		pmu->pmu = (struct pmu) {
-			.attr_groups	= pmu->type->attr_groups,
-			.task_ctx_nr	= perf_invalid_context,
-			.pmu_enable	= uncore_pmu_enable,
-			.pmu_disable	= uncore_pmu_disable,
-			.event_init	= uncore_pmu_event_init,
-			.add		= uncore_pmu_event_add,
-			.del		= uncore_pmu_event_del,
-			.start		= uncore_pmu_event_start,
-			.stop		= uncore_pmu_event_stop,
-			.read		= uncore_pmu_event_read,
-			.module		= THIS_MODULE,
-			.capabilities	= PERF_PMU_CAP_NO_EXCLUDE,
+		pmu->pmu = (struct pmu){
+			.attr_groups = pmu->type->attr_groups,
+			.task_ctx_nr = perf_invalid_context,
+			.pmu_enable = uncore_pmu_enable,
+			.pmu_disable = uncore_pmu_disable,
+			.event_init = uncore_pmu_event_init,
+			.add = uncore_pmu_event_add,
+			.del = uncore_pmu_event_del,
+			.start = uncore_pmu_event_start,
+			.stop = uncore_pmu_event_stop,
+			.read = uncore_pmu_event_read,
+			.module = THIS_MODULE,
+			.capabilities = PERF_PMU_CAP_NO_EXCLUDE,
 		};
 	} else {
 		pmu->pmu = *pmu->type->pmu;
@@ -1998,18 +2012,17 @@ static int __init uncore_type_init(struct zhaoxin_uncore_type *type, bool setid)
 	}
 
 	for (i = 0; i < type->num_boxes; i++) {
-		pmus[i].func_id	= setid ? i : -1;
-		pmus[i].pmu_idx	= i;
-		pmus[i].type	= type;
-		pmus[i].boxes	= kzalloc(size, GFP_KERNEL);
+		pmus[i].func_id = setid ? i : -1;
+		pmus[i].pmu_idx = i;
+		pmus[i].type = type;
+		pmus[i].boxes = kzalloc(size, GFP_KERNEL);
 		if (!pmus[i].boxes)
 			goto err;
 	}
 
 	type->pmus = pmus;
-	type->unconstrainted = (struct event_constraint)
-				__EVENT_CONSTRAINT(0, (1ULL << type->num_counters) - 1, 0,
-				type->num_counters, 0, 0);
+	type->unconstrainted = (struct event_constraint)__EVENT_CONSTRAINT(
+		0, (1ULL << type->num_counters) - 1, 0, type->num_counters, 0, 0);
 
 	if (type->event_descs) {
 		struct {
@@ -2059,7 +2072,7 @@ static int __init uncore_types_init(struct zhaoxin_uncore_type **types, bool set
 /*
  * add a pci uncore device
  */
-static int uncore_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+static int uncore_pci_type_init(struct pci_dev *pdev, const struct pci_device_id *id)
 {
 	struct zhaoxin_uncore_type *type;
 	struct zhaoxin_uncore_pmu *pmu;
@@ -2067,7 +2080,7 @@ static int uncore_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id
 	struct zhaoxin_uncore_box **boxes;
 	char mc_dev[10];
 	int loop = 1;
-	int i, j = 0;
+	int i;
 	int subnode_id = 0;
 	int ret = 0;
 
@@ -2090,15 +2103,11 @@ static int uncore_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id
 	if (!boxes)
 		return -ENOMEM;
 
-	for (i = 0; i < loop; i++) {
-		type = uncore_pci_uncores[UNCORE_PCI_DEV_TYPE(id->driver_data) + j];
+	pci_set_drvdata(pdev, boxes);
 
-		if (!type)
-			continue;
-		/*
-		 * for performance monitoring unit with multiple boxes,
-		 * each box has a different function id.
-		 */
+	for (i = 0; i < loop; i++) {
+		type = uncore_pci_uncores[UNCORE_PCI_DEV_TYPE(id->driver_data) + i];
+
 		pmu = &type->pmus[UNCORE_PCI_DEV_IDX(id->driver_data)];
 
 		if (WARN_ON_ONCE(pmu->boxes[subnode_id] != NULL))
@@ -2120,91 +2129,116 @@ static int uncore_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id
 		uncore_box_init(box);
 		boxes[i] = box;
 
-		pci_set_drvdata(pdev, boxes);
 		pmu->boxes[subnode_id] = box;
 		if (atomic_inc_return(&pmu->activeboxes) > 1) {
 			if (!strcmp(type->name, mc_dev))
-				goto next_loop;
+				continue;
 			else
 				return 0;
 		}
+
 		/* First active box registers the pmu */
 		ret = uncore_pmu_register(pmu);
-		if (ret) {
-			pci_set_drvdata(pdev, NULL);
-			pmu->boxes[subnode_id] = NULL;
-			uncore_box_exit(box);
-			kfree(box);
-		}
-next_loop:
-		j++;
+		if (ret)
+			return ret;
 	}
 
-	return ret;
+	return 0;
 }
 
-static void uncore_pci_remove(struct pci_dev *pdev)
+static void uncore_pci_type_exit(void)
 {
+	struct zhaoxin_uncore_type **types;
+	struct zhaoxin_uncore_type *type;
 	struct zhaoxin_uncore_box **boxes;
 	struct zhaoxin_uncore_box *box;
 	struct zhaoxin_uncore_pmu *pmu;
-	int subnode_id = 0;
-	int i = 0;
-	int loop = 1;
+	int i, j;
+	int max;
+	struct pci_dev *pdev = NULL;
 
-	boxes = pci_get_drvdata(pdev);
+	for (types = uncore_pci_uncores; *types; types++) {
+		type = *types;
+		pmu = type->pmus;
 
-	if (boot_cpu_data.x86_model == ZHAOXIN_FAM7_KH40000) {
-		if (!strcmp(boxes[0]->pmu->type->name, "mc0"))
-			loop = 2;
-		else
-			loop = 1;
-	} else if (boot_cpu_data.x86_model == ZHAOXIN_FAM7_KX7000) {
-		if (!strcmp(boxes[0]->pmu->type->name, "mc_a0"))
-			loop = 4;
-		else
-			loop = 1;
+		if (boot_cpu_data.x86_model == ZHAOXIN_FAM7_KH40000) {
+			if (!strcmp(type->name, "llc"))
+				max = max_clusters;
+			else
+				max = max_subnodes;
+		} else {
+			max = max_packages;
+		}
+
+		for (i = 0; i < type->num_boxes; i++, pmu++) {
+			if (atomic_dec_return(&pmu->activeboxes) == 0)
+				uncore_pmu_unregister(pmu);
+
+			for (j = 0; j < max; j++) {
+				box = pmu->boxes[j];
+				/* check if device exist */
+				if (!box)
+					continue;
+
+				pdev = box->pci_dev;
+
+				uncore_box_exit(box);
+				kfree(box);
+
+				/*
+				 * MC use one PCI device for mc0/mc1 mc_a0/mc_a1/mc_b0/mc_b1
+				 * So just put and free once: only put mc0 and mc_a0.
+				 */
+				if (boot_cpu_data.x86_model == ZHAOXIN_FAM7_KH40000)
+					if (strncmp(type->name, "mc", 2) == 0 &&
+					    strcmp(type->name, "mc0") != 0)
+						break;
+
+				if (boot_cpu_data.x86_model == ZHAOXIN_FAM7_KX7000)
+					if (strncmp(type->name, "mc", 2) == 0 &&
+					    strcmp(type->name, "mc_a0") != 0)
+						break;
+
+				boxes = pci_get_drvdata(pdev);
+				kfree(boxes);
+				pci_set_drvdata(pdev, NULL);
+				pci_dev_put(pdev);
+			}
+		}
 	}
-
-	for (i = 0; i < loop; i++) {
-		box = boxes[i];
-		pmu = box->pmu;
-		if (WARN_ON_ONCE(subnode_id != box->subnode_id))
-			return;
-
-		pci_set_drvdata(pdev, NULL);
-		pmu->boxes[subnode_id] = NULL;
-		if (atomic_dec_return(&pmu->activeboxes) == 0)
-			uncore_pmu_unregister(pmu);
-
-		uncore_box_exit(box);
-		kfree(box);
-	}
-
-	kfree(boxes);
 }
 
 static int __init uncore_pci_init(void)
 {
 	int ret;
+	const struct pci_device_id *id = uncore_pci_ids;
+	struct pci_dev *pdev = NULL;
 
 	ret = uncore_types_init(uncore_pci_uncores, false);
 	if (ret)
-		goto errtype;
+		goto err;
 
-	uncore_pci_driver->probe = uncore_pci_probe;
-	uncore_pci_driver->remove = uncore_pci_remove;
+	while (id && id->vendor) {
+		pdev = pci_get_device(id->vendor, id->device, NULL);
+		while (pdev) {
+			ret = uncore_pci_type_init(pdev, id);
+			if (ret) {
+				pci_dev_put(pdev);
+				goto err;
+			}
 
-	ret = pci_register_driver(uncore_pci_driver);
-	if (ret)
-		goto errtype;
+			pdev = pci_get_device(id->vendor, id->device, pdev);
+		}
+
+		id++;
+	}
 
 	pcidrv_registered = true;
 	return 0;
 
-errtype:
+err:
+	uncore_pci_type_exit();
 	uncore_types_exit(uncore_pci_uncores);
-	uncore_free_pcibus_map();
 	uncore_pci_uncores = empty_uncore;
 	return ret;
 }
@@ -2213,9 +2247,8 @@ static void uncore_pci_exit(void)
 {
 	if (pcidrv_registered) {
 		pcidrv_registered = false;
-		pci_unregister_driver(uncore_pci_driver);
+		uncore_pci_type_exit();
 		uncore_types_exit(uncore_pci_uncores);
-		uncore_free_pcibus_map();
 	}
 }
 
@@ -2370,7 +2403,6 @@ static void kh40000_event_cpu_offline(int cpu)
 	} else {
 		uncore_box_unref(uncore_msr_subnode_uncores, subnode_id);
 	}
-
 }
 
 static int uncore_event_cpu_offline(unsigned int cpu)
@@ -2550,6 +2582,7 @@ static int kh40000_event_cpu_online(unsigned int cpu)
 	 * Check if there is an online cpu in the cluster or subnode
 	 * which collects uncore events already.
 	 */
+
 	cluster_target =
 		cpumask_any_and(&uncore_cpu_cluster_mask, topology_cluster_core_cpumask(cpu));
 	subnode_target =
@@ -2676,12 +2709,11 @@ void kh40000_uncore_cpu_init(void)
 
 int kh40000_uncore_pci_init(void)
 {
-	int ret = kh40000_pci2node_map_init(); /*pci_bus to package mapping, do nothing*/
-
-	if (ret)
-		return ret;
+	/* Register pci driver will conflict with other PCI device use pci_get_device instead */
 	uncore_pci_uncores = kh40000_pci_uncores;
-	uncore_pci_driver = &kh40000_uncore_pci_driver;
+
+	uncore_pci_ids = kh40000_uncore_pci_ids;
+
 	return 0;
 }
 
@@ -2707,8 +2739,10 @@ void kx7000_uncore_cpu_init(void)
 
 int kx7000_uncore_pci_init(void)
 {
+	/* Register pci driver will conflict with other PCI device use pci_get_device instead */
 	uncore_pci_uncores = kx7000_pci_uncores;
-	uncore_pci_driver = &kx7000_uncore_pci_driver;
+
+	uncore_pci_ids = kx7000_uncore_pci_ids;
 
 	return 0;
 }
@@ -2737,11 +2771,33 @@ static const struct x86_cpu_id zhaoxin_uncore_match[] __initconst = {
 };
 MODULE_DEVICE_TABLE(x86cpu, zhaoxin_uncore_match);
 
+/*
+ * Process kernel command-line parameter at boot time.
+ * zhaoxin_pmc_uncore={0|off} or zhaoxin_pmc_uncore={1|on}
+ */
+static int __init zhaoxin_uncore_enable(char *str)
+{
+	if (!strcasecmp(str, "off") || !strcmp(str, "0"))
+		uncore_enabled = 0;
+	else if (!strcasecmp(str, "on") || !strcmp(str, "1"))
+		uncore_enabled = 1;
+	else
+		pr_err("zhaoxin_pmc_uncore: invalid parameter value (%s)\n", str);
+
+	pr_info("Zhaoxin PMC uncore %s\n", uncore_enabled ? "enabled" : "disabled");
+
+	return 1;
+}
+__setup("zhaoxin_pmc_uncore=", zhaoxin_uncore_enable);
+
 static int __init zhaoxin_uncore_init(void)
 {
 	const struct x86_cpu_id *id = NULL;
 	struct zhaoxin_uncore_init_fun *uncore_init;
 	int pret = 0, cret = 0, mret = 0, ret;
+
+	if (!uncore_enabled)
+		return 0;
 
 	id = x86_match_cpu(zhaoxin_uncore_match);
 	if (!id)
@@ -2781,10 +2837,8 @@ static int __init zhaoxin_uncore_init(void)
 	if (cret && pret && mret)
 		return -ENODEV;
 
-	ret = cpuhp_setup_state(CPUHP_AP_PERF_X86_UNCORE_ONLINE,
-				"perf/x86/zhaoxin/uncore:online",
-				uncore_event_cpu_online,
-				uncore_event_cpu_offline);
+	ret = cpuhp_setup_state(CPUHP_AP_PERF_X86_UNCORE_ONLINE, "perf/x86/zhaoxin/uncore:online",
+				uncore_event_cpu_online, uncore_event_cpu_offline);
 	if (ret)
 		goto err;
 	pr_info("uncore init success!\n");

--- a/arch/x86/events/zhaoxin/uncore.h
+++ b/arch/x86/events/zhaoxin/uncore.h
@@ -7,24 +7,24 @@
 #include <linux/perf_event.h>
 #include "../perf_event.h"
 
-#define ZHAOXIN_FAM7_KX5000		0x1b
-#define ZHAOXIN_FAM7_KX6000		0x3b
-#define ZHAOXIN_FAM7_KH40000		0x5b
-#define ZHAOXIN_FAM7_KX7000		0x6b
+#define ZHAOXIN_FAM7_KX5000 0x1b
+#define ZHAOXIN_FAM7_KX6000 0x3b
+#define ZHAOXIN_FAM7_KH40000 0x5b
+#define ZHAOXIN_FAM7_KX7000 0x6b
 
-#define UNCORE_PMU_NAME_LEN		32
-#define UNCORE_PMU_HRTIMER_INTERVAL	(60LL * NSEC_PER_SEC)
+#define UNCORE_PMU_NAME_LEN 32
+#define UNCORE_PMU_HRTIMER_INTERVAL (60LL * NSEC_PER_SEC)
 
-#define UNCORE_FIXED_EVENT              0xff
-#define UNCORE_PMC_IDX_MAX_GENERIC      4
-#define UNCORE_PMC_IDX_MAX_FIXED        1
-#define UNCORE_PMC_IDX_FIXED            UNCORE_PMC_IDX_MAX_GENERIC
+#define UNCORE_FIXED_EVENT 0xff
+#define UNCORE_PMC_IDX_MAX_GENERIC 4
+#define UNCORE_PMC_IDX_MAX_FIXED 1
+#define UNCORE_PMC_IDX_FIXED UNCORE_PMC_IDX_MAX_GENERIC
 
-#define UNCORE_PMC_IDX_MAX              (UNCORE_PMC_IDX_FIXED + 1)
+#define UNCORE_PMC_IDX_MAX (UNCORE_PMC_IDX_FIXED + 1)
 
-#define UNCORE_PCI_DEV_DATA(type, idx)  ((type << 8) | idx)
-#define UNCORE_PCI_DEV_TYPE(data)       ((data >> 8) & 0xff)
-#define UNCORE_PCI_DEV_IDX(data)        (data & 0xff)
+#define UNCORE_PCI_DEV_DATA(type, idx) ((type << 8) | idx)
+#define UNCORE_PCI_DEV_TYPE(data) ((data >> 8) & 0xff)
+#define UNCORE_PCI_DEV_IDX(data) (data & 0xff)
 
 struct zhaoxin_uncore_ops;
 struct zhaoxin_uncore_pmu;
@@ -98,12 +98,12 @@ struct zhaoxin_uncore_extra_reg {
 
 struct zhaoxin_uncore_box {
 	int pci_phys_id;
-	int package_id;	/*Package ID */
+	int package_id; /*Package ID */
 	int cluster_id;
 	int subnode_id;
-	int n_active;	/* number of active events */
+	int n_active; /* number of active events */
 	int n_events;
-	int cpu;	/* cpu to collect events */
+	int cpu; /* cpu to collect events */
 	unsigned long flags;
 	atomic_t refcnt;
 	struct perf_event *events[UNCORE_PMC_IDX_MAX];
@@ -121,8 +121,7 @@ struct zhaoxin_uncore_box {
 	struct zhaoxin_uncore_extra_reg shared_regs[];
 };
 
-#define UNCORE_BOX_FLAG_INITIATED	0
-
+#define UNCORE_BOX_FLAG_INITIATED 0
 struct uncore_event_desc {
 	struct device_attribute attr;
 	const char *config;
@@ -135,22 +134,20 @@ struct hw_info {
 
 ssize_t zx_uncore_event_show(struct device *dev, struct device_attribute *attr, char *buf);
 
-#define ZHAOXIN_UNCORE_EVENT_DESC(_name, _config)			\
-{									\
-	.attr	= __ATTR(_name, 0444, zx_uncore_event_show, NULL),	\
-	.config	= _config,						\
-}
+#define ZHAOXIN_UNCORE_EVENT_DESC(_name, _config)                                           \
+	{                                                                                   \
+		.attr = __ATTR(_name, 0444, zx_uncore_event_show, NULL), .config = _config, \
+	}
 
-#define DEFINE_UNCORE_FORMAT_ATTR(_var, _name, _format)			\
-static ssize_t __uncore_##_var##_show(struct device *dev,		\
-				struct device_attribute *attr,		\
-				char *page)				\
-{									\
-	BUILD_BUG_ON(sizeof(_format) >= PAGE_SIZE);			\
-	return sprintf(page, _format "\n");				\
-}									\
-static struct device_attribute format_attr_##_var =			\
-	__ATTR(_name, 0444, __uncore_##_var##_show, NULL)
+#define DEFINE_UNCORE_FORMAT_ATTR(_var, _name, _format)                                          \
+	static ssize_t __uncore_##_var##_show(struct device *dev, struct device_attribute *attr, \
+					      char *page)                                        \
+	{                                                                                        \
+		BUILD_BUG_ON(sizeof(_format) >= PAGE_SIZE);                                      \
+		return sprintf(page, _format "\n");                                              \
+	}                                                                                        \
+	static struct device_attribute format_attr_##_var =                                      \
+		__ATTR(_name, 0444, __uncore_##_var##_show, NULL)
 
 static inline bool uncore_pmc_fixed(int idx)
 {
@@ -194,9 +191,8 @@ static inline unsigned int uncore_msr_box_offset(struct zhaoxin_uncore_box *box)
 {
 	struct zhaoxin_uncore_pmu *pmu = box->pmu;
 
-	return pmu->type->msr_offsets ?
-		pmu->type->msr_offsets[pmu->pmu_idx] :
-		pmu->type->msr_offset * pmu->pmu_idx;
+	return pmu->type->msr_offsets ? pmu->type->msr_offsets[pmu->pmu_idx] :
+					pmu->type->msr_offset * pmu->pmu_idx;
 }
 
 static inline unsigned int uncore_msr_box_ctl(struct zhaoxin_uncore_box *box)
@@ -226,9 +222,8 @@ static inline unsigned int uncore_msr_event_ctl(struct zhaoxin_uncore_box *box, 
 
 static inline unsigned int uncore_msr_perf_ctr(struct zhaoxin_uncore_box *box, int idx)
 {
-	return box->pmu->type->perf_ctr +
-		(box->pmu->type->pair_ctr_ctl ? 2 * idx : idx) +
-		uncore_msr_box_offset(box);
+	return box->pmu->type->perf_ctr + (box->pmu->type->pair_ctr_ctl ? 2 * idx : idx) +
+	       uncore_msr_box_offset(box);
 }
 
 static inline unsigned int uncore_fixed_ctl(struct zhaoxin_uncore_box *box)


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

This patch makes several improvements to Zhaoxin PMU uncore.

1. Zhaoxin uncore PMC driver control: Adds kernel parameters zhaoxin_pmc_uncore={0|off} or zhaoxin_pmc_uncore={1|on}. These parameters can be used to enable the Zhaoxin uncore PMC driver during Linux kernel boot. By default, the driver is disabled.
2. Fix PCI device conflict bug: Resolves the previous PCI device conflict bug. For the PCI/MC/PXPTRF devices which are based on PCI access, the method of accessing them has been changed from probe to pci_get_device.
3. Fix MC bug on KX-7000: Identifies and fixes a bug related to the MC on KX-7000. When running the stream test and repeatedly executing the command perf stat -e uncore_mc_a0/umask=0xf, event=0x1/ sleep 10 2~3 times, a large abnormal value occurs.
Debugging reveals that the read_counter function has an issue when reading high-order data. This patch corrects this problem to ensure accurate performance measurement and operation of the MC on KX-7000.

## Summary by Sourcery

Implement runtime control and robustness improvements for Zhaoxin uncore perf support

New Features:
- Add zhaoxin_pmc_uncore={0|off|1|on} boot parameter to enable or disable Zhaoxin PMC uncore driver

Bug Fixes:
- Avoid PCI device conflicts by using pci_get_device/pci_dev_put instead of driver registration
- Correct high-order data reads in KX-7000 memory controller counter to eliminate abnormal values

Enhancements:
- Simplify cluster/subnode topology determination logic
- Refactor uncore PCI probe and removal paths and inline initialization/cleanup
- Normalize code formatting and macro alignments throughout the uncore driver