### PR TITLE
[linux-6.6.y] x86/kvm: expose CPUID 0xC000_0000 for Zhaoxin "Shanghai" vendor

### DIFF
--- a/arch/x86/kvm/cpuid.c
+++ b/arch/x86/kvm/cpuid.c
@@ -1406,7 +1406,8 @@ static int get_cpuid_func(struct kvm_cpuid_array *array, u32 func,
 	int r;
 
 	if (func == CENTAUR_CPUID_SIGNATURE &&
-	    boot_cpu_data.x86_vendor != X86_VENDOR_CENTAUR)
+	    boot_cpu_data.x86_vendor != X86_VENDOR_CENTAUR &&
+	    boot_cpu_data.x86_vendor != X86_VENDOR_ZHAOXIN)
 		return 0;
 
 	r = do_cpuid_func(array, func, type);


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

Both vendor IDs used by Zhaoxin(" Shanghai " and "Centaurhauls") rely on leaf 0XC000_0000 to advertise the max 0xC000_00XX function. Extend KVM so the leaf is returned for either ID.

## Summary by Sourcery

New Features:
- Extend KVM CPUID handling to allow leaf 0xC0000000 for Zhaoxin vendor