### PR TITLE
[linux-6.6.y] pinctrl: Zhaoxin: Add KH-50000 support

### DIFF
--- a/drivers/pinctrl/zhaoxin/Kconfig
+++ b/drivers/pinctrl/zhaoxin/Kconfig
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-# Intel pin control drivers
+# Zhaoxin pin control drivers
 
 if (X86 || COMPILE_TEST)
 
@@ -10,13 +10,24 @@ config PINCTRL_ZHAOXIN
 	select GENERIC_PINCONF
 	select GPIOLIB
 	select GPIOLIB_IRQCHIP
+	default m
 
 config PINCTRL_KX7000
 	tristate "Zhaoxin KX7000 pinctrl and GPIO driver"
 	depends on ACPI
 	select PINCTRL_ZHAOXIN
+	default m
 	help
 	  This pinctrl driver provides an interface that allows configuring
 	  of Zhaoxin KX7000 chipset pins and using them as GPIOs.
+
+config PINCTRL_KH50000
+	tristate "Zhaoxin KH50000 pinctrl and GPIO driver"
+	depends on ACPI
+	select PINCTRL_ZHAOXIN
+	default m
+	help
+	  This pinctrl driver provides an interface that allows configuring
+	  of Zhaoxin KH50000 chipset pins and using them as GPIOs.
 
 endif

--- a/drivers/pinctrl/zhaoxin/Makefile
+++ b/drivers/pinctrl/zhaoxin/Makefile
@@ -1,4 +1,5 @@
-# zhaoxin pin control drivers
+# Zhaoxin pin control drivers
 
 obj-$(CONFIG_PINCTRL_ZHAOXIN)		+= pinctrl-zhaoxin.o
 obj-$(CONFIG_PINCTRL_KX7000)		+= pinctrl-kx7000.o
+obj-$(CONFIG_PINCTRL_KH50000)		+= pinctrl-kh50000.o

--- a/drivers/pinctrl/zhaoxin/pinctrl-kh50000.c
+++ b/drivers/pinctrl/zhaoxin/pinctrl-kh50000.c
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * zhaoxin KH50000 pinctrl/GPIO driver
+ *
+ *
+ *    Copyright(c) 2021 Shanghai Zhaoxin Corporation. All rights reserved.
+ *
+ */
+
+#define DRIVER_VERSION "1.0.0"
+
+#include <linux/mod_devicetable.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/pinctrl/pinctrl.h>
+
+#include "pinctrl-zhaoxin.h"
+
+/* kh50000 pin define */
+static const struct pinctrl_pin_desc kh50000_pins[] = {
+	PINCTRL_PIN(0, "IOD_CLK27M_G0"),
+	PINCTRL_PIN(1, "IOD_CLK27M_G1"),
+	PINCTRL_PIN(2, "IOD_CLK27M_G2"),
+	PINCTRL_PIN(3, "IOD_CLK27M_G3"),
+	PINCTRL_PIN(4, "IOD_CPURST_G0"),
+	PINCTRL_PIN(5, "IOD_CPURST_G1"),
+	PINCTRL_PIN(6, "IOD_CPURST_G2"),
+	PINCTRL_PIN(7, "IOD_CPURST_G3"),
+	PINCTRL_PIN(8, "IOD_RSMRST_G0"),
+	PINCTRL_PIN(9, "IOD_RSMRST_G1"),
+	PINCTRL_PIN(10, "IOD_RSMRST_G2"),
+	PINCTRL_PIN(11, "IOD_RSMRST_G3"),
+	PINCTRL_PIN(12, "IOD_PWROK_G0"),
+	PINCTRL_PIN(13, "IOD_PWROK_G1"),
+	PINCTRL_PIN(14, "IOD_PWROK_G2"),
+	PINCTRL_PIN(15, "IOD_PWROK_G3"),
+	PINCTRL_PIN(16, "IOD_THRMTRIP_G0"),
+	PINCTRL_PIN(17, "IOD_THRMTRIP_G1"),
+	PINCTRL_PIN(18, "IOD_THRMTRIP_G2"),
+	PINCTRL_PIN(19, "IOD_THRMTRIP_G3"),
+	PINCTRL_PIN(20, "IOD_CLK50M_G0"),
+	PINCTRL_PIN(21, "IOD_CLK50M_G1"),
+	PINCTRL_PIN(22, "IOD_CLK50M_G2"),
+	PINCTRL_PIN(23, "IOD_CLK50M_G3"),
+	/* GPIO range 0 */
+	PINCTRL_PIN(24, "USBHOC0"),
+	PINCTRL_PIN(25, "USBHOC1"),
+	PINCTRL_PIN(26, "USBHOC2"),
+	PINCTRL_PIN(27, "USBHOC3"),
+	PINCTRL_PIN(28, "I3C0DT"),
+	PINCTRL_PIN(29, "I3C0CK"),
+	PINCTRL_PIN(30, "I3C1DT"),
+	PINCTRL_PIN(31, "I3C1CK"),
+	PINCTRL_PIN(32, "I3C2DT"),
+	PINCTRL_PIN(33, "I3C2CK"),
+	PINCTRL_PIN(34, "I3C3DT"),
+	PINCTRL_PIN(35, "I3C3CK"),
+	PINCTRL_PIN(36, "SMBDT0"),
+	/* GPIO range 1 */
+	PINCTRL_PIN(37, "SMBCK0"),
+	PINCTRL_PIN(38, "SMBDT1"),
+	PINCTRL_PIN(39, "SMBCK1"),
+	PINCTRL_PIN(40, "SMBDT2"),
+	PINCTRL_PIN(41, "SMBCK2"),
+	PINCTRL_PIN(42, "SMBALRT"),
+	PINCTRL_PIN(43, "SME_I2CDT_S"),
+	PINCTRL_PIN(44, "SME_I2CCK_S"),
+	/* GPIO range 2 */
+	PINCTRL_PIN(45, "GPIO0"),
+	PINCTRL_PIN(46, "GPIO1"),
+	PINCTRL_PIN(47, "GPIO2"),
+	PINCTRL_PIN(48, "GPIO3"),
+	PINCTRL_PIN(49, "GPIO4"),
+	PINCTRL_PIN(50, "GPIO5"),
+	PINCTRL_PIN(51, "GPIO6"),
+	PINCTRL_PIN(52, "GPIO7"),
+	PINCTRL_PIN(53, "GPIO8"),
+	PINCTRL_PIN(54, "GPIO9"),
+	PINCTRL_PIN(55, "GPIO10"),
+	PINCTRL_PIN(56, "GPIO11"),
+	PINCTRL_PIN(57, "GPIO12"),
+	PINCTRL_PIN(58, "GPIO13"),
+	PINCTRL_PIN(59, "GPIO14"),
+	PINCTRL_PIN(60, "GPIO15"),
+	PINCTRL_PIN(61, "GPIO16"),
+	PINCTRL_PIN(62, "GPIO17"),
+	PINCTRL_PIN(63, "GPIO18"),
+	PINCTRL_PIN(64, "GPIO19"),
+	PINCTRL_PIN(65, "GPIO20"),
+	PINCTRL_PIN(66, "GPIO21"),
+	PINCTRL_PIN(67, "GPIO22"),
+	PINCTRL_PIN(68, "GPIO23"),
+	PINCTRL_PIN(69, "GPIO24"),
+	PINCTRL_PIN(70, "GPIO25"),
+	PINCTRL_PIN(71, "GPIO26"),
+	PINCTRL_PIN(72, "GPIO27"),
+	PINCTRL_PIN(73, "GPIO28"),
+	PINCTRL_PIN(74, "GPIO29"),
+	PINCTRL_PIN(75, "GPIO30"),
+	PINCTRL_PIN(76, "GPIO31"),
+	PINCTRL_PIN(77, "GPIO32"),
+	PINCTRL_PIN(78, "GPIO33"),
+	PINCTRL_PIN(79, "GPIO34"),
+	PINCTRL_PIN(80, "GPIO35"),
+	/* GPIO range 3 */
+	PINCTRL_PIN(81, "LPCCLK"),
+	PINCTRL_PIN(82, "LPCDRQ1"),
+	PINCTRL_PIN(83, "LPCDRQ0"),
+	PINCTRL_PIN(84, "LPCFRAME"),
+	PINCTRL_PIN(85, "LPCAD3"),
+	PINCTRL_PIN(86, "LPCAD2"),
+	PINCTRL_PIN(87, "LPCAD1"),
+	PINCTRL_PIN(88, "LPCAD0"),
+	PINCTRL_PIN(89, "SERIRQ"),
+	/* GPIO range 4 */
+	PINCTRL_PIN(90, "ESPICLK"),
+	/* GPIO range 5 */
+	PINCTRL_PIN(91, "ESPIRST"),
+	PINCTRL_PIN(92, "ESPICS"),
+	PINCTRL_PIN(93, "ESPIIO3"),
+	/* GPIO range 6 */
+	PINCTRL_PIN(94, "ESPIIO2"),
+	PINCTRL_PIN(95, "ESPIIO1"),
+	PINCTRL_PIN(96, "ESPIIO0"),
+	PINCTRL_PIN(97, "SPIDI"),
+	PINCTRL_PIN(98, "SPIDO"),
+	PINCTRL_PIN(99, "SPICLK"),
+	PINCTRL_PIN(100, "SPISS"),
+	PINCTRL_PIN(101, "TPMRST"),
+	PINCTRL_PIN(102, "TPMIRQ"),
+	PINCTRL_PIN(103, "MSPIDI"),
+	PINCTRL_PIN(104, "MSPIDO"),
+	PINCTRL_PIN(105, "MSPIIO2"),
+	PINCTRL_PIN(106, "MSPIIO3"),
+	PINCTRL_PIN(107, "MSPICLK"),
+	PINCTRL_PIN(108, "MSPISS0"),
+	/* GPIO range 7 */
+	PINCTRL_PIN(109, "MSPISS1"),
+	/* GPIO range 8 */
+	PINCTRL_PIN(110, "MSPISS2"),
+	/* GPIO range 9 */
+	PINCTRL_PIN(111, "SPIDEVINT"),
+	PINCTRL_PIN(112, "ZLSDATA_TX_P0"),
+	PINCTRL_PIN(113, "ZLSDATA_RX_P0"),
+	PINCTRL_PIN(114, "ZLSDATA_TX_P1"),
+	PINCTRL_PIN(115, "ZLSDATA_RX_P1"),
+	PINCTRL_PIN(116, "ZLSDATA_TX_P2"),
+	PINCTRL_PIN(117, "ZLSDATA_RX_P2"),
+	PINCTRL_PIN(118, "BOOT_EN"),
+	PINCTRL_PIN(119, "BOOT_DONE"),
+	PINCTRL_PIN(120, "MST_SKT"),
+	PINCTRL_PIN(121, "HRX_BEVO_CLK"),
+	PINCTRL_PIN(122, "HRX_BEVO_DATA"),
+	PINCTRL_PIN(123, "HTX_BEVO_CLK"),
+	PINCTRL_PIN(124, "HTX_BEVO_DATA"),
+	PINCTRL_PIN(125, "THRMTRIP_I"),
+	PINCTRL_PIN(126, "CLK50M_I"),
+	PINCTRL_PIN(127, "CLK50M_O"),
+	PINCTRL_PIN(128, "PCIRST_IO"),
+	PINCTRL_PIN(129, "RSMRST_IO"),
+	PINCTRL_PIN(130, "PWRGD_IO"),
+	PINCTRL_PIN(131, "CLK32K_IO"),
+	PINCTRL_PIN(132, "BIOSSEL"),
+	PINCTRL_PIN(133, "THRMRIP"),
+	/* GPIO range 10 */
+	PINCTRL_PIN(134, "THRM"),
+	/* GPIO range 11 */
+	PINCTRL_PIN(135, "PEXWAKE"),
+	PINCTRL_PIN(136, "PWRBTN"),
+	PINCTRL_PIN(137, "PCIRST"),
+	/* GPIO range 12 */
+	PINCTRL_PIN(138, "SPKR"),
+	PINCTRL_PIN(139, "PME"),
+	PINCTRL_PIN(140, "SUSA"),
+	PINCTRL_PIN(141, "SUSB"),
+	PINCTRL_PIN(142, "SUSC"),
+	PINCTRL_PIN(143, "SVID0_VREN"),
+	PINCTRL_PIN(144, "SVID1_VREN"),
+};
+
+#define NOT_DEFINE -30000
+
+static int calibrate_int[] = {
+	0,  1,	2,  3,	4,  5,	6,  7,	8,  9,
+	10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+	20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+	30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+	40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+	50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	60, 61, 62, 63, 64, 65, 66, 67,
+};
+
+static int calibrate_status[] = {
+	0,  1,	2,  3,	4,  5,	6,  7,	8,  9,
+	10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+	20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+	30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+	40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+	50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	60, 61, 62, 63, 64, 65, 66, 67,
+};
+
+static const struct reg_cal_array kh50000_int_cal[] = {
+	ZX_CAL_ARRAY((0xCC - 0xCC), 16), /* GPIO0-15 */
+	ZX_CAL_ARRAY((0xCE - 0xCC), 16), /* GPIO15-31 */
+	ZX_CAL_ARRAY((0xD4 - 0xCC), 4), /* GPIO32-35 */
+	ZX_CAL_ARRAY((0xD0 - 0xCC), 16), /* PGPIO0-PGPIO15 */
+	ZX_CAL_ARRAY((0xD2 - 0xCC), 16), /* PGPIO16-PGPIO31 */
+};
+
+static const struct reg_calibrate int_cal[] = {
+	{
+		.reg = kh50000_int_cal,
+		.reg_cal_size = ARRAY_SIZE(kh50000_int_cal),
+		.cal_array = calibrate_int,
+		.size = ARRAY_SIZE(calibrate_int),
+		.is_pmio = false,
+	}
+};
+
+static const struct reg_cal_array kh50000_status_cal[] = {
+	ZX_CAL_ARRAY((0xE4 - 0xCC), 16),
+	ZX_CAL_ARRAY((0xE6 - 0xCC), 16),
+	ZX_CAL_ARRAY((0xEC - 0xCC), 4),
+	ZX_CAL_ARRAY((0xE8 - 0xCC), 16),
+	ZX_CAL_ARRAY((0xEA - 0xCC), 16),
+};
+
+static const struct reg_calibrate status_cal[] = { {
+	.reg = kh50000_status_cal,
+	.reg_cal_size = ARRAY_SIZE(kh50000_status_cal),
+	.cal_array = calibrate_status,
+	.size = ARRAY_SIZE(calibrate_status),
+} };
+
+static const struct reg_cal_array kh50000_mod_sel_cal[] = {
+	ZX_CAL_ARRAY((0xD8 - 0xCC), 16),
+	ZX_CAL_ARRAY((0xDA - 0xCC), 16),
+	ZX_CAL_ARRAY((0xE0 - 0xCC), 4),
+	ZX_CAL_ARRAY((0xDC - 0xCC), 16),
+	ZX_CAL_ARRAY((0xDE - 0xCC), 16),
+};
+
+static const struct reg_calibrate mod_sel_cal[] = {
+	{
+		.reg = kh50000_mod_sel_cal,
+		.reg_cal_size = ARRAY_SIZE(kh50000_mod_sel_cal),
+		.cal_array = calibrate_status,
+		.size = ARRAY_SIZE(calibrate_status),
+	}
+};
+
+static const struct index_cal_array kh50000_gpio_in_cal[] = {
+	ZX_CAL_INDEX_ARRAY(0xC8, NULL, 68),
+};
+
+static const struct index_cal_array kh50000_gpio_out_cal[] = {
+	ZX_CAL_INDEX_ARRAY(0xC0, NULL, 68),
+};
+
+static int calibrate_trigger[] = {
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+	10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+	20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+	30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+	40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+	50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	60, 61, 62, 63, 64, 65, 66, 67
+};
+
+static const struct index_cal_array kh50000_trigger_cal[] = {
+	ZX_CAL_INDEX_ARRAY_MASK(0xD0, calibrate_trigger, 68, 3, 0x7),
+};
+
+static const struct zhaoxin_pin_topology kh50000_pin_topologys[] = { {
+	.int_cal = int_cal,
+	.status_cal = status_cal,
+	.mod_sel_cal = mod_sel_cal,
+	.gpio_in_cal = kh50000_gpio_in_cal,
+	.gpio_out_cal = kh50000_gpio_out_cal,
+	.trigger_cal = kh50000_trigger_cal,
+} };
+
+static const struct zhaoxin_pin_map2_gpio kh50000_pinmap_gpps[] = {
+	ZHAOXIN_GPP(0, 23, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+	ZHAOXIN_GPP(24, 27, 10), /* gpio range 0 */
+	ZHAOXIN_GPP(28, 36, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+	ZHAOXIN_GPP(37, 42, 47), /* gpio range 1 */
+	ZHAOXIN_GPP(43, 44, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+	ZHAOXIN_GPP(45, 80, 0), /* gpio range 2 */
+	ZHAOXIN_GPP(81, 89, 52), /* gpio range 3 */
+	ZHAOXIN_GPP(90, 90, 51), /* gpio range 4 */
+	ZHAOXIN_GPP(91, 93, 65), /* gpio range 5 */
+	ZHAOXIN_GPP(94, 96, 40), /* gpio range 6 */
+	ZHAOXIN_GPP(97, 108, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+	ZHAOXIN_GPP(109, 109, 45), /* gpio range 7 */
+	ZHAOXIN_GPP(110, 110, 58), /* gpio range 8 */
+	ZHAOXIN_GPP(111, 111, 61), /* gpio range 9 */
+	ZHAOXIN_GPP(112, 133, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+	ZHAOXIN_GPP(134, 134, 62), /* gpio range 10 */
+	ZHAOXIN_GPP(135, 135, 46), /* gpio range 11 */
+	ZHAOXIN_GPP(136, 137, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+	ZHAOXIN_GPP(138, 139, 63), /* gpio range 12 */
+	ZHAOXIN_GPP(140, 144, ZHAOXIN_GPIO_BASE_NOMAP), /* no range */
+};
+
+static zx_gpio_type kh50000_gpio_type(struct zhaoxin_pinctrl *pctrl, unsigned int pin)
+{
+	if (pin >= 24 && pin <= 27)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 37 && pin <= 42)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 45 && pin <= 80)
+		return ZX_TYPE_GPIO;
+	else if (pin >= 81 && pin <= 96)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 109 && pin <= 111)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 134 && pin <= 135)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 138 && pin <= 139)
+		return ZX_TYPE_PGPIO;
+	else
+		return ZX_TYPE_ERROR;
+}
+
+static void kh50000_gpio_init(struct zhaoxin_pinctrl *pctrl)
+{
+	pctrl->pmio_base = 0x800;
+	pctrl->pmio_rx90 = 0x90;
+	pctrl->pmio_rx8c = 0x8c;
+
+	zx_pad_write16(pctrl, 0xF8, 0x7F);
+	dev_info(pctrl->dev, "KH50000 private init\n");
+}
+
+static const struct zhaoxin_pinctrl_soc_data kh50000_soc_data = {
+	.pins = kh50000_pins,
+	.npins = ARRAY_SIZE(kh50000_pins),
+	.pin_topologys = kh50000_pin_topologys,
+	.gpio_type = kh50000_gpio_type,
+	.private_init = kh50000_gpio_init,
+	.zhaoxin_pin_maps = kh50000_pinmap_gpps,
+	.pin_map_size = ARRAY_SIZE(kh50000_pinmap_gpps),
+};
+
+static const struct acpi_device_id kh50000_pinctrl_acpi_match[] = {
+	{ "KH8344B", (kernel_ulong_t)&kh50000_soc_data },
+	{}
+};
+MODULE_DEVICE_TABLE(acpi, kh50000_pinctrl_acpi_match);
+
+static const struct dev_pm_ops kh50000_pinctrl_pm_ops = {
+	SET_NOIRQ_SYSTEM_SLEEP_PM_OPS(zhaoxin_pinctrl_suspend_noirq, zhaoxin_pinctrl_resume_noirq)
+};
+
+static struct platform_driver kh50000_pinctrl_driver = {
+	.probe = zhaoxin_pinctrl_probe_by_hid,
+	.driver = {
+		.name = "kh50000-pinctrl",
+		.acpi_match_table = kh50000_pinctrl_acpi_match,
+		.pm = &kh50000_pinctrl_pm_ops,
+	},
+};
+
+module_platform_driver(kh50000_pinctrl_driver);
+
+MODULE_AUTHOR("www.zhaoxin.com");
+MODULE_DESCRIPTION("Shanghai Zhaoxin pinctrl driver");
+MODULE_VERSION(DRIVER_VERSION);
+MODULE_LICENSE("GPL");

--- a/drivers/pinctrl/zhaoxin/pinctrl-kx7000.c
+++ b/drivers/pinctrl/zhaoxin/pinctrl-kx7000.c
@@ -1,42 +1,22 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * zhaoxin KX7000 pinctrl/GPIO driver
+ * Zhaoxin KX7000 pinctrl/GPIO driver
  *
- * Copyright(c) 2023 Shanghai Zhaoxin Corporation. All rights reserved.
+ * Copyright(c) 2021 Shanghai Zhaoxin Corporation. All rights reserved.
  *
  */
 
-#define DRIVER_VERSION "1.0.0"
+#define DRIVER_VERSION "1.0.1"
 
 #include <linux/mod_devicetable.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
-
 #include <linux/pinctrl/pinctrl.h>
 
 #include "pinctrl-zhaoxin.h"
 
-#define ZX_CAL_ARRAY(a, b) \
-{ \
-	.pmio_offset = (a), \
-	.size = (b), \
-}
-
-#define PMIO_RX90 100
-#define PMIO_RX8C 200
-
-#define ZX_CAL_INDEX_ARRAY(a, b, c) \
-{ \
-	.reg_port_base = (PMIO_RX90), \
-	.reg_data_base = (PMIO_RX8C), \
-	.index = (a), \
-	.cal_array = (b), \
-	.size = (c), \
-}
-
 /* kx7000 pin define */
 static const struct pinctrl_pin_desc kx7000_pins[] = {
-
 	PINCTRL_PIN(0, "IOD_CPUTCK"),
 	PINCTRL_PIN(1, "IOD_CPUTMS"),
 	PINCTRL_PIN(2, "IOD_CPUTRST"),
@@ -51,7 +31,7 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(11, "IOD_PWORK"),
 	PINCTRL_PIN(12, "IOD_RSMRST"),
 	PINCTRL_PIN(13, "IOD_THRMTRIP"),
-	//GPIO range 0
+	/* GPIO range 0 */
 	PINCTRL_PIN(14, "USBHOC0"),
 	PINCTRL_PIN(15, "USBHOC1"),
 	PINCTRL_PIN(16, "USBHOC2"),
@@ -60,33 +40,33 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(19, "USBHOC5"),
 	PINCTRL_PIN(20, "USBHOC6"),
 	PINCTRL_PIN(21, "USBHOC7"),
-	//gpio range 1
+	/* GPIO range 1 */
 	PINCTRL_PIN(22, "USB4SBTX0"),
 	PINCTRL_PIN(23, "USB4SBRX0"),
 	PINCTRL_PIN(24, "USB4SBTX1"),
 	PINCTRL_PIN(25, "USB4SBRX1"),
-	//gpio range 2
+	/* GPIO range 2 */
 	PINCTRL_PIN(26, "I2C1DT"),
 	PINCTRL_PIN(27, "I2C1CK"),
 	PINCTRL_PIN(28, "I2C1INT"),
-	//gpio range 3
+	/* GPIO range 3 */
 	PINCTRL_PIN(29, "I2C2DT"),
 	PINCTRL_PIN(30, "I2C2CK"),
-	//gpio range 4
+	/* GPIO range 4 */
 	PINCTRL_PIN(31, "I2C2INT"),
-	//gpio range 5
+	/* GPIO range 5 */
 	PINCTRL_PIN(32, "SMBDT1"),
 	PINCTRL_PIN(33, "SMBCK1"),
 	PINCTRL_PIN(34, "SMBDT2"),
 	PINCTRL_PIN(35, "SMBCK2"),
 	PINCTRL_PIN(36, "SMBALRT"),
-	//gpio range 6
+	/* GPIO range 6 */
 	PINCTRL_PIN(37, "SME_I2CDT"),
 	PINCTRL_PIN(38, "SME_I2CCK"),
-	//gpio range 7
+	/* GPIO range 7 */
 	PINCTRL_PIN(39, "PWM"),
 	PINCTRL_PIN(40, "TACH"),
-	//gpio range 8
+	/* GPIO range 8 */
 	PINCTRL_PIN(41, "GPIO0"),
 	PINCTRL_PIN(42, "GPIO1"),
 	PINCTRL_PIN(43, "GPIO2"),
@@ -99,14 +79,14 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(50, "GPIO9"),
 	PINCTRL_PIN(51, "LPCCLK"),
 	PINCTRL_PIN(52, "LPCDRQ1"),
-	//gpio range 9
+	/* GPIO range 9 */
 	PINCTRL_PIN(53, "LPCDRQ0"),
 	PINCTRL_PIN(54, "LPCFRAME"),
 	PINCTRL_PIN(55, "LPCAD3"),
 	PINCTRL_PIN(56, "LPCAD2"),
 	PINCTRL_PIN(57, "LPCAD1"),
 	PINCTRL_PIN(58, "LPCAD0"),
-	//gpio range 10
+	/* GPIO range 10 */
 	PINCTRL_PIN(59, "SERIRQ"),
 	PINCTRL_PIN(60, "AZRST"),
 	PINCTRL_PIN(61, "AZBITCLK"),
@@ -114,14 +94,14 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(63, "AZSDIN1"),
 	PINCTRL_PIN(64, "AZSDOUT"),
 	PINCTRL_PIN(65, "AZSYNC"),
-	//gpio range 11
+	/* GPIO range 11 */
 	PINCTRL_PIN(66, "I2S1_SCLK"),
 	PINCTRL_PIN(67, "I2S1_TXD"),
 	PINCTRL_PIN(68, "I2S1_WS"),
 	PINCTRL_PIN(69, "I2S1_MCLK"),
-	//gpio range 12
+	/* GPIO range 12 */
 	PINCTRL_PIN(70, "I2S1_RXD"),
-	//gpio range 13
+	/* GPIO range 13 */
 	PINCTRL_PIN(71, "I2S1_INT"),
 	PINCTRL_PIN(72, "MSPIDI"),
 	PINCTRL_PIN(73, "MSPIDO"),
@@ -129,20 +109,20 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(75, "MSPIIO3"),
 	PINCTRL_PIN(76, "MSPICLK"),
 	PINCTRL_PIN(77, "MSPISS0"),
-	//gpio range 14
+	/* GPIO range 14 */
 	PINCTRL_PIN(78, "MSPISS1"),
 	PINCTRL_PIN(79, "MSPISS2"),
-	//gpio range 15
+	/* GPIO range 15 */
 	PINCTRL_PIN(80, "SPIDEVINT"),
 	PINCTRL_PIN(81, "BIOSSEL"),
-	//gpio range 16
+	/* GPIO range 16 */
 	PINCTRL_PIN(82, "THRM"),
 	PINCTRL_PIN(83, "PEXWAKE"),
 	PINCTRL_PIN(84, "PWRBTN"),
-	//gpio range 17
+	/* GPIO range 17 */
 	PINCTRL_PIN(85, "SPKR"),
 	PINCTRL_PIN(86, "PME"),
-	//gpio range 18
+	/* GPIO range 18 */
 	PINCTRL_PIN(87, "BATLOW"),
 	PINCTRL_PIN(88, "EXTSMI"),
 	PINCTRL_PIN(89, "SUSA"),
@@ -154,9 +134,9 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(95, "SLPS0"),
 	PINCTRL_PIN(96, "PCIRST"),
 	PINCTRL_PIN(97, "SVID_VREN"),
-	//gpio range 19
+	/* GPIO range 19 */
 	PINCTRL_PIN(98, "INTRUDER"),
-	//gpio range 20
+	/* GPIO range 20 */
 	PINCTRL_PIN(99, "GFX_I2CCLK0"),
 	PINCTRL_PIN(100, "GFX_I2CDAT0"),
 	PINCTRL_PIN(101, "GFX_I2CCLK1"),
@@ -173,22 +153,22 @@ static const struct pinctrl_pin_desc kx7000_pins[] = {
 	PINCTRL_PIN(112, "CRTVSYNC"),
 };
 
-#define NOT_DEFINE	-30000
+#define NOT_DEFINE -30000
 
 static int calibrate_int[] = {
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-	63, 64, 65, 66, 67, 68,
-	69, 70,
-	18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
-	34, 35, 36, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+	63, 64, 65, 66, 67, 68, 69, 70, 18, 19,
+	20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+	30, 31, 32, 33, 34, 35, 36, 50, 51, 52,
+	53, 54, 55, 56, 57, 58, 59, 60, 61, 62
 };
 
-static int calibrate_sattus[] = {
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-	63, 64, 65, 66, 67, 68,
-	69, 70,
-	18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
-	34, 35, 36, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62
+static int calibrate_status[] = {
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+	63, 64, 65, 66, 67, 68, 69, 70, 18, 19,
+	20, 21, 22, 23, 24, 25,	26, 27, 28, 29,
+	30, 31, 32, 33, 34, 35, 36, 50, 51, 52,
+	53, 54, 55, 56, 57, 58, 59, 60, 61, 62
 };
 
 static const struct reg_cal_array kx7000_int_cal[] = {
@@ -204,6 +184,7 @@ static const struct reg_calibrate int_cal[] = {
 		.reg_cal_size = ARRAY_SIZE(kx7000_int_cal),
 		.cal_array = calibrate_int,
 		.size = ARRAY_SIZE(calibrate_int),
+		.is_pmio = true,
 	}
 };
 
@@ -218,8 +199,8 @@ static const struct reg_calibrate status_cal[] = {
 	{
 		.reg = kx7000_status_cal,
 		.reg_cal_size = ARRAY_SIZE(kx7000_status_cal),
-		.cal_array = calibrate_sattus,
-		.size = ARRAY_SIZE(calibrate_sattus),
+		.cal_array = calibrate_status,
+		.size = ARRAY_SIZE(calibrate_status),
 	}
 };
 
@@ -234,8 +215,8 @@ static const struct reg_calibrate mod_sel_cal[] = {
 	{
 		.reg = kx7000_mod_sel_cal,
 		.reg_cal_size = ARRAY_SIZE(kx7000_mod_sel_cal),
-		.cal_array = calibrate_sattus,
-		.size = ARRAY_SIZE(calibrate_sattus),
+		.cal_array = calibrate_status,
+		.size = ARRAY_SIZE(calibrate_status),
 	}
 };
 
@@ -248,22 +229,15 @@ static const struct index_cal_array kx7000_gpio_out_cal[] = {
 };
 
 static int calibrate_trigger[] = {
-	0, 1, 2, 3, 4, 5, 6, 7,
-	8, 9, 18, 19,
-	20, 21, 22, 23,
-	24, 25, 26, 27,
-	28, 29, 30, 31,
-	32, 33, 34, 35,
-	36, 50, 51, 52,
-	53, 54, 55, 56,
-	57, 58, 59, 60,
-	61, 62, 63, 64,
-	65, 66, 67, 68,
-	69, 70
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+	18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+	28, 29, 30, 31, 32, 33, 34, 35, 36, 50,
+	51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+	61, 62, 63, 64, 65, 66, 67, 68, 69, 70
 };
 
 static const struct index_cal_array kx7000_trigger_cal[] = {
-	ZX_CAL_INDEX_ARRAY(0xA0, calibrate_trigger, 50),
+	ZX_CAL_INDEX_ARRAY_MASK(0xA0, calibrate_trigger, 50, 4, 0x7),
 };
 
 static const struct zhaoxin_pin_topology kx7000_pin_topologys[] = {
@@ -274,62 +248,89 @@ static const struct zhaoxin_pin_topology kx7000_pin_topologys[] = {
 		.gpio_in_cal = kx7000_gpio_in_cal,
 		.gpio_out_cal = kx7000_gpio_out_cal,
 		.trigger_cal = kx7000_trigger_cal,
-	}
+	},
 };
-
-#define KX7000_GPP(s, e, g) \
-{ \
-	.zhaoxin_range_pin_base = (s), \
-	.zhaoxin_range_pin_size = ((e) - (s) + 1), \
-	.zhaoxin_range_gpio_base = (g), \
-}
 
 static const struct zhaoxin_pin_map2_gpio kx7000_pinmap_gpps[] = {
-	KX7000_GPP(0, 13, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(14, 19, 10),
-	KX7000_GPP(20, 21, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(22, 25, 65),
-	KX7000_GPP(26, 28, 43),
-	KX7000_GPP(29, 30, 41),
-	KX7000_GPP(31, 31, 49),
-	KX7000_GPP(32, 36, 16),
-	KX7000_GPP(37, 38, 69),
-	KX7000_GPP(39, 40, 67),
-	KX7000_GPP(41, 50, 0),
-	KX7000_GPP(51, 52, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(53, 53, 39),
-	KX7000_GPP(54, 58, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(59, 59, 40),
-	KX7000_GPP(60, 65, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(66, 69, 35),
-	KX7000_GPP(70, 70, 46),
-	KX7000_GPP(71, 71, 64),
-	KX7000_GPP(72, 77, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(78, 78, 50),
-	KX7000_GPP(79, 79, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(80, 80, 51),
-	KX7000_GPP(81, 81, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(82, 82, 52),
-	KX7000_GPP(83, 84, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(85, 85, 53),
-	KX7000_GPP(86, 86, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(87, 95, 54),
-	KX7000_GPP(96, 97, ZHAOXIN_GPIO_BASE_NOMAP),
-	KX7000_GPP(98, 98, 63),
-	KX7000_GPP(99, 112, 21),
+	ZHAOXIN_GPP(0, 13, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(14, 19, 10),
+	ZHAOXIN_GPP(20, 21, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(22, 25, 65),
+	ZHAOXIN_GPP(26, 28, 43),
+	ZHAOXIN_GPP(29, 30, 41),
+	ZHAOXIN_GPP(31, 31, 49),
+	ZHAOXIN_GPP(32, 36, 16),
+	ZHAOXIN_GPP(37, 38, 69),
+	ZHAOXIN_GPP(39, 40, 67),
+	ZHAOXIN_GPP(41, 50, 0),
+	ZHAOXIN_GPP(51, 52, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(53, 53, 39),
+	ZHAOXIN_GPP(54, 58, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(59, 59, 40),
+	ZHAOXIN_GPP(60, 65, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(66, 69, 35),
+	ZHAOXIN_GPP(70, 70, 46),
+	ZHAOXIN_GPP(71, 71, 64),
+	ZHAOXIN_GPP(72, 77, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(78, 78, 50),
+	ZHAOXIN_GPP(79, 79, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(80, 80, 51),
+	ZHAOXIN_GPP(81, 81, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(82, 82, 52),
+	ZHAOXIN_GPP(83, 84, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(85, 85, 53),
+	ZHAOXIN_GPP(86, 86, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(87, 95, 54),
+	ZHAOXIN_GPP(96, 97, ZHAOXIN_GPIO_BASE_NOMAP),
+	ZHAOXIN_GPP(98, 98, 63),
+	ZHAOXIN_GPP(99, 112, 21),
 };
+
+static zx_gpio_type kx7000_gpio_type(struct zhaoxin_pinctrl *pctrl, unsigned int pin)
+{
+	if (pin >= 0xE && pin <= 0x13)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 0x16 && pin <= 0x28)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 0x29 && pin <= 0x32)
+		return ZX_TYPE_GPIO;
+	else if (pin == 0x35 || pin == 0x3B)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 0x42 && pin <= 0x47)
+		return ZX_TYPE_PGPIO;
+	else if (pin == 0x4E || pin == 0x50)
+		return ZX_TYPE_PGPIO;
+	else if (pin == 0x52 || pin == 0x55)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 0x57 && pin <= 0x5F)
+		return ZX_TYPE_PGPIO;
+	else if (pin >= 0x62 && pin <= 0x70)
+		return ZX_TYPE_PGPIO;
+	else
+		return ZX_TYPE_ERROR;
+}
+
+static void kx7000_gpio_init(struct zhaoxin_pinctrl *pctrl)
+{
+	pctrl->pmio_base = 0x800;
+	pctrl->pmio_rx90 = 0x90;
+	pctrl->pmio_rx8c = 0x8c;
+	dev_info(pctrl->dev, "kx7000 private init\n");
+}
 
 static const struct zhaoxin_pinctrl_soc_data kx7000_soc_data = {
 	.pins = kx7000_pins,
 	.npins = ARRAY_SIZE(kx7000_pins),
 	.pin_topologys = kx7000_pin_topologys,
+	.gpio_type = kx7000_gpio_type,
+	.private_init = kx7000_gpio_init,
 	.zhaoxin_pin_maps = kx7000_pinmap_gpps,
 	.pin_map_size = ARRAY_SIZE(kx7000_pinmap_gpps),
 };
 
 static const struct acpi_device_id kx7000_pinctrl_acpi_match[] = {
 	{ "KX8344B", (kernel_ulong_t)&kx7000_soc_data },
-	{ }
+	{}
 };
 MODULE_DEVICE_TABLE(acpi, kx7000_pinctrl_acpi_match);
 
@@ -345,7 +346,6 @@ static struct platform_driver kx7000_pinctrl_driver = {
 		.pm = &kx7000_pinctrl_pm_ops,
 	},
 };
-
 module_platform_driver(kx7000_pinctrl_driver);
 
 MODULE_AUTHOR("www.zhaoxin.com");

--- a/drivers/pinctrl/zhaoxin/pinctrl-zhaoxin.c
+++ b/drivers/pinctrl/zhaoxin/pinctrl-zhaoxin.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  *    zhaoxin pinctrl common code
  *
@@ -6,7 +6,7 @@
  *
  */
 
-#define DRIVER_VERSION "1.0.0"
+#define DRIVER_VERSION "1.0.1"
 
 #include <linux/acpi.h>
 #include <linux/gpio/driver.h>
@@ -17,26 +17,28 @@
 #include <linux/property.h>
 #include <linux/time.h>
 
+#include <linux/pinctrl/consumer.h>
 #include <linux/pinctrl/pinctrl.h>
 #include <linux/pinctrl/pinmux.h>
 #include <linux/pinctrl/pinconf.h>
 #include <linux/pinctrl/pinconf-generic.h>
-#include <linux/pinctrl/consumer.h>
 
 #include "../core.h"
 #include "pinctrl-zhaoxin.h"
 
-static u16 zx_pad_read16(struct zhaoxin_pinctrl *pctrl, u8 index)
+u16 zx_pad_read16(struct zhaoxin_pinctrl *pctrl, u8 index)
 {
-	outb(index, pctrl->pmio_rx90+pctrl->pmio_base);
-	return inw(pctrl->pmio_rx8c+pctrl->pmio_base);
+	outb(index, pctrl->pmio_rx90 + pctrl->pmio_base);
+	return inw(pctrl->pmio_rx8c + pctrl->pmio_base);
 }
+EXPORT_SYMBOL_GPL(zx_pad_read16);
 
-static void zx_pad_write16(struct zhaoxin_pinctrl *pctrl, u8 index, u16 value)
+void zx_pad_write16(struct zhaoxin_pinctrl *pctrl, u8 index, u16 value)
 {
-	outb(index, pctrl->pmio_rx90+pctrl->pmio_base);
-	outw(value, pctrl->pmio_rx8c+pctrl->pmio_base);
+	outb(index, pctrl->pmio_rx90 + pctrl->pmio_base);
+	outw(value, pctrl->pmio_rx8c + pctrl->pmio_base);
 }
+EXPORT_SYMBOL_GPL(zx_pad_write16);
 
 static int zhaoxin_get_groups_count(struct pinctrl_dev *pctldev)
 {
@@ -65,7 +67,6 @@ static int zhaoxin_get_group_pins(struct pinctrl_dev *pctldev, unsigned int grou
 
 static void zhaoxin_pin_dbg_show(struct pinctrl_dev *pctldev, struct seq_file *s, unsigned int pin)
 {
-
 }
 
 static const struct pinctrl_ops zhaoxin_pinctrl_ops = {
@@ -106,12 +107,12 @@ static int zhaoxin_pinmux_set_mux(struct pinctrl_dev *pctldev, unsigned int func
 	return 0;
 }
 
-#define ZHAOXIN_PULL_UP_20K		0x80
-#define ZHAOXIN_PULL_UP_10K		0x40
-#define ZHAOXIN_PULL_UP_47K		0x20
-#define ZHAOXIN_PULL_DOWN		0x10
+#define ZHAOXIN_PULL_UP_20K 0x80
+#define ZHAOXIN_PULL_UP_10K 0x40
+#define ZHAOXIN_PULL_UP_47K 0x20
+#define ZHAOXIN_PULL_DOWN 0x10
 
-#define ZHAOXIN_PULL_UP	0xe0
+#define ZHAOXIN_PULL_UP 0xe0
 
 static void zhaoxin_gpio_set_gpio_mode_and_pull(struct zhaoxin_pinctrl *pctrl, unsigned int pin,
 						bool isup)
@@ -121,12 +122,12 @@ static void zhaoxin_gpio_set_gpio_mode_and_pull(struct zhaoxin_pinctrl *pctrl, u
 	u16 value_back = 0;
 
 	if (isup)
-		tmp = ZHAOXIN_PULL_UP_10K|1;
+		tmp = ZHAOXIN_PULL_UP_10K | 1;
 	else
-		tmp = ZHAOXIN_PULL_DOWN|1;
-	value = zx_pad_read16(pctrl, pin);
+		tmp = ZHAOXIN_PULL_DOWN | 1;
 
-	if (pin <= 0x32 && pin >= 0x29) {
+	if (pctrl->gpio_type(pctrl, pin) == ZX_TYPE_GPIO) {
+		value = zx_pad_read16(pctrl, pin);
 		if (isup) {
 			value &= (~(ZHAOXIN_PULL_DOWN));
 			value |= tmp;
@@ -134,20 +135,26 @@ static void zhaoxin_gpio_set_gpio_mode_and_pull(struct zhaoxin_pinctrl *pctrl, u
 			value &= (~(ZHAOXIN_PULL_UP));
 			value |= tmp;
 		}
-		value &= ~(0x1);
+
+		value &= (~(0xf));
+		zx_pad_write16(pctrl, pin, value);
+		value_back = zx_pad_read16(pctrl, pin);
+	} else if (pctrl->gpio_type(pctrl, pin) == ZX_TYPE_PGPIO) {
+		value = zx_pad_read16(pctrl, pin);
+		if (isup) {
+			value &= (~(ZHAOXIN_PULL_DOWN));
+			value |= tmp;
+		} else {
+			value &= (~(ZHAOXIN_PULL_UP));
+			value |= tmp;
+		}
+
+		value &= (~(0xf));
+		value |= 1;
 		zx_pad_write16(pctrl, pin, value);
 		value_back = zx_pad_read16(pctrl, pin);
 	} else {
-		if (isup) {
-			value &= (~(ZHAOXIN_PULL_DOWN));
-			value |= tmp;
-		} else {
-			value &= (~(ZHAOXIN_PULL_UP));
-			value |= tmp;
-		}
-		value |= 0x1;
-		zx_pad_write16(pctrl, pin, value);
-		value_back = zx_pad_read16(pctrl, pin);
+		dev_info(pctrl->dev, "pin %d is not a gpio or pgpio\n", pin);
 	}
 }
 
@@ -155,8 +162,11 @@ static int zhaoxin_gpio_request_enable(struct pinctrl_dev *pctldev,
 				       struct pinctrl_gpio_range *range, unsigned int pin)
 {
 	struct zhaoxin_pinctrl *pctrl = pinctrl_dev_get_drvdata(pctldev);
+	unsigned long flags;
 
+	raw_spin_lock_irqsave(&pctrl->lock, flags);
 	zhaoxin_gpio_set_gpio_mode_and_pull(pctrl, pin, true);
+	raw_spin_unlock_irqrestore(&pctrl->lock, flags);
 
 	return 0;
 }
@@ -214,7 +224,6 @@ static int zhaoxin_gpio_to_pin(struct zhaoxin_pinctrl *pctrl, unsigned int offse
 			return pin;
 		}
 	}
-
 	return -EINVAL;
 }
 
@@ -233,15 +242,18 @@ static int zhaoxin_gpio_get(struct gpio_chip *chip, unsigned int offset)
 {
 	struct zhaoxin_pinctrl *pctrl = gpiochip_get_data(chip);
 	const struct index_cal_array *gpio_in_cal;
-	int gap = offset/16;
-	int bit = offset%16;
+	unsigned long flags;
+	int gap = offset / 16;
+	int bit = offset % 16;
 	int pin;
 	int value;
 
 	gpio_in_cal = pctrl->pin_topologys->gpio_in_cal;
 	pin = zhaoxin_gpio_to_pin(pctrl, offset, NULL, NULL);
-	value = zx_pad_read16(pctrl, gpio_in_cal->index+gap);
-	value &= (1<<bit);
+	raw_spin_lock_irqsave(&pctrl->lock, flags);
+	value = zx_pad_read16(pctrl, gpio_in_cal->index + gap);
+	raw_spin_unlock_irqrestore(&pctrl->lock, flags);
+	value &= (1 << bit);
 
 	return !!value;
 }
@@ -261,12 +273,12 @@ static void zhaoxin_gpio_set(struct gpio_chip *chip, unsigned int offset, int va
 
 	raw_spin_lock_irqsave(&pctrl->lock, flags);
 
-	org = zx_pad_read16(pctrl, gpio_out_cal->index+gap);
+	org = zx_pad_read16(pctrl, gpio_out_cal->index + gap);
 	if (value)
-		org |= (1<<bit);
+		org |= (1 << bit);
 	else
-		org &= (~(1<<bit));
-	zx_pad_write16(pctrl, gpio_out_cal->index+gap, org);
+		org &= (~(1 << bit));
+	zx_pad_write16(pctrl, gpio_out_cal->index + gap, org);
 	raw_spin_unlock_irqrestore(&pctrl->lock, flags);
 }
 
@@ -317,7 +329,6 @@ static void zhaoxin_gpio_irq_ack(struct irq_data *d)
 	int base_offset = 0;
 	int bit_off = 0;
 	u16 value;
-	u16 value_read;
 
 	status_cal = pctrl->pin_topologys->status_cal;
 	if (gpio >= 0) {
@@ -329,13 +340,13 @@ static void zhaoxin_gpio_irq_ack(struct irq_data *d)
 				break;
 			offset += status_cal->reg[j].size;
 		}
-		reg_off = &status_cal->reg[j-1];
-		bit_off = i-(offset-reg_off->size);
+		reg_off = &status_cal->reg[j - 1];
+		bit_off = i - (offset - reg_off->size);
 		base_offset = reg_off->pmio_offset;
-		value = readw(pctrl->pm_pmio_base+reg_off->pmio_offset);
-		value_read = value;
-		value |= (1<<bit_off);
-		writew(value, pctrl->pm_pmio_base+reg_off->pmio_offset);
+		value = (1 << bit_off);
+		raw_spin_lock(&pctrl->lock);
+		writew(value, pctrl->pm_pmio_base + reg_off->pmio_offset);
+		raw_spin_unlock(&pctrl->lock);
 	}
 }
 
@@ -353,10 +364,10 @@ static void zhaoxin_gpio_irq_mask_unmask(struct irq_data *d, bool mask)
 	int bit_off = 0;
 	u16 value;
 	u16 value1;
+	unsigned long flags;
 
 	int_cal = pctrl->pin_topologys->int_cal;
 	mod_sel_cal = pctrl->pin_topologys->mod_sel_cal;
-
 	if (gpio >= 0) {
 		for (i = 0; i < int_cal->size; i++)
 			if (gpio == int_cal->cal_array[i])
@@ -366,27 +377,39 @@ static void zhaoxin_gpio_irq_mask_unmask(struct irq_data *d, bool mask)
 				break;
 			offset += int_cal->reg[j].size;
 		}
-		reg_off = &(int_cal->reg[j-1]);
-		mod = &(mod_sel_cal->reg[j-1]);
-		bit_off = i-(offset-reg_off->size);
+		reg_off = &(int_cal->reg[j - 1]);
+		mod = &(mod_sel_cal->reg[j - 1]);
+		bit_off = i - (offset - reg_off->size);
 		base_offset = reg_off->pmio_offset;
 
-		value = inw(pctrl->pmio_base+reg_off->pmio_offset);
-		if (mask)
-			value &= (~(1<<bit_off));
-		else
-			value |= (1<<bit_off);
+		raw_spin_lock_irqsave(&pctrl->lock, flags);
+		if (!int_cal->is_pmio) {
+			value = readw(pctrl->pm_pmio_base + reg_off->pmio_offset);
+			if (mask)
+				value &= (~(1 << bit_off));
+			else
+				value |= (1 << bit_off);
 
-		outw(value, pctrl->pmio_base+reg_off->pmio_offset);
-		if (mask) {
-			value1 = readw(pctrl->pm_pmio_base+mod->pmio_offset);
-			value1 |= (1<<bit_off);
-			writew(value1, pctrl->pm_pmio_base+mod->pmio_offset);
+			writew(value, pctrl->pm_pmio_base + reg_off->pmio_offset);
 		} else {
-			value1 = readw(pctrl->pm_pmio_base+mod->pmio_offset);
-			value1 |= (1<<bit_off);
-			writew(value1, pctrl->pm_pmio_base+mod->pmio_offset);
+			value = inw(pctrl->pmio_base + reg_off->pmio_offset);
+			if (mask)
+				value &= (~(1 << bit_off));
+			else
+				value |= (1 << bit_off);
+
+			outw(value, pctrl->pmio_base + reg_off->pmio_offset);
 		}
+		if (mask) {
+			value1 = readw(pctrl->pm_pmio_base + mod->pmio_offset);
+			value1 |= (1 << bit_off);
+			writew(value1, pctrl->pm_pmio_base + mod->pmio_offset);
+		} else {
+			value1 = readw(pctrl->pm_pmio_base + mod->pmio_offset);
+			value1 |= (1 << bit_off);
+			writew(value1, pctrl->pm_pmio_base + mod->pmio_offset);
+		}
+		raw_spin_unlock_irqrestore(&pctrl->lock, flags);
 	}
 }
 
@@ -416,17 +439,24 @@ static irqreturn_t zhaoxin_gpio_irq(int irq, void *data)
 	int ret = 0;
 	int subirq;
 	unsigned int hwirq;
+	unsigned long flags;
 
 	init = pctrl->pin_topologys->int_cal;
 	stat_cal = pctrl->pin_topologys->status_cal;
 	for (i = 0; i < init->reg_cal_size; i++) {
 		pending = 0;
+		raw_spin_lock_irqsave(&pctrl->lock, flags);
 		status = readw(pctrl->pm_pmio_base + stat_cal->reg[i].pmio_offset);
-		enable = inw(pctrl->pmio_base + init->reg[i].pmio_offset);
+
+		if (!init->is_pmio)
+			enable = readw(pctrl->pm_pmio_base + init->reg[i].pmio_offset);
+		else
+			enable = inw(pctrl->pmio_base + init->reg[i].pmio_offset);
+		raw_spin_unlock_irqrestore(&pctrl->lock, flags);
 		enable &= status;
 		pending = enable;
 		for_each_set_bit(bit_offset, &pending, init->reg[i].size) {
-			hwirq = init->cal_array[index + bit_offset] ;
+			hwirq = init->cal_array[index + bit_offset];
 			subirq = irq_find_mapping(gc->irq.domain, hwirq);
 			generic_handle_irq(subirq);
 		}
@@ -450,6 +480,10 @@ static int zhaoxin_gpio_irq_type(struct irq_data *d, unsigned int type)
 	int position, point;
 	u16 value;
 	bool isup = true;
+	bool high_bit = false;
+	u16 mask = 0;
+	int bits_num = 0;
+	u16 test_mask;
 
 	trigger_cal = pctrl->pin_topologys->trigger_cal;
 	pin = zhaoxin_gpio_to_pin(pctrl, irqd_to_hwirq(d), NULL, NULL);
@@ -467,26 +501,63 @@ static int zhaoxin_gpio_irq_type(struct irq_data *d, unsigned int type)
 	for (position = 0; position < trigger_cal->size; position++)
 		if (trigger_cal->cal_array[position] == gpio)
 			break;
-
-	index = trigger_cal->index + ALIGN(position+1, 4)/4-1;
+	mask = trigger_cal->mask;
+	bits_num = trigger_cal->bits_num;
+	index = trigger_cal->index + ALIGN(position + 1, 4) / 4 - 1;
 	point = position % 4;
+	if (point > 1)
+		high_bit = true;
 
 	raw_spin_lock_irqsave(&pctrl->lock, flags);
 
 	value = zx_pad_read16(pctrl, index);
 
-	if ((type & IRQ_TYPE_EDGE_BOTH) == IRQ_TYPE_EDGE_BOTH)
-		value |= TRIGGER_BOTH_EDGE << (point*4);
-	else if (type & IRQ_TYPE_EDGE_FALLING)
-		value |= TRIGGER_FALL_EDGE << (point*4);
-	else if (type & IRQ_TYPE_EDGE_RISING)
-		value |= TRIGGER_RISE_EDGE << (point*4);
-	else if (type & IRQ_TYPE_LEVEL_LOW)
-		value |= TRIGGER_LOW_LEVEL << (point*4);
-	else if (type & IRQ_TYPE_LEVEL_HIGH)
-		value |= TRIGGER_HIGH_LEVEL << (point*4);
-	else
-		pr_debug("%s wrong type\n", __func__);
+	if ((type & IRQ_TYPE_EDGE_BOTH) == IRQ_TYPE_EDGE_BOTH) {
+		if (high_bit) {
+			point = point - 2;
+			position = 8;
+		} else
+			position = 0;
+		test_mask = (~(mask << (point * bits_num + position)));
+		value &= (~(mask << (point * bits_num + position)));
+		value |= TRIGGER_BOTH_EDGE << (point * bits_num + position);
+	} else if (type & IRQ_TYPE_EDGE_FALLING) {
+		if (high_bit) {
+			point = point - 2;
+			position = 8;
+		} else
+			position = 0;
+		test_mask = (~(mask << (point * bits_num + position)));
+		value &= (~(mask << (point * bits_num + position)));
+		value |= TRIGGER_FALL_EDGE << (point * bits_num + position);
+	} else if (type & IRQ_TYPE_EDGE_RISING) {
+		if (high_bit) {
+			point = point - 2;
+			position = 8;
+		} else
+			position = 0;
+		test_mask = (~(mask << (point * bits_num + position)));
+		value &= (~(mask << (point * bits_num + position)));
+		value |= TRIGGER_RISE_EDGE << (point * bits_num + position);
+	} else if (type & IRQ_TYPE_LEVEL_LOW) {
+		if (high_bit) {
+			point = point - 2;
+			position = 8;
+		} else
+			position = 0;
+		test_mask = (~(mask << (point * bits_num + position)));
+		value &= (~(mask << (point * bits_num + position)));
+		value |= TRIGGER_LOW_LEVEL << (point * bits_num + position);
+	} else if (type & IRQ_TYPE_LEVEL_HIGH) {
+		if (high_bit) {
+			point = point - 2;
+			position = 8;
+		} else
+			position = 0;
+		test_mask = (~(mask << (point * bits_num + position)));
+		value &= (~(mask << (point * bits_num + position)));
+		value |= TRIGGER_HIGH_LEVEL << (point * bits_num + position);
+	}
 
 	zx_pad_write16(pctrl, index, value);
 
@@ -506,6 +577,7 @@ static int zhaoxin_gpio_irq_wake(struct irq_data *d, unsigned int on)
 	unsigned int pin;
 
 	pin = zhaoxin_gpio_to_pin(pctrl, irqd_to_hwirq(d), NULL, NULL);
+
 	if (pin) {
 		if (on)
 			enable_irq_wake(pctrl->irq);
@@ -613,7 +685,7 @@ static int zhaoxin_pinctrl_probe(struct platform_device *pdev,
 				 const struct zhaoxin_pinctrl_soc_data *soc_data)
 {
 	struct zhaoxin_pinctrl *pctrl;
-	int  ret, i, irq;
+	int ret, i, irq;
 	struct resource *res;
 	void __iomem *regs;
 
@@ -624,9 +696,11 @@ static int zhaoxin_pinctrl_probe(struct platform_device *pdev,
 	pctrl->soc = soc_data;
 	raw_spin_lock_init(&pctrl->lock);
 	pctrl->pin_topologys = pctrl->soc->pin_topologys;
+	pctrl->gpio_type = pctrl->soc->gpio_type;
+	pctrl->private_init = pctrl->soc->private_init;
 	pctrl->pin_map_size = pctrl->soc->pin_map_size;
-	pctrl->pin_maps = devm_kcalloc(&pdev->dev, pctrl->pin_map_size, sizeof(*pctrl->pin_maps),
-				       GFP_KERNEL);
+	pctrl->pin_maps =
+		devm_kcalloc(&pdev->dev, pctrl->pin_map_size, sizeof(*pctrl->pin_maps), GFP_KERNEL);
 	if (!pctrl->pin_maps)
 		return -ENOMEM;
 	for (i = 0; i < pctrl->pin_map_size; i++) {
@@ -637,11 +711,10 @@ static int zhaoxin_pinctrl_probe(struct platform_device *pdev,
 	regs = devm_ioremap_resource(&pdev->dev, res);
 	if (IS_ERR(regs))
 		return PTR_ERR(regs);
+	if (pctrl->private_init)
+		pctrl->private_init(pctrl);
 
 	pctrl->pm_pmio_base = regs;
-	pctrl->pmio_base = 0x800;
-	pctrl->pmio_rx90 = 0x90;
-	pctrl->pmio_rx8c = 0x8c;
 	irq = platform_get_irq(pdev, 0);
 	if (irq < 0)
 		return irq;
@@ -659,7 +732,6 @@ static int zhaoxin_pinctrl_probe(struct platform_device *pdev,
 		return PTR_ERR(pctrl->pctldev);
 	}
 	ret = zhaoxin_gpio_probe(pctrl, irq);
-
 	if (ret)
 		return ret;
 	platform_set_drvdata(pdev, pctrl);
@@ -689,7 +761,6 @@ int zhaoxin_pinctrl_probe_by_uid(struct platform_device *pdev)
 	return zhaoxin_pinctrl_probe(pdev, data);
 }
 EXPORT_SYMBOL_GPL(zhaoxin_pinctrl_probe_by_uid);
-
 
 const struct zhaoxin_pinctrl_soc_data *zhaoxin_pinctrl_get_soc_data(struct platform_device *pdev)
 {
@@ -725,6 +796,7 @@ const struct zhaoxin_pinctrl_soc_data *zhaoxin_pinctrl_get_soc_data(struct platf
 EXPORT_SYMBOL_GPL(zhaoxin_pinctrl_get_soc_data);
 
 #ifdef CONFIG_PM_SLEEP
+
 int zhaoxin_pinctrl_suspend_noirq(struct device *dev)
 {
 	return 0;
@@ -736,7 +808,7 @@ int zhaoxin_pinctrl_resume_noirq(struct device *dev)
 	return 0;
 }
 EXPORT_SYMBOL_GPL(zhaoxin_pinctrl_resume_noirq);
-#endif /* CONFIG_PM_SLEEP */
+#endif
 
 MODULE_AUTHOR("www.zhaoxin.com");
 MODULE_DESCRIPTION("Shanghai Zhaoxin pinctrl driver");

--- a/drivers/pinctrl/zhaoxin/pinctrl-zhaoxin.h
+++ b/drivers/pinctrl/zhaoxin/pinctrl-zhaoxin.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
- * zhaoxin pinctrl common code
- * Copyright(c) 2023 Shanghai Zhaoxin Corporation. All rights reserved.
+ * Zhaoxin pinctrl common code
+ * Copyright(c) 2021 Shanghai Zhaoxin Corporation. All rights reserved.
  */
 
 #ifndef PINCTRL_zhaoxin_H
@@ -18,6 +18,43 @@
 
 struct platform_device;
 struct device;
+struct zhaoxin_pinctrl;
+
+#define PMIO_RX90 100
+#define PMIO_RX8C 200
+
+#define ZX_CAL_ARRAY(a, b)		\
+	{				\
+		.pmio_offset = (a),	\
+		.size = (b),		\
+	}
+
+#define ZX_CAL_INDEX_ARRAY(a, b, c)		\
+	{					\
+		.reg_port_base = (PMIO_RX90),	\
+		.reg_data_base = (PMIO_RX8C),	\
+		.index = (a),			\
+		.cal_array = (b),		\
+		.size = (c),			\
+	}
+
+#define ZX_CAL_INDEX_ARRAY_MASK(a, b, c, d, e)	\
+	{					\
+		.reg_port_base = (PMIO_RX90),	\
+		.reg_data_base = (PMIO_RX8C),	\
+		.index = (a),			\
+		.cal_array = (b),		\
+		.size = (c),			\
+		.bits_num = (d),		\
+		.mask = (e),			\
+	}
+
+#define ZHAOXIN_GPP(s, e, g)					\
+	{							\
+		.zhaoxin_range_pin_base = (s),			\
+		.zhaoxin_range_pin_size = ((e) - (s) + 1),	\
+		.zhaoxin_range_gpio_base = (g),			\
+	}
 
 /*
  * struct zhaoxin_pingroup pin define
@@ -35,11 +72,11 @@ struct zhaoxin_pingroup {
  */
 struct zhaoxin_function {
 	const char *name;
-	const char * const *groups;
+	const char *const *groups;
 	size_t ngroups;
 };
 
-/*
+/**
  * struct zhaoxin_pin_map2_gpio
  * @zhaoxin_range_pin_base
  * @size: pin number
@@ -51,7 +88,7 @@ struct zhaoxin_pin_map2_gpio {
 	int zhaoxin_range_gpio_base;
 };
 
-#define MAX_GPIO		256
+#define MAX_GPIO 256
 
 struct reg_cal_array {
 	int pmio_offset;
@@ -63,6 +100,7 @@ struct reg_calibrate {
 	const int reg_cal_size;
 	const int *cal_array;
 	const int size;
+	bool is_pmio;
 };
 
 struct index_cal_array {
@@ -71,6 +109,8 @@ struct index_cal_array {
 	int index;
 	int *cal_array;
 	int size;
+	int bits_num;
+	u16 mask;
 };
 
 struct zhaoxin_pin_topology {
@@ -83,13 +123,19 @@ struct zhaoxin_pin_topology {
 	const struct index_cal_array *trigger_cal;
 };
 
-#define TRIGGER_FALL_EDGE	0
-#define TRIGGER_RISE_EDGE	1
-#define TRIGGER_BOTH_EDGE	2
-#define TRIGGER_LOW_LEVEL	3
-#define TRIGGER_HIGH_LEVEL	4
+#define TRIGGER_FALL_EDGE 0
+#define TRIGGER_RISE_EDGE 1
+#define TRIGGER_BOTH_EDGE 2
+#define TRIGGER_LOW_LEVEL 3
+#define TRIGGER_HIGH_LEVEL 4
 
-#define	ZHAOXIN_GPIO_BASE_NOMAP -1
+#define ZHAOXIN_GPIO_BASE_NOMAP -1
+
+typedef enum {
+	ZX_TYPE_ERROR = 0,
+	ZX_TYPE_GPIO,
+	ZX_TYPE_PGPIO,
+} zx_gpio_type;
 
 struct zhaoxin_pinctrl_soc_data {
 	const char *uid;
@@ -100,11 +146,14 @@ struct zhaoxin_pinctrl_soc_data {
 	const struct zhaoxin_function *functions;
 	size_t nfunctions;
 	const struct zhaoxin_pin_topology *pin_topologys;
+
+	zx_gpio_type (*gpio_type)(struct zhaoxin_pinctrl *pctrl, unsigned int pin);
+
+	void (*private_init)(struct zhaoxin_pinctrl *pctrl);
+
 	const struct zhaoxin_pin_map2_gpio *zhaoxin_pin_maps;
 	size_t pin_map_size;
 };
-
-const struct zhaoxin_pinctrl_soc_data *zhaoxin_pinctrl_get_soc_data(struct platform_device *pdev);
 
 struct zhaoxin_pinctrl {
 	struct device *dev;
@@ -116,6 +165,10 @@ struct zhaoxin_pinctrl {
 	const struct zhaoxin_pinctrl_soc_data *soc;
 	const struct zhaoxin_pin_topology *pin_topologys;
 	struct zhaoxin_pin_map2_gpio *pin_maps;
+
+	zx_gpio_type (*gpio_type)(struct zhaoxin_pinctrl *pctrl, unsigned int pin);
+
+	void (*private_init)(struct zhaoxin_pinctrl *pctrl);
 	size_t pin_map_size;
 	int irq;
 	int pmio_base;
@@ -123,6 +176,10 @@ struct zhaoxin_pinctrl {
 	int pmio_rx90;
 	int pmio_rx8c;
 };
+
+const struct zhaoxin_pinctrl_soc_data *zhaoxin_pinctrl_get_soc_data(struct platform_device *pdev);
+void zx_pad_write16(struct zhaoxin_pinctrl *pctrl, u8 index, u16 value);
+u16 zx_pad_read16(struct zhaoxin_pinctrl *pctrl, u8 index);
 
 int zhaoxin_pinctrl_probe_by_hid(struct platform_device *pdev);
 int zhaoxin_pinctrl_probe_by_uid(struct platform_device *pdev);


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

This patch adds GPIO and pinctrl driver support for the Zhaoxin KH-50000 chipset. It includes:

A new driver file `pinctrl-kh50000.c` which defines the pin configuration and GPIO functionality for the KH-50000 platform, covering a wide range of pins from general-purpose GPIOs to specialized functions like USB, SMBus, and LPC.

Updates to `Kconfig` to introduce the `PINCTRL_KH50000` configuration option, enabling build support for the new driver.

Modifications to `Makefile` to compile the new `pinctrl-kh50000.o` module when `CONFIG_PINCTRL_KH50000` is enabled.

Enhancements to `pinctrl-zhaoxin.h` to introduce new macros, data structures, and enumerations necessary for supporting the KH-50000's specific pin configurations and GPIO types.

Refinements in `pinctrl-zhaoxin.c` to improve the generic Zhaoxin pinctrl/GPIO driver, including updates to interrupt handling and probe functions to accommodate the new hardware.

Improvements to `pinctrl-kx7000.c` to enhance code quality and maintainability.

This change enables full GPIO functionality support for the Zhaoxin KH-50000 platform.