### PR TITLE
[linux-6.6.y] Add platform-specific quirks for ZX-200 device

### DIFF
--- a/drivers/ata/ahci.c
+++ b/drivers/ata/ahci.c
@@ -81,6 +81,16 @@ enum board_ids {
 	board_ahci_mcp79	= board_ahci_mcp77,
 };
 
+static bool is_zhaoxin_cpu(void)
+{
+#ifdef CONFIG_X86
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN ||
+	    boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR)
+		return true;
+#endif
+	return false;
+}
+
 static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent);
 static void ahci_remove_one(struct pci_dev *dev);
 static void ahci_shutdown_one(struct pci_dev *dev);
@@ -1893,6 +1903,9 @@ static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
 	/* only some SB600s can do 64bit DMA */
 	if (ahci_sb600_enable_64bit(pdev))
 		hpriv->flags &= ~AHCI_HFLAG_32BIT_ONLY;
+
+	if (pdev->vendor == PCI_VENDOR_ID_ZHAOXIN && !is_zhaoxin_cpu())
+		hpriv->flags |= AHCI_HFLAG_32BIT_ONLY;
 
 	hpriv->mmio = pcim_iomap_table(pdev)[ahci_pci_bar];
 

--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -309,6 +309,16 @@ static int xhci_pci_reinit(struct xhci_hcd *xhci, struct pci_dev *pdev)
 	return 0;
 }
 
+static bool is_zhaoxin_cpu(void)
+{
+#ifdef CONFIG_X86
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN ||
+	    boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR)
+		return true;
+#endif
+	return false;
+}
+
 static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 {
 	struct pci_dev                  *pdev = to_pci_dev(dev);
@@ -502,12 +512,6 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 		xhci->quirks |= XHCI_ZERO_64B_REGS;
 	}
 
-	if (pdev->vendor == PCI_VENDOR_ID_ZHAOXIN) {
-		if (pdev->device == 0x9202 ||
-		    pdev->device == 0x9203)
-			xhci->quirks |= XHCI_RESET_ON_RESUME;
-	}
-
 	if (pdev->vendor == PCI_VENDOR_ID_VIA)
 		xhci->quirks |= XHCI_RESET_ON_RESUME;
 
@@ -576,6 +580,12 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 
 		if (pdev->device == 0x9203)
 			xhci->quirks |= XHCI_TRB_OVERFETCH;
+	}
+
+	if (pdev->vendor == PCI_VENDOR_ID_ZHAOXIN && !is_zhaoxin_cpu()) {
+		xhci->quirks |= XHCI_NO_64BIT_SUPPORT;
+		if (pdev->device == 0x9203)
+			xhci->quirks |= XHCI_RESET_ON_RESUME;
 	}
 
 	if (pdev->vendor == PCI_DEVICE_ID_CADENCE &&


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

Adds platform-specific handling for Zhaoxin ZX-200 in both AHCI and xHCI drivers.

For non-Zhaoxin CPU platforms, it applies the following quirks:
1. In AHCI driver (ahci.c):
   - Sets AHCI_HFLAG_32BIT_ONLY flag to restrict DMA operations to 32-bit addressing

2. In xHCI driver (xhci-pci.c):
   - Sets XHCI_RESET_ON_RESUME quirk to handle device resume issues
   - Sets XHCI_NO_64BIT_SUPPORT quirk to disable 64-bit DMA addressing

These changes ensure proper functionality and compatibility of Zhaoxin ZX-200 on third-party platforms.

## Summary by Sourcery

Add platform-specific AHCI and xHCI driver quirks for Zhaoxin ZX-200 devices when running on non-Zhaoxin CPUs to ensure proper DMA addressing and resume behavior.

New Features:
- Introduce is_zhaoxin_cpu helper to detect Zhaoxin/Centaur CPUs in AHCI and xHCI drivers
- Apply 32-bit-only DMA restriction for Zhaoxin AHCI devices on non-Zhaoxin CPUs
- Disable 64-bit DMA support and enable reset-on-resume quirk for Zhaoxin ZX-200 xHCI devices on non-Zhaoxin CPUs