### PR TITLE
[linux 6.6.y] Update Zhaoxin-aes/sha driver for CPU matching

### DIFF
--- a/drivers/crypto/padlock-aes.c
+++ b/drivers/crypto/padlock-aes.c
@@ -475,7 +475,6 @@ static struct skcipher_alg cbc_aes_alg = {
 };
 
 static const struct x86_cpu_id padlock_cpu_id[] = {
-	{ X86_VENDOR_CENTAUR, 6, X86_MODEL_ANY, X86_FEATURE_XCRYPT },
 	X86_MATCH_VENDOR_FAM_FEATURE(CENTAUR, 6, X86_FEATURE_XCRYPT, NULL),
 	{}
 };

--- a/drivers/crypto/padlock-aes.c
+++ b/drivers/crypto/padlock-aes.c
@@ -476,6 +476,7 @@ static struct skcipher_alg cbc_aes_alg = {
 
 static const struct x86_cpu_id padlock_cpu_id[] = {
 	{ X86_VENDOR_CENTAUR, 6, X86_MODEL_ANY, X86_FEATURE_XCRYPT },
+	X86_MATCH_VENDOR_FAM_FEATURE(CENTAUR, 6, X86_FEATURE_XCRYPT, NULL),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, padlock_cpu_id);

--- a/drivers/crypto/padlock-sha.c
+++ b/drivers/crypto/padlock-sha.c
@@ -491,7 +491,7 @@ static struct shash_alg sha256_alg_nano = {
 };
 
 static const struct x86_cpu_id padlock_sha_ids[] = {
-	{ X86_VENDOR_CENTAUR, 6, X86_MODEL_ANY, X86_FEATURE_PHE },
+	X86_MATCH_VENDOR_FAM_FEATURE(CENTAUR, 6, X86_FEATURE_PHE, NULL),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, padlock_sha_ids);

--- a/drivers/crypto/zhaoxin-aes.c
+++ b/drivers/crypto/zhaoxin-aes.c
@@ -22,7 +22,7 @@
 #include <asm/byteorder.h>
 #include <asm/fpu/api.h>
 
-#define DRIVER_VERSION "1.0.0"
+#define DRIVER_VERSION "1.0.1"
 
 /*
  * Number of data blocks actually fetched for each xcrypt insn.
@@ -62,7 +62,7 @@ struct aes_ctx {
 	u32 *D;
 };
 
-static DEFINE_PER_CPU(struct cword *, paes_last_cword_zx);
+static DEFINE_PER_CPU(struct cword *, zx_paes_last_cword);
 
 /* Tells whether the ACE is capable to generate the extended key for a given key_len. */
 static inline int aes_hw_extkey_available(uint8_t key_len)
@@ -142,15 +142,14 @@ static int aes_set_key(struct crypto_tfm *tfm, const u8 *in_key, unsigned int ke
 
 ok:
 	for_each_online_cpu(cpu)
-		if (&ctx->cword.encrypt == per_cpu(paes_last_cword_zx, cpu) ||
-			&ctx->cword.decrypt == per_cpu(paes_last_cword_zx, cpu))
-			per_cpu(paes_last_cword_zx, cpu) = NULL;
+		if (&ctx->cword.encrypt == per_cpu(zx_paes_last_cword, cpu) ||
+		    &ctx->cword.decrypt == per_cpu(zx_paes_last_cword, cpu))
+			per_cpu(zx_paes_last_cword, cpu) = NULL;
 
 	return 0;
 }
 
-static int aes_set_key_skcipher(struct crypto_skcipher *tfm, const u8 *in_key,
-				unsigned int key_len)
+static int aes_set_key_skcipher(struct crypto_skcipher *tfm, const u8 *in_key, unsigned int key_len)
 {
 	return aes_set_key(crypto_skcipher_tfm(tfm), in_key, key_len);
 }
@@ -162,17 +161,17 @@ static inline void padlock_reset_key(struct cword *cword)
 {
 	int cpu = raw_smp_processor_id();
 
-	if (cword != per_cpu(paes_last_cword_zx, cpu))
+	if (cword != per_cpu(zx_paes_last_cword, cpu))
 #ifndef CONFIG_X86_64
-		asm volatile ("pushfl; popfl");
+		asm volatile("pushfl; popfl");
 #else
-		asm volatile ("pushfq; popfq");
+		asm volatile("pushfq; popfq");
 #endif
 }
 
 static inline void padlock_store_cword(struct cword *cword)
 {
-	per_cpu(paes_last_cword_zx, raw_smp_processor_id()) = cword;
+	per_cpu(zx_paes_last_cword, raw_smp_processor_id()) = cword;
 }
 
 /*
@@ -180,19 +179,19 @@ static inline void padlock_store_cword(struct cword *cword)
  * when CR0.TS is '1'. Fortunately, the kernel doesn't use CR0.TS.
  */
 static inline void rep_xcrypt_ecb(const u8 *input, u8 *output, void *key,
-				struct cword *control_word, int count)
+				  struct cword *control_word, int count)
 {
-	asm volatile (".byte 0xf3,0x0f,0xa7,0xc8"	/* rep xcryptecb */
-	: "+S"(input), "+D"(output)
-	: "d"(control_word), "b"(key), "c"(count));
+	asm volatile(".byte 0xf3, 0x0f, 0xa7, 0xc8" /* rep xcryptecb */
+		     : "+S"(input), "+D"(output)
+		     : "d"(control_word), "b"(key), "c"(count));
 }
 
 static inline u8 *rep_xcrypt_cbc(const u8 *input, u8 *output, void *key, u8 *iv,
-				struct cword *control_word, int count)
+				 struct cword *control_word, int count)
 {
-	asm volatile (".byte 0xf3,0x0f,0xa7,0xd0"	/* rep xcryptcbc */
-	: "+S" (input), "+D" (output), "+a" (iv)
-	: "d" (control_word), "b" (key), "c" (count));
+	asm volatile(".byte 0xf3, 0x0f, 0xa7, 0xd0" /* rep xcryptcbc */
+		     : "+S"(input), "+D"(output), "+a"(iv)
+		     : "d"(control_word), "b"(key), "c"(count));
 	return iv;
 }
 
@@ -236,8 +235,7 @@ static inline void ecb_crypt(const u8 *in, u8 *out, u32 *key, struct cword *cwor
 	rep_xcrypt_ecb(in, out, key, cword, count);
 }
 
-static inline u8 *cbc_crypt(const u8 *in, u8 *out, u32 *key, u8 *iv, struct cword *cword,
-				int count)
+static inline u8 *cbc_crypt(const u8 *in, u8 *out, u32 *key, u8 *iv, struct cword *cword, int count)
 {
 	/* Padlock in CBC mode fetches at least cbc_fetch_bytes of data. */
 	if (unlikely(offset_in_page(in) + cbc_fetch_bytes > PAGE_SIZE))
@@ -247,7 +245,7 @@ static inline u8 *cbc_crypt(const u8 *in, u8 *out, u32 *key, u8 *iv, struct cwor
 }
 
 static inline void padlock_xcrypt_ecb(const u8 *input, u8 *output, void *key, void *control_word,
-				u32 count)
+				      u32 count)
 {
 	u32 initial = count & (ecb_fetch_blocks - 1);
 
@@ -259,17 +257,17 @@ static inline void padlock_xcrypt_ecb(const u8 *input, u8 *output, void *key, vo
 	count -= initial;
 
 	if (initial)
-		asm volatile (".byte 0xf3,0x0f,0xa7,0xc8"	/* rep xcryptecb */
-		: "+S"(input), "+D"(output)
-		: "d"(control_word), "b"(key), "c"(initial));
+		asm volatile(".byte 0xf3, 0x0f, 0xa7, 0xc8" /* rep xcryptecb */
+			     : "+S"(input), "+D"(output)
+			     : "d"(control_word), "b"(key), "c"(initial));
 
-	asm volatile (".byte 0xf3,0x0f,0xa7,0xc8"	/* rep xcryptecb */
-	: "+S"(input), "+D"(output)
-	: "d"(control_word), "b"(key), "c"(count));
+	asm volatile(".byte 0xf3, 0x0f, 0xa7, 0xc8" /* rep xcryptecb */
+		     : "+S"(input), "+D"(output)
+		     : "d"(control_word), "b"(key), "c"(count));
 }
 
 static inline u8 *padlock_xcrypt_cbc(const u8 *input, u8 *output, void *key, u8 *iv,
-				void *control_word, u32 count)
+				     void *control_word, u32 count)
 {
 	u32 initial = count & (cbc_fetch_blocks - 1);
 
@@ -279,13 +277,13 @@ static inline u8 *padlock_xcrypt_cbc(const u8 *input, u8 *output, void *key, u8 
 	count -= initial;
 
 	if (initial)
-		asm volatile (".byte 0xf3,0x0f,0xa7,0xd0"	/* rep xcryptcbc */
-		: "+S" (input), "+D" (output), "+a" (iv)
-		: "d" (control_word), "b" (key), "c" (initial));
+		asm volatile(".byte 0xf3, 0x0f, 0xa7, 0xd0" /* rep xcryptcbc */
+			     : "+S"(input), "+D"(output), "+a"(iv)
+			     : "d"(control_word), "b"(key), "c"(initial));
 
-	asm volatile (".byte 0xf3,0x0f,0xa7,0xd0"	/* rep xcryptcbc */
-	: "+S" (input), "+D" (output), "+a" (iv)
-	: "d" (control_word), "b" (key), "c" (count));
+	asm volatile(".byte 0xf3, 0x0f, 0xa7, 0xd0" /* rep xcryptcbc */
+		     : "+S"(input), "+D"(output), "+a"(iv)
+		     : "d"(control_word), "b"(key), "c"(count));
 	return iv;
 }
 
@@ -308,21 +306,21 @@ static void padlock_aes_decrypt(struct crypto_tfm *tfm, u8 *out, const u8 *in)
 }
 
 static struct crypto_alg aes_alg = {
-	.cra_name			=	"aes",
-	.cra_driver_name	=	"aes-padlock",
-	.cra_priority		=	PADLOCK_CRA_PRIORITY,
-	.cra_flags			=	CRYPTO_ALG_TYPE_CIPHER,
-	.cra_blocksize		=	AES_BLOCK_SIZE,
-	.cra_ctxsize		=	sizeof(struct aes_ctx),
-	.cra_alignmask		=	PADLOCK_ALIGNMENT - 1,
-	.cra_module			=	THIS_MODULE,
+	.cra_name = "aes",
+	.cra_driver_name = "aes-padlock",
+	.cra_priority = PADLOCK_CRA_PRIORITY,
+	.cra_flags = CRYPTO_ALG_TYPE_CIPHER,
+	.cra_blocksize = AES_BLOCK_SIZE,
+	.cra_ctxsize = sizeof(struct aes_ctx),
+	.cra_alignmask = PADLOCK_ALIGNMENT - 1,
+	.cra_module = THIS_MODULE,
 	.cra_u = {
 		.cipher = {
-			.cia_min_keysize	=	AES_MIN_KEY_SIZE,
-			.cia_max_keysize	=	AES_MAX_KEY_SIZE,
-			.cia_setkey			=	aes_set_key,
-			.cia_encrypt		=	padlock_aes_encrypt,
-			.cia_decrypt		=	padlock_aes_decrypt,
+			.cia_min_keysize = AES_MIN_KEY_SIZE,
+			.cia_max_keysize = AES_MAX_KEY_SIZE,
+			.cia_setkey = aes_set_key,
+			.cia_encrypt = padlock_aes_encrypt,
+		.cia_decrypt = padlock_aes_decrypt,
 		}
 	}
 };
@@ -340,9 +338,8 @@ static int ecb_aes_encrypt(struct skcipher_request *req)
 	err = skcipher_walk_virt(&walk, req, false);
 
 	while ((nbytes = walk.nbytes) != 0) {
-		padlock_xcrypt_ecb(walk.src.virt.addr, walk.dst.virt.addr,
-					ctx->E, &ctx->cword.encrypt,
-					nbytes / AES_BLOCK_SIZE);
+		padlock_xcrypt_ecb(walk.src.virt.addr, walk.dst.virt.addr, ctx->E,
+				   &ctx->cword.encrypt, nbytes / AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
 	}
@@ -365,9 +362,8 @@ static int ecb_aes_decrypt(struct skcipher_request *req)
 	err = skcipher_walk_virt(&walk, req, false);
 
 	while ((nbytes = walk.nbytes) != 0) {
-		padlock_xcrypt_ecb(walk.src.virt.addr, walk.dst.virt.addr,
-					ctx->D, &ctx->cword.decrypt,
-					nbytes / AES_BLOCK_SIZE);
+		padlock_xcrypt_ecb(walk.src.virt.addr, walk.dst.virt.addr, ctx->D,
+				   &ctx->cword.decrypt, nbytes / AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
 	}
@@ -378,18 +374,18 @@ static int ecb_aes_decrypt(struct skcipher_request *req)
 }
 
 static struct skcipher_alg ecb_aes_alg = {
-	.base.cra_name		=	"ecb(aes)",
-	.base.cra_driver_name	=	"ecb-aes-padlock",
-	.base.cra_priority	=	PADLOCK_COMPOSITE_PRIORITY,
-	.base.cra_blocksize	=	AES_BLOCK_SIZE,
-	.base.cra_ctxsize	=	sizeof(struct aes_ctx),
-	.base.cra_alignmask	=	PADLOCK_ALIGNMENT - 1,
-	.base.cra_module	=	THIS_MODULE,
-	.min_keysize		=	AES_MIN_KEY_SIZE,
-	.max_keysize		=	AES_MAX_KEY_SIZE,
-	.setkey			=	aes_set_key_skcipher,
-	.encrypt		=	ecb_aes_encrypt,
-	.decrypt		=	ecb_aes_decrypt,
+	.base.cra_name = "ecb(aes)",
+	.base.cra_driver_name = "ecb-aes-padlock",
+	.base.cra_priority = PADLOCK_COMPOSITE_PRIORITY,
+	.base.cra_blocksize = AES_BLOCK_SIZE,
+	.base.cra_ctxsize = sizeof(struct aes_ctx),
+	.base.cra_alignmask = PADLOCK_ALIGNMENT - 1,
+	.base.cra_module = THIS_MODULE,
+	.min_keysize = AES_MIN_KEY_SIZE,
+	.max_keysize = AES_MAX_KEY_SIZE,
+	.setkey = aes_set_key_skcipher,
+	.encrypt = ecb_aes_encrypt,
+	.decrypt = ecb_aes_decrypt,
 };
 
 static int cbc_aes_encrypt(struct skcipher_request *req)
@@ -405,10 +401,8 @@ static int cbc_aes_encrypt(struct skcipher_request *req)
 	err = skcipher_walk_virt(&walk, req, false);
 
 	while ((nbytes = walk.nbytes) != 0) {
-		u8 *iv = padlock_xcrypt_cbc(walk.src.virt.addr,
-						walk.dst.virt.addr, ctx->E,
-						walk.iv, &ctx->cword.encrypt,
-						nbytes / AES_BLOCK_SIZE);
+		u8 *iv = padlock_xcrypt_cbc(walk.src.virt.addr, walk.dst.virt.addr, ctx->E, walk.iv,
+					    &ctx->cword.encrypt, nbytes / AES_BLOCK_SIZE);
 		memcpy(walk.iv, iv, AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
@@ -432,9 +426,8 @@ static int cbc_aes_decrypt(struct skcipher_request *req)
 	err = skcipher_walk_virt(&walk, req, false);
 
 	while ((nbytes = walk.nbytes) != 0) {
-		padlock_xcrypt_cbc(walk.src.virt.addr, walk.dst.virt.addr,
-				ctx->D, walk.iv, &ctx->cword.decrypt,
-				nbytes / AES_BLOCK_SIZE);
+		padlock_xcrypt_cbc(walk.src.virt.addr, walk.dst.virt.addr, ctx->D, walk.iv,
+				   &ctx->cword.decrypt, nbytes / AES_BLOCK_SIZE);
 		nbytes &= AES_BLOCK_SIZE - 1;
 		err = skcipher_walk_done(&walk, nbytes);
 	}
@@ -445,33 +438,34 @@ static int cbc_aes_decrypt(struct skcipher_request *req)
 }
 
 static struct skcipher_alg cbc_aes_alg = {
-	.base.cra_name		=	"cbc(aes)",
-	.base.cra_driver_name	=	"cbc-aes-padlock",
-	.base.cra_priority	=	PADLOCK_COMPOSITE_PRIORITY,
-	.base.cra_blocksize	=	AES_BLOCK_SIZE,
-	.base.cra_ctxsize	=	sizeof(struct aes_ctx),
-	.base.cra_alignmask	=	PADLOCK_ALIGNMENT - 1,
-	.base.cra_module	=	THIS_MODULE,
-	.min_keysize		=	AES_MIN_KEY_SIZE,
-	.max_keysize		=	AES_MAX_KEY_SIZE,
-	.ivsize			=	AES_BLOCK_SIZE,
-	.setkey			=	aes_set_key_skcipher,
-	.encrypt		=	cbc_aes_encrypt,
-	.decrypt		=	cbc_aes_decrypt,
+	.base.cra_name = "cbc(aes)",
+	.base.cra_driver_name = "cbc-aes-padlock",
+	.base.cra_priority = PADLOCK_COMPOSITE_PRIORITY,
+	.base.cra_blocksize = AES_BLOCK_SIZE,
+	.base.cra_ctxsize = sizeof(struct aes_ctx),
+	.base.cra_alignmask = PADLOCK_ALIGNMENT - 1,
+	.base.cra_module = THIS_MODULE,
+	.min_keysize = AES_MIN_KEY_SIZE,
+	.max_keysize = AES_MAX_KEY_SIZE,
+	.ivsize = AES_BLOCK_SIZE,
+	.setkey = aes_set_key_skcipher,
+	.encrypt = cbc_aes_encrypt,
+	.decrypt = cbc_aes_decrypt,
 };
 
-static const struct x86_cpu_id zhaoxin_cpu_id[] = {
-	{ X86_VENDOR_CENTAUR, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_XCRYPT },
-	{ X86_VENDOR_ZHAOXIN, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_XCRYPT },
+static const struct x86_cpu_id zhaoxin_aes_cpu_ids[] __initconst = {
+	X86_MATCH_VENDOR_FAM_FEATURE(CENTAUR, 7, X86_FEATURE_XCRYPT, NULL),
+	X86_MATCH_VENDOR_FAM_FEATURE(ZHAOXIN, 7, X86_FEATURE_XCRYPT, NULL),
+	X86_MATCH_VENDOR_FAM_FEATURE(ZHAOXIN, 6, X86_FEATURE_XCRYPT, NULL),
 	{}
 };
-MODULE_DEVICE_TABLE(x86cpu, zhaoxin_cpu_id);
+MODULE_DEVICE_TABLE(x86cpu, zhaoxin_aes_cpu_ids);
 
 static int __init padlock_init(void)
 {
 	int ret;
 
-	if (!x86_match_cpu(zhaoxin_cpu_id))
+	if (!x86_match_cpu(zhaoxin_aes_cpu_ids))
 		return -ENODEV;
 
 	if (!boot_cpu_has(X86_FEATURE_XCRYPT_EN)) {
@@ -515,9 +509,9 @@ static void __exit padlock_fini(void)
 module_init(padlock_init);
 module_exit(padlock_fini);
 
-MODULE_DESCRIPTION("ACE AES algorithm support");
+MODULE_DESCRIPTION("Zhaoxin ACE AES algorithm support");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Michal Ludvig");
 MODULE_VERSION(DRIVER_VERSION);
 
-MODULE_ALIAS_CRYPTO("aes");
+MODULE_ALIAS_CRYPTO("zx-aes");

--- a/drivers/crypto/zhaoxin-sha.c
+++ b/drivers/crypto/zhaoxin-sha.c
@@ -17,7 +17,7 @@
 #include <asm/cpu_device_id.h>
 #include <asm/fpu/api.h>
 
-#define DRIVER_VERSION "1.0.0"
+#define DRIVER_VERSION "1.0.1"
 
 static inline void padlock_output_block(uint32_t *src, uint32_t *dst, size_t count)
 {
@@ -40,7 +40,7 @@ static int padlock_sha1_init_zhaoxin(struct shash_desc *desc)
 	return 0;
 }
 
-static int padlock_sha1_update_zhaoxin(struct shash_desc *desc, const u8 *data,	unsigned int len)
+static int padlock_sha1_update_zhaoxin(struct shash_desc *desc, const u8 *data, unsigned int len)
 {
 	struct sha1_state *sctx = shash_desc_ctx(desc);
 	unsigned int partial, done;
@@ -62,18 +62,19 @@ static int padlock_sha1_update_zhaoxin(struct shash_desc *desc, const u8 *data,	
 			done = -partial;
 			memcpy(sctx->buffer + partial, data, done + SHA1_BLOCK_SIZE);
 			src = sctx->buffer;
-			asm volatile (".byte 0xf3,0x0f,0xa6,0xc8"
-			: "+S"(src), "+D"(dst)
-			: "a"((long)-1), "c"((unsigned long)1));
+			asm volatile(".byte 0xf3, 0x0f, 0xa6, 0xc8"
+				     : "+S"(src), "+D"(dst)
+				     : "a"((long)-1), "c"(1UL));
 			done += SHA1_BLOCK_SIZE;
 			src = data + done;
 		}
 
 		/* Process the left bytes from the input data */
 		if (len - done >= SHA1_BLOCK_SIZE) {
-			asm volatile (".byte 0xf3,0x0f,0xa6,0xc8"
-			: "+S"(src), "+D"(dst)
-			: "a"((long)-1), "c"((unsigned long)((len - done) / SHA1_BLOCK_SIZE)));
+			asm volatile(".byte 0xf3, 0x0f, 0xa6, 0xc8"
+				     : "+S"(src), "+D"(dst)
+				     : "a"((long)-1),
+				       "c"((unsigned long)((len - done) / SHA1_BLOCK_SIZE)));
 			done += ((len - done) - (len - done) % SHA1_BLOCK_SIZE);
 			src = data + done;
 		}
@@ -96,7 +97,7 @@ static int padlock_sha1_final_zhaoxin(struct shash_desc *desc, u8 *out)
 
 	/* Pad out to 56 mod 64 */
 	partial = state->count & 0x3f;
-	padlen = (partial < 56) ? (56 - partial) : ((64+56) - partial);
+	padlen = (partial < 56) ? (56 - partial) : ((64 + 56) - partial);
 	padlock_sha1_update_zhaoxin(desc, padding, padlen);
 
 	/* Append length field bytes */
@@ -112,7 +113,7 @@ static int padlock_sha256_init_zhaoxin(struct shash_desc *desc)
 {
 	struct sha256_state *sctx = shash_desc_ctx(desc);
 
-	*sctx = (struct sha256_state) {
+	*sctx = (struct sha256_state){
 		.state = {
 			SHA256_H0, SHA256_H1, SHA256_H2, SHA256_H3,
 			SHA256_H4, SHA256_H5, SHA256_H6, SHA256_H7
@@ -139,24 +140,23 @@ static int padlock_sha256_update_zhaoxin(struct shash_desc *desc, const u8 *data
 	memcpy(dst, (u8 *)(sctx->state), SHA256_DIGEST_SIZE);
 
 	if ((partial + len) >= SHA256_BLOCK_SIZE) {
-
 		/* Append the bytes in state's buffer to a block to handle */
 		if (partial) {
 			done = -partial;
 			memcpy(sctx->buf + partial, data, done + SHA256_BLOCK_SIZE);
 			src = sctx->buf;
-			asm volatile (".byte 0xf3,0x0f,0xa6,0xd0"
-			: "+S"(src), "+D"(dst)
-			: "a"((long)-1), "c"((unsigned long)1));
+			asm volatile(".byte 0xf3, 0x0f, 0xa6, 0xd0"
+				     : "+S"(src), "+D"(dst)
+				     : "a"((long)-1), "c"(1UL));
 			done += SHA256_BLOCK_SIZE;
 			src = data + done;
 		}
 
 		/* Process the left bytes from input data */
 		if (len - done >= SHA256_BLOCK_SIZE) {
-			asm volatile (".byte 0xf3,0x0f,0xa6,0xd0"
-			: "+S"(src), "+D"(dst)
-			: "a"((long)-1), "c"((unsigned long)((len - done) / 64)));
+			asm volatile(".byte 0xf3, 0x0f, 0xa6, 0xd0"
+				     : "+S"(src), "+D"(dst)
+				     : "a"((long)-1), "c"((unsigned long)((len - done) / 64)));
 			done += ((len - done) - (len - done) % 64);
 			src = data + done;
 		}
@@ -179,7 +179,7 @@ static int padlock_sha256_final_zhaoxin(struct shash_desc *desc, u8 *out)
 
 	/* Pad out to 56 mod 64 */
 	partial = state->count & 0x3f;
-	padlen = (partial < 56) ? (56 - partial) : ((64+56) - partial);
+	padlen = (partial < 56) ? (56 - partial) : ((64 + 56) - partial);
 	padlock_sha256_update_zhaoxin(desc, padding, padlen);
 
 	/* Append length field bytes */
@@ -210,47 +210,48 @@ static int padlock_sha_import_zhaoxin(struct shash_desc *desc, const void *in)
 }
 
 static struct shash_alg sha1_alg_zhaoxin = {
-	.digestsize	=	SHA1_DIGEST_SIZE,
-	.init		=	padlock_sha1_init_zhaoxin,
-	.update		=	padlock_sha1_update_zhaoxin,
-	.final		=	padlock_sha1_final_zhaoxin,
-	.export		=	padlock_sha_export_zhaoxin,
-	.import		=	padlock_sha_import_zhaoxin,
-	.descsize	=	sizeof(struct sha1_state),
-	.statesize	=	sizeof(struct sha1_state),
+	.digestsize = SHA1_DIGEST_SIZE,
+	.init = padlock_sha1_init_zhaoxin,
+	.update = padlock_sha1_update_zhaoxin,
+	.final = padlock_sha1_final_zhaoxin,
+	.export = padlock_sha_export_zhaoxin,
+	.import = padlock_sha_import_zhaoxin,
+	.descsize = sizeof(struct sha1_state),
+	.statesize = sizeof(struct sha1_state),
 	.base = {
-		.cra_name			=	"sha1",
-		.cra_driver_name	=	"sha1-padlock-zhaoxin",
-		.cra_priority		=	PADLOCK_CRA_PRIORITY,
-		.cra_blocksize		=	SHA1_BLOCK_SIZE,
-		.cra_module			=	THIS_MODULE,
+		.cra_name = "sha1",
+		.cra_driver_name = "sha1-padlock-zhaoxin",
+		.cra_priority = PADLOCK_CRA_PRIORITY,
+		.cra_blocksize = SHA1_BLOCK_SIZE,
+		.cra_module = THIS_MODULE,
 	}
 };
 
 static struct shash_alg sha256_alg_zhaoxin = {
-	.digestsize	=	SHA256_DIGEST_SIZE,
-	.init		=	padlock_sha256_init_zhaoxin,
-	.update		=	padlock_sha256_update_zhaoxin,
-	.final		=	padlock_sha256_final_zhaoxin,
-	.export		=	padlock_sha_export_zhaoxin,
-	.import		=	padlock_sha_import_zhaoxin,
-	.descsize	=	sizeof(struct sha256_state),
-	.statesize	=	sizeof(struct sha256_state),
+	.digestsize = SHA256_DIGEST_SIZE,
+	.init = padlock_sha256_init_zhaoxin,
+	.update = padlock_sha256_update_zhaoxin,
+	.final = padlock_sha256_final_zhaoxin,
+	.export = padlock_sha_export_zhaoxin,
+	.import = padlock_sha_import_zhaoxin,
+	.descsize = sizeof(struct sha256_state),
+	.statesize = sizeof(struct sha256_state),
 	.base = {
-		.cra_name			=	"sha256",
-		.cra_driver_name	=	"sha256-padlock-zhaoxin",
-		.cra_priority		=	PADLOCK_CRA_PRIORITY,
-		.cra_blocksize		=	SHA256_BLOCK_SIZE,
-		.cra_module			=	THIS_MODULE,
+		.cra_name = "sha256",
+		.cra_driver_name = "sha256-padlock-zhaoxin",
+		.cra_priority = PADLOCK_CRA_PRIORITY,
+		.cra_blocksize = SHA256_BLOCK_SIZE,
+		.cra_module = THIS_MODULE,
 	}
 };
 
-static const struct x86_cpu_id zhaoxin_sha_ids[] = {
-	{ X86_VENDOR_CENTAUR, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_PHE },
-	{ X86_VENDOR_ZHAOXIN, 7, X86_MODEL_ANY, X86_STEPPING_ANY, X86_FEATURE_PHE },
+static const struct x86_cpu_id zhaoxin_sha_cpu_ids[] __initconst = {
+	X86_MATCH_VENDOR_FAM_FEATURE(CENTAUR, 7, X86_FEATURE_PHE, NULL),
+	X86_MATCH_VENDOR_FAM_FEATURE(ZHAOXIN, 7, X86_FEATURE_PHE, NULL),
+	X86_MATCH_VENDOR_FAM_FEATURE(ZHAOXIN, 6, X86_FEATURE_PHE, NULL),
 	{}
 };
-MODULE_DEVICE_TABLE(x86cpu, zhaoxin_sha_ids);
+MODULE_DEVICE_TABLE(x86cpu, zhaoxin_sha_cpu_ids);
 
 static int __init padlock_init(void)
 {
@@ -258,7 +259,7 @@ static int __init padlock_init(void)
 	struct shash_alg *sha1;
 	struct shash_alg *sha256;
 
-	if (!x86_match_cpu(zhaoxin_sha_ids) || !boot_cpu_has(X86_FEATURE_PHE_EN))
+	if (!x86_match_cpu(zhaoxin_sha_cpu_ids) || !boot_cpu_has(X86_FEATURE_PHE_EN))
 		return -ENODEV;
 
 	sha1 = &sha1_alg_zhaoxin;
@@ -293,12 +294,12 @@ static void __exit padlock_fini(void)
 module_init(padlock_init);
 module_exit(padlock_fini);
 
-MODULE_DESCRIPTION("ACE SHA1/SHA256 algorithms support.");
+MODULE_DESCRIPTION("Zhaoxin ACE SHA1/SHA256 algorithms support.");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Michal Ludvig");
 MODULE_VERSION(DRIVER_VERSION);
 
-MODULE_ALIAS_CRYPTO("sha1-all");
-MODULE_ALIAS_CRYPTO("sha256-all");
-MODULE_ALIAS_CRYPTO("sha1-padlock");
-MODULE_ALIAS_CRYPTO("sha256-padlock");
+MODULE_ALIAS_CRYPTO("zx-sha1-all");
+MODULE_ALIAS_CRYPTO("zx-sha256-all");
+MODULE_ALIAS_CRYPTO("zx-sha1-padlock");
+MODULE_ALIAS_CRYPTO("zx-sha256-padlock");


### PR DESCRIPTION
Due to the introduction of kernel patch 93022482b294 <"x86/cpu: Fix x86_match_cpu() to match just X86_VENDOR_INTEL">, direct use of array matching for processor lists becomes ineffective. Therefore, it's necessary to modify to use X86_MATCH_* macros for matching.
Additionally, adjust some code formatting according to checkpatch.pl, and modify some variable and comment names to unify the patch version content.

## Summary by Sourcery

Update Zhaoxin AES and SHA drivers to use X86_MATCH macros for CPU matching, bump versions, clean up naming and formatting, and refresh module metadata

Enhancements:
- Switch CPU matching arrays in Zhaoxin and Padlock AES/SHA drivers to X86_MATCH_VENDOR_FAM_FEATURE macros for compatibility with the revised x86_match_cpu API
- Bump DRIVER_VERSION to 1.0.1 in Zhaoxin AES and SHA drivers
- Rename per-CPU cword variable from paes_last_cword_zx to zx_paes_last_cword and unify variable/comment naming
- Reformat code (whitespace, asm volatile syntax, struct initializers) per checkpatch.pl guidelines
- Update MODULE_DESCRIPTION and MODULE_ALIAS_CRYPTO entries to prefix crypto aliases with "zx-" and reflect Zhaoxin branding