### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] drm/mwv207: define MAX after not define

### DIFF
--- a/drivers/gpu/drm/mwv207/mwv207_ctx.c
+++ b/drivers/gpu/drm/mwv207/mwv207_ctx.c
@@ -19,7 +19,10 @@
 #include "mwv207_drm.h"
 #include "mwv207_ctx.h"
 
+#ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 struct mwv207_ctx *mwv207_ctx_lookup(struct drm_device *dev,
 		struct drm_file *filp, u32 handle)
 {


### PR DESCRIPTION
deepin inclusion
category: bugfix

After v6.6.109 update minmax.h cause the driver build err. Fix it.

Log:
2025-10-13T03:11:52.8996805Z drivers/gpu/drm/mwv207/mwv207_ctx.c:22: error: "MAX" redefined [-Werror]
2025-10-13T03:11:52.9001800Z    22 | #define MAX(a, b) ((a) > (b) ? (a) : (b))
2025-10-13T03:11:52.9002368Z       |
2025-10-13T03:11:52.9002932Z In file included from ./include/linux/kernel.h:27,
2025-10-13T03:11:52.9004679Z                  from ./include/linux/cpumask.h:10,
2025-10-13T03:11:52.9005546Z                  from ./arch/loongarch/include/asm/processor.h:9,
2025-10-13T03:11:52.9006431Z                  from ./arch/loongarch/include/asm/thread_info.h:15,
2025-10-13T03:11:52.9007161Z                  from ./include/linux/thread_info.h:60,
2025-10-13T03:11:52.9007970Z                  from ./include/asm-generic/preempt.h:5,
2025-10-13T03:11:52.9009922Z                  from ./arch/loongarch/include/generated/asm/preempt.h:1,
2025-10-13T03:11:52.9011462Z                  from ./include/linux/preempt.h:79,
2025-10-13T03:11:52.9012222Z                  from ./include/linux/spinlock.h:56,
2025-10-13T03:11:52.9012989Z                  from ./include/linux/swait.h:7,
2025-10-13T03:11:52.9015555Z                  from ./include/linux/completion.h:12,
2025-10-13T03:11:52.9016312Z                  from ./include/drm/drm_file.h:34,
2025-10-13T03:11:52.9017096Z                  from drivers/gpu/drm/mwv207/mwv207_ctx.c:15:
2025-10-13T03:11:52.9018835Z ./include/linux/minmax.h:315: note: this is the location of the previous definition
2025-10-13T03:11:52.9019885Z   315 | #define MAX(a, b) __cmp(max, a, b)

## Summary by Sourcery

Bug Fixes:
- Wrap the MAX macro definition in mwv207_ctx.c with an #ifndef to prevent redefinition errors after the update to minmax.h