### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] drm/mwv207: check MAX define before define

### DIFF
--- a/drivers/gpu/drm/mwv207/mwv207_pipe_codec_common.h
+++ b/drivers/gpu/drm/mwv207/mwv207_pipe_codec_common.h
@@ -14,7 +14,10 @@
  */
 #include "mwv207_sched.h"
 
+#ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #define JPIPE_WRITE_ENTRY_SIZE  16
 #define JPIPE_ENC_REG_NUM       500
 #define JPIPE_DEC_REG_NUM       503


### PR DESCRIPTION
deepin inclusion
category: bugfix

After v6.6.109 update minmax.h cause the driver build err. Fix it.

Log:

2025-10-13T07:30:25.7639520Z In file included from drivers/gpu/drm/mwv207/mwv207_pipe_codec_common.c:15: 2025-10-13T07:30:25.7640933Z drivers/gpu/drm/mwv207/mwv207_pipe_codec_common.h:17: error: "MAX" redefined [-Werror]
2025-10-13T07:30:25.7641974Z    17 | #define MAX(a, b) ((a) > (b) ? (a) : (b))
2025-10-13T07:30:25.7642552Z       |
2025-10-13T07:30:25.7643467Z In file included from ./include/linux/kernel.h:27,
2025-10-13T07:30:25.7644491Z                  from ./arch/x86/include/asm/percpu.h:27,
2025-10-13T07:30:25.7645256Z                  from ./arch/x86/include/asm/preempt.h:6,
2025-10-13T07:30:25.7680165Z                  from ./include/linux/preempt.h:79,
2025-10-13T07:30:25.7682763Z                  from ./include/drm/spsc_queue.h:28,
2025-10-13T07:30:25.7683667Z                  from ./include/drm/gpu_scheduler.h:27,
2025-10-13T07:30:25.7684454Z                  from drivers/gpu/drm/mwv207/mwv207_sched.h:17,
2025-10-13T07:30:25.7685497Z                  from drivers/gpu/drm/mwv207/mwv207_pipe_codec_common.h:15:
2025-10-13T07:30:25.7687287Z ./include/linux/minmax.h:315: note: this is the location of the previous definition
2025-10-13T07:30:25.7688276Z   315 | #define MAX(a, b) __cmp(max, a, b)
2025-10-13T07:30:25.7688899Z       |

## Summary by Sourcery

Bug Fixes:
- Wrap MAX macro in #ifndef/#endif guard to avoid conflicts with existing definition in minmax.h