### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] drm: cix: linlondp: minmax: convert to MAX_T

### DIFF
--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_wb_connector.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_wb_connector.c
@@ -285,7 +285,7 @@ linlondp_wb_connector_create_color_prop(struct linlondp_wb_connector *wb_conn)
 {
 	struct drm_device *dev = wb_conn->base.base.dev;
 	struct drm_property *prop;
-	struct drm_prop_enum_list enum_list[max_t(int, DRM_COLOR_ENCODING_MAX,
+	struct drm_prop_enum_list enum_list[MAX_T(int, DRM_COLOR_ENCODING_MAX,
 						  DRM_COLOR_RANGE_MAX)];
 	u32 supported_encoding = BIT(DRM_COLOR_YCBCR_BT601) |
 	    BIT(DRM_COLOR_YCBCR_BT709);


### PR DESCRIPTION
deepin inclusion
category: bugfix

After v6.6.109 update minmax.h cause the driver build err. Fix it.

Log:

drivers/gpu/drm/cix/linlon-dp/linlondp_wb_connector.c: In function ‘linlondp_wb_connector_create_color_prop’: drivers/gpu/drm/cix/linlon-dp/linlondp_wb_connector.c:288:16: error: ISO C90 forbids variable length array ‘enum_list’ [-Werror=vla]
  288 |         struct drm_prop_enum_list enum_list[max_t(int, DRM_COLOR_ENCODING_MAX,
      |                ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Fixes: 3a7e02c040b1 ("minmax: avoid overly complicated constant expressions in VM code")
Fixes: 4477b39c32fd ("minmax: add a few more MIN_T/MAX_T users")

## Summary by Sourcery

Bug Fixes:
- Replace max_t with MAX_T in linlondp_wb_connector to fix C90 build error caused by variable-length arrays