### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] nvmem: layouts: fix nvmem_layout_bus_uevent

### DIFF
--- a/drivers/nvmem/layouts.c
+++ b/drivers/nvmem/layouts.c
@@ -51,7 +51,7 @@ static int nvmem_layout_bus_uevent(const struct device *dev,
 	int ret;
 
 	ret = of_device_uevent_modalias(dev, env);
-	if (ret != ENODEV)
+	if (ret != -ENODEV)
 		return ret;
 
 	return 0;


### PR DESCRIPTION
maillist inclusion
category: bugfix

correctly check the ENODEV return value.

## Summary by Sourcery

Bug Fixes:
- Compare the return code from of_device_uevent_modalias against -ENODEV instead of ENODEV