### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] Revert "wifi: mac80211: chan: chandef is non-NULL for reserved"

### DIFF
--- a/net/mac80211/chan.c
+++ b/net/mac80211/chan.c
@@ -89,11 +89,11 @@ ieee80211_chanctx_reserved_chandef(struct ieee80211_local *local,
 
 	lockdep_assert_held(&local->chanctx_mtx);
 
-	if (WARN_ON(!compat))
-		return NULL;
-
 	list_for_each_entry(link, &ctx->reserved_links,
 			    reserved_chanctx_list) {
+		if (!compat)
+			compat = &link->reserved_chandef;
+
 		compat = cfg80211_chandef_compatible(&link->reserved_chandef,
 						     compat);
 		if (!compat)


### PR DESCRIPTION
deepin inclusion
category: bugfix

The patch is depend on prev huge patches, we need more carefull to solve. Before it, revert the patch.

Log:
Injecting memory failure for pfn 0x462ba at process virtual address 0x200000ffc000 Memory failure: 0x462ba: already hardware poisoned ------------[ cut here ]------------
------------[ cut here ]------------
WARNING: CPU: 0 PID: 297 at net/mac80211/chan.c:92 ieee80211_chanctx_reserved_chandef+0x156/0x190 net/mac80211/chan.c:92 WARNING: CPU: 1 PID: 9631 at net/mac80211/chan.c:92 ieee80211_chanctx_reserved_chandef+0x156/0x190 net/mac80211/chan.c:92 Modules linked in:
CPU: 1 PID: 9631 Comm: kworker/u4:12 Tainted: G        W          6.6.0-amd64-desktop #74
Hardware name: QEMU Ubuntu 24.04 PC (i440FX + PIIX, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
Workqueue: phy3 ieee80211_csa_finalize_work
RIP: 0010:ieee80211_chanctx_reserved_chandef+0x156/0x190 net/mac80211/chan.c:92
Code: 89 c6 e8 6d 56 f3 fc 45 85 ed 0f 85 2a ff ff ff e8 df 5d f3 fc 0f 0b e8 d8 5d f3 fc 48 85 db 0f 85 23 ff ff ff e8 ca 5d f3 fc <0f> 0b 31 db eb a0 48 c7 c7 38 19 d6 b6 e8 a8 70 5d fd e9 df fe ff
RSP: 0018:ff1100004d1cfaa0 EFLAGS: 00010293
RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffffffffb3588b36
Modules linked in:
CPU: 0 PID: 297 Comm: kworker/u4:4 Tainted: G        W          6.6.0-amd64-desktop #74
RDX: ff1100004aa20000 RSI: 0000000000000000 RDI: 0000000000000005
RBP: ff1100004d1cfac0 R08: ff1100004aa20000 R09: ffe21c0008b822cb
R10: ff11000045c1165f R11: 0000000000000000 R12: ff1100002f81d300
R13: ff110000082d8fc0 R14: 0000000000000000 R15: ff1100002f81d310
FS:  0000000000000000(0000) GS:ff1100006c900000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 000055557f6e2808 CR3: 000000004a990005 CR4: 0000000000771ee0
Hardware name: QEMU Ubuntu 24.04 PC (i440FX + PIIX, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000600
PKRU: 55555554
Call Trace:
 <TASK>
 ieee80211_chsw_switch_hwconf net/mac80211/chan.c:1422 [inline]
 ieee80211_vif_use_reserved_switch+0x83d/0x1cb0 net/mac80211/chan.c:1638
 ieee80211_link_use_reserved_context+0x30f/0x470 net/mac80211/chan.c:1927
 __ieee80211_csa_finalize+0x1ec/0xba0 net/mac80211/cfg.c:3692
Workqueue: phy2 ieee80211_csa_finalize_work
 ieee80211_csa_finalize net/mac80211/cfg.c:3733 [inline]
 ieee80211_csa_finalize_work+0x1d3/0x2d0 net/mac80211/cfg.c:3758

RIP: 0010:ieee80211_chanctx_reserved_chandef+0x156/0x190 net/mac80211/chan.c:92
 process_one_work+0x97d/0x1a40 kernel/workqueue.c:2634
Code: 89 c6 e8 6d 56 f3 fc 45 85 ed 0f 85 2a ff ff ff e8 df 5d f3 fc 0f 0b e8 d8 5d f3 fc 48 85 db 0f 85 23 ff ff ff e8 ca 5d f3 fc <0f> 0b 31 db eb a0 48 c7 c7 38 19 d6 b6 e8 a8 70 5d fd e9 df fe ff RSP: 0018:ff1100001d2afaa0 EFLAGS: 00010293

RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffffffffb3588b36 RDX: ff11000021070000 RSI: 0000000000000000 RDI: 0000000000000005 RBP: ff1100001d2afac0 R08: ff11000021070000 R09: ffe21c0000f7aacb R10: ff11000007bd565f R11: 0000000000000159 R12: ff110000037d9e00
 process_scheduled_works kernel/workqueue.c:2711 [inline]
 worker_thread+0x8ac/0x1280 kernel/workqueue.c:2792
R13: ff110000218a0fc0 R14: 0000000000000000 R15: ff110000037d9e10 FS:  0000000000000000(0000) GS:ff1100006c800000(0000) knlGS:0000000000000000
 kthread+0x34b/0x460 kernel/kthread.c:391
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 00007fc320586028 CR3: 000000000521e003 CR4: 0000000000771ef0
 ret_from_fork+0x528/0x600 arch/x86/kernel/process.c:152
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000 DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000600 PKRU: 55555554
Call Trace:
 ret_from_fork_asm+0x1b/0x30 arch/x86/entry/entry_64.S:293
 <TASK>
 ieee80211_chsw_switch_hwconf net/mac80211/chan.c:1422 [inline]
 ieee80211_vif_use_reserved_switch+0x83d/0x1cb0 net/mac80211/chan.c:1638
 ieee80211_link_use_reserved_context+0x30f/0x470 net/mac80211/chan.c:1927
 </TASK>
 __ieee80211_csa_finalize+0x1ec/0xba0 net/mac80211/cfg.c:3692
irq event stamp: 0
hardirqs last  enabled at (0): [<0000000000000000>] 0x0
 ieee80211_csa_finalize net/mac80211/cfg.c:3733 [inline]
 ieee80211_csa_finalize_work+0x1d3/0x2d0 net/mac80211/cfg.c:3758
hardirqs last disabled at (0): [<ffffffffb0061efa>] copy_process+0x1a6a/0x6080 kernel/fork.c:2571
 process_one_work+0x97d/0x1a40 kernel/workqueue.c:2634
softirqs last  enabled at (0): [<ffffffffb0061f4a>] copy_process+0x1aba/0x6080 kernel/fork.c:2572 softirqs last disabled at (0): [<0000000000000000>] 0x0 ---[ end trace 0000000000000000 ]---
------------[ cut here ]------------
 process_scheduled_works kernel/workqueue.c:2711 [inline]
 worker_thread+0x8ac/0x1280 kernel/workqueue.c:2792
WARNING: CPU: 1 PID: 9631 at net/mac80211/chan.c:1423 ieee80211_chsw_switch_hwconf net/mac80211/chan.c:1423 [inline] WARNING: CPU: 1 PID: 9631 at net/mac80211/chan.c:1423 ieee80211_vif_use_reserved_switch+0x17f0/0x1cb0 net/mac80211/chan.c:1638 Modules linked in:

CPU: 1 PID: 9631 Comm: kworker/u4:12 Tainted: G        W          6.6.0-amd64-desktop #74
Hardware name: QEMU Ubuntu 24.04 PC (i440FX + PIIX, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
Workqueue: phy3 ieee80211_csa_finalize_work
 kthread+0x34b/0x460 kernel/kthread.c:391

RIP: 0010:ieee80211_chsw_switch_hwconf net/mac80211/chan.c:1423 [inline] RIP: 0010:ieee80211_vif_use_reserved_switch+0x17f0/0x1cb0 net/mac80211/chan.c:1638
 ret_from_fork+0x528/0x600 arch/x86/kernel/process.c:152
Code: 48 8b 7d 88 e8 01 bf 5c fd e9 0f ec ff ff 4c 89 e7 e8 94 be 5c fd e9 2f e9 ff ff e8 5a be 5c fd e9 57 e9 ff ff e8 60 ab f2 fc <0f> 0b 48 b8 00 00 00 00 00 fc ff df 48 8b 55 c8 48 c1 ea 03 80 3c RSP: 0018:ff1100004d1cfad0 EFLAGS: 00010293
 ret_from_fork_asm+0x1b/0x30 arch/x86/entry/entry_64.S:293

 </TASK>
irq event stamp: 0
hardirqs last  enabled at (0): [<0000000000000000>] 0x0 hardirqs last disabled at (0): [<ffffffffb0061efa>] copy_process+0x1a6a/0x6080 kernel/fork.c:2571 softirqs last  enabled at (0): [<ffffffffb0061f4a>] copy_process+0x1aba/0x6080 kernel/fork.c:2572 softirqs last disabled at (0): [<0000000000000000>] 0x0 ---[ end trace 0000000000000000 ]---
------------[ cut here ]------------
RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffffffffb3593da0 WARNING: CPU: 0 PID: 297 at net/mac80211/chan.c:1423 ieee80211_chsw_switch_hwconf net/mac80211/chan.c:1423 [inline] WARNING: CPU: 0 PID: 297 at net/mac80211/chan.c:1423 ieee80211_vif_use_reserved_switch+0x17f0/0x1cb0 net/mac80211/chan.c:1638 RDX: ff1100004aa20000 RSI: 0000000000000000 RDI: 0000000000000005 Modules linked in:
CPU: 0 PID: 297 Comm: kworker/u4:4 Tainted: G        W          6.6.0-amd64-desktop #74
RBP: ff1100004d1cfb58 R08: ff1100004aa20000 R09: ffe21c0008b822cb
Hardware name: QEMU Ubuntu 24.04 PC (i440FX + PIIX, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
R10: ff11000045c1165f R11: 0000000000000000 R12: ff110000082dae90
Workqueue: phy2 ieee80211_csa_finalize_work
R13: 0000000000000001 R14: 0000000000000001 R15: ff1100002f81d310
FS:  0000000000000000(0000) GS:ff1100006c900000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 000055557f6e2808 CR3: 000000004a990005 CR4: 0000000000771ee0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000600
PKRU: 55555554
Call Trace:
 <TASK>
 ieee80211_link_use_reserved_context+0x30f/0x470 net/mac80211/chan.c:1927
 __ieee80211_csa_finalize+0x1ec/0xba0 net/mac80211/cfg.c:3692

RIP: 0010:ieee80211_chsw_switch_hwconf net/mac80211/chan.c:1423 [inline] RIP: 0010:ieee80211_vif_use_reserved_switch+0x17f0/0x1cb0 net/mac80211/chan.c:1638
 ieee80211_csa_finalize net/mac80211/cfg.c:3733 [inline]
 ieee80211_csa_finalize_work+0x1d3/0x2d0 net/mac80211/cfg.c:3758
 process_one_work+0x97d/0x1a40 kernel/workqueue.c:2634
Code: 48 8b 7d 88 e8 01 bf 5c fd e9 0f ec ff ff 4c 89 e7 e8 94 be 5c fd e9 2f e9 ff ff e8 5a be 5c fd e9 57 e9 ff ff e8 60 ab f2 fc <0f> 0b 48 b8 00 00 00 00 00 fc ff df 48 8b 55 c8 48 c1 ea 03 80 3c RSP: 0018:ff1100001d2afad0 EFLAGS: 00010293

RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffffffffb3593da0
 process_scheduled_works kernel/workqueue.c:2711 [inline]
 worker_thread+0x8ac/0x1280 kernel/workqueue.c:2792
RDX: ff11000021070000 RSI: 0000000000000000 RDI: 0000000000000005 RBP: ff1100001d2afb58 R08: ff11000021070000 R09: ffe21c0000f7aacb
 kthread+0x34b/0x460 kernel/kthread.c:391
R10: ff11000007bd565f R11: 0000000000000159 R12: ff110000218a2e90 R13: 0000000000000001 R14: 0000000000000001 R15: ff110000037d9e10
 ret_from_fork+0x528/0x600 arch/x86/kernel/process.c:152
FS:  0000000000000000(0000) GS:ff1100006c800000(0000) knlGS:0000000000000000 CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
 ret_from_fork_asm+0x1b/0x30 arch/x86/entry/entry_64.S:293
CR2: 00007fc320586028 CR3: 000000000521e003 CR4: 0000000000771ef0
 </TASK>
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000 irq event stamp: 0
DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000600 PKRU: 55555554
Call Trace:
 <TASK>
hardirqs last  enabled at (0): [<0000000000000000>] 0x0
 ieee80211_link_use_reserved_context+0x30f/0x470 net/mac80211/chan.c:1927
hardirqs last disabled at (0): [<ffffffffb0061efa>] copy_process+0x1a6a/0x6080 kernel/fork.c:2571
 __ieee80211_csa_finalize+0x1ec/0xba0 net/mac80211/cfg.c:3692
softirqs last  enabled at (0): [<ffffffffb0061f4a>] copy_process+0x1aba/0x6080 kernel/fork.c:2572 softirqs last disabled at (0): [<0000000000000000>] 0x0
 ieee80211_csa_finalize net/mac80211/cfg.c:3733 [inline]
 ieee80211_csa_finalize_work+0x1d3/0x2d0 net/mac80211/cfg.c:3758
---[ end trace 0000000000000000 ]---
 process_one_work+0x97d/0x1a40 kernel/workqueue.c:2634
wlan1: failed to finalize CSA, disconnecting
 process_scheduled_works kernel/workqueue.c:2711 [inline]
 worker_thread+0x8ac/0x1280 kernel/workqueue.c:2792
 kthread+0x34b/0x460 kernel/kthread.c:391
 ret_from_fork+0x528/0x600 arch/x86/kernel/process.c:152
 ret_from_fork_asm+0x1b/0x30 arch/x86/entry/entry_64.S:293
 </TASK>
irq event stamp: 0
hardirqs last  enabled at (0): [<0000000000000000>] 0x0 hardirqs last disabled at (0): [<ffffffffb0061efa>] copy_process+0x1a6a/0x6080 kernel/fork.c:2571 softirqs last  enabled at (0): [<ffffffffb0061f4a>] copy_process+0x1aba/0x6080 kernel/fork.c:2572 softirqs last disabled at (0): [<0000000000000000>] 0x0 ---[ end trace 0000000000000000 ]---
wlan0: failed to finalize CSA, disconnecting
------------[ cut here ]------------
WARNING: CPU: 0 PID: 247 at net/mac80211/tx.c:5052 __ieee80211_beacon_update_cntdwn net/mac80211/tx.c:5052 [inline] WARNING: CPU: 0 PID: 247 at net/mac80211/tx.c:5052 __ieee80211_beacon_get+0x115a/0x12c0 net/mac80211/tx.c:5463 Modules linked in:
CPU: 0 PID: 247 Comm: syz-executor Tainted: G        W          6.6.0-amd64-desktop #74
Hardware name: QEMU Ubuntu 24.04 PC (i440FX + PIIX, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
RIP: 0010:__ieee80211_beacon_update_cntdwn net/mac80211/tx.c:5052 [inline]
RIP: 0010:__ieee80211_beacon_get+0x115a/0x12c0 net/mac80211/tx.c:5463
Code: fc 48 c7 c2 e0 9f d5 b4 be 51 15 00 00 48 c7 c7 40 a0 d5 b4 c6 05 f0 65 7a 03 01 e8 20 76 d3 fc e9 3a f9 ff ff e8 f6 aa f7 fc <0f> 0b e9 e7 f9 ff ff e8 0a be 61 fd e9 3a ef ff ff e8 00 be 61 fd
RSP: 0018:ff1100006c809b70 EFLAGS: 00010246
RAX: 0000000000000000 RBX: ff11000007bd6a00 RCX: ffffffffb3543e0a
RDX: ff110000068a0000 RSI: 0000000000000000 RDI: 0000000000000001
RBP: ff1100006c809bd8 R08: ff110000068a0000 R09: 0000000000000000
R10: ff1100006c809c20 R11: 0000000000000000 R12: ff1100000422ac00
R13: 0000000000000000 R14: ff11000007bd4ce0 R15: ff11000007bd6488
FS:  000055556a3d1500(0000) GS:ff1100006c800000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 000055556a3ec9e8 CR3: 0000000045c1c005 CR4: 0000000000771ef0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000600
PKRU: 80000000
Call Trace:
 <IRQ>
 ieee80211_beacon_get_tim+0xab/0x5d0 net/mac80211/tx.c:5590
 ieee80211_beacon_get include/net/mac80211.h:5460 [inline]
 mac80211_hwsim_beacon_tx+0x400/0x730 drivers/net/wireless/virtual/mac80211_hwsim.c:2265
 __iterate_interfaces+0x2d6/0x590 net/mac80211/util.c:779
 ieee80211_iterate_active_interfaces_atomic+0x79/0x1d0 net/mac80211/util.c:815
 mac80211_hwsim_beacon+0x110/0x210 drivers/net/wireless/virtual/mac80211_hwsim.c:2295
 __run_hrtimer kernel/time/hrtimer.c:1756 [inline]
 __hrtimer_run_queues+0x1e2/0xbc0 kernel/time/hrtimer.c:1820
 hrtimer_run_softirq+0x150/0x310 kernel/time/hrtimer.c:1837
 handle_softirqs+0x210/0x7e0 kernel/softirq.c:578
 __do_softirq kernel/softirq.c:612 [inline]
 invoke_softirq kernel/softirq.c:452 [inline]
 __irq_exit_rcu+0x147/0x190 kernel/softirq.c:661
 irq_exit_rcu+0xe/0x20 kernel/softirq.c:673
 instr_sysvec_apic_timer_interrupt arch/x86/kernel/apic/apic.c:1088 [inline]
 sysvec_apic_timer_interrupt+0x7c/0xa0 arch/x86/kernel/apic/apic.c:1088
 </IRQ>
 <TASK>
 asm_sysvec_apic_timer_interrupt+0x1b/0x20 arch/x86/include/asm/idtentry.h:687
RIP: 0010:__sanitizer_cov_trace_pc+0x42/0x80 kernel/kcov.c:216
Code: a9 00 01 ff 00 74 1d f6 c4 01 74 4a a9 00 00 0f 00 75 43 a9 00 00 f0 00 75 3c 8b 82 b4 20 00 00 85 c0 74 32 8b 82 90 20 00 00 <83> f8 02 75 27 48 8b b2 98 20 00 00 8b 92 94 20 00 00 48 8b 06 48
RSP: 0018:ff11000007a57920 EFLAGS: 00000246
RAX: 0000000000000000 RBX: ffffffffb64ed1e0 RCX: ffffffffb04c8305
RDX: ff110000068a0000 RSI: 0000000000000000 RDI: 0000000000000005
RBP: ff11000007a57920 R08: ff110000068a0000 R09: fffffbfff6dab554
R10: ffffffffb6d5aaa7 R11: 0000000000000000 R12: 0000000000000000
R13: 0000000000000000 R14: ff11000007a57aa8 R15: ff110000068a0000
 __is_insn_slot_addr+0x65/0x2a0 kernel/kprobes.c:304
 is_kprobe_insn_slot include/linux/kprobes.h:346 [inline]
 kernel_text_address+0xc8/0x170 kernel/extable.c:123
 __kernel_text_address+0x12/0x50 kernel/extable.c:79
 unwind_get_return_address+0x87/0xf0 arch/x86/kernel/unwind_frame.c:19
 arch_stack_walk+0xc2/0x180 arch/x86/kernel/stacktrace.c:26
 stack_trace_save+0x94/0xd0 kernel/stacktrace.c:122
 kasan_save_stack+0x38/0x60 mm/kasan/common.c:45
 kasan_set_track+0x25/0x40 mm/kasan/common.c:52
 kasan_save_alloc_info+0x1e/0x30 mm/kasan/generic.c:511
 __kasan_slab_alloc+0x72/0x80 mm/kasan/common.c:328
 kasan_slab_alloc include/linux/kasan.h:188 [inline]
 slab_post_alloc_hook mm/slab.h:773 [inline]
 slab_alloc_node mm/slub.c:3617 [inline]
 slab_alloc mm/slub.c:3625 [inline]
 __kmem_cache_alloc_lru mm/slub.c:3632 [inline]
 kmem_cache_alloc+0x1b6/0x3b0 mm/slub.c:3641
 getname_flags+0xd5/0x5c0 fs/namei.c:144
 user_path_at_empty+0x34/0x70 fs/namei.c:2914
 user_path_at include/linux/namei.h:57 [inline]
 ksys_umount fs/namespace.c:1939 [inline]
 __do_sys_umount fs/namespace.c:1947 [inline]
 __se_sys_umount fs/namespace.c:1945 [inline]
 __x64_sys_umount+0x11b/0x1b0 fs/namespace.c:1945
 x64_sys_call+0x1a26/0x1c90 arch/x86/include/generated/asm/syscalls_64.h:167
 do_syscall_x64 arch/x86/entry/common.c:51 [inline]
 do_syscall_64+0x74/0x360 arch/x86/entry/common.c:81
 entry_SYSCALL_64_after_hwframe+0x78/0xe2
RIP: 0033:0x7f26fc7a50ab
Code: 3b 16 00 00 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa 31 f6 e9 05 00 00 00 0f 1f 44 00 00 f3 0f 1e fa b8 a6 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 05 c3 0f 1f 40 00 48 c7 c2 b0 ff ff ff f7 d8
RSP: 002b:00007ffe8f31ef48 EFLAGS: 00000246 ORIG_RAX: 00000000000000a6
RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007f26fc7a50ab
RDX: 00007f26fc650ba1 RSI: 0000000000000009 RDI: 00007ffe8f31f000
RBP: 00007ffe8f31f000 R08: 0000000000000073 R09: 0000000000000000
R10: 0000000000000000 R11: 0000000000000246 R12: 00007ffe8f3200d0
R13: 00007f26fc846c96 R14: 0000000000000032 R15: 000000000001dc69
 </TASK>
irq event stamp: 0
hardirqs last  enabled at (0): [<0000000000000000>] 0x0
hardirqs last disabled at (0): [<ffffffffb0061efa>] copy_process+0x1a6a/0x6080 kernel/fork.c:2571
softirqs last  enabled at (0): [<ffffffffb0061f4a>] copy_process+0x1aba/0x6080 kernel/fork.c:2572
softirqs last disabled at (0): [<0000000000000000>] 0x0
---[ end trace 0000000000000000 ]---
wlan1: failed to finalize CSA, disconnecting
wlan0: failed to finalize CSA, disconnecting
pim6reg9 (unregistering): left allmulticast mode
----------------
Code disassembly (best guess):
   0:	a9 00 01 ff 00       	test   $0xff0100,%eax
   5:	74 1d                	je     0x24
   7:	f6 c4 01             	test   $0x1,%ah
   a:	74 4a                	je     0x56
   c:	a9 00 00 0f 00       	test   $0xf0000,%eax
  11:	75 43                	jne    0x56
  13:	a9 00 00 f0 00       	test   $0xf00000,%eax
  18:	75 3c                	jne    0x56
  1a:	8b 82 b4 20 00 00    	mov    0x20b4(%rdx),%eax
  20:	85 c0                	test   %eax,%eax
  22:	74 32                	je     0x56
  24:	8b 82 90 20 00 00    	mov    0x2090(%rdx),%eax
* 2a:	83 f8 02             	cmp    $0x2,%eax <-- trapping instruction
  2d:	75 27                	jne    0x56
  2f:	48 8b b2 98 20 00 00 	mov    0x2098(%rdx),%rsi
  36:	8b 92 94 20 00 00    	mov    0x2094(%rdx),%edx
  3c:	48 8b 06             	mov    (%rsi),%rax
  3f:	48                   	rex.W
This reverts commit 2ca7c57981498bb1333d5b2fc1deb9ffd1ef2d2b.

Reported-by: syzkaller <syzkaller@googlegroups.com>

## Summary by Sourcery

Revert the chanctx_reserved_chandef changes in mac80211 that introduced a WARN_ON guard and early return, restoring prior behavior to avoid memory failure–induced kernel issues.

Bug Fixes:
- Revert the mac80211 patch enforcing non-NULL reserved chandef to eliminate WARN_ON checks that led to kernel warnings and panics

Chores:
- Remove commit 2ca7c57981498bb1333d5b2fc1deb9ffd1ef2d2b