### PR TITLE
Fix HAOC and KASAN conflicts

### DIFF
--- a/arch/x86/mm/kasan_init_64.c
+++ b/arch/x86/mm/kasan_init_64.c
@@ -429,6 +429,41 @@ void __init kasan_init(void)
 	kasan_populate_early_shadow(kasan_mem_to_shadow((void *)MODULES_END),
 					(void *)KASAN_SHADOW_END);
 
+#ifdef CONFIG_IEE
+	/*
+	 * Mirror KASAN shadow for the IEE alias of the direct map (4-level only):
+	 * Map the shadow range corresponding to the upper 32TB of the direct
+	 * mapping to the same physical shadow pages as the lower 32TB range.
+	 *
+	 * Layout per Documentation/arch/x86/x86_64/mm.rst (4-level):
+	 *   - Low  32TB direct map: 0xffff888000000000 - 0xffffa88000000000
+	 *   - High 32TB direct map: 0xffffa88000000000 - 0xffffc87fffffffff
+	 * Shadow is 1/8 sized, so we can mirror by PGD entries (512GB each).
+	 */
+	if (!pgtable_l5_enabled()) {
+		/* Derive from current PAGE_OFFSET to handle dynamic layout. */
+		const unsigned long half_linear_size = (1UL << 45); /* 32TB */
+		unsigned long low_lin_start  = PAGE_OFFSET;
+		unsigned long high_lin_start = low_lin_start + half_linear_size;
+		unsigned long high_lin_end_exclusive = high_lin_start + half_linear_size; /* end+1 */
+
+		unsigned long src = (unsigned long)kasan_mem_to_shadow((void *)low_lin_start);
+		unsigned long dst = (unsigned long)kasan_mem_to_shadow((void *)high_lin_start);
+		unsigned long end = (unsigned long)kasan_mem_to_shadow((void *)high_lin_end_exclusive);
+
+		/* The ranges should be PGD-size aligned under 4-level paging. */
+		while (dst < end) {
+			pgd_t *src_pgd = pgd_offset_k(src);
+			pgd_t *dst_pgd = pgd_offset_k(dst);
+
+			set_pgd(dst_pgd, *src_pgd);
+
+			src += PGDIR_SIZE;
+			dst += PGDIR_SIZE;
+		}
+	}
+#endif /* CONFIG_IEE */
+
 	load_cr3(init_top_pgt);
 	__flush_tlb_all();
 

--- a/mm/slub.c
+++ b/mm/slub.c
@@ -2147,7 +2147,13 @@ static struct slab *allocate_slab(struct kmem_cache *s, gfp_t flags, int node)
 		iee_allocate_slab_data(s, slab, oo_order(oo));
 #endif
 #ifdef CONFIG_CREDP
-	if (haoc_enabled && s == cred_jar)
+	/*
+	 * Under KASAN, slab/object metadata is written at allocation time
+	 * (e.g., __kasan_init_slab_obj, setup_object). Marking cred_jar
+	 * pages read-only here would trigger faults on those writes.
+	 * Skip enforcing RO for cred slabs when KASAN is enabled.
+	 */
+	if (haoc_enabled && s == cred_jar && !IS_ENABLED(CONFIG_KASAN))
 		set_iee_page((unsigned long)page_address(folio_page(slab_folio(slab), 0)),
 							oo_order(oo));
 #endif
@@ -2216,7 +2222,8 @@ static void __free_slab(struct kmem_cache *s, struct slab *slab)
 		iee_free_slab(s, slab, iee_free_cred_slab);
 		return;
 		#else
-		unset_iee_page((unsigned long)page_address(folio_page(folio, 0)), order);
+		if (!IS_ENABLED(CONFIG_KASAN))
+			unset_iee_page((unsigned long)page_address(folio_page(folio, 0)), order);
 		#endif
 	}
 #endif


### PR DESCRIPTION
In certain cases, enabling both KASAN and HAOC CREDP at the same time can trigger a crash. This PR addresses the following two issues:

	1.	When KASAN is enabled, the shadow memory corresponding to HAOC IEE is not mapped, leading to memory access errors.
	2.	When KASAN is enabled, HAOC CREDP places cred_jar in the IEE region and marks it as read-only, causing KASAN to throw an error when it attempts to write redzone data.

## Summary by Sourcery

Fix conflicts between HAOC and KASAN by mirroring the KASAN shadow for the IEE alias of the direct map and disabling read-only marking on cred_jar slabs when KASAN is enabled

Bug Fixes:
- Mirror KASAN shadow mappings for the IEE alias of the direct map under 4-level paging to cover the upper 32 TB of the direct map
- Skip enforcing read-only IEE pages on cred_jar slab allocations and frees when KASAN is enabled to avoid metadata write faults