### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Deepin] scripts: Fix ./init/build-version: not found

### DIFF
--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -152,7 +152,7 @@ version=$KERNELRELEASE
 if [ "${KDEB_PKGVERSION:+set}" ]; then
 	packageversion=$KDEB_PKGVERSION
 else
-	packageversion=$($srctree/init/build-version)
+	packageversion=$($srctree/scripts/build-version)
 fi
 sourcename=${KDEB_SOURCENAME:-linux-upstream}
 


### PR DESCRIPTION
deepin inclusion
category: bugfix

Per ae4c4cee8110a ("kbuild: move init/build-version to scripts/") change init/ to scripts/

Log:
time make bindeb-pkg -j$(nproc)
  UPD     include/config/kernel.release
  GEN     debian
./scripts/package/mkdebian: 155: ./init/build-version: not found

Fixes: e3161c1715546 ("scripts: adapt to UOS/deepin scripting")

## Summary by Sourcery

Bug Fixes:
- Update mkdebian to invoke build-version from scripts/init instead of init