### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] crypto: fix the issue that KABI reservation caused the Loongson hardw…

### DIFF
--- a/include/crypto/skcipher.h
+++ b/include/crypto/skcipher.h
@@ -146,9 +146,10 @@ struct skcipher_alg {
 	struct crypto_istat_cipher stat;
 #endif
 
-	struct crypto_alg base;
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
+
+	struct crypto_alg base;
 };
 
 #define MAX_SYNC_SKCIPHER_REQSIZE      384


### PR DESCRIPTION
…are encryption SM4 test to freeze

deepin inclusion
category: bugfix

Log:

must reserve before base in struct skcipher_alg.
struct skcipher_instance {
	void (*free)(struct skcipher_instance *inst);
	union {
		struct {
			char head[offsetof(struct skcipher_alg, base)];
			struct crypto_instance base;
		} s;
		struct skcipher_alg alg;
	};
};

Fixes: cd90e7cb9d0e ("deepin: KABI:crypto: kabi: KABI reservation for crypto")

## Summary by Sourcery

Bug Fixes:
- Reorder fields in struct skcipher_alg so that DEEPIN_KABI_RESERVE entries precede the crypto_alg base field to avoid test freezes.