### PR TITLE
[linux-6.6.y] ACPI: processor: idle: Set timer broadcast state on C3 for KH-50000

### DIFF
--- a/drivers/acpi/processor_idle.c
+++ b/drivers/acpi/processor_idle.c
@@ -130,6 +130,12 @@ static void lapic_timer_check_state(int state, struct acpi_processor *pr,
 	if (cpu_has(&cpu_data(pr->id), X86_FEATURE_ARAT))
 		return;
 
+	/* On the KH-50000 platform, the local APIC stops in C3 state */
+	if ((boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR ||
+	     boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN) &&
+	    (boot_cpu_data.x86 == 0x7 && boot_cpu_data.x86_model == 0x7b))
+		type = ACPI_STATE_C3;
+
 	if (boot_cpu_has_bug(X86_BUG_AMD_APIC_C1E))
 		type = ACPI_STATE_C1;
 


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

For avoid broadcast timer interrupt at C2 state on KH-50000 platform, to increace performance and low interrupt count, so set timer broadcast state on C3 state.

Reviewed-by: Alan Song <alansong@zhaoxin.com>
Tested-by: Lyle Li <lyleli@zhaoxin.com>

## Summary by Sourcery

New Features:
- Force ACPI timer broadcast to C3 state on KH-50000 platforms to reduce interrupts and improve performance