### PR TITLE
[linux-6.6.y] x86/hpet: Set dynamic IRQ feature for HPET for KH-50000

### DIFF
--- a/arch/x86/kernel/hpet.c
+++ b/arch/x86/kernel/hpet.c
@@ -457,6 +457,15 @@ static void __init hpet_legacy_clockevent_register(struct hpet_channel *hc)
 	hc->evt.features		|= CLOCK_EVT_FEAT_PERIODIC;
 	hc->evt.set_state_periodic	= hpet_clkevt_set_state_periodic;
 
+	/*
+	 * On the KH-50000 platform, enable dynamic HPET interrupts
+	 * to prevent unnecessary wakeups of core 0 caused by broadcast timer events.
+	 */
+	if ((boot_cpu_data.x86_vendor == X86_VENDOR_CENTAUR ||
+	     boot_cpu_data.x86_vendor == X86_VENDOR_ZHAOXIN) &&
+	    (boot_cpu_data.x86 == 0x7 && boot_cpu_data.x86_model == 0x7b))
+		hc->evt.features |= CLOCK_EVT_FEAT_DYNIRQ;
+
 	/* Start HPET legacy interrupts */
 	hpet_enable_legacy_int();
 


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

To avoid unnecessary wakeups of core 0 caused by HPET broadcast timer interrupts, enable the dynamic IRQ feature for HPET on the KH-50000 platform.

Reviewed-by: Alan Song <alansong@zhaoxin.com>
Tested-by: Lyle Li <lyleli@zhaoxin.com>

## Summary by Sourcery

New Features:
- Enable dynamic HPET interrupts on KH-50000 platform to avoid unnecessary core 0 wakeups from broadcast timers