### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Sunway] 6.6: update patches for sw64 architecture 

### DIFF
--- a/arch/sw_64/Kconfig
+++ b/arch/sw_64/Kconfig
@@ -681,8 +681,9 @@ config ARCH_HIBERNATION_POSSIBLE
 
 config SW64_POWERCAP
 	bool "Sunway powercap driver"
+	select IPMI_HANDLER
 	select IPMI_SI
-	depends on SW64 && CPU_FREQ && ACPI && IPMI_HANDLER
+	depends on SW64_CPUFREQ && ACPI
 	help
 	  This enables support for the sunway powercap driver
 	  based on BMC and IPMI system interface.

--- a/arch/sw_64/include/asm/syscall.h
+++ b/arch/sw_64/include/asm/syscall.h
@@ -13,7 +13,7 @@ extern syscall_fn_t sys_call_table[];
 static inline int syscall_get_nr(struct task_struct *task,
 				 struct pt_regs *regs)
 {
-	return regs->regs[0];
+	return regs->orig_r0;
 }
 
 static inline long

--- a/arch/sw_64/kernel/chip_setup.c
+++ b/arch/sw_64/kernel/chip_setup.c
@@ -90,6 +90,7 @@ static void i2c_srst(void)
 	writeq(0x1, spbu_base + OFFSET_I2C2_SRST_L);
 }
 
+#ifdef CONFIG_PCI
 static void pcie_save(void)
 {
 	struct pci_controller *hose;
@@ -130,6 +131,17 @@ static void pcie_restore(void)
 	}
 
 }
+#else
+static void pcie_save(void)
+{
+
+}
+
+static void pcie_restore(void)
+{
+
+}
+#endif
 
 static unsigned long saved_dvc_int, saved_long_time;
 

--- a/arch/sw_64/kernel/cpu.c
+++ b/arch/sw_64/kernel/cpu.c
@@ -70,7 +70,7 @@ static int cpuinfo_cpu_online(unsigned int cpu)
 	return 0;
 }
 
-static const char * __init dmi_get_string(const struct dmi_header *dm, u8 s)
+static __maybe_unused const char * __init dmi_get_string(const struct dmi_header *dm, u8 s)
 {
 	const u8 *bp = ((u8 *) dm) + dm->length;
 	const u8 *nsp;
@@ -90,7 +90,7 @@ static const char * __init dmi_get_string(const struct dmi_header *dm, u8 s)
 	return "";
 }
 
-static void __init find_dmi_processor_version(const struct dmi_header *dm,
+static __maybe_unused void __init find_dmi_processor_version(const struct dmi_header *dm,
 		void *private)
 {
 	char *dmi_data = (char *)dm;
@@ -113,10 +113,12 @@ static void __init get_model_id(void)
 	int i;
 	unsigned long val;
 
+#ifdef CONFIG_EFI
 	/* Prefer model id from SMBIOS */
 	if (!IS_ENABLED(CONFIG_SUBARCH_C3B) &&
 			sunway_bios_version)
 		dmi_walk(find_dmi_processor_version, NULL);
+#endif
 
 	if (strlen(model_id) > 0)
 		return;
@@ -128,7 +130,7 @@ static void __init get_model_id(void)
 	}
 }
 
-static void __init find_dmi_processor_manufacturer(const struct dmi_header *dm,
+static __maybe_unused void __init find_dmi_processor_manufacturer(const struct dmi_header *dm,
 		void *private)
 {
 	char *dmi_data = (char *)dm;
@@ -151,10 +153,12 @@ static void __init get_vendor_id(void)
 	int i;
 	unsigned long val;
 
+#ifdef CONFIG_EFI
 	/* Prefer vendor id from SMBIOS */
 	if (!IS_ENABLED(CONFIG_SUBARCH_C3B) &&
 			sunway_bios_version)
 		dmi_walk(find_dmi_processor_manufacturer, NULL);
+#endif
 
 	if (strlen(vendor_id) > 0)
 		return;
@@ -166,7 +170,7 @@ static void __init get_vendor_id(void)
 	}
 }
 
-static void __init find_dmi_processor_family(const struct dmi_header *dm,
+static __maybe_unused void __init find_dmi_processor_family(const struct dmi_header *dm,
 		void *private)
 {
 	char *dmi_data = (char *)dm;
@@ -182,10 +186,12 @@ static void __init find_dmi_processor_family(const struct dmi_header *dm,
 
 static void __init get_family(void)
 {
+#ifdef CONFIG_EFI
 	/* Prefer processor family from SMBIOS */
 	if (!IS_ENABLED(CONFIG_SUBARCH_C3B) &&
 			sunway_bios_version)
 		dmi_walk(find_dmi_processor_family, NULL);
+#endif
 
 	if (family)
 		return;

--- a/arch/sw_64/kernel/ptrace.c
+++ b/arch/sw_64/kernel/ptrace.c
@@ -146,6 +146,20 @@ put_reg(struct task_struct *task, unsigned long regno, unsigned long data)
 		return PTR_ERR(addr);
 	else {
 		*addr = data;
+
+		/*
+		 * Any modifications made to $0 and $19 at syscall entry
+		 * should also be reflected on orig_r0 and orig_r19.
+		 *
+		 * See syscall_set() for how to modify orig_r0 only.
+		 */
+		if (task->ptrace_message == PTRACE_EVENTMSG_SYSCALL_ENTRY) {
+			if (regno == PT_REG_BASE)
+				task_pt_regs(task)->orig_r0 = data;
+			if (regno == (PT_REG_BASE + 19))
+				task_pt_regs(task)->orig_r19 = data;
+		}
+
 		return 0;
 	}
 }
@@ -423,7 +437,6 @@ long arch_ptrace(struct task_struct *child, long request,
 
 asmlinkage unsigned long syscall_trace_enter(void)
 {
-	unsigned long ret = 0;
 	struct pt_regs *regs = current_pt_regs();
 
 	if (test_thread_flag(TIF_SYSCALL_TRACE) &&
@@ -437,9 +450,10 @@ asmlinkage unsigned long syscall_trace_enter(void)
 #endif
 
 	if (unlikely(test_thread_flag(TIF_SYSCALL_TRACEPOINT)))
-		trace_sys_enter(regs, regs->regs[0]);
-	audit_syscall_entry(regs->regs[0], regs->regs[16], regs->regs[17], regs->regs[18], regs->regs[19]);
-	return ret ?: regs->regs[0];
+		trace_sys_enter(regs, regs->orig_r0);
+	audit_syscall_entry(regs->orig_r0, regs->regs[16],
+			regs->regs[17], regs->regs[18], regs->regs[19]);
+	return regs->orig_r0;
 }
 
 asmlinkage void

--- a/arch/sw_64/kernel/setup.c
+++ b/arch/sw_64/kernel/setup.c
@@ -578,7 +578,7 @@ cmd_handle:
 
 static void __init setup_cpu_caps(void)
 {
-	if (!IS_ENABLED(CONFIG_SUBARCH_C3B) && !is_junzhang_v1())
+	if (cpuid(GET_FEATURES, 0) & CPU_FEAT_UNA)
 		static_branch_enable(&hw_una_enabled);
 }
 

--- a/arch/sw_64/kernel/smp.c
+++ b/arch/sw_64/kernel/smp.c
@@ -72,7 +72,7 @@ static void upshift_freq(void)
 	if (is_guest_or_emul())
 		return;
 
-	if (!sunway_machine_is_compatible("sunway,junzhang"))
+	if (!is_junzhang_v1())
 		return;
 
 	cpu_num = sw64_chip->get_cpu_num();
@@ -95,7 +95,7 @@ static void downshift_freq(void)
 	if (is_guest_or_emul())
 		return;
 
-	if (!sunway_machine_is_compatible("sunway,junzhang"))
+	if (!is_junzhang_v1())
 		return;
 
 	for_each_online_cpu(cpu) {

--- a/arch/sw_64/kernel/sys_sw64.c
+++ b/arch/sw_64/kernel/sys_sw64.c
@@ -346,7 +346,7 @@ asmlinkage void noinstr do_entSys(struct pt_regs *regs)
 
 	regs->orig_r0 = regs->regs[0];
 	regs->orig_r19 = regs->regs[19];
-	nr = regs->regs[0];
+	nr = regs->orig_r0;
 
 	if (ti_flags & _TIF_SYSCALL_WORK) {
 		nr = syscall_trace_enter();
@@ -369,8 +369,6 @@ asmlinkage void noinstr do_entSys(struct pt_regs *regs)
 			syscall_set_return_value(current, regs, -ENOSYS, 0);
 		if (nr == NO_SYSCALL)
 			goto syscall_out;
-		regs->orig_r0 = regs->regs[0];
-		regs->orig_r19 = regs->regs[19];
 	}
 
 	if (nr < __NR_syscalls) {

--- a/arch/sw_64/lib/iomap.c
+++ b/arch/sw_64/lib/iomap.c
@@ -262,8 +262,8 @@ EXPORT_SYMBOL(_memset_c_io);
 void __iomem *ioport_map(unsigned long port, unsigned int size)
 {
 	if (port >= 0x100000)
-		return ioremap(port, size);
+		return __va(port);
 
-	return ioremap((port << legacy_io_shift) | legacy_io_base, size);
+	return __va((port << legacy_io_shift) | legacy_io_base);
 }
 EXPORT_SYMBOL(ioport_map);

--- a/drivers/irqchip/irq-sunway-msi-v2.c
+++ b/drivers/irqchip/irq-sunway-msi-v2.c
@@ -233,6 +233,9 @@ static int __assign_irq_vector(int virq, unsigned int nr_irqs,
 	if (irqd_affinity_is_managed(irq_data)) {
 		mask = irq_data_get_affinity_mask(irq_data);
 		cpumask_and(&searchmask, mask, cpu_online_mask);
+
+		if (cpumask_empty(&searchmask))
+			return -EINVAL;
 	} else {
 		node = irq_data_get_node(irq_data);
 		cpumask_copy(&searchmask, cpumask_of_node(node));

--- a/drivers/irqchip/irq-sunway-msi.c
+++ b/drivers/irqchip/irq-sunway-msi.c
@@ -214,6 +214,9 @@ static int __assign_irq_vector(int virq, unsigned int nr_irqs,
 	if (irqd_affinity_is_managed(irq_data)) {
 		mask = irq_data_get_affinity_mask(irq_data);
 		cpumask_and(&searchmask, mask, cpu_online_mask);
+
+		if (cpumask_empty(&searchmask))
+			return -EINVAL;
 	} else {
 		node = irq_data_get_node(irq_data);
 		cpumask_copy(&searchmask, cpumask_of_node(node));

--- a/drivers/irqchip/irq-sunway-pci-intx.c
+++ b/drivers/irqchip/irq-sunway-pci-intx.c
@@ -60,6 +60,7 @@ static int __assign_piu_intx_config(struct intx_chip_data *chip_data,
 	unsigned int cpu;
 	int thread, node, core, rcid;
 	unsigned int i;
+	struct irq_data *irq_data;
 
 	if (is_guest_or_emul())
 		return 0;
@@ -89,6 +90,9 @@ static int __assign_piu_intx_config(struct intx_chip_data *chip_data,
 					(i << PCI_INTXCONFIG_OFFSET));
 		chip_data->intxconfig[i] = intxconfig;
 	}
+	irq_data = irq_get_irq_data(hose->int_irq);
+	irq_data_update_effective_affinity(irq_data, cpumask_of(cpu));
+
 	return 0;
 }
 

--- a/drivers/platform/sw64/powercap.c
+++ b/drivers/platform/sw64/powercap.c
@@ -243,6 +243,16 @@ static inline bool is_powercap_cpu_match(const struct sunway_powercap_cpu *data,
 	return true;
 }
 
+static inline bool is_powercap_enabled(const struct sunway_powercap_freq *freq)
+{
+	return !!(freq->flags & FREQ_FLAG_ENABLE);
+}
+
+static inline bool is_powercap_no_limit(const struct sunway_powercap_freq *freq)
+{
+	return !!(freq->flags & FREQ_FLAG_FREE);
+}
+
 static int sunway_powercap_validate_freq(const struct sunway_powercap_freq *freq,
 		struct sunway_powercap_ack *ack)
 {
@@ -268,6 +278,10 @@ static int sunway_powercap_validate_freq(const struct sunway_powercap_freq *freq
 		ack->flags |= ACK_FLAG_VALID_NODE;
 		ack->flags |= ACK_FLAG_VALID_CORE;
 
+		/* Make sure that the target freq field is meaningful */
+		if (!is_powercap_enabled(freq) || is_powercap_no_limit(freq))
+			return 0;
+
 		if (cpufreq_frequency_table_get_index(policy, target_freq) < 0) {
 			pr_err("invalid target freq %u\n", target_freq);
 			return -EINVAL;
@@ -282,16 +296,6 @@ out_validate_freq:
 	pr_err("invalid core %u on node %u\n", core, node);
 
 	return -EINVAL;
-}
-
-static inline bool is_powercap_enabled(const struct sunway_powercap_freq *freq)
-{
-	return !!(freq->flags & FREQ_FLAG_ENABLE);
-}
-
-static inline bool is_powercap_no_limit(const struct sunway_powercap_freq *freq)
-{
-	return !!(freq->flags & FREQ_FLAG_FREE);
 }
 
 static inline bool

--- a/drivers/platform/sw64/powercap.c
+++ b/drivers/platform/sw64/powercap.c
@@ -704,10 +704,10 @@ static int sunway_powercap_probe(struct platform_device *pdev)
 		struct freq_qos_request *req;
 
 		/* Initial state */
-		powercap_cpu_data[related_cpu].state = SUNWAY_POWERCAP_STATE_FREE;
+		powercap_cpu_data[cpu].state = SUNWAY_POWERCAP_STATE_FREE;
 
-		powercap_cpu_data[related_cpu].core = rcid_to_core_id(rcid);
-		powercap_cpu_data[related_cpu].node = rcid_to_domain_id(rcid);
+		powercap_cpu_data[cpu].core = rcid_to_core_id(rcid);
+		powercap_cpu_data[cpu].node = rcid_to_domain_id(rcid);
 
 		if (powercap_cpu_data[cpu].policy)
 			continue;

--- a/drivers/platform/sw64/powercap.c
+++ b/drivers/platform/sw64/powercap.c
@@ -18,6 +18,8 @@
 
 #define SUNWAY_POWERCAP_ACPI_NOTIFY_VALUE 0x84
 
+#define POLL_INTERVAL_UNIT_10MS 10
+
 enum sunway_powercap_version {
 	SUNWAY_POWERCAP_V1 = 1,
 	SUNWAY_POWERCAP_VERSION_MAX,
@@ -531,7 +533,7 @@ static int sunway_powercap_setup_cfg(const struct sunway_powercap_cfg *cfg)
 
 	driver_data.version = cfg->version;
 	driver_data.mode = cfg->mode;
-	driver_data.poll_interval = cfg->poll_interval;
+	driver_data.poll_interval = cfg->poll_interval * POLL_INTERVAL_UNIT_10MS;
 
 	if (is_poll_mode) {
 		timer_setup(&driver_data.timer, sunway_powercap_poll_func, 0);


### PR DESCRIPTION
Link:https://gitcode.com/deepin-community/kernel/pull/10

## Summary by Sourcery

Update SW64 architecture patches in Linux 6.6 to enhance powercap management, syscall handling, hardware setup, IRQ affinity, SMP scaling, I/O mapping, and CPU feature detection

Bug Fixes:
- Fix CPU data initialization index in sunway_powercap_probe to use the correct cpu variable
- Enforce error when IRQ MSI and MSI-V2 cpumask is empty to avoid invalid affinity assignment
- Ensure syscall tracing and syscall_get_nr consistently use regs->orig_r0 for correct syscall number

Enhancements:
- Parameterize powercap polling interval with POLL_INTERVAL_UNIT_10MS and skip validation for disabled or unlimited flags
- Introduce nearly helper inline functions for powercap flag checks
- Optimize ioport_map to map ports via __va instead of ioremap
- Guard SMBIOS DMI lookups under CONFIG_EFI and mark related functions __maybe_unused
- Provide no-op stubs for pcie_save/restore when PCI support is disabled
- Replace sunway_machine_is_compatible checks with is_junzhang_v1 for SMP frequency shifts
- Add effective IRQ affinity update in irq-sunway-pci-intx driver
- Shift CPU UNA feature detection to use CPUID GET_FEATURES flag instead of subarchitecture macro