### PR TITLE
CIX ：Integrate ACPI support and SCMI protocol adaptations for CIX platform

### DIFF
--- a/drivers/acpi/property.c
+++ b/drivers/acpi/property.c
@@ -1009,6 +1009,64 @@ int __acpi_node_get_property_reference(const struct fwnode_handle *fwnode,
 }
 EXPORT_SYMBOL_GPL(__acpi_node_get_property_reference);
 
+int __acpi_node_count_property_reference(const struct fwnode_handle *fwnode,
+	const char *propname)
+{
+	const union acpi_object *element, *end;
+	const union acpi_object *obj;
+	const struct acpi_device_data *data;
+	struct acpi_device *device;
+	int ret, idx = 0;
+
+	data = acpi_device_data_of_node(fwnode);
+	if (!data)
+		return -ENOENT;
+
+	ret = acpi_data_get_property(data, propname, ACPI_TYPE_ANY, &obj);
+	if (ret)
+		return ret == -EINVAL ? -ENOENT : -EINVAL;
+
+	switch (obj->type) {
+	case ACPI_TYPE_LOCAL_REFERENCE:
+		return 1;
+	case ACPI_TYPE_PACKAGE:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	element = obj->package.elements;
+	end = element + obj->package.count;
+
+	while (element < end) {
+		switch (element->type) {
+		case ACPI_TYPE_LOCAL_REFERENCE:
+			device = acpi_fetch_acpi_dev(element->reference.handle);
+			if (!device)
+				return -EINVAL;
+
+			element++;
+
+			ret = acpi_get_ref_args(NULL, acpi_fwnode_handle(device),
+						&element, end, NR_FWNODE_REFERENCE_ARGS);
+			if (ret < 0)
+				return ret;
+
+			break;
+		case ACPI_TYPE_INTEGER:
+			element++;
+			break;
+		default:
+			return -EINVAL;
+		}
+
+		idx++;
+	}
+
+	return idx;
+}
+EXPORT_SYMBOL_GPL(__acpi_node_count_property_reference);
+
 static int acpi_data_prop_read_single(const struct acpi_device_data *data,
 				      const char *propname,
 				      enum dev_prop_type proptype, void *val)
@@ -1536,6 +1594,13 @@ acpi_fwnode_get_reference_args(const struct fwnode_handle *fwnode,
 						  args_count, args);
 }
 
+static int
+acpi_fwnode_count_reference_with_args(const struct fwnode_handle *fwnode,
+			       const char *list_name, const char *cells_name)
+{
+	return __acpi_node_count_property_reference(fwnode, list_name);
+}
+
 static const char *acpi_fwnode_get_name(const struct fwnode_handle *fwnode)
 {
 	const struct acpi_device *adev;
@@ -1641,6 +1706,7 @@ static int acpi_fwnode_irq_get(const struct fwnode_handle *fwnode,
 		.graph_get_port_parent = acpi_fwnode_get_parent,	\
 		.graph_parse_endpoint = acpi_fwnode_graph_parse_endpoint, \
 		.irq_get = acpi_fwnode_irq_get,				\
+		.property_count_reference_with_args = acpi_fwnode_count_reference_with_args, \
 	};								\
 	EXPORT_SYMBOL_GPL(ops)
 

--- a/drivers/base/property.c
+++ b/drivers/base/property.c
@@ -543,6 +543,18 @@ int fwnode_property_get_reference_args(const struct fwnode_handle *fwnode,
 }
 EXPORT_SYMBOL_GPL(fwnode_property_get_reference_args);
 
+int fwnode_count_reference_with_args(const struct fwnode_handle *fwnode,
+			       const char *list_name, const char *cells_name)
+{
+
+	if (IS_ERR_OR_NULL(fwnode))
+		return -ENOENT;
+
+	return fwnode_call_int_op(fwnode,
+			property_count_reference_with_args, list_name, cells_name);
+}
+EXPORT_SYMBOL_GPL(fwnode_count_reference_with_args);
+
 /**
  * fwnode_find_reference - Find named reference to a fwnode_handle
  * @fwnode: Firmware node where to look for the reference

--- a/drivers/of/property.c
+++ b/drivers/of/property.c
@@ -1431,6 +1431,13 @@ static int of_fwnode_add_links(struct fwnode_handle *fwnode)
 	return 0;
 }
 
+static int of_count_phandle_with_fwnode_args(
+		const struct fwnode_handle *fwnode,
+		const char *list_name, const char *cells_name)
+{
+	return of_count_phandle_with_args(to_of_node(fwnode), list_name, cells_name);
+}
+
 const struct fwnode_operations of_fwnode_ops = {
 	.get = of_fwnode_get,
 	.put = of_fwnode_put,
@@ -1454,5 +1461,6 @@ const struct fwnode_operations of_fwnode_ops = {
 	.iomap = of_fwnode_iomap,
 	.irq_get = of_fwnode_irq_get,
 	.add_links = of_fwnode_add_links,
+	.property_count_reference_with_args = of_count_phandle_with_fwnode_args,
 };
 EXPORT_SYMBOL_GPL(of_fwnode_ops);

--- a/include/linux/acpi.h
+++ b/include/linux/acpi.h
@@ -1303,6 +1303,8 @@ int acpi_dev_get_property(const struct acpi_device *adev, const char *name,
 int __acpi_node_get_property_reference(const struct fwnode_handle *fwnode,
 				const char *name, size_t index, size_t num_args,
 				struct fwnode_reference_args *args);
+int __acpi_node_count_property_reference(const struct fwnode_handle *fwnode,
+	const char *name);
 
 static inline int acpi_node_get_property_reference(
 				const struct fwnode_handle *fwnode,

--- a/include/linux/fwnode.h
+++ b/include/linux/fwnode.h
@@ -171,6 +171,9 @@ struct fwnode_operations {
 	void __iomem *(*iomap)(struct fwnode_handle *fwnode, int index);
 	int (*irq_get)(const struct fwnode_handle *fwnode, unsigned int index);
 	int (*add_links)(struct fwnode_handle *fwnode);
+	int (*property_count_reference_with_args)(
+		const struct fwnode_handle *fwnode, const char *list_name,
+		const char *cells_name);
 
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)

--- a/include/linux/property.h
+++ b/include/linux/property.h
@@ -129,6 +129,9 @@ int fwnode_property_get_reference_args(const struct fwnode_handle *fwnode,
 				       unsigned int nargs, unsigned int index,
 				       struct fwnode_reference_args *args);
 
+int fwnode_count_reference_with_args(const struct fwnode_handle *fwnode,
+			       const char *list_name, const char *cells_name);
+
 struct fwnode_handle *fwnode_find_reference(const struct fwnode_handle *fwnode,
 					    const char *name,
 					    unsigned int index);


### PR DESCRIPTION
This patch series includes:

1. Add a property reference count interface for ACPI.
2. Adapt SCMI protocols to support ACPI.
3. ACPI regulator adaptations.
4. Add CIX CPU platform check interface.
5. Adapt PCIE driver for ACPI.
6. Add a fwnode interface for ACPI to find panel.
7. Adapt linlon-dp driver for ACPI.
8. Update clk gate operation and set rate after enabling clk.
9. Update DMA driver to fix power bugs.
10. Update DSP remoteproc driver.
11. Sync PDC IRQ hardware numbers with GIC.
12. Update PD driver rts5453.
13. Update gpio-cadence driver.
14. Update CIX I2C driver.