### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] jfs: add check read-only before txBeginAnon() call

### DIFF
--- a/fs/jfs/jfs_extent.c
+++ b/fs/jfs/jfs_extent.c
@@ -74,6 +74,11 @@ extAlloc(struct inode *ip, s64 xlen, s64 pno, xad_t * xp, bool abnr)
 	int rc;
 	int xflag;
 
+	if (isReadOnly(ip)) {
+		jfs_error(ip->i_sb, "read-only filesystem\n");
+		return -EIO;
+	}
+
 	/* This blocks if we are low on resources */
 	txBeginAnon(ip->i_sb);
 
@@ -252,6 +257,11 @@ out:
 int extRecord(struct inode *ip, xad_t * xp)
 {
 	int rc;
+
+	if (isReadOnly(ip)) {
+		jfs_error(ip->i_sb, "read-only filesystem\n");
+		return -EIO;
+	}
 
 	txBeginAnon(ip->i_sb);
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.15-rc1
commit 0176e69743ecc02961f2ae1ea42439cd2bf9ed58
category: bugfix
CVE: CVE-2024-58095

Reference: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=0176e69743ecc02961f2ae1ea42439cd2bf9ed58

--------------------------------

Added a read-only check before calling `txBeginAnon` in `extAlloc` and `extRecord`. This prevents modification attempts on a read-only mounted filesystem, avoiding potential errors or crashes.

Call trace:
 txBeginAnon+0xac/0x154
 extAlloc+0xe8/0xdec fs/jfs/jfs_extent.c:78
 jfs_get_block+0x340/0xb98 fs/jfs/inode.c:248
 __block_write_begin_int+0x580/0x166c fs/buffer.c:2128
 __block_write_begin fs/buffer.c:2177 [inline]
 block_write_begin+0x98/0x11c fs/buffer.c:2236
 jfs_write_begin+0x44/0x88 fs/jfs/inode.c:299

Fixes: 1da177e4c3f4 ("Linux-2.6.12-rc2")
Reported-by: syzbot+4e89b5368baba8324e07@syzkaller.appspotmail.com
Link: https://syzkaller.appspot.com/bug?extid=4e89b5368baba8324e07


(cherry picked from commit 0176e69743ecc02961f2ae1ea42439cd2bf9ed58)

## Summary by Sourcery

Bug Fixes:
- Add read-only filesystem checks before txBeginAnon calls in JFS extAlloc and extRecord to prevent writes on read-only mounts