### PR TITLE
drivers: net: linkdata: Fix KASAN build error on Kunpeng 920

### DIFF
--- a/drivers/net/ethernet/linkdata/sxe/sxepf/sxe_ptp.c
+++ b/drivers/net/ethernet/linkdata/sxe/sxepf/sxe_ptp.c
@@ -566,7 +566,7 @@ l_ret:
 
 int sxe_ptp_hw_tstamp_config_set(struct sxe_adapter *adapter, struct ifreq *ifr)
 {
-	struct hwtstamp_config config;
+	struct hwtstamp_config config = {0};
 	int ret;
 
 	if (copy_from_user(&config, ifr->ifr_data, sizeof(config))) {


### PR DESCRIPTION
When enabling CONFIG_KASAN on Kunpeng 920 ARM servers, compiling the linkdata sxe ptp driver fails with a "-Werror=maybe-uninitialized" error for the 'config' variable in 'sxe_ptp_hw_tstamp_config_set()'.

The compiler—augmented by KASAN's strict checks—flags `config` as potentially uninitialized. Even though `copy_from_user()` initializes it in valid execution paths, the compiler cannot infer this for all code paths, triggering the warning.

Initialize `struct hwtstamp_config config` to zero to silence the warning and resolve the KASAN-enabled build failure on Kunpeng 920.

## Summary by Sourcery

Bug Fixes:
- Initialize hwtstamp_config config to zero to silence the maybe-uninitialized warning under KASAN