### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] fwnode: Fix kabi breakage due to reference count interface

### DIFF
--- a/include/linux/deepin_kabi.h
+++ b/include/linux/deepin_kabi.h
@@ -31,6 +31,7 @@
 #ifndef _LINUX_DEEPIN_KABI_H
 #define _LINUX_DEEPIN_KABI_H
 
+#include <linux/args.h>
 #include <linux/kconfig.h>
 #include <linux/compiler.h>
 #include <linux/stringify.h>

--- a/include/linux/fwnode.h
+++ b/include/linux/fwnode.h
@@ -171,11 +171,10 @@ struct fwnode_operations {
 	void __iomem *(*iomap)(struct fwnode_handle *fwnode, int index);
 	int (*irq_get)(const struct fwnode_handle *fwnode, unsigned int index);
 	int (*add_links)(struct fwnode_handle *fwnode);
-	int (*property_count_reference_with_args)(
-		const struct fwnode_handle *fwnode, const char *list_name,
-		const char *cells_name);
 
-	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_USE(1, int (*property_count_reference_with_args)(
+		const struct fwnode_handle *fwnode, const char *list_name,
+		const char *cells_name))
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)


### PR DESCRIPTION
fwnode: Fix kabi breakage due to reference count interface
deepin inclusion
category: kabi

Fixes: https://github.com/deepin-community/kernel/commit/12cd73c440fa5aa1f107b24da57bdac428637900 ("Add a property reference count interface for ACPI.")
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

kABI: Fix kABI macros use COUNT_ARGS
deepin inclusion
category: bugfix

commit https://github.com/deepin-community/kernel/commit/b229baa374dbb1bb47dccad2cc8887d9438ca3e7 ("kernel.h: split out COUNT_ARGS() and CONCATENATE() to args.h")
move COUNT_ARGS to linux/args.h, it lead to make some headers not include it.
lead to strange build failed when use KABI_USE.
It can be reproduced in original rh_kabi.h(use centos 10) + upstream 6.6 in fwnode.h,
and commit https://github.com/deepin-community/kernel/commit/1dc05a274a7b13fd61b6c43f0136153752e6f731 ("device property: Replace custom implementation of COUNT_ARGS()")
include args.h, so it cannot be reproduced after v6.7 upstream.

Log:
In file included from ./include/linux/property.h:15,
                 from drivers/base/firmware_loader/fallback_platform.c:4:
./include/linux/fwnode.h:178:8: error: macro "_RH_KABI_REPLACE" requires 2 arguments, but only 1 given
  178 |         RH_KABI_USE(1, int b)
      | ^       ~~~~~~~~~~~~~~~~~~~~~
In file included from ./include/linux/fwnode.h:130:
./include/linux/rh_kabi.h:441: note: macro "_RH_KABI_REPLACE" defined here
  441 | # define _RH_KABI_REPLACE(_orig, _new)                    \
      |
./include/linux/rh_kabi.h:490:33: error: expected specifier-qualifier-list before ‘_RH_KABI_REPLACE’
  490 | #define _RH_KABI_USE(...)       _RH_KABI_REPLACE(__VA_ARGS__)
      |                                 ^~~~~~~~~~~~~~~~
./include/linux/rh_kabi.h:491:33: note: in expansion of macro ‘_RH_KABI_USE’
  491 | #define RH_KABI_USE(n, ...)     _RH_KABI_USE(__PASTE(_RH_KABI_USE, COUNT_ARGS(__VA_ARGS__))(n, __VA_ARGS__));
      |                                 ^~~~~~~~~~~~
./include/linux/fwnode.h:178:9: note: in expansion of macro ‘RH_KABI_USE’
  178 |         RH_KABI_USE(1, int b)

Fixes: https://github.com/deepin-community/kernel/commit/50839500544dbac370097932898d833d3acabf03 ("kABI: Introduce generic kABI macros to use for kABI workarounds")
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

## Summary by Sourcery

Fix build failures in the fwnode reference count interface by ensuring kABI macros have the required COUNT_ARGS definition and properly exposing the new operation slot.

Bug Fixes:
- Include <linux/args.h> in deepin_kabi.h so COUNT_ARGS is available for kABI macros
- Use DEEPIN_KABI_USE for property_count_reference_with_args in fwnode.h instead of reserving the slot to correctly apply the kABI replacement