### PR TITLE
fs: deepin_err_notify: add admin permission flag to multicast group

### DIFF
--- a/fs/deepin_err_notify.c
+++ b/fs/deepin_err_notify.c
@@ -115,6 +115,7 @@ void deepin_check_and_notify_ro_fs_err(const struct path *path,
 static const struct genl_multicast_group deepin_err_notify_nl_mcgrps[] = {
 	{
 		.name = "ro_fs_events",
+		.flags = GENL_UNS_ADMIN_PERM,
 	},
 };
 


### PR DESCRIPTION
This patch adds the GENL_UNS_ADMIN_PERM flag to the "ro_fs_events"
multicast group in the deepin_err_notify module, ensuring that only
users with administrative permissions can access this group.

Signed-off-by: electricface <songwentai@uniontech.com>

## Summary by Sourcery

Enhancements:
- Restrict the "ro_fs_events" multicast group to administrative users by adding the GENL_UNS_ADMIN_PERM flag