### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] perf: Fix dangling cgroup pointer in cpuctx

### DIFF
--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -2056,18 +2056,6 @@ list_del_event(struct perf_event *event, struct perf_event_context *ctx)
 	if (event->group_leader == event)
 		del_event_from_groups(event, ctx);
 
-	/*
-	 * If event was in error state, then keep it
-	 * that way, otherwise bogus counts will be
-	 * returned on read(). The only way to get out
-	 * of error state is by explicit re-enabling
-	 * of the event
-	 */
-	if (event->state > PERF_EVENT_STATE_OFF) {
-		perf_cgroup_event_disable(event, ctx);
-		perf_event_set_state(event, PERF_EVENT_STATE_OFF);
-	}
-
 	ctx->generation++;
 	event->pmu_ctx->nr_events--;
 }
@@ -2381,11 +2369,14 @@ __perf_remove_from_context(struct perf_event *event,
 	 */
 	if (flags & DETACH_EXIT)
 		state = PERF_EVENT_STATE_EXIT;
-	if (flags & DETACH_DEAD) {
-		event->pending_disable = 1;
+	if (flags & DETACH_DEAD)
 		state = PERF_EVENT_STATE_DEAD;
-	}
+
 	event_sched_out(event, ctx);
+
+	if (event->state > PERF_EVENT_STATE_OFF)
+		perf_cgroup_event_disable(event, ctx);
+
 	perf_event_set_state(event, min(event->state, state));
 	if (flags & DETACH_GROUP)
 		perf_group_detach(event);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.16-rc3
commit 12b6c62c038e85354154aee4eb2cf7a2168b3ecc
category: bugfix

Reference: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=12b6c62c038e85354154aee4eb2cf7a2168b3ecc

--------------------------------

Commit a3c3c6667("perf/core: Fix child_total_time_enabled accounting bug at task exit") moves the event->state update to before list_del_event(). This makes the event->state test in list_del_event() always false; never calling perf_cgroup_event_disable().

As a result, cpuctx->cgrp won't be cleared properly; causing havoc.

Fixes: a3c3c6667("perf/core: Fix child_total_time_enabled accounting bug at task exit")
Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>
Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Tested-by: David Wang <00107082@163.com>
Link: https://lore.kernel.org/all/aD2TspKH%2F7yvfYoO@e129823.arm.com/ (cherry picked from commit 3b7a34aebbdf2a4b7295205bf0c654294283ec82)
Signed-off-by: Wentao Guan <guanwentao@uniontech.com>

Conflicts:
	kernel/events/core.c

## Summary by Sourcery

Restore correct cgroup cleanup for perf events by moving perf_cgroup_event_disable to __perf_remove_from_context and removing outdated disable logic from list_del_event, fixing dangling cgroup pointers in CPU contexts

Bug Fixes:
- Re-enable cgroup event disable in __perf_remove_from_context for events with non-off state to clear dangling cgroup pointers
- Remove obsolete disable logic from list_del_event that blocked perf_cgroup_event_disable