### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] exfat: fix double free in delayed_free

### DIFF
--- a/fs/exfat/nls.c
+++ b/fs/exfat/nls.c
@@ -804,4 +804,5 @@ load_default:
 void exfat_free_upcase_table(struct exfat_sb_info *sbi)
 {
 	kvfree(sbi->vol_utbl);
+	sbi->vol_utbl = NULL;
 }


### PR DESCRIPTION
mainline inclusion
from mainline-v6.16-rc1
category: bugfix
CVE: CVE-2025-38206

The double free could happen in the following path.

exfat_create_upcase_table()
        exfat_create_upcase_table() : return error
        exfat_free_upcase_table() : free ->vol_utbl
        exfat_load_default_upcase_table : return error
     exfat_kill_sb()
           delayed_free()
                  exfat_free_upcase_table() <--------- double free
This patch set ->vol_util as NULL after freeing it.

Reported-by: Jianzhou Zhao <xnxc22xnxc22@qq.com>

(cherry picked from commit 1f3d9724e16d62c7d42c67d6613b8512f2887c22)

## Summary by Sourcery

Bug Fixes:
- Null out sbi->vol_utbl after kvfree to avoid a double free in delayed_free