### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] deepin: config: disable 3snic date and default config

### DIFF
--- a/drivers/net/ethernet/3snic/sssnic/Kconfig
+++ b/drivers/net/ethernet/3snic/sssnic/Kconfig
@@ -7,7 +7,6 @@ config SSSNIC
 	tristate "3SNIC Ethernet Controller SSSNIC Support"
 	depends on PCI
 	depends on ARM64 || X86_64
-	default y
 	help
 	  This driver supports 3SNIC Ethernet Controller SSSNIC device.
 	  For more information about this product, go to the product

--- a/drivers/net/ethernet/3snic/sssnic/nic/Makefile
+++ b/drivers/net/ethernet/3snic/sssnic/nic/Makefile
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 3SNIC
 #
 
-SYS_TIME=$(shell date +%Y-%m-%d_%H:%M:%S)
+SYS_TIME=2025-11-20_10:13:25
 ccflags-y += -D __TIME_STR__=\"$(SYS_TIME)\"
 
 ccflags-y += -I$(srctree)/drivers/net/ethernet/3snic/sssnic/include


### PR DESCRIPTION
deepin inclusion
category: other

## Summary by Sourcery

Fix the 3snic driver configuration by removing dynamic date stamping and disabling its default Kconfig selection

Enhancements:
- Hardcode the 3snic driver build timestamp to a fixed value instead of using the date command
- Disable the 3snic driver default configuration entry in Kconfig