### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] deepin: arm64: cpufeature: disable LSE on UMA

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3065,6 +3065,9 @@
 	ltpc=		[NET]
 			Format: <io>,<irq>,<dma>
 
+	lse_disable_force [ARM64]
+			Force disable LSE without detect, default off.
+
 	lse_disable_on_uma [ARM64]
 			Disable LSE (Large System Extension) atomic instructions
 			on UMA (Uniform Memory Access) systems to improve

--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3065,6 +3065,27 @@
 	ltpc=		[NET]
 			Format: <io>,<irq>,<dma>
 
+	lse_disable_on_uma [ARM64]
+			Disable LSE (Large System Extension) atomic instructions
+			on UMA (Uniform Memory Access) systems to improve
+			performance of per-CPU atomic operations. LSE atomics can
+			exhibit significant overhead on certain microarchitectures
+			(e.g., Neoverse V2) due to "far atomic" implementations
+			bypassing L1 cache. LL/SC (Load-Link/Store-Conditional)
+			is substantially faster for uncontended per-CPU workloads
+			typical on UMA systems.
+
+			The default value is 1 (enabled), which automatically
+			disables LSE on single-node (UMA) systems. Set to 0 to
+			force LSE enablement on UMA systems regardless of
+			performance impact.
+
+			When this feature is active, the kernel logs:
+			"LSE atomics: disabled on UMA, use lse_disable_on_uma=0 to enable."
+
+			NUMA systems are unaffected and continue using hardware
+			detected LSE capability normally.
+
 	lsm.debug	[SECURITY] Enable LSM initialization debugging output.
 
 	lsm=lsm1,...,lsmN

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1540,6 +1540,14 @@ static bool has_32bit_el0(const struct arm64_cpu_capabilities *entry, int scope)
 	return true;
 }
 
+static bool lse_disable_force __read_mostly;
+
+static int __init arm64_lse_disable_force_setup(char *str)
+{
+	return kstrtobool(str, &lse_disable_force);
+}
+early_param("lse_disable_force", arm64_lse_disable_force_setup);
+
 static bool lse_disable_on_uma __read_mostly = true;  // UMA decision enabled by default
 
 static int __init arm64_lse_disable_on_uma_setup(char *str)
@@ -1552,6 +1560,12 @@ static bool has_lse_capability_uma_aware(const struct arm64_cpu_capabilities *ca
 										 int scope)
 {
 	int num_nodes = num_possible_nodes();
+
+	if (lse_disable_force) {
+		if (scope == SCOPE_SYSTEM && smp_processor_id() == 0)
+			pr_info("LSE atomics: force disabled by lse_disable_force=1.\n");
+		return false;
+	}
 
 	/* UMA system: disable LSE when lse_disable_on_uma is enabled */
 	if (num_nodes <= 1 && lse_disable_on_uma) {

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1540,6 +1540,30 @@ static bool has_32bit_el0(const struct arm64_cpu_capabilities *entry, int scope)
 	return true;
 }
 
+static bool lse_disable_on_uma __read_mostly = true;  // UMA decision enabled by default
+
+static int __init arm64_lse_disable_on_uma_setup(char *str)
+{
+	return kstrtobool(str, &lse_disable_on_uma);
+}
+early_param("lse_disable_on_uma", arm64_lse_disable_on_uma_setup);
+
+static bool has_lse_capability_uma_aware(const struct arm64_cpu_capabilities *cap,
+										 int scope)
+{
+	int num_nodes = num_possible_nodes();
+
+	/* UMA system: disable LSE when lse_disable_on_uma is enabled */
+	if (num_nodes <= 1 && lse_disable_on_uma) {
+		if (scope == SCOPE_SYSTEM && smp_processor_id() == 0)
+			pr_info("LSE atomics: disabled on UMA, use lse_disable_on_uma=0 to enable.\n");
+		return false;
+	}
+
+	/* NUMA system or user disabled the feature, use hardware capability */
+	return has_cpuid_feature(cap, scope);
+}
+
 static bool has_useable_gicv3_cpuif(const struct arm64_cpu_capabilities *entry, int scope)
 {
 	bool has_sre;
@@ -2348,7 +2372,7 @@ static const struct arm64_cpu_capabilities arm64_features[] = {
 		.desc = "LSE atomic instructions",
 		.capability = ARM64_HAS_LSE_ATOMICS,
 		.type = ARM64_CPUCAP_SYSTEM_FEATURE,
-		.matches = has_cpuid_feature,
+		.matches = has_lse_capability_uma_aware,
 		ARM64_CPUID_FIELDS(ID_AA64ISAR0_EL1, ATOMIC, IMP)
 	},
 #endif /* CONFIG_ARM64_LSE_ATOMICS */


### PR DESCRIPTION
deepin inclusion
category: performance

Disable LSE (Large System Extension) atomic instructions on UMA (Uniform Memory Access) systems to improve
performance of per-CPU atomic operations. LSE atomics can exhibit significant overhead on certain microarchitectures (e.g., Neoverse V2) due to "far atomic" implementations bypassing L1 cache [1]. LL/SC (Load-Link/Store-Conditional) is substantially faster for uncontended per-CPU workloads typical on UMA systems.

The default value is 1 (enabled), which automatically disables LSE on single-node (UMA) systems. Set to 0 to force LSE enablement on UMA systems regardless of
performance impact.
When this feature is active, the kernel logs:
"LSE atomics: disabled on UMA, use lse_disable_on_uma=0 to enable."

NUMA systems are unaffected and continue using hardware detected LSE capability normally.

PS:
Test with byte-unixbench6 in kp920 24c and 64GB memory, improve whole scores by 3.8%.

Link: https://lore.kernel.org/r/e7d539ed-ced0-4b96-8ecd-048a5b803b85@paulmck-laptop [1]

## Summary by Sourcery

Disable LSE atomics on single-node UMA systems by default to improve per-CPU atomic performance, add an lse_disable_on_uma kernel parameter to override the behavior, and update documentation.

New Features:
- Add lse_disable_on_uma early kernel parameter to control disabling of LSE atomics on UMA systems

Enhancements:
- Automatically disable LSE atomics on UMA systems by default while leaving NUMA systems unaffected
- Emit an informational log on CPU0 when LSE atomics are disabled on UMA

Documentation:
- Document the lse_disable_on_uma kernel parameter in kernel-parameters.txt