### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] ksmbd: transport_ipc: validate payload size before reading handle

### DIFF
--- a/fs/smb/server/transport_ipc.c
+++ b/fs/smb/server/transport_ipc.c
@@ -249,9 +249,15 @@ static void ipc_msg_handle_free(int handle)
 
 static int handle_response(int type, void *payload, size_t sz)
 {
-	unsigned int handle = *(unsigned int *)payload;
+	unsigned int handle;
 	struct ipc_msg_table_entry *entry;
 	int ret = 0;
+
+	/* Prevent 4-byte read beyond declared payload size */
+	if (sz < sizeof(unsigned int))
+		return -EINVAL;
+
+	handle = *(unsigned int *)payload;
 
 	ipc_update_last_active();
 	down_read(&ipc_msg_table_lock);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.18-rc4
category: bugfix
CVE: CVE-2025-40084

handle_response() dereferences the payload as a 4-byte handle without verifying that the declared payload size is at least 4 bytes. A malformed or truncated message from ksmbd.mountd can lead to a 4-byte read past the declared payload size. Validate the size before dereferencing.

This is a minimal fix to guard the initial handle read.

Fixes: 0626e6641f6b ("cifsd: add server handler for central processing and tranport layers")
Cc: stable@vger.kernel.org
Reported-by: Qianchang Zhao <pioooooooooip@gmail.com>

Acked-by: Namjae Jeon <linkinjeon@kernel.org>

(cherry picked from commit 6f40e50ceb99fc8ef37e5c56e2ec1d162733fef0)

## Summary by Sourcery

Bug Fixes:
- Add a check in handle_response() to ensure the payload is at least 4 bytes before reading the handle