### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Backport] ASoC: SOF: ipc4-topology: Harden loops for looking up ALH copiers

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -602,8 +602,14 @@ static int sof_ipc4_widget_setup_comp_dai(struct snd_sof_widget *swidget)
 		}
 
 		list_for_each_entry(w, &sdev->widget_list, list) {
-			if (w->widget->sname &&
+			struct snd_sof_dai *alh_dai;
+
+			if (!WIDGET_IS_DAI(w->id) || !w->widget->sname ||
 			    strcmp(w->widget->sname, swidget->widget->sname))
+				continue;
+
+			alh_dai = w->private;
+			if (alh_dai->type != SOF_DAI_INTEL_ALH)
 				continue;
 
 			blob->alh_cfg.device_count++;
@@ -1901,11 +1907,13 @@ sof_ipc4_prepare_copier_module(struct snd_sof_widget *swidget,
 			 */
 			i = 0;
 			list_for_each_entry(w, &sdev->widget_list, list) {
-				if (w->widget->sname &&
+				if (!WIDGET_IS_DAI(w->id) || !w->widget->sname ||
 				    strcmp(w->widget->sname, swidget->widget->sname))
 					continue;
 
 				dai = w->private;
+				if (dai->type != SOF_DAI_INTEL_ALH)
+					continue;
 				alh_copier = (struct sof_ipc4_copier *)dai->private;
 				alh_data = &alh_copier->data;
 				blob->alh_cfg.mapping[i].device = alh_data->gtw_cfg.node_id;

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -558,6 +558,7 @@ static int sof_ipc4_widget_setup_comp_dai(struct snd_sof_widget *swidget)
 	dev_dbg(scomp->dev, "dai %s node_type %u dai_type %u dai_index %d\n", swidget->widget->name,
 		node_type, ipc4_copier->dai_type, ipc4_copier->dai_index);
 
+	dai->type = ipc4_copier->dai_type;
 	ipc4_copier->data.gtw_cfg.node_id = SOF_IPC4_NODE_TYPE(node_type);
 
 	pipe_widget = swidget->spipe->pipe_widget;

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -521,6 +521,7 @@ struct snd_sof_route {
 struct snd_sof_dai {
 	struct snd_soc_component *scomp;
 	const char *name;
+	u32 type;
 
 	int number_configs;
 	int current_config;

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -2355,7 +2355,10 @@ static int sof_dspless_widget_ready(struct snd_soc_component *scomp, int index,
 				    struct snd_soc_tplg_dapm_widget *tw)
 {
 	if (WIDGET_IS_DAI(w->id)) {
+		static const struct sof_topology_token dai_tokens[] = {
+			{SOF_TKN_DAI_TYPE, SND_SOC_TPLG_TUPLE_TYPE_STRING, get_token_dai_type, 0}};
 		struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
+		struct snd_soc_tplg_private *priv = &tw->priv;
 		struct snd_sof_widget *swidget;
 		struct snd_sof_dai *sdai;
 		int ret;
@@ -2368,6 +2371,15 @@ static int sof_dspless_widget_ready(struct snd_soc_component *scomp, int index,
 		if (!sdai) {
 			kfree(swidget);
 			return -ENOMEM;
+		}
+
+		ret = sof_parse_tokens(scomp, &sdai->type, dai_tokens, ARRAY_SIZE(dai_tokens),
+				       priv->array, le32_to_cpu(priv->size));
+		if (ret < 0) {
+			dev_err(scomp->dev, "Failed to parse DAI tokens for %s\n", tw->name);
+			kfree(swidget);
+			kfree(sdai);
+			return ret;
 		}
 
 		ret = sof_connect_dai_widget(scomp, w, tw, sdai);


### PR DESCRIPTION
Peter Ujfalusi (1):
  ASoC: SOF: ipc4-topology: Harden loops for looking up ALH copiers

Ranjani Sridharan (1):
  ASoC: SOF: topology: Parse DAI type token for dspless mode

 sound/soc/sof/ipc4-topology.c | 13 +++++++++++--
 sound/soc/sof/sof-audio.h     |  1 +
 sound/soc/sof/topology.c      | 12 ++++++++++++
 3 files changed, 24 insertions(+), 2 deletions(-)

## Summary by Sourcery

Harden ALH copier discovery in IPC4 topology by filtering on widget type and add support for parsing DAI type tokens in dspless mode.

New Features:
- Parse DAI type token in dspless topology to initialize DAI type before connecting widgets.

Enhancements:
- Add 'type' field to snd_sof_dai and set it from IPC4 copier dai_type information.
- Harden loops in IPC4 topology to skip non-DAI widgets and only match Intel ALH copiers during setup and preparation.