### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] ACPI: video: Fix use-after-free in acpi_video_switch_brightness()

### DIFF
--- a/drivers/acpi/acpi_video.c
+++ b/drivers/acpi/acpi_video.c
@@ -1952,8 +1952,10 @@ static void acpi_video_bus_remove_notify_handler(struct acpi_video_bus *video)
 	struct acpi_video_device *dev;
 
 	mutex_lock(&video->device_list_lock);
-	list_for_each_entry(dev, &video->video_device_list, entry)
+	list_for_each_entry(dev, &video->video_device_list, entry) {
 		acpi_video_dev_remove_notify_handler(dev);
+		cancel_delayed_work_sync(&dev->switch_brightness_work);
+	}
 	mutex_unlock(&video->device_list_lock);
 
 	acpi_video_bus_stop_devices(video);


### PR DESCRIPTION
ACPI: video: Fix use-after-free in acpi_video_switch_brightness()
    
    commit 8f067aa59430266386b83c18b983ca583faa6a11 upstream.
    
    The switch_brightness_work delayed work accesses device->brightness
    and device->backlight, freed by acpi_video_dev_unregister_backlight()
    during device removal.
    
    If the work executes after acpi_video_bus_unregister_backlight()
    frees these resources, it causes a use-after-free when
    acpi_video_switch_brightness() dereferences device->brightness or
    device->backlight.
    
    Fix this by calling cancel_delayed_work_sync() for each device's
    switch_brightness_work in acpi_video_bus_remove_notify_handler()
    after removing the notify handler that queues the work. This ensures
    the work completes before the memory is freed.
    
    Fixes: 8ab58e8e7e097 ("ACPI / video: Fix backlight taking 2 steps on a brightness up/down keypress")
    Cc: All applicable <stable@vger.kernel.org>
    Signed-off-by: Yuhao Jiang <danisjiang@gmail.com>
    Reviewed-by: Hans de Goede <hansg@kernel.org>
    [ rjw: Changelog edit ]
    Link: https://patch.msgid.link/20251022200704.2655507-1-danisjiang@gmail.com
    Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
    Signed-off-by: WangYuli <wangyl5933@chinaunicom.cn>

## Summary by Sourcery

Prevent use-after-free in ACPI video brightness handling and extend Intel Speed Select CPU support.

Bug Fixes:
- Ensure delayed brightness work is cancelled for each ACPI video device before associated resources are freed to avoid use-after-free during device removal.

Enhancements:
- Add Intel ATOM_DARKMONT_X to the list of CPUs supporting Intel Speed Select HPM in the common interface code.