### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Backport] [Intel] Support OOB CPU frequency control for EMR/GNR/SRF/GRR/CWF

### DIFF
--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2432,6 +2432,10 @@ static const struct x86_cpu_id intel_pstate_cpu_oob_ids[] __initconst = {
 	X86_MATCH(ICELAKE_X,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
 	X86_MATCH(EMERALDRAPIDS_X,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_D,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
+	X86_MATCH(ATOM_CRESTMONT,	core_funcs),
+	X86_MATCH(ATOM_CRESTMONT_X,	core_funcs),
 	{}
 };
 #endif

--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2436,6 +2436,7 @@ static const struct x86_cpu_id intel_pstate_cpu_oob_ids[] __initconst = {
 	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
 	X86_MATCH(ATOM_CRESTMONT,	core_funcs),
 	X86_MATCH(ATOM_CRESTMONT_X,	core_funcs),
+	X86_MATCH(ATOM_DARKMONT_X,	core_funcs),
 	{}
 };
 #endif

--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2431,6 +2431,7 @@ static const struct x86_cpu_id intel_pstate_cpu_oob_ids[] __initconst = {
 	X86_MATCH(SKYLAKE_X,		core_funcs),
 	X86_MATCH(ICELAKE_X,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
+	X86_MATCH(EMERALDRAPIDS_X,	core_funcs),
 	{}
 };
 #endif


### PR DESCRIPTION
1. cpufreq: intel_pstate: Support Clearwater Forest OOB mode
2. cpufreq: intel_pstate: Support Granite Rapids and Sierra Forest OOB mode
3. cpufreq: intel_pstate: Support Emerald Rapids OOB mode

Link: https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel/pulls/482

## Summary by Sourcery

Enhancements:
- Enable OOB cpufreq control for Emerald Rapids, Granite Rapids (X and D), Sierra Forest/Clearwater Forest Atom cores via intel_pstate.