### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Backport] [Intel] cpufreq: intel_pstate: Add Granite Rapids support in no-HWP mode

### DIFF
--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2420,6 +2420,8 @@ static const struct x86_cpu_id intel_pstate_cpu_ids[] = {
 	X86_MATCH(TIGERLAKE,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
 	X86_MATCH(EMERALDRAPIDS_X,      core_funcs),
+	X86_MATCH(GRANITERAPIDS_D,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, intel_pstate_cpu_ids);


### PR DESCRIPTION
commit fc64e0421598aaa87d61184f6777b52614a095be upstream.

Users may disable HWP in firmware, in which case intel_pstate wouldn't load unless the CPU model is explicitly supported.

Intel-SIG: commit fc64e0421598 cpufreq: intel_pstate: Add Granite Rapids support in no-HWP mode Support legacy/noHWP CPU frequency control for GNR/GNR-D


Link: https://patch.msgid.link/20250623105601.3924-1-lirongqing@baidu.com

[ Zhang Rui: resolve conflict (X86_MATCH changed) and amend commit log ]

## Summary by Sourcery

New Features:
- Enable intel_pstate cpufreq support for Granite Rapids server platforms in legacy/no-HWP mode.