### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] deepin: arm64: cpufeature: disable LSE on some cpus

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3065,6 +3065,21 @@
 	ltpc=		[NET]
 			Format: <io>,<irq>,<dma>
 
+	lse_disable_check [ARM64]
+			Disable LSE (Large System Extensions) atomic instructions
+			on some systems to improve performance of per-CPU atomic
+			operations. LSE atomics can exhibit significant overhead
+			on certain microarchitectures (e.g., TSV110) due
+			to "far atomic" implementations bypassing L1 cache. LL/SC
+			(Load-Link/Store-Conditional) is substantially faster.
+
+			The default value is 0 (enabled), which automatically
+			disables LSE on some systems. Set to 1 to bypassing
+			the automatic disabling of LSE on affected systems.
+
+			When this feature is active, the kernel logs:
+			"LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature."
+
 	lsm.debug	[SECURITY] Enable LSM initialization debugging output.
 
 	lsm=lsm1,...,lsmN

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1540,6 +1540,33 @@ static bool has_32bit_el0(const struct arm64_cpu_capabilities *entry, int scope)
 	return true;
 }
 
+static bool lse_disable_check __read_mostly;
+
+static int __init arm64_lse_disable_check(char *str)
+{
+	return kstrtobool(str, &lse_disable_check);
+}
+early_param("lse_disable_check", arm64_lse_disable_check);
+
+static bool has_lse_capability_check(const struct arm64_cpu_capabilities *cap,
+										 int scope)
+{
+	/* List of CPUs that LSE are slow more than llsc */
+	static const struct midr_range lse_disable_list[] = {
+		MIDR_ALL_VERSIONS(MIDR_HISI_TSV110),
+		{ /* sentinel */ }
+	};
+
+	/* Disable LSE when lse_disable_check is enabled */
+	if (lse_disable_check == 0 && is_midr_in_range_list(read_cpuid_id(), lse_disable_list)) {
+		if (scope == SCOPE_SYSTEM)
+			pr_info("LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature.\n");
+		return false;
+	}
+
+	return has_cpuid_feature(cap, scope);
+}
+
 static bool has_useable_gicv3_cpuif(const struct arm64_cpu_capabilities *entry, int scope)
 {
 	bool has_sre;
@@ -2348,7 +2375,7 @@ static const struct arm64_cpu_capabilities arm64_features[] = {
 		.desc = "LSE atomic instructions",
 		.capability = ARM64_HAS_LSE_ATOMICS,
 		.type = ARM64_CPUCAP_SYSTEM_FEATURE,
-		.matches = has_cpuid_feature,
+		.matches = has_lse_capability_check,
 		ARM64_CPUID_FIELDS(ID_AA64ISAR0_EL1, ATOMIC, IMP)
 	},
 #endif /* CONFIG_ARM64_LSE_ATOMICS */


### PR DESCRIPTION
V2 of https://github.com/deepin-community/kernel/pull/1302

deepin inclusion
category: performance

Disable LSE (Large System Extension) atomic instructions on some systems to improve performance of per-CPU atomic operations. LSE atomics can exhibit significant overhead on certain microarchitectures (e.g., TSV110) due to "far atomic" implementations	bypassing L1 cache. LL/SC (Load-Link/Store-Conditional) is substantially faster.

The default value is 0 (enabled), which automatically disables LSE on some systems. Set to 1 to skip the check enablement on our test systems regardless of performance impact.

When this feature is active, the kernel logs:
"LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature."

PS:
Test with byte-unixbench6 in kp920 24c and 64GB memory, improve whole scores by 3.8%.

Link: https://lore.kernel.org/r/e7d539ed-ced0-4b96-8ecd-048a5b803b85@paulmck-laptop [1]
Tested-by: liujiangtao <liujiangtao@uniontech.com>

## Summary by Sourcery

Gate use of ARM64 LSE atomic instructions behind a CPU-specific performance check and tunable kernel parameter.

New Features:
- Introduce a kernel parameter to control whether CPU-based disabling of LSE atomic instructions is applied at boot.

Enhancements:
- Disable LSE atomics in favor of LL/SC on specific arm64 CPUs with known LSE performance issues, with a boot-time log message indicating the behavior.

Documentation:
- Document the new kernel parameter for controlling LSE atomic instruction disabling behavior in the admin guide.