### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Deepin] deepin: arm64: entry: inline cortex_a76_erratum_1463225_svc_handler

### DIFF
--- a/arch/arm64/kernel/entry-common.c
+++ b/arch/arm64/kernel/entry-common.c
@@ -342,7 +342,7 @@ asmlinkage void noinstr el##_##regsize##_##vector##_handler(struct pt_regs *regs
 #ifdef CONFIG_ARM64_ERRATUM_1463225
 static DEFINE_PER_CPU(int, __in_cortex_a76_erratum_1463225_wa);
 
-static void cortex_a76_erratum_1463225_svc_handler(void)
+static __always_inline void cortex_a76_erratum_1463225_svc_handler(void)
 {
 	u32 reg, val;
 


### PR DESCRIPTION
deepin inclusion
category: performance

enable CONFIG_ARM64_ERRATUM_1463225 causes 4% in noaffected cpu unixbench syscall test, before we decide to disable it, test inline it bring up ~1%, cortex_a76_erratum_1463225_debug_handler had been inlined, so it should not bring any functional change.

## Summary by Sourcery

Enhancements:
- Mark the cortex_a76_erratum_1463225_svc_handler as always_inline to minimize overhead from the erratum workaround without changing functionality.