### PR TITLE
CI: control the concurrency of workflows

### DIFF
--- a/.github/workflows/build-kernel-arm64.yml
+++ b/.github/workflows/build-kernel-arm64.yml
@@ -9,6 +9,10 @@ env:
   KBUILD_BUILD_HOST: deepin-kernel-builder
   email: support@deepin.org
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/build-kernel-loong64.yml
+++ b/.github/workflows/build-kernel-loong64.yml
@@ -9,6 +9,10 @@ env:
   KBUILD_BUILD_HOST: deepin-kernel-builder
   email: support@deepin.org
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/build-kernel-riscv64.yml
+++ b/.github/workflows/build-kernel-riscv64.yml
@@ -9,6 +9,10 @@ env:
   KBUILD_BUILD_HOST: deepin-kernel-builder
   email: support@deepin.org
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/build-kernel-s390.yml
+++ b/.github/workflows/build-kernel-s390.yml
@@ -9,6 +9,10 @@ env:
   KBUILD_BUILD_HOST: deepin-kernel-builder
   email: support@deepin.org
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/build-kernel-sw64.yml
+++ b/.github/workflows/build-kernel-sw64.yml
@@ -9,6 +9,10 @@ env:
   KBUILD_BUILD_HOST: deepin-kernel-builder
   email: support@deepin.org
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -9,6 +9,10 @@ env:
   KBUILD_BUILD_HOST: deepin-kernel-builder
   email: support@deepin.org
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/check-config-arm64.yml
+++ b/.github/workflows/check-config-arm64.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-defconfig:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/check-config.yml
+++ b/.github/workflows/check-config.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-defconfig:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -3,6 +3,10 @@ name: Patch Check
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-patch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel any currently running workflow when new one create, this prevent our machines from blocking by lots of workflows created in one PR

## Summary by Sourcery

CI:
- Add concurrency groups to all kernel build and configuration check workflows so that only the latest run per ref executes, cancelling any previous in-progress runs.