### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] bpf: Do not audit capability check in do_jit()

### DIFF
--- a/arch/x86/net/bpf_jit_comp.c
+++ b/arch/x86/net/bpf_jit_comp.c
@@ -1995,7 +1995,7 @@ emit_jmp:
 			ctx->cleanup_addr = proglen;
 
 			if (bpf_prog_was_classic(bpf_prog) &&
-			    !capable(CAP_SYS_ADMIN)) {
+			    !ns_capable_noaudit(&init_user_ns, CAP_SYS_ADMIN)) {
 				u8 *ip = image + addrs[i - 1];
 
 				if (emit_spectre_bhb_barrier(&prog, ip, bpf_prog))


### PR DESCRIPTION
mainline inclusion
from mainline-v6.18-rc4
category: bugfix

The failure of this check only results in a security mitigation being applied, slightly affecting performance of the compiled BPF program. It doesn't result in a failed syscall, an thus auditing a failed LSM permission check for it is unwanted. For example with SELinux, it causes a denial to be reported for confined processes running as root, which tends to be flagged as a problem to be fixed in the policy. Yet dontauditing or allowing CAP_SYS_ADMIN to the domain may not be desirable, as it would allow/silence also other checks - either going against the principle of least privilege or making debugging potentially harder.

Fix it by changing it from capable() to ns_capable_noaudit(), which instructs the LSMs to not audit the resulting denials.

Link: https://bugzilla.redhat.com/show_bug.cgi?id=2369326
Fixes: d4e89d212d40 ("x86/bpf: Call branch history clearing sequence on exit")

Reviewed-by: Paul Moore <paul@paul-moore.com>
Link: https://lore.kernel.org/r/20251021122758.2659513-1-omosnace@redhat.com

(cherry picked from commit 881a9c9cb7856b24e390fad9f59acfd73b98b3b2)

## Summary by Sourcery

Bug Fixes:
- Stop generating LSM audit denials for CAP_SYS_ADMIN failures during x86 BPF JIT Spectre mitigation checks by using a no-audit capability check.