### PR TITLE
[linux 6.6-y] chore: fix package-kernel-daily upload deb

### DIFF
--- a/.github/workflows/package-kernel-amd64-daily.yml
+++ b/.github/workflows/package-kernel-amd64-daily.yml
@@ -29,7 +29,7 @@ jobs:
           mv ../*.deb .
 
       - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kernel-amd64-deb
           path: "*.deb"

--- a/.github/workflows/package-kernel-arm64-daily.yml
+++ b/.github/workflows/package-kernel-arm64-daily.yml
@@ -29,7 +29,7 @@ jobs:
           mv ../*.deb .
 
       - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kernel-arm64-deb
           path: "*.deb"

--- a/.github/workflows/package-kernel-loong64-daily.yml
+++ b/.github/workflows/package-kernel-loong64-daily.yml
@@ -29,7 +29,7 @@ jobs:
           mv ../*.deb .
 
       - name: 'Upload Kernel Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kernel-loong64-deb
           path: "*.deb"


### PR DESCRIPTION
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024.

Link: https://github.com/actions/upload-artifact

## Summary by Sourcery

CI:
- Bump actions/upload-artifact from v3 to v4 in amd64, arm64, and loong64 daily kernel packaging workflows to avoid deprecation.