### PR TITLE
refactor(overlayfs): remove code and configurations related to deepin_err_notify

### DIFF
--- a/fs/overlayfs/ovl_entry.h
+++ b/fs/overlayfs/ovl_entry.h
@@ -19,9 +19,6 @@ struct ovl_config {
 	bool metacopy;
 	bool userxattr;
 	bool ovl_volatile;
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-	bool deepin_err_notify;
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
 };
 
 struct ovl_sb {

--- a/fs/overlayfs/params.c
+++ b/fs/overlayfs/params.c
@@ -59,9 +59,6 @@ enum ovl_opt {
 	Opt_metacopy,
 	Opt_verity,
 	Opt_volatile,
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-	Opt_deepin_err_notify,
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
 };
 
 static const struct constant_table ovl_parameter_bool[] = {
@@ -162,9 +159,6 @@ const struct fs_parameter_spec ovl_parameter_spec[] = {
 	fsparam_enum("metacopy",            Opt_metacopy, ovl_parameter_bool),
 	fsparam_enum("verity",              Opt_verity, ovl_parameter_verity),
 	fsparam_flag("volatile",            Opt_volatile),
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-	fsparam_flag("deepin_err_notify",   Opt_deepin_err_notify),
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
 	{}
 };
 
@@ -606,11 +600,6 @@ static int ovl_parse_param(struct fs_context *fc, struct fs_parameter *param)
 	case Opt_userxattr:
 		config->userxattr = true;
 		break;
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-	case Opt_deepin_err_notify:
-		config->deepin_err_notify = true;
-		break;
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
 	default:
 		pr_err("unrecognized mount option \"%s\" or missing value\n",
 		       param->key);
@@ -1022,9 +1011,5 @@ int ovl_show_options(struct seq_file *m, struct dentry *dentry)
 	if (ofs->config.verity_mode != ovl_verity_mode_def())
 		seq_printf(m, ",verity=%s",
 			   ovl_verity_mode(&ofs->config));
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-	if (ofs->config.deepin_err_notify)
-		seq_puts(m, ",deepin_err_notify");
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
 	return 0;
 }

--- a/fs/overlayfs/super.c
+++ b/fs/overlayfs/super.c
@@ -267,16 +267,6 @@ static int ovl_statfs(struct dentry *dentry, struct kstatfs *buf)
 	return err;
 }
 
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-static bool ovl_deepin_should_notify_error(struct super_block *sb)
-{
-	struct ovl_fs *ofs = OVL_FS(sb);
-
-	/* Return true if deepin_err_notify mount option was set */
-	return ofs->config.deepin_err_notify;
-}
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
-
 static const struct super_operations ovl_super_operations = {
 	.alloc_inode	= ovl_alloc_inode,
 	.free_inode	= ovl_free_inode,
@@ -286,9 +276,6 @@ static const struct super_operations ovl_super_operations = {
 	.sync_fs	= ovl_sync_fs,
 	.statfs		= ovl_statfs,
 	.show_options	= ovl_show_options,
-#ifdef CONFIG_DEEPIN_ERR_NOTIFY
-	.deepin_should_notify_error = ovl_deepin_should_notify_error,
-#endif /* CONFIG_DEEPIN_ERR_NOTIFY */
 };
 
 #define OVL_WORKDIR_NAME "work"


### PR DESCRIPTION
Clean up all conditional compilation code related to
CONFIG_DEEPIN_ERR_NOTIFY

Signed-off-by: electricface <songwentai@uniontech.com>

## Summary by Sourcery

Enhancements:
- Drop the deepin_err_notify mount option, configuration flag, and related superblock operation from overlayfs.