### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Deepin] deepin: arm64: cpufeature: disable LSE on some cpus

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3249,6 +3249,21 @@
 			unlikely, in the extreme case this might damage your
 			hardware.
 
+	lse_disable_check [ARM64]
+			Disable LSE (Large System Extensions) atomic instructions
+			on some systems to improve performance of per-CPU atomic
+			operations. LSE atomics can exhibit significant overhead
+			on certain microarchitectures (e.g., TSV110) due
+			to "far atomic" implementations bypassing L1 cache. LL/SC
+			(Load-Link/Store-Conditional) is substantially faster.
+
+			The default value is 0 (enabled), which automatically
+			disables LSE on some systems. Set to 1 to bypass
+			the automatic disabling of LSE on affected systems.
+
+			When this feature is active, the kernel logs:
+			"LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature."
+
 	lsm.debug	[SECURITY] Enable LSM initialization debugging output.
 
 	lsm=lsm1,...,lsmN

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1657,6 +1657,33 @@ static bool has_32bit_el0(const struct arm64_cpu_capabilities *entry, int scope)
 	return true;
 }
 
+static bool lse_disable_check __read_mostly;
+
+static int __init arm64_lse_disable_check(char *str)
+{
+	return kstrtobool(str, &lse_disable_check);
+}
+early_param("lse_disable_check", arm64_lse_disable_check);
+
+static bool has_lse_capability_check(const struct arm64_cpu_capabilities *cap,
+										 int scope)
+{
+	/* List of CPUs that LSE are slow more than llsc */
+	static const struct midr_range lse_disable_list[] = {
+		MIDR_ALL_VERSIONS(MIDR_HISI_TSV110),
+		{ /* sentinel */ }
+	};
+
+	/* Disable LSE when lse_disable_check is 0 and in lse_disable_list */
+	if (lse_disable_check == 0 && is_midr_in_range_list(read_cpuid_id(), lse_disable_list)) {
+		if (scope == SCOPE_SYSTEM)
+			pr_info("LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature.\n");
+		return false;
+	}
+
+	return has_cpuid_feature(cap, scope);
+}
+
 static bool has_useable_gicv3_cpuif(const struct arm64_cpu_capabilities *entry, int scope)
 {
 	bool has_sre;
@@ -2438,7 +2465,7 @@ static const struct arm64_cpu_capabilities arm64_features[] = {
 		.desc = "LSE atomic instructions",
 		.capability = ARM64_HAS_LSE_ATOMICS,
 		.type = ARM64_CPUCAP_SYSTEM_FEATURE,
-		.matches = has_cpuid_feature,
+		.matches = has_lse_capability_check,
 		ARM64_CPUID_FIELDS(ID_AA64ISAR0_EL1, ATOMIC, IMP)
 	},
 #endif /* CONFIG_ARM64_LSE_ATOMICS */


### PR DESCRIPTION
deepin inclusion
category: performance

Disable LSE (Large System Extensions) atomic instructions on some systems to improve performance of per-CPU atomic operations. LSE atomics can exhibit significant overhead on certain microarchitectures (e.g., TSV110) due
to "far atomic" implementations	bypassing L1 cache. LL/SC (Load-Link/Store-Conditional) is substantially faster.

The default value is 0 (enabled), which automatically disables LSE on some systems. Set to 1 to skip the check enablement on our test systems regardless of performance impact.

When this feature is active, the kernel logs:
"LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature."

PS:
Test with byte-unixbench6 in kp920 24c and 64GB memory, improve whole scores by 3.8%.

Test with https://github.com/leitao/debug/tree/main/LSE percpu_bench CPU0:
LSE (stadd) (c 0, d 0): p50: 029.00 ns p95: 029.09 ns p99: 029.12 ns LL/SC (c 0, d 0): p50: 006.57 ns p95: 006.57 ns p99: 006.57 ns LDADD (c 0, d 0): p50: 069.55 ns p95: 069.57 ns p99: 069.71 ns CPU1:
LSE (stadd) (c 0, d 0): p50: 005.79 ns p95: 029.00 ns p99: 029.01 ns LL/SC (c 0, d 0): p50: 006.56 ns p95: 006.58 ns p99: 006.58 ns LDADD (c 0, d 0): p50: 010.04 ns p95: 010.06 ns p99: 010.06 ns CPU2:
LSE (stadd) (c 0, d 0): p50: 005.79 ns p95: 005.79 ns p99: 005.79 ns LL/SC (c 0, d 0): p50: 006.57 ns p95: 006.57 ns p99: 006.57 ns LDADD (c 0, d 0): p50: 069.53 ns p95: 069.56 ns p99: 069.58 ns ...
CPU23:
LSE (stadd) (c 0, d 0): p50: 005.79 ns p95: 005.79 ns p99: 005.79 ns LL/SC (c 0, d 0): p50: 006.57 ns p95: 006.57 ns p99: 006.57 ns LDADD (c 0, d 0): p50: 064.93 ns p95: 064.95 ns p99: 064.97 ns

Link: https://lore.kernel.org/r/e7d539ed-ced0-4b96-8ecd-048a5b803b85@paulmck-laptop [1]
Link: https://github.com/deepin-community/kernel/pull/1320
Link: https://github.com/deepin-community/kernel/pull/1302

(cherry picked from commit 6afecf69e828ec117fa0677841da65a05b18d832) Conflicts:
	Documentation/admin-guide/kernel-parameters.txt

## Summary by Sourcery

Gate enabling of ARM64 LSE atomic instructions behind a CPU-specific performance check and optional boot-time override to prefer LL/SC atomics on affected systems.

New Features:
- Add a boot parameter to control whether LSE atomics are conditionally disabled based on CPU model.

Enhancements:
- Introduce a CPU model blacklist (e.g., HiSilicon TSV110) to automatically disable LSE atomics when they are slower than LL/SC, improving per-CPU atomic performance on those systems.