### PR TITLE
[RFC] [Deepin-Kernel-SIG] [linux 6.6-y] Revert "Revert "LoongArch: Add support for relocating the kernel with RELR relocation""

### DIFF
--- a/arch/loongarch/Kconfig
+++ b/arch/loongarch/Kconfig
@@ -618,6 +618,7 @@ config ARCH_SELECTS_CRASH_DUMP
 
 config RELOCATABLE
 	bool "Relocatable kernel"
+	select ARCH_HAS_RELR
 	help
 	  This builds the kernel as a Position Independent Executable (PIE),
 	  which retains all relocation metadata required, so as to relocate

--- a/arch/loongarch/include/asm/asmmacro.h
+++ b/arch/loongarch/include/asm/asmmacro.h
@@ -609,6 +609,7 @@
 	lu32i.d	\reg, 0
 	lu52i.d	\reg, \reg, 0
 	.pushsection ".la_abs", "aw", %progbits
+	.p2align 3
 	.dword	766b
 	.dword	\sym
 	.popsection

--- a/arch/loongarch/include/asm/setup.h
+++ b/arch/loongarch/include/asm/setup.h
@@ -34,6 +34,11 @@ extern long __la_abs_end;
 extern long __rela_dyn_begin;
 extern long __rela_dyn_end;
 
+#ifdef CONFIG_RELR
+extern long __relr_dyn_begin;
+extern long __relr_dyn_end;
+#endif
+
 extern unsigned long __init relocate_kernel(void);
 
 #endif

--- a/arch/loongarch/kernel/relocate.c
+++ b/arch/loongarch/kernel/relocate.c
@@ -40,6 +40,24 @@ static inline void __init relocate_relative(void)
 
 		*(Elf64_Addr *)RELOCATED(addr) = relocated_addr;
 	}
+
+#ifdef CONFIG_RELR
+	u64 *addr = NULL;
+	u64 *relr = (u64 *)&__relr_dyn_begin;
+	u64 *relr_end = (u64 *)&__relr_dyn_end;
+
+	for ( ; relr < relr_end; relr++) {
+		if ((*relr & 1) == 0) {
+			addr = (u64 *)(*relr + reloc_offset);
+			*addr++ += reloc_offset;
+		} else {
+			for (u64 *p = addr, r = *relr >> 1; r; p++, r >>= 1)
+				if (r & 1)
+					*p += reloc_offset;
+			addr += 63;
+		}
+	}
+#endif
 }
 
 static inline void __init relocate_absolute(long random_offset)

--- a/arch/loongarch/kernel/vmlinux.lds.S
+++ b/arch/loongarch/kernel/vmlinux.lds.S
@@ -113,6 +113,14 @@ SECTIONS
 		__rela_dyn_end = .;
 	}
 
+#ifdef CONFIG_RELR
+	.relr.dyn : ALIGN(8) {
+		__relr_dyn_begin = .;
+		 *(.relr.dyn)
+		__relr_dyn_end = .;
+	}
+#endif
+
 	.data.rel : { *(.data.rel*) }
 
 #ifdef CONFIG_RELOCATABLE


### PR DESCRIPTION
Reverts deepin-community/kernel#505

[ WangYuli: In my discussion with @opsiff today I realized that backporting RELR isn’t necessarily a bad idea; besides, if that configuration option isn’t enabled it actually has no effect. ]

## Summary by Sourcery

Reintroduce RELR-based kernel relocation support for LoongArch when CONFIG_RELR is enabled.

New Features:
- Add processing of RELR relocation entries to the LoongArch kernel relocation logic when CONFIG_RELR is set.
- Define and export linker script symbols and a dedicated .relr.dyn section for RELR relocation data on LoongArch.

Enhancements:
- Align LoongArch .la_abs section entries to 8 bytes to ensure proper layout with the added relocation metadata.