### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] ALSA: hda: Poll jack events for LS7A HD-Audio

### DIFF
--- a/sound/pci/hda/hda_intel.c
+++ b/sound/pci/hda/hda_intel.c
@@ -1984,6 +1984,8 @@ static int azx_first_init(struct azx *chip)
 		bus->polling_mode = 1;
 		bus->not_use_interrupts = 1;
 		bus->access_sdnctl_in_dword = 1;
+		if (!chip->jackpoll_interval)
+			chip->jackpoll_interval = msecs_to_jiffies(1500);
 	}
 
 	if (chip->driver_type == AZX_DRIVER_HYGON &&


### PR DESCRIPTION
mainline inclusion
from mainline-v6.13-rc1
category: bugfix

LS7A HD-Audio disable interrupts and use polling mode due to hardware drawbacks. As a result, unsolicited jack events are also unusable. If we want to support headphone hotplug, we need to also poll jack events.

Here we use 1500ms as the poll interval if no module parameter specify it.

Cc: stable@vger.kernel.org

Link: https://patch.msgid.link/20241115150653.2819100-1-chenhuacai@loongson.cn

(cherry picked from commit e3f8064d8b29036f037fd1ff6000e5d959d84843)

## Summary by Sourcery

Bug Fixes:
- Ensure jack events are polled on LS7A HD-Audio when interrupts are disabled by assigning a default jack poll interval.