### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Upstream] ALSA: hda: Poll jack events for LS7A HD-Audio

### DIFF
--- a/sound/pci/hda/hda_intel.c
+++ b/sound/pci/hda/hda_intel.c
@@ -1914,6 +1914,8 @@ static int azx_first_init(struct azx *chip)
 		bus->polling_mode = 1;
 		bus->not_use_interrupts = 1;
 		bus->access_sdnctl_in_dword = 1;
+		if (!chip->jackpoll_interval)
+			chip->jackpoll_interval = msecs_to_jiffies(1500);
 	}
 
 	chip->remap_diu_addr = NULL;


### PR DESCRIPTION
mainline inclusion
from mainline-v6.13-rc1
category: bugfix

LS7A HD-Audio disable interrupts and use polling mode due to hardware drawbacks. As a result, unsolicited jack events are also unusable. If we want to support headphone hotplug, we need to also poll jack events.

Here we use 1500ms as the poll interval if no module parameter specify it.

Cc: stable@vger.kernel.org

Link: https://patch.msgid.link/20241115150653.2819100-1-chenhuacai@loongson.cn

(cherry picked from commit e3f8064d8b29036f037fd1ff6000e5d959d84843)

## Summary by Sourcery

Bug Fixes:
- Ensure LS7A HD-Audio polls jack events by default when interrupts are disabled, using a 1500ms interval if none is specified.