### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Sunway] sw64: efi: fix boot failure when Secure Boot unsupported in firmware

### DIFF
--- a/drivers/firmware/efi/fdtparams.c
+++ b/drivers/firmware/efi/fdtparams.c
@@ -56,7 +56,11 @@ static __initconst const struct {
 			[MMSIZE] = "linux,uefi-mmap-size",
 			[DCSIZE] = "linux,uefi-mmap-desc-size",
 			[DCVERS] = "linux,uefi-mmap-desc-ver",
+#ifndef CONFIG_SW64
 			[SBMODE] = "linux,uefi-secure-boot",
+#else
+			[SBMODE] = "",
+#endif
 		}
 	}
 };

--- a/drivers/firmware/efi/libstub/fdt.c
+++ b/drivers/firmware/efi/libstub/fdt.c
@@ -132,11 +132,13 @@ static efi_status_t update_fdt(void *orig_fdt, unsigned long orig_fdt_size,
 		}
 	}
 
+#ifndef CONFIG_SW64
 	fdt_val32 = cpu_to_fdt32(efi_get_secureboot());
 	status = fdt_setprop(fdt, node, "linux,uefi-secure-boot",
 			     &fdt_val32, sizeof(fdt_val32));
 	if (status)
 		goto fdt_set_fail;
+#endif
 
 	/* Shrink the FDT back to its minimum size: */
 	fdt_pack(fdt);


### PR DESCRIPTION
Reviewed-by: He Sheng <hesheng@wxiat.com>

## Summary by Sourcery

Bug Fixes:
- Prevent boot failures on SW64 platforms by omitting the linux,uefi-secure-boot FDT property when Secure Boot is unsupported in firmware.