### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net: netpoll: Fix kabi in netpoll_info by using KABI_BROKEN_REPLACE

### DIFF
--- a/include/linux/netpoll.h
+++ b/include/linux/netpoll.h
@@ -47,7 +47,24 @@ struct netpoll_info {
 
 	struct delayed_work tx_work;
 
-	struct netpoll *netpoll;
+	/* !!! Kernel Internal USE */
+	DEEPIN_KABI_BROKEN_REPLACE(
+	struct netpoll {
+		struct net_device *dev;
+		netdevice_tracker dev_tracker;
+		char dev_name[IFNAMSIZ];
+		const char *name;
+		union inet_addr local_ip;
+		union inet_addr remote_ip;
+		bool ipv6;
+		u16 local_port;
+		u16 remote_port;
+		u8 remote_mac[ETH_ALEN];
+
+		DEEPIN_KABI_RESERVE(1)
+		DEEPIN_KABI_RESERVE(2)
+	} *netpoll,
+	struct netpoll *netpoll)
 	struct rcu_head rcu;
 };
 


### PR DESCRIPTION
deepin inclusion
category: kabi

When DEEPIN_KABI_RESERVE=y, struct net_device is kabi whitelist, commit dc67d67a995e ("net: netpoll: Individualize the skb pool") upstream introduce skb_pool in every struct netpoll which "modify the netpoll system to assign a skb pool to each target instead of using a global one."
and be backport to v6.6.117 stable version for it is Stable-dep-of 49c8d2c1f94c ("net: netpoll: fix incorrect refcount handling causing incorrect cleanup")

change struct netpoll { ... +struct sk_buff_head skb_pool; } ->change netpoll_info { ... struct netpoll *netpoll; } ->change net_device { struct netpoll_info *npinfo; } ->change some EXPORT_SYMBOL such as free_netdev etc ... in our KABI whitelist.

The struct sk_buff_head { struct sk_buff	*next;
struct sk_buff	*prev; .. } is larger than KABI reverse in the struct, so cannot use KABI_USE in this situation.
For netpoll pointer after change is same as before and use internel. We can use DEEPIN_KABI_BROKEN_REPLACE to fix it.

Fixes: ca946eea1bcf ("net: netpoll: Individualize the skb pool")

## Summary by Sourcery

Enhancements:
- Wrap netpoll pointer in netpoll_info with DEEPIN_KABI_BROKEN_REPLACE to maintain ABI layout while accommodating the upstream netpoll struct changes.