### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net: netpoll: Fix kabi in netpoll by using KABI_EXTEND

### DIFF
--- a/include/linux/netpoll.h
+++ b/include/linux/netpoll.h
@@ -32,10 +32,10 @@ struct netpoll {
 	bool ipv6;
 	u16 local_port, remote_port;
 	u8 remote_mac[ETH_ALEN];
-	struct sk_buff_head skb_pool;
 
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_EXTEND(struct sk_buff_head skb_pool)
 };
 
 struct netpoll_info {


### PR DESCRIPTION
deepin inclusion
category: kabi

When DEEPIN_KABI_RESERVE=y, struct net_device is kabi whitelist, commit dc67d67a995e ("net: netpoll: Individualize the skb pool") upstream introduce skb_pool in every struct netpoll which "modify the netpoll system to assign a skb pool to each target instead of using a global one."
and be backport to v6.6.117 stable version for it is Stable-dep-of commit 49c8d2c1f94c ("net: netpoll: fix incorrect refcount handling causing incorrect cleanup")

change struct netpoll { ... +struct sk_buff_head skb_pool; } ->change netpoll_info { ... struct netpoll *netpoll; } ->change net_device { struct netpoll_info *npinfo; } ->change some EXPORT_SYMBOL such as free_netdev etc ... in our KABI whitelist.

The struct sk_buff_head { struct sk_buff	*next;
struct sk_buff	*prev; .. } is larger than KABI reverse in the struct, so cannot use KABI_USE in this situation.
For netpoll pointer after change is same as before and use internal. We can use DEEPIN_KABI_EXTEND to fix it.

Fixes: ca946eea1bcf ("net: netpoll: Individualize the skb pool")

## Summary by Sourcery

Bug Fixes:
- Restore KABI compatibility for netpoll by moving skb_pool into a DEEPIN_KABI_EXTEND field in struct netpoll.