### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] bpf: Fix kabi in bpf_map_owner by using KABI_EXTEND

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -276,7 +276,7 @@ struct bpf_map_owner {
 	bool xdp_has_frags;
 	u64 storage_cookie[MAX_BPF_CGROUP_STORAGE_TYPE];
 	const struct btf_type *attach_func_proto;
-	enum bpf_attach_type expected_attach_type;
+	DEEPIN_KABI_EXTEND(enum bpf_attach_type expected_attach_type)
 };
 
 struct bpf_map {


### PR DESCRIPTION
deepin inclusion
category: kabi

When DEEPIN_KABI_RESERVE=y, struct bpf_map is kabi whitelist, commit bcb817018419 ("bpf: Enforce expected_attach_type for tailcall compatibility") upstream introduce expected_attach_type in bpf_map_owner to enforce expected_attach_type for tailcall compatibility and backport to v6.6.112.

As expected_attach_type use internal and bpf_map_owner used by pointer. We can use DEEPIN_KABI_EXTEND to fix it.

Fixes: bcb817018419 ("bpf: Enforce expected_attach_type for tailcall compatibility")

## Summary by Sourcery

Bug Fixes:
- Fix a kernel ABI compatibility issue introduced by adding expected_attach_type to bpf_map_owner by wrapping the field with DEEPIN_KABI_EXTEND.