### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] mm/memory: Fix kabi breakage for zap_vma_ptes by moving include

### DIFF
--- a/mm/memory.c
+++ b/mm/memory.c
@@ -67,7 +67,9 @@
 #include <linux/gfp.h>
 #include <linux/migrate.h>
 #include <linux/string.h>
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 #include <linux/shmem_fs.h>
+#endif  /* !CONFIG_DEEPIN_KABI_RESERVE */
 #include <linux/memory-tiers.h>
 #include <linux/debugfs.h>
 #include <linux/userfaultfd_k.h>
@@ -4478,6 +4480,9 @@ static bool vmf_pte_changed(struct vm_fault *vmf)
  *
  * Return: %0 on success, %VM_FAULT_ code in case of error.
  */
+#ifdef CONFIG_DEEPIN_KABI_RESERVE
+#include <linux/shmem_fs.h>
+#endif /* CONFIG_DEEPIN_KABI_RESERVE */
 vm_fault_t finish_fault(struct vm_fault *vmf)
 {
 	struct vm_area_struct *vma = vmf->vma;


### PR DESCRIPTION
deepin inclusion
category: kabi

No functional change, just move the headers which cause kabi break in CONFIG_DEEPIN_KABI_RESERVE=y.

Log:
cat Module.symvers | grep zap_vma_ptes
before fix:
0x7d0ccd7f      zap_vma_ptes    vmlinux EXPORT_SYMBOL_GPL
after fix:
0x4bf1f352      zap_vma_ptes    vmlinux EXPORT_SYMBOL_GPL

## Summary by Sourcery

Enhancements:
- Move linux/shmem_fs.h inclusion under CONFIG_DEEPIN_KABI_RESERVE to avoid KABI breakage while keeping existing functionality unchanged.