### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] [Intel] Add IFS support for ClearWater Forest

### DIFF
--- a/drivers/platform/x86/intel/ifs/core.c
+++ b/drivers/platform/x86/intel/ifs/core.c
@@ -21,6 +21,7 @@ static const struct x86_cpu_id ifs_cpu_ids[] __initconst = {
 	X86_MATCH(GRANITERAPIDS_X, ARRAY_GEN0),
 	X86_MATCH(GRANITERAPIDS_D, ARRAY_GEN0),
 	X86_MATCH(ATOM_CRESTMONT_X, ARRAY_GEN1),
+	X86_MATCH(ATOM_DARKMONT_X, ARRAY_GEN1),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, ifs_cpu_ids);


### PR DESCRIPTION
Add IFS support for ClearWater Forest

Tests:
Tested on CWF, IFS test cases passed and no regression found.

platform/x86/intel/ifs: Add Clearwater Forest to CPU support list

## Summary by Sourcery

New Features:
- Enable IFS functionality on Clearwater Forest platforms by recognizing ATOM_DARKMONT_X CPUs in the IFS core driver.