### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net: Fix kabi breakage for skbuff by exclude header

### DIFF
--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -67,7 +67,12 @@
 #include <net/dst.h>
 #include <net/sock.h>
 #include <net/checksum.h>
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 #include <net/gro.h>
+#else  /* !CONFIG_DEEPIN_KABI_RESERVE */
+/* This should be increased if a protocol with a bigger head is added. */
+#define GRO_MAX_HEAD (MAX_HEADER + 128)
+#endif /* CONFIG_DEEPIN_KABI_RESERVE */
 #include <net/gso.h>
 #include <net/ip6_checksum.h>
 #include <net/xfrm.h>


### PR DESCRIPTION
deepin inclusion
category: kabi

No functioncal change.

Log: fix kabi white list symbol in skbuff.c:
slab_build_skb
build_skb
__alloc_skb
__netdev_alloc_skb
__napi_alloc_skb
...

Fixes: dae142e2abc5 ("net: allow small head cache usage with large MAX_SKB_FRAGS values")

## Summary by Sourcery

Enhancements:
- Guard the inclusion of <net/gro.h> with CONFIG_DEEPIN_KABI_RESERVE and define a local GRO_MAX_HEAD constant to avoid skbuff KABI breakage without changing runtime behavior.