### PR TITLE
HAOC: Add log message when HAOC is enabled

### DIFF
--- a/arch/x86/mm/init_64.c
+++ b/arch/x86/mm/init_64.c
@@ -1392,8 +1392,10 @@ void __init mem_init(void)
 	 * The upper region becomes the IEE linear mapping area.
 	 * Note that the IEE mapping region is mapped with read-only permissions.
 	 */
-	if (haoc_enabled)
+	if (haoc_enabled) {
+		pr_info("HAOC is enabled by kernel command line.");
 		iee_init();
+	}
 	#endif
 	preallocate_vmalloc_pages();
 }


### PR DESCRIPTION
When HAOC  is enabled via kernel  command line, print an informational message to dmesg. This helps in verifying the feature status during boot.

## Summary by Sourcery

Enhancements:
- Add an informational kernel log message when HAOC is enabled via the command line during x86_64 memory initialization.