### PR TITLE
drm: arise: use dummy version in-tree to avoid conflicting with DKMS

### DIFF
--- a/drivers/gpu/drm/arise/gf_version.h
+++ b/drivers/gpu/drm/arise/gf_version.h
@@ -21,6 +21,7 @@
  * IN THE SOFTWARE.
  *
  */
+/* Original version
 
 #define DRIVER_DATE                 "05/19/2025"
 #define DRIVER_MAJOR                0x25
@@ -36,3 +37,19 @@
 #define CC_VERSION                  ""
 #define LD_VERSION                  ""
 
+*/
+
+/* Dummy version to avoid conflicting with DKMS */
+#define DRIVER_DATE                 "05/19/2025"
+#define DRIVER_MAJOR                0x20
+#define DRIVER_MINOR                0x00
+#define DRIVER_PATCHLEVEL           0x46
+#define DRIVER_CLASS                ""
+#define DRIVER_NAME                 arise
+#define DRIVER_VENDOR               "Glenfly Tech Co., Ltd."
+#define DRIVER_LICENSE              "Glenfly"
+#define DRIVER_VERSION              ((DRIVER_MAJOR<<24)|(DRIVER_MINOR<<16)|DRIVER_PATCHLEVEL)
+#define DRIVER_VERSION_CHAR         "20.00.46"
+#define OS_VERSION                  ""
+#define CC_VERSION                  ""
+#define LD_VERSION                  ""


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Comment out the original Arise DRM driver version block and replace it with a reduced dummy version identifier that will not clash with DKMS builds.