### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Upstream] bpf: annotate file argument as __nullable in bpf_lsm_mmap_file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4291,6 +4291,7 @@ S:	Maintained
 F:	Documentation/bpf/prog_lsm.rst
 F:	include/linux/bpf_lsm.h
 F:	kernel/bpf/bpf_lsm.c
+F:	kernel/bpf/bpf_lsm_proto.c
 F:	kernel/trace/bpf_trace.c
 F:	security/bpf/
 

--- a/kernel/bpf/Makefile
+++ b/kernel/bpf/Makefile
@@ -42,7 +42,17 @@ endif
 ifeq ($(CONFIG_BPF_JIT),y)
 obj-$(CONFIG_BPF_SYSCALL) += bpf_struct_ops.o
 obj-$(CONFIG_BPF_SYSCALL) += cpumask.o
-obj-${CONFIG_BPF_LSM} += bpf_lsm.o
+# bpf_lsm_proto.o must precede bpf_lsm.o. The current pahole logic
+# deduplicates function prototypes within
+# btf_encoder__add_saved_func() by keeping the first instance seen. We
+# need the function prototype(s) in bpf_lsm_proto.o to take precedence
+# over those within bpf_lsm.o. Having bpf_lsm_proto.o precede
+# bpf_lsm.o ensures its DWARF CU is processed early, forcing the
+# generated BTF to contain the overrides.
+#
+# Notably, this is a temporary workaround whilst the deduplication
+# semantics within pahole are revisited accordingly.
+obj-${CONFIG_BPF_LSM} += bpf_lsm_proto.o bpf_lsm.o
 endif
 ifneq ($(CONFIG_CRYPTO),)
 obj-$(CONFIG_BPF_SYSCALL) += crypto.o

--- a/kernel/bpf/bpf_lsm.c
+++ b/kernel/bpf/bpf_lsm.c
@@ -18,10 +18,11 @@
 #include <linux/bpf-cgroup.h>
 
 /* For every LSM hook that allows attachment of BPF programs, declare a nop
- * function where a BPF program can be attached.
+ * function where a BPF program can be attached. Notably, we qualify each with
+ * weak linkage such that strong overrides can be implemented if need be.
  */
 #define LSM_HOOK(RET, DEFAULT, NAME, ...)	\
-noinline RET bpf_lsm_##NAME(__VA_ARGS__)	\
+__weak noinline RET bpf_lsm_##NAME(__VA_ARGS__)	\
 {						\
 	return DEFAULT;				\
 }

--- a/kernel/bpf/bpf_lsm_proto.c
+++ b/kernel/bpf/bpf_lsm_proto.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright 2025 Google LLC.
+ */
+
+#include <linux/fs.h>
+#include <linux/bpf_lsm.h>
+
+/*
+ * Strong definition of the mmap_file() BPF LSM hook. The __nullable suffix on
+ * the struct file pointer parameter name marks it as PTR_MAYBE_NULL. This
+ * explicitly enforces that BPF LSM programs check for NULL before attempting to
+ * dereference it.
+ */
+int bpf_lsm_mmap_file(struct file *file__nullable, unsigned long reqprot,
+		      unsigned long prot, unsigned long flags)
+{
+	return 0;
+}


### PR DESCRIPTION
up stream bpf_lsm_mmap_file bug link:
    https://lore.kernel.org/all/5e460d3c.4c3e9.19adde547d8.Coremail.kaiyanm@hust.edu.cn/

fix patch from mail url:
    https://lore.kernel.org/all/20251216133000.3690723-1-mattbobrowski@google.com/

WARNING: bpf_lsm_proto.c must compiled before bpf_lsm.c, this is ensured by the Makefile currently, which is not a good approach because the pahole may make mistake while bpf_lsm_proto.c is changed and a re-make is called without make clean first

## Summary by Sourcery

Ensure BPF LSM mmap_file hook arguments are correctly treated as maybe-null and allow strong overrides of LSM hook stubs.

New Features:
- Add a strong bpf_lsm_mmap_file LSM hook definition that explicitly marks the file argument as nullable for BPF verification.

Bug Fixes:
- Correct BTF-based argument nullability handling so mmap_file and other annotated LSM hook parameters are recognized as possibly null.

Enhancements:
- Mark generated BPF LSM hook stubs as weak to permit strong overrides in separate compilation units.
- Adjust BPF LSM build ordering so the prototype/override unit is processed before the generic LSM stubs to influence BTF generation.

Build:
- Update BPF kernel Makefile to compile bpf_lsm_proto.o before bpf_lsm.o to control BTF prototype precedence.