### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] fbdev: bitblit: fix bound-check glyph index in bit_putcs for cjktty

### DIFF
--- a/drivers/video/fbdev/core/bitblit.c
+++ b/drivers/video/fbdev/core/bitblit.c
@@ -66,6 +66,7 @@ u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,
 	u16 ch = scr_readw(s) & charmask;
 	const struct font_desc *font;
 
+	fontdata = ops ? ops->fontbuffer : vc->vc_font.data;
 	if (ch == 0xff || ch == 0xfe) {
 		/* assume current font not support unicode */
 		if (charcnt < 65536) {
@@ -75,22 +76,21 @@ u8 *font_bits(struct vc_data *vc, const u16 *s, u32 cellsize, u16 charmask,
 				font = find_font(fontname);
 				fontdata = (font && font->data) ? (void *) font->data : NULL;
 			}
-			if (fontdata) {
-				c_utf = utf8_pos(vc, s);
-				if (ch == 0xff)
-					src = fontdata + (c_utf * cellsize_utf * 2);
-				else
-					src = fontdata + (c_utf * cellsize_utf * 2 + cellsize_utf);
-				return src;
-			}
-			/* ch=0 for fontdata=0 */
-			ch = 0;
 		}
+		if (fontdata) {
+			c_utf = utf8_pos(vc, s);
+			if (ch == 0xff)
+				src = fontdata + (c_utf * cellsize_utf * 2);
+			else
+				src = fontdata + (c_utf * cellsize_utf * 2 + cellsize_utf);
+			return src;
+		}
+		/* ch=0 for fontdata=0 */
+		ch = 0;
 	} else if (ch >= charcnt) {
 		ch = 0;
 	}
 
-	fontdata = ops ? ops->fontbuffer : vc->vc_font.data;
 	src = fontdata + (unsigned int)ch * cellsize;
 	return src;
 }


### PR DESCRIPTION
deepin inclusion
category: bugfix

charcount in cjk 16*16 and cjk 32*32 is 65536 * 2, so do this logic to map the source,
c_utf = utf8_pos(vc, s);
if (ch == 0xff)
	src = fontdata + (c_utf * cellsize_utf * 2);
else
	src = fontdata + (c_utf * cellsize_utf * 2 + cellsize_utf);

Fixes: 458d7956461d ("fbdev: bitblit: bound-check glyph index in bit_putcs*")

## Summary by Sourcery

Fix font data selection and glyph index handling for UTF-8 CJK framebuffer console rendering to avoid out-of-bounds access.

Bug Fixes:
- Correct glyph source pointer calculation for 16x16 and 32x32 CJK fonts in fbdev bitblit path when using UTF-8 pseudo-characters 0xff/0xfe.
- Ensure font buffer is initialized before CJK-specific bounds-checked access and fall back to glyph 0 when font data is unavailable.