### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Wangxun]deepin: net: txgbe: fix CONFIG_DCB=N compile error

### DIFF
--- a/drivers/net/ethernet/wangxun/txgbe/Makefile
+++ b/drivers/net/ethernet/wangxun/txgbe/Makefile
@@ -11,10 +11,7 @@ txgbe-objs := txgbe_main.o \
               txgbe_phy.o \
               txgbe_ethtool.o \
 			  txgbe_bp.o \
-			  txgbe_dcb_nl.o \
-			  txgbe_dcb.o \
 			  txgbe_debugfs.o \
-			  txgbe_fcoe.o \
 			  txgbe_mbx.o \
 			  txgbe_mtd.o \
 			  txgbe_e56.o \
@@ -29,9 +26,7 @@ txgbe-objs := txgbe_main.o \
 			  txgbe_pcierr.o \
 			  txgbe_e56_bp.o
 
-KERNELDIR ?= /lib/modules/$(shell uname -r)/build
-all:
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
-clean:
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
-	rm -rf *.${MANSECTION}.gz *.ko
+txgbe-$(CONFIG_DCB) += txgbe_dcb_nl.o txgbe_dcb.o
+txgbe-$(CONFIG_FCOE:m=y) += txgbe_fcoe.o
+txgbe-$(CONFIG_SYSFS) += txgbe_sysfs.o
+txgbe-$(CONFIG_DEBUG_FS) += txgbe_debugfs.o

--- a/drivers/net/ethernet/wangxun/txgbe/txgbe.h
+++ b/drivers/net/ethernet/wangxun/txgbe/txgbe.h
@@ -1041,8 +1041,9 @@ struct txgbe_cb {
 /* ESX txgbe CIM IOCTL definition */
 void txgbe_sysfs_exit(struct txgbe_adapter *adapter);
 int txgbe_sysfs_init(struct txgbe_adapter *adapter);
-
+#if IS_ENABLED(CONFIG_DCB)
 extern struct dcbnl_rtnl_ops dcbnl_ops;
+#endif /* CONFIG_DCB */
 int txgbe_copy_dcb_cfg(struct txgbe_adapter *adapter, int tc_max);
 
 u8 txgbe_dcb_txq_to_tc(struct txgbe_adapter *adapter, u8 index);
@@ -1125,7 +1126,7 @@ void txgbe_free_fcoe_ddp_resources(struct txgbe_adapter *adapter);
 int txgbe_fcoe_enable(struct net_device *netdev);
 int txgbe_fcoe_disable(struct net_device *netdev);
 #endif /* CONFIG_FCOE */
-#if IS_ENABLED(CONFIG_DCB)
+#if IS_ENABLED(CONFIG_FCOE)
 u8 txgbe_fcoe_getapp(struct net_device *netdev);
 u8 txgbe_fcoe_get_tc(struct txgbe_adapter *adapter);
 int txgbe_fcoe_get_wwn(struct net_device *netdev, u64 *wwn, int type);
@@ -1144,10 +1145,6 @@ static inline struct netdev_queue *txring_txq(const struct txgbe_ring *ring)
 {
 	return netdev_get_tx_queue(ring->netdev, ring->queue_index);
 }
-
-#if IS_ENABLED(CONFIG_DCB)
-s32 txgbe_dcb_hw_ets(struct txgbe_hw *hw, struct ieee_ets *ets, int max_frame);
-#endif /* CONFIG_DCB */
 
 int txgbe_wol_supported(struct txgbe_adapter *adapter);
 int txgbe_get_settings(struct net_device *netdev,

--- a/drivers/net/ethernet/wangxun/txgbe/txgbe_dcb.c
+++ b/drivers/net/ethernet/wangxun/txgbe/txgbe_dcb.c
@@ -364,6 +364,39 @@ s32 txgbe_dcb_config_pfc(struct txgbe_hw *hw, u8 pfc_en, u8 *map)
 	return ret;
 }
 
+s32 txgbe_dcb_hw_ets(struct txgbe_hw *hw, struct ieee_ets *ets, int max_frame)
+{
+	__u16 refill[IEEE_8021QAZ_MAX_TCS], max[IEEE_8021QAZ_MAX_TCS];
+	__u8 prio_type[IEEE_8021QAZ_MAX_TCS];
+	int i;
+
+	/* naively give each TC a bwg to map onto CEE hardware */
+	__u8 bwg_id[IEEE_8021QAZ_MAX_TCS] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+	/* Map TSA onto CEE prio type */
+	for (i = 0; i < IEEE_8021QAZ_MAX_TCS; i++) {
+		switch (ets->tc_tsa[i]) {
+		case IEEE_8021QAZ_TSA_STRICT:
+			prio_type[i] = 2;
+			break;
+		case IEEE_8021QAZ_TSA_ETS:
+			prio_type[i] = 0;
+			break;
+		default:
+			/* Hardware only supports priority strict or
+			 * ETS transmission selection algorithms if
+			 * we receive some other value from dcbnl
+			 * throw an error
+			 */
+			return -EINVAL;
+		}
+	}
+
+	txgbe_dcb_calculate_tc_credits(ets->tc_tx_bw, refill, max, max_frame);
+	return txgbe_dcb_hw_config(hw, refill, max,
+				   bwg_id, prio_type, ets->prio_tc);
+}
+
 s32 txgbe_dcb_hw_config(struct txgbe_hw *hw, u16 *refill, u16 *max,
 			u8 *bwg_id, u8 *tsa, u8 *map)
 {

--- a/drivers/net/ethernet/wangxun/txgbe/txgbe_dcb.h
+++ b/drivers/net/ethernet/wangxun/txgbe/txgbe_dcb.h
@@ -4,6 +4,7 @@
 #ifndef _TXGBE_DCB_H_
 #define _TXGBE_DCB_H_
 
+#include <linux/dcbnl.h>
 #include "txgbe_type.h"
 
 /* DCB defines */
@@ -181,7 +182,7 @@ void txgbe_dcb_unpack_map_cee(struct txgbe_dcb_config *cfg, int direction,
 s32 txgbe_dcb_config_tc_stats(struct txgbe_hw __always_unused *hw,
 			      struct txgbe_dcb_config __always_unused *dcb_config);
 u8 txgbe_dcb_get_tc_from_up(struct txgbe_dcb_config *cfg, int direction, u8 up);
-
+s32 txgbe_dcb_hw_ets(struct txgbe_hw *hw, struct ieee_ets *ets, int max_frame);
 /* DCB initialization */
 s32 txgbe_dcb_config(struct txgbe_hw *hw,
 		     struct txgbe_dcb_config *dcb_config);

--- a/drivers/net/ethernet/wangxun/txgbe/txgbe_fcoe.c
+++ b/drivers/net/ethernet/wangxun/txgbe/txgbe_fcoe.c
@@ -935,6 +935,10 @@ int txgbe_fcoe_get_wwn(struct net_device *netdev, u64 *wwn, int type)
  */
 u8 txgbe_fcoe_get_tc(struct txgbe_adapter *adapter)
 {
+#if IS_ENABLED(CONFIG_DCB)
 	return netdev_get_prio_tc_map(adapter->netdev, adapter->fcoe.up);
+#else
+	return 0;
+#endif /* CONFIG_DCB */
 }
 #endif /* CONFIG_FCOE */

--- a/drivers/net/ethernet/wangxun/txgbe/txgbe_lib.c
+++ b/drivers/net/ethernet/wangxun/txgbe/txgbe_lib.c
@@ -4,6 +4,7 @@
 #include "txgbe.h"
 #include "txgbe_sriov.h"
 
+#if IS_ENABLED(CONFIG_DCB)
 /**
  * txgbe_cache_ring_dcb_vmdq - Descriptor ring to register mapping for VMDq
  * @adapter: board private structure to initialize
@@ -147,6 +148,7 @@ static bool txgbe_cache_ring_dcb(struct txgbe_adapter *adapter)
 
 	return true;
 }
+#endif /* CONFIG_DCB */
 
 /**
  * txgbe_cache_ring_vmdq - Descriptor ring to register mapping for VMDq
@@ -248,12 +250,13 @@ static bool txgbe_cache_ring_rss(struct txgbe_adapter *adapter)
  **/
 static void txgbe_cache_ring_register(struct txgbe_adapter *adapter)
 {
+#if IS_ENABLED(CONFIG_DCB)
 	if (txgbe_cache_ring_dcb_vmdq(adapter))
 		return;
 
 	if (txgbe_cache_ring_dcb(adapter))
 		return;
-
+#endif /* CONFIG_DCB */
 	if (txgbe_cache_ring_vmdq(adapter))
 		return;
 
@@ -267,6 +270,7 @@ static void txgbe_cache_ring_register(struct txgbe_adapter *adapter)
 #define TXGBE_RSS_2Q_MASK       0x1
 #define TXGBE_RSS_DISABLED_MASK 0x0
 
+#if IS_ENABLED(CONFIG_DCB)
 /**
  * txgbe_set_dcb_vmdq_queues: Allocate queues for VMDq devices w/ DCB
  * @adapter: board private structure to initialize
@@ -441,6 +445,7 @@ static bool txgbe_set_dcb_queues(struct txgbe_adapter *adapter)
 
 	return true;
 }
+#endif /* CONFIG_DCB */
 
 static u16 txgbe_xdp_queues(struct txgbe_adapter *adapter)
 {
@@ -642,11 +647,13 @@ static void txgbe_set_num_queues(struct txgbe_adapter *adapter)
 	adapter->num_rx_pools = adapter->num_rx_queues;
 	adapter->num_rx_queues_per_pool = 1;
 
+#if IS_ENABLED(CONFIG_DCB)
 	if (txgbe_set_dcb_vmdq_queues(adapter))
 		return;
 
 	if (txgbe_set_dcb_queues(adapter))
 		return;
+#endif /* CONFIG_DCB */
 
 	if (txgbe_set_vmdq_queues(adapter))
 		return;

--- a/drivers/net/ethernet/wangxun/txgbe/txgbe_main.c
+++ b/drivers/net/ethernet/wangxun/txgbe/txgbe_main.c
@@ -4528,39 +4528,6 @@ static void txgbe_napi_disable_all(struct txgbe_adapter *adapter)
 	}
 }
 
-s32 txgbe_dcb_hw_ets(struct txgbe_hw *hw, struct ieee_ets *ets, int max_frame)
-{
-	__u16 refill[IEEE_8021QAZ_MAX_TCS], max[IEEE_8021QAZ_MAX_TCS];
-	__u8 prio_type[IEEE_8021QAZ_MAX_TCS];
-	int i;
-
-	/* naively give each TC a bwg to map onto CEE hardware */
-	__u8 bwg_id[IEEE_8021QAZ_MAX_TCS] = {0, 1, 2, 3, 4, 5, 6, 7};
-
-	/* Map TSA onto CEE prio type */
-	for (i = 0; i < IEEE_8021QAZ_MAX_TCS; i++) {
-		switch (ets->tc_tsa[i]) {
-		case IEEE_8021QAZ_TSA_STRICT:
-			prio_type[i] = 2;
-			break;
-		case IEEE_8021QAZ_TSA_ETS:
-			prio_type[i] = 0;
-			break;
-		default:
-			/* Hardware only supports priority strict or
-			 * ETS transmission selection algorithms if
-			 * we receive some other value from dcbnl
-			 * throw an error
-			 */
-			return -EINVAL;
-		}
-	}
-
-	txgbe_dcb_calculate_tc_credits(ets->tc_tx_bw, refill, max, max_frame);
-	return txgbe_dcb_hw_config(hw, refill, max,
-				   bwg_id, prio_type, ets->prio_tc);
-}
-
 void txgbe_clear_vxlan_port(struct txgbe_adapter *adapter)
 {
 	if (!(adapter->flags & TXGBE_FLAG_VXLAN_OFFLOAD_CAPABLE))
@@ -4586,6 +4553,7 @@ static inline unsigned long txgbe_tso_features(void)
 	return features;
 }
 
+#if IS_ENABLED(CONFIG_DCB)
 static void txgbe_configure_dcb(struct txgbe_adapter *adapter)
 {
 	struct txgbe_hw *hw = &adapter->hw;
@@ -4637,6 +4605,7 @@ static void txgbe_configure_dcb(struct txgbe_adapter *adapter)
 	/* write msb to all 8 TCs in one write */
 	wr32(hw, TXGBE_RDB_RSS_TC, msb * 0x11111111);
 }
+#endif /* CONFIG_DCB */
 
 static void txgbe_configure_lli(struct txgbe_adapter *adapter)
 {
@@ -4967,8 +4936,9 @@ static void txgbe_configure(struct txgbe_adapter *adapter)
 	struct txgbe_hw *hw = &adapter->hw;
 
 	txgbe_configure_pb(adapter);
+#if IS_ENABLED(CONFIG_DCB)
 	txgbe_configure_dcb(adapter);
-
+#endif
 	/* We must restore virtualization before VLANs or else
 	 * the VLVF registers will not be populated
 	 */
@@ -7120,8 +7090,8 @@ static void txgbe_watchdog_update_link(struct txgbe_adapter *adapter)
 
 static void txgbe_update_default_up(struct txgbe_adapter *adapter)
 {
+#if IS_ENABLED(CONFIG_DCB)
 	u8 up = 0;
-
 	struct net_device *netdev = adapter->netdev;
 	struct dcb_app app = {
 			      .selector = DCB_APP_IDTYPE_ETHTYPE,
@@ -7133,6 +7103,7 @@ static void txgbe_update_default_up(struct txgbe_adapter *adapter)
 	adapter->default_up = (up > 1) ? (ffs(up) - 1) : 0;
 #else
 	adapter->default_up = up;
+#endif
 #endif
 }
 
@@ -9787,6 +9758,7 @@ static int txgbe_siocdevprivate(struct net_device *netdev, struct ifreq *ifr,
 	return txgbe_ioctl(netdev, ifr, cmd);
 }
 
+#if IS_ENABLED(CONFIG_DCB)
 /* txgbe_validate_rtr - verify 802.1Qp to Rx packet buffer mapping is valid.
  * @adapter: pointer to txgbe_adapter
  * @tc: number of traffic classes currently enabled
@@ -9839,6 +9811,7 @@ static void txgbe_set_prio_tc_map(struct txgbe_adapter *adapter)
 		netdev_set_prio_tc_map(dev, prio, tc);
 	}
 }
+#endif /* CONFIG_DCB */
 
 /**
  * txgbe_setup_tc - routine to configure net_device for multiple traffic
@@ -9879,6 +9852,7 @@ int txgbe_setup_tc(struct net_device *dev, u8 tc)
 
 	txgbe_clear_interrupt_scheme(adapter);
 
+#if IS_ENABLED(CONFIG_DCB)
 	if (tc) {
 		netdev_set_num_tc(dev, tc);
 		txgbe_set_prio_tc_map(adapter);
@@ -9895,7 +9869,7 @@ int txgbe_setup_tc(struct net_device *dev, u8 tc)
 	}
 
 	txgbe_validate_rtr(adapter, tc);
-
+#endif
 	txgbe_init_interrupt_scheme(adapter);
 	if (netif_running(dev))
 		txgbe_open(dev);


### PR DESCRIPTION
wangxun inclusion
category: bugfix

fix set CONFIG_DCB=N, related txgbe dcb module compile error.

## Summary by Sourcery

Fix txgbe driver build and runtime behavior when optional features like DCB and FCoE are disabled by tightening configuration guards and modularizing feature-specific code.

Bug Fixes:
- Resolve txgbe driver compilation errors when CONFIG_DCB is disabled by wrapping DCB-dependent code and declarations in appropriate CONFIG_DCB conditionals and moving ETS handling into the DCB module.

Enhancements:
- Refine txgbe driver feature modularity so that DCB, FCoE, sysfs, and debugfs components are built and used only when their corresponding kernel config options are enabled.