### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] bpf: a temporary supplement fix for bpf_lsm_mmap_file null access

### DIFF
--- a/kernel/bpf/btf.c
+++ b/kernel/bpf/btf.c
@@ -6666,6 +6666,13 @@ bool btf_ctx_access(int off, int size, enum bpf_access_type type,
 	if (btf_param_match_suffix(btf, &args[arg], "__nullable"))
 		info->reg_type |= PTR_MAYBE_NULL;
 
+	/* a temporary workaround for bpf_lsm_mmap_file null pointer access,
+	 * urgly but effective, should be removed while BTF weak symbol is
+	 * supported by pahole
+	 */
+	if (!strcmp(tname, "bpf_lsm_mmap_file") && arg == 0)
+		info->reg_type |= PTR_MAYBE_NULL;
+
 	if (prog->expected_attach_type == BPF_TRACE_RAW_TP) {
 		struct btf *btf = prog->aux->attach_btf;
 		const struct btf_type *t;


### PR DESCRIPTION
fix patch before(check url below for details) might not work until pahole support BTF weak symbol override.
This commit is a temporary workaround, ugly but effective, and should be remove in the future when pahole is updated

fix patch before:
patch1: https://github.com/deepin-community/kernel/pull/1392
patch2: https://github.com/deepin-community/kernel/pull/1393

## Summary by Sourcery

Bug Fixes:
- Prevent potential null pointer access when handling the first parameter of the bpf_lsm_mmap_file hook by treating it as maybe-null in BPF verifier context.