### PR TITLE
fix s3 problems and npu driver build failure

### DIFF
--- a/drivers/clocksource/timer-sky1-gpt.c
+++ b/drivers/clocksource/timer-sky1-gpt.c
@@ -225,9 +225,6 @@ static int sky1_tick_resume(struct clock_event_device *ced)
 {
 	struct sky1_timer *sky1tm = to_sky1_timer(ced);
 
-	/* reset timer */
-	reset_control_reset(sky1tm->func_reset);
-
 	sky1_gpt_setup_tctl(sky1tm);
 
 	sky1_shutdown(ced);

--- a/drivers/soc/cix/npu/driver/Makefile
+++ b/drivers/soc/cix/npu/driver/Makefile
@@ -1,93 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0
-# Copyright (C) 2024 Arm Technology (China) Co. Ltd.
+#
+# Makefile for Cix Technology NPU (Zhouyi) Driver
+#
 
-COMPASS_DRV_BTENVAR_KMD_VERSION := 5.11.0
-# COMPASS_DRV_BTENVAR_KPATH=${PATH_LINUX}
-BUILD_AIPU_VERSION_KMD := BUILD_ZHOUYI_V3
-BUILD_TARGET_PLATFORM_KMD := BUILD_PLATFORM_SKY1
-BUILD_NPU_DEVFREQ := y
+obj-$(CONFIG_ARMCHINA_NPU) += cix-aipu.o
 
-MODULE_NAME := aipu
-SRC_DIR := .
-EXTRA_CFLAGS += -DKMD_VERSION=\"$(COMPASS_DRV_BTENVAR_KMD_VERSION)\" \
-                   -I$(PWD)/armchina-npu/ -I$(PWD)/armchina-npu/include -I$(PWD)/armchina-npu/zhouyi \
-                   -D$(BUILD_AIPU_VERSION_KMD)
+cix-aipu-y := armchina-npu/aipu.o armchina-npu/aipu_common.o armchina-npu/aipu_io.o armchina-npu/aipu_irq.o  \
+                armchina-npu/aipu_job_manager.o armchina-npu/aipu_mm.o armchina-npu/aipu_dma_buf.o armchina-npu/aipu_priv.o \
+                armchina-npu/aipu_tcb.o armchina-npu/zhouyi/zhouyi.o armchina-npu/zhouyi/v3.o armchina-npu/zhouyi/v3_priv.o armchina-npu/sky1/sky1.o
 
-COMM_OBJ := $(SRC_DIR)/armchina-npu/aipu.o \
-            $(SRC_DIR)/armchina-npu/aipu_common.o \
-            $(SRC_DIR)/armchina-npu/aipu_io.o \
-            $(SRC_DIR)/armchina-npu/aipu_irq.o \
-            $(SRC_DIR)/armchina-npu/aipu_job_manager.o \
-            $(SRC_DIR)/armchina-npu/aipu_mm.o \
-            $(SRC_DIR)/armchina-npu/aipu_dma_buf.o \
-            $(SRC_DIR)/armchina-npu/aipu_priv.o \
-            $(SRC_DIR)/armchina-npu/aipu_tcb.o \
-            $(SRC_DIR)/armchina-npu/zhouyi/zhouyi.o
+ccflags-y += -I$(src)/armchina-npu/include \
+             -I$(src)/armchina-npu/zhouyi \
+             -I$(src)/armchina-npu/sky1 \
+             -I$(src) \
+             -I$(src)/armchina-npu
 
-ifeq ($(BUILD_AIPU_VERSION_KMD), BUILD_ZHOUYI_V1)
-    AIPU_OBJ := $(SRC_DIR)/armchina-npu/zhouyi/v1.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v1v2_priv.o
-    EXTRA_CFLAGS += -DCONFIG_ARMCHINA_NPU_ARCH_V1
-else ifeq ($(BUILD_AIPU_VERSION_KMD), BUILD_ZHOUYI_V2)
-    AIPU_OBJ := $(SRC_DIR)/armchina-npu/zhouyi/v2.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v1v2_priv.o
-    EXTRA_CFLAGS += -DCONFIG_ARMCHINA_NPU_ARCH_V2
-else ifeq ($(BUILD_AIPU_VERSION_KMD), BUILD_ZHOUYI_V3)
-    AIPU_OBJ := $(SRC_DIR)/armchina-npu/zhouyi/v3.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v3_priv.o
-    EXTRA_CFLAGS += -DCONFIG_ARMCHINA_NPU_ARCH_V3
-else ifeq ($(BUILD_AIPU_VERSION_KMD), BUILD_ZHOUYI_V3_1)
-    AIPU_OBJ := $(SRC_DIR)/armchina-npu/zhouyi/v3_1.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v3_1_priv.o
-    EXTRA_CFLAGS += -DCONFIG_ARMCHINA_NPU_ARCH_V3_1
-else
-    #build all
-    AIPU_OBJ := $(SRC_DIR)/armchina-npu/zhouyi/v1.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v2.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v3.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v3_1.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v1v2_priv.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v3_priv.o \
-                $(SRC_DIR)/armchina-npu/zhouyi/v3_1_priv.o
-    EXTRA_CFLAGS += -DCONFIG_ARMCHINA_NPU_ARCH_V1 \
-                    -DCONFIG_ARMCHINA_NPU_ARCH_V2 \
-                    -DCONFIG_ARMCHINA_NPU_ARCH_V3 \
-                    -DCONFIG_ARMCHINA_NPU_ARCH_V3_1
-endif
-
-ifeq ($(BUILD_TARGET_PLATFORM_KMD), BUILD_PLATFORM_R329)
-    INIT_OBJ  := $(SRC_DIR)/armchina-npu/r329/r329.o
-else ifeq ($(BUILD_TARGET_PLATFORM_KMD), BUILD_PLATFORM_SKY1)
-    INIT_OBJ := $(SRC_DIR)/armchina-npu/sky1/sky1.o
-    EXTRA_CFLAGS += -DCONFIG_SKY1
-else ifeq ($(BUILD_TARGET_PLATFORM_KMD), BUILD_PLATFORM_SKY1_ANDROID)
-    INIT_OBJ := $(SRC_DIR)/armchina-npu/sky1/sky1.o
-    EXTRA_CFLAGS += -DCONFIG_SKY1
-    EXTRA_CFLAGS += -DCONFIG_ANDROID
-else ifeq ($(BUILD_TARGET_PLATFORM_KMD), BUILD_PLATFORM_SKY1_ANDROID_DFT)
-    INIT_OBJ := $(SRC_DIR)/armchina-npu/default/default.o
-    EXTRA_CFLAGS += -DCONFIG_ANDROID
-else
-    INIT_OBJ := $(SRC_DIR)/armchina-npu/default/default.o
-endif
-
-ifneq ($(BUILD_NPU_DEVFREQ), n)
-    EXTRA_CFLAGS  += -DCONFIG_ENABLE_DEVFREQ
-endif
-
-OBJS     := $(COMM_OBJ) $(AIPU_OBJ) $(SOC_OBJ)
-
-ifeq ($(KERNELRELEASE),)
-
-	obj-m := $(MODULE_NAME).o
-	$(MODULE_NAME)-objs := $(INIT_OBJ) $(OBJS)
-else
-	COMPASS_DRV_BTENVAR_KPATH ?= /lib/modules/`uname -r`/build
-	PWD :=$(shell pwd)
-
-all:
-	echo "COMPASS_DRV_BTENVAR_KMD_VERSION"
-	$(MAKE) -C $(COMPASS_DRV_BTENVAR_KPATH) M=$(PWD) modules
-clean:
-	$(MAKE) -C $(COMPASS_DRV_BTENVAR_KPATH) M=$(PWD) clean
-endif

--- a/drivers/soc/cix/npu/driver/armchina-npu/Makefile
+++ b/drivers/soc/cix/npu/driver/armchina-npu/Makefile
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0
 
-subdir-ccflags-y += -I$(src)
-subdir-ccflags-y += -I$(src)/include
-subdir-ccflags-y += -I$(src)/zhouyi
-subdir-ccflags-y += -I$(src)/sky1
+subdir-ccflags-y += -I$(srctree)/$(src)
+subdir-ccflags-y += -I$(srctree)/$(src)/include
+subdir-ccflags-y += -I$(srctree)/$(src)/zhouyi
+subdir-ccflags-y += -I$(srctree)/$(src)/sky1
 
 # obj-$(CONFIG_ARMCHINA_NPU) += armchina_npu.o
 aipu-objs := aipu.o aipu_common.o aipu_io.o aipu_irq.o  \

--- a/drivers/soc/cix/vpu/driver/Kbuild
+++ b/drivers/soc/cix/vpu/driver/Kbuild
@@ -2,7 +2,7 @@
 # Set the include-path according to the defined interface.
 ###########################################################
 
-ccflags-y += -I$(src) -I$(src)/if -I$(src)/dev -I$(src)/if/v4l2 -I$(src)/external
+ccflags-y += -I$(srctree)/$(src) -I$(srctree)/$(src)/if -I$(srctree)/$(src)/dev -I$(srctree)/$(src)/if/v4l2 -I$(srctree)/$(src)/external
 ccflags-$(CONFIG_VIDEO_LINLON_FTRACE) += -DMVX_LOG_FTRACE_ENABLE
 ccflags-$(CONFIG_VIDEO_LINLON_PRINT_FILE) += -DMVX_LOG_PRINT_FILE_ENABLE
 ccflags-y += $(EXTRA_CCFLAGS)


### PR DESCRIPTION
## Summary by Sourcery

Align Cix SoC multimedia drivers and timer behavior with in-tree kernel expectations to fix build and resume issues.

Bug Fixes:
- Fix NPU driver build by converting its Makefile to standard in-tree kernel build rules and include paths.
- Fix VPU driver build by using srctree-based include paths in its Kbuild file.
- Avoid unnecessary reset of the SKY1 GPT timer on resume to prevent suspend-to-RAM (S3) resume issues.

Enhancements:
- Simplify the ArmChina NPU driver build configuration by removing out-of-tree module build logic and hard-coded variant/platform flags.
- Unify ArmChina NPU subdirectory include handling with the rest of the tree by basing paths on srctree.