### PR TITLE
riscv: dts: ultrarisc: Add serial aliases for dp1000 boards

### DIFF
--- a/arch/riscv/boot/dts/ultrarisc/dp1000-evb-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-evb-v1.dts
@@ -12,7 +12,8 @@
 	compatible = "ultrarisc,evb-v1", "ultrarisc,dp1000";
 
 	chosen {
-		stdout-path = "serial1:115200n8";
+		bootargs = "earlycon=sbi console=ttyS1,115200";
+		stdout-path = &uart1;
 	};
 };
 

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-evb-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-evb-v1.dts
@@ -12,8 +12,14 @@
 	compatible = "ultrarisc,evb-v1", "ultrarisc,dp1000";
 
 	chosen {
-		bootargs = "earlycon=sbi console=ttyS1,115200";
-		stdout-path = &uart1;
+		stdout-path = "serial1:115200n8";
+	};
+
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+		serial2 = &uart2;
+		serial3 = &uart3;
 	};
 };
 

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-m0-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-m0-v1.dts
@@ -12,8 +12,14 @@
 	compatible = "rongda,m0-v1", "ultrarisc,dp1000";
 
 	chosen {
-		bootargs = "earlycon=sbi console=ttyS0,115200";
-		stdout-path = &uart0;
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+		serial2 = &uart2;
+		serial3 = &uart3;
 	};
 
 	gpio-poweroff {

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-m0-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-m0-v1.dts
@@ -12,7 +12,8 @@
 	compatible = "rongda,m0-v1", "ultrarisc,dp1000";
 
 	chosen {
-		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=sbi console=ttyS0,115200";
+		stdout-path = &uart0;
 	};
 
 	gpio-poweroff {

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-titan-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-titan-v1.dts
@@ -15,8 +15,14 @@
 	compatible = "milkv,titan-v1.2", "ultrarisc,dp1000";
 
 	chosen {
-		bootargs = "earlycon=sbi console=ttyS0,115200";
-		stdout-path = &uart0;
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+		serial2 = &uart2;
+		serial3 = &uart3;
 	};
 
 	gpio-poweroff {

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-titan-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-titan-v1.dts
@@ -15,7 +15,8 @@
 	compatible = "milkv,titan-v1.2", "ultrarisc,dp1000";
 
 	chosen {
-		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=sbi console=ttyS0,115200";
+		stdout-path = &uart0;
 	};
 
 	gpio-poweroff {


### PR DESCRIPTION
Add serial aliases (serial0-serial3) for UART devices (uart0-uart3)
in dp1000-evb-v1, dp1000-m0-v1, and dp1000-titan-v1 board DTS files.

## Summary by Sourcery

Enhancements:
- Define serial0–serial3 aliases for existing uart0–uart3 nodes in the dp1000-evb-v1, dp1000-m0-v1, and dp1000-titan-v1 DTS files to standardize serial port naming.