### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] [Deepin] Revert "arm64, mm: avoid always making PTE dirty in pte_mkwrite()"

### DIFF
--- a/arch/arm64/include/asm/pgtable.h
+++ b/arch/arm64/include/asm/pgtable.h
@@ -212,8 +212,7 @@ static inline pmd_t set_pmd_bit(pmd_t pmd, pgprot_t prot)
 static inline pte_t pte_mkwrite_novma(pte_t pte)
 {
 	pte = set_pte_bit(pte, __pgprot(PTE_WRITE));
-	if (pte_sw_dirty(pte))
-		pte = clear_pte_bit(pte, __pgprot(PTE_RDONLY));
+	pte = clear_pte_bit(pte, __pgprot(PTE_RDONLY));
 	return pte;
 }
 


### PR DESCRIPTION
deepin inclusion
category: bugfix

This reverts commit 4dfc1700a13c7d2fa3809c8430fbfe6f6f1dce91. which 4f32f754343a8888c9b2196633491d7b2665c8c4 stable, which 143937ca51cc6ae2fccc61a1cb916abb24cd34f5 upstream.

It broken s4 and kexec, before solution upstreamed, revert it.

Link: https://lore.kernel.org/all/20251204062722.3367201-1-jianpeng.chang.cn@windriver.com/


(cherry picked from commit 5da58aefdb90ed5b98b266c6e312db3d99fe6b57)

## Summary by Sourcery

Bug Fixes:
- Restore correct arm64 suspend-to-RAM and kexec behavior by undoing the change that only cleared PTE_RDONLY when the PTE was already dirty.