### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] bpf: a temporary fix for bpf_lsm_mmap_file null access

### DIFF
--- a/kernel/bpf/btf.c
+++ b/kernel/bpf/btf.c
@@ -6092,6 +6092,13 @@ bool btf_ctx_access(int off, int size, enum bpf_access_type type,
 	if (prog_arg_maybe_null(prog, btf, &args[arg]))
 		info->reg_type |= PTR_MAYBE_NULL;
 
+	/* a temporary workaround for bpf_lsm_mmap_file null pointer access,
+	 * ugly but effective, should be removed while BTF weak symbol is
+	 * supported by pahole
+	 */
+	if (!strcmp(tname, "bpf_lsm_mmap_file") && arg == 0)
+		info->reg_type |= PTR_MAYBE_NULL;
+
 	if (tgt_prog) {
 		enum bpf_prog_type tgt_type;
 


### PR DESCRIPTION
fix patch before(check url below for details) might not work until pahole support BTF weak symbol override.
This commit is a temporary workaround, ugly but effective, and should be remove in the future when pahole is updated

fix patch before:
https://github.com/deepin-community/kernel/pull/1393