### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] serial: sh-sci: Check that the DMA cookie is valid

### DIFF
--- a/drivers/tty/serial/sh-sci.c
+++ b/drivers/tty/serial/sh-sci.c
@@ -1731,7 +1731,7 @@ static void sci_dma_check_tx_occurred(struct sci_port *s)
 	struct dma_tx_state state;
 	enum dma_status status;
 
-	if (!s->chan_tx)
+	if (!s->chan_tx || s->cookie_tx <= 0)
 		return;
 
 	status = dmaengine_tx_status(s->chan_tx, s->cookie_tx, &state);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.19-rc3
category: bugfix

The driver updates struct sci_port::tx_cookie to zero right before the TX work is scheduled, or to -EINVAL when DMA is disabled. dma_async_is_complete(), called through dma_cookie_status() (and possibly through dmaengine_tx_status()), considers cookies valid only if they have values greater than or equal to 1.

Passing zero or -EINVAL to dmaengine_tx_status() before any TX DMA transfer has started leads to an incorrect TX status being reported, as the cookie is invalid for the DMA subsystem. This may cause long wait times when the serial device is opened for configuration before any TX activity has occurred.

Check that the TX cookie is valid before passing it to dmaengine_tx_status().

Fixes: 7cc0e0a43a91 ("serial: sh-sci: Check if TX data was written to device in .tx_empty()")
Cc: stable <stable@kernel.org>

Link: https://patch.msgid.link/20251217135759.402015-1-claudiu.beznea.uj@bp.renesas.com

(cherry picked from commit c3ca8a0aac832fe8047608bb2ae2cca314c6d717)

## Summary by Sourcery

Bug Fixes:
- Avoid reporting incorrect TX DMA status in the SH-SCI serial driver by skipping dmaengine_tx_status() calls when the DMA cookie is invalid.