### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net/ipv6: Fix KABI for Remove expired routes with a separated list of…

### DIFF
--- a/include/net/ip6_fib.h
+++ b/include/net/ip6_fib.h
@@ -186,8 +186,6 @@ struct fib6_info {
 	refcount_t			fib6_ref;
 	unsigned long			expires;
 
-	struct hlist_node		gc_link;
-
 	struct dst_metrics		*fib6_metrics;
 #define fib6_pmtu		fib6_metrics->metrics[RTAX_MTU-1]
 
@@ -213,8 +211,7 @@ struct fib6_info {
 	struct rcu_head			rcu;
 	struct nexthop			*nh;
 
-	DEEPIN_KABI_RESERVE(1)
-	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_USE(1, 2, struct hlist_node		gc_link)
 
 	struct fib6_nh			fib6_nh[];
 };
@@ -414,7 +411,7 @@ struct fib6_table {
 	struct inet_peer_base	tb6_peers;
 	unsigned int		flags;
 	unsigned int		fib_seq;
-	struct hlist_head       tb6_gc_hlist;	/* GC candidates */
+	DEEPIN_KABI_EXTEND(struct hlist_head       tb6_gc_hlist)	/* GC candidates */
 #define RT6_TABLE_HAS_DFLT_ROUTER	BIT(0)
 };
 


### PR DESCRIPTION
… routes

deepin inclusion
category: kabi

Fix kabi change in some whitelist symbols like nf_ct_netns_get..etc.

Log:
struct hlist_node {
        struct hlist_node *        next;                 /*     0     8 */
        struct hlist_node * *      pprev;                /*     8     8 */

        /* size: 16, cachelines: 1, members: 2 */
        /* last cacheline: 16 bytes */
};

Fixes: 87ef084fd893 ("ipv6: add exception routes to GC list in rt6_insert_exception")

## Summary by Sourcery

Preserve Deepin kernel ABI while keeping IPv6 route GC structures for exception routes.

Bug Fixes:
- Restore KABI compatibility for IPv6 fib6_info by moving gc_link into reserved Deepin KABI slots.
- Maintain KABI safety for fib6_table by wrapping the GC candidate list head in a Deepin KABI extension macro.