### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] cpufreq: Fix re-boost issue after hotplugging a CPU

### DIFF
--- a/drivers/cpufreq/cpufreq.c
+++ b/drivers/cpufreq/cpufreq.c
@@ -1504,6 +1504,10 @@ static int cpufreq_online(unsigned int cpu)
 
 		blocking_notifier_call_chain(&cpufreq_policy_notifier_list,
 				CPUFREQ_CREATE_POLICY, policy);
+	} else {
+		ret = freq_qos_update_request(policy->max_freq_req, policy->max);
+		if (ret < 0)
+			goto out_destroy_policy;
 	}
 
 	if (cpufreq_driver->get && has_target()) {


### PR DESCRIPTION
mainline inclusion
from maineline-v6.14-rc1
category: bugfix

It turns out that CPUX will stay on the base frequency after performing these operations:

 1. boost all CPUs: echo 1 > /sys/devices/system/cpu/cpufreq/boost

 2. offline one CPU: echo 0 > /sys/devices/system/cpu/cpuX/online

 3. deboost all CPUs: echo 0 > /sys/devices/system/cpu/cpufreq/boost

 4. online CPUX: echo 1 > /sys/devices/system/cpu/cpuX/online

 5. boost all CPUs again: echo 1 > /sys/devices/system/cpu/cpufreq/boost

This is because max_freq_req of the policy is not updated during the online process, and the value of max_freq_req before the last offline is retained.

When the CPU is boosted again, freq_qos_update_request() will do nothing because the old value is the same as the new one. This causes the CPU to stay at the base frequency. Updating max_freq_req  in cpufreq_online() will solve this problem.


Acked-by: Viresh Kumar <viresh.kumar@linaro.org>
Link: https://patch.msgid.link/20250117101457.1530653-2-zhenglifeng1@huawei.com
[ rjw: Subject and changelog edits ]

(cherry picked from commit 1608f0230510489d74a2e24e47054233b7e4678a)

## Summary by Sourcery

Bug Fixes:
- Update the cpufreq policy's maximum frequency QoS request during CPU online to prevent CPUs from remaining stuck at base frequency after a boost/deboost/hotplug sequence.