### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] sched/fair: Disable newidle balance for KABI

### DIFF
--- a/include/linux/sched/topology.h
+++ b/include/linux/sched/topology.h
@@ -5,7 +5,7 @@
 #include <linux/topology.h>
 
 #include <linux/sched/idle.h>
-
+#include <linux/deepin_kabi.h>
 /*
  * sched-domains (multiprocessor balancing) declarations:
  */
@@ -106,9 +106,12 @@ struct sched_domain {
 	unsigned int nr_balance_failed; /* initialise to 0 */
 
 	/* idle_balance() stats */
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 	unsigned int newidle_call;
 	unsigned int newidle_success;
 	unsigned int newidle_ratio;
+#endif  /* !CONFIG_DEEPIN_KABI_RESERVE */
+
 	u64 max_newidle_lb_cost;
 	unsigned long last_decay_max_lb_cost;
 

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -11923,6 +11923,7 @@ void update_max_interval(void)
 
 static inline void update_newidle_stats(struct sched_domain *sd, unsigned int success)
 {
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 	sd->newidle_call++;
 	sd->newidle_success += success;
 
@@ -11931,6 +11932,7 @@ static inline void update_newidle_stats(struct sched_domain *sd, unsigned int su
 		sd->newidle_call /= 2;
 		sd->newidle_success /= 2;
 	}
+#endif  /* !CONFIG_DEEPIN_KABI_RESERVE */
 }
 
 static inline bool
@@ -12629,6 +12631,7 @@ static int sched_balance_newidle(struct rq *this_rq, struct rq_flags *rf)
 		if (sd->flags & SD_BALANCE_NEWIDLE) {
 			unsigned int weight = 1;
 
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 			if (sched_feat(NI_RANDOM)) {
 				/*
 				 * Throw a 1k sided dice; and only run
@@ -12643,6 +12646,7 @@ static int sched_balance_newidle(struct rq *this_rq, struct rq_flags *rf)
 				}
 				weight = (1024 + weight/2) / weight;
 			}
+#endif  /* !CONFIG_DEEPIN_KABI_RESERVE */
 
 			pulled_task = load_balance(this_cpu, this_rq,
 						   sd, CPU_NEWLY_IDLE,

--- a/kernel/sched/features.h
+++ b/kernel/sched/features.h
@@ -122,9 +122,11 @@ SCHED_FEAT(UTIL_EST, true)
 
 SCHED_FEAT(LATENCY_WARN, false)
 
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 /*
  * Do newidle balancing proportional to its success rate using randomization.
  */
 SCHED_FEAT(NI_RANDOM, true)
+#endif  /* !CONFIG_DEEPIN_KABI_RESERVE */
 
 SCHED_FEAT(HZ_BW, true)

--- a/kernel/sched/topology.c
+++ b/kernel/sched/topology.c
@@ -1616,10 +1616,12 @@ sd_init(struct sched_domain_topology_level *tl,
 		.last_balance		= jiffies,
 		.balance_interval	= sd_weight,
 
+#ifndef CONFIG_DEEPIN_KABI_RESERVE
 		/* 50% success rate */
 		.newidle_call		= 512,
 		.newidle_success	= 256,
 		.newidle_ratio		= 512,
+#endif  /* !CONFIG_DEEPIN_KABI_RESERVE */
 
 		.max_newidle_lb_cost	= 0,
 		.last_decay_max_lb_cost	= jiffies,


### PR DESCRIPTION
deepin inclusion
category: kabi

some kabi whitelist symbol changed, such as set_cpus_allowed_ptr..etc. the symbol chain is:
int wake_up_process(struct task_struct *tsk);->struct task_struct ->struct sched_dl_entity dl,*dl_server;
->struct rq *rq;
->struct sched_domain __rcu	*sd;
->
+unsigned int newidle_call;
+unsigned int newidle_success;
+unsigned int newidle_ratio;

Before find the way to solve it, disable it for CONFIG_DEEPIN_KABI_RESERVE.

Log:

change set_cpus_allowed_ptr
change wake_up_process
change set_user_nice

Fixes: 97d553786121 ("sched/fair: Proportional newidle balance")

## Summary by Sourcery

Disable proportional newidle balancing when Deepin KABI reservation is enabled to preserve kernel ABI stability.

Enhancements:
- Guard newidle balancing statistics and randomized NI_RANDOM feature behind CONFIG_DEEPIN_KABI_RESERVE to avoid KABI-visible struct sched_domain changes.
- Initialize sched_domain instances without newidle statistics fields when KABI reservation is active.

## Summary by Sourcery

Guard proportional newidle balancing and its statistics behind Deepin KABI reservation to avoid changing the sched_domain ABI layout.

Enhancements:
- Wrap newidle balance statistics fields in sched_domain and related initialization in sd_init() with CONFIG_DEEPIN_KABI_RESERVE to keep the struct layout stable.
- Disable NI_RANDOM-based proportional newidle balancing and its feature flag when Deepin KABI reservation is enabled.
- Include Deepin KABI header in scheduler topology to support the new configuration guard.