### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin]  CI: add extra build ci

### DIFF
--- a/.github/workflows/build-kernel-extra.yml
+++ b/.github/workflows/build-kernel-extra.yml
@@ -1,0 +1,58 @@
+name: build kernel extra
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  KBUILD_BUILD_USER: deepin-kernel-sig
+  KBUILD_BUILD_HOST: deepin-kernel-builder
+  email: support@deepin.org
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  build-kernel-extra:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Install Deps"
+        run: |
+          git config --global user.email $email
+          git config --global user.name $KBUILD_BUILD_USER
+
+      - name: "Compile kernel x86_64_defconfig"
+        run: |
+          # .config
+          make x86_64_defconfig
+          make -j$(nproc)
+
+      - name: "Clang build kernel x86_64_defconfig"
+        run: |
+          # .config
+          make LLVM=-18 x86_64_defconfig
+          make LLVM=-18 -j$(nproc)
+
+      - name: "Clang build kernel arm64 defconfig"
+        run: |
+          # .config
+          make LLVM=-18 ARCH=arm64 defconfig
+          make LLVM=-18 ARCH=arm64 -j$(nproc)
+
+      - name: "Clang build kernel loongarch loongson3_defconfig"
+        run: |
+          # .config
+          make LLVM=-18 ARCH=loongarch loongson3_defconfig
+          make LLVM=-18 ARCH=loongarch -j$(nproc)
+
+      - name: "Clang build kernel riscv rv32_defconfig"
+        run: |
+          # .config
+          make LLVM=-18 ARCH=riscv rv32_defconfig
+          make LLVM=-18 ARCH=riscv -j$(nproc)
+


### PR DESCRIPTION
deepin inclusion
category: other

Add an extra build test to detect more cases for there code.

## Summary by Sourcery

CI:
- Introduce a new self-hosted GitHub Actions workflow that builds the kernel with x86_64_defconfig using GCC and Clang and performs Clang-based builds for arm64, loongarch, and riscv configurations.