### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] ALSA: usb-audio: Fix missing unlock at error path of maxpacksize check

### DIFF
--- a/sound/usb/endpoint.c
+++ b/sound/usb/endpoint.c
@@ -1386,7 +1386,8 @@ int snd_usb_endpoint_set_params(struct snd_usb_audio *chip,
 	if (ep->packsize[1] > ep->maxpacksize) {
 		usb_audio_dbg(chip, "Too small maxpacksize %u for rate %u / pps %u\n",
 			      ep->maxpacksize, ep->cur_rate, ep->pps);
-		return -EINVAL;
+		err = -EINVAL;
+		goto unlock;
 	}
 
 	/* calculate the frequency in 16.16 format */


### PR DESCRIPTION
stable inclusion
from stable-v6.12.60
category: bugfix

The recent backport of the upstream commit 05a1fc5efdd8 ("ALSA: usb-audio: Fix potential overflow of PCM transfer buffer") on the older stable kernels like 6.12.y was broken since it doesn't consider the mutex unlock, where the upstream code manages with guard(). In the older code, we still need an explicit unlock.

This is a fix that corrects the error path, applied only on old stable trees.

Reported-by: Pavel Machek <pavel@denx.de>
Closes: https://lore.kernel.org/aSWtH0AZH5+aeb+a@duo.ucw.cz
Fixes: 98e9d5e33bda ("ALSA: usb-audio: Fix potential overflow of PCM transfer buffer")
Reviewed-by: Pavel Machek <pavel@denx.de>


(cherry picked from commit fdf0dc82eb60091772ecea73cbc5a8fb7562fc45)

## Summary by Sourcery

Bug Fixes:
- Ensure the mutex is properly released on the error path when max packet size is too small in the USB audio endpoint configuration.