### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] update hygon qos to new version

### DIFF
--- a/arch/x86/kernel/cpu/hygon.c
+++ b/arch/x86/kernel/cpu/hygon.c
@@ -18,6 +18,7 @@
 #include <asm/page.h>
 #include <linux/module.h>
 #include <linux/init.h>
+#include <asm/resctrl.h>
 
 #include "cpu.h"
 
@@ -246,6 +247,8 @@ static void bsp_init_hygon(struct cpuinfo_x86 *c)
 			x86_amd_ls_cfg_ssbd_mask = 1ULL << 10;
 		}
 	}
+
+	resctrl_cpu_detect(c);
 }
 
 static void init_hygon_cap(struct cpuinfo_x86 *c)

--- a/arch/x86/kernel/cpu/hygon.c
+++ b/arch/x86/kernel/cpu/hygon.c
@@ -18,7 +18,6 @@
 #include <asm/page.h>
 #include <linux/module.h>
 #include <linux/init.h>
-#include <asm/resctrl.h>
 
 #include "cpu.h"
 
@@ -247,7 +246,6 @@ static void bsp_init_hygon(struct cpuinfo_x86 *c)
 			x86_amd_ls_cfg_ssbd_mask = 1ULL << 10;
 		}
 	}
-	resctrl_cpu_detect(c);
 }
 
 static void init_hygon_cap(struct cpuinfo_x86 *c)

--- a/arch/x86/kernel/cpu/resctrl/core.c
+++ b/arch/x86/kernel/cpu/resctrl/core.c
@@ -943,8 +943,19 @@ void resctrl_cpu_detect(struct cpuinfo_x86 *c)
 		c->x86_cache_occ_scale = ebx;
 		c->x86_cache_mbm_width_offset = eax & 0xff;
 
-		if (c->x86_vendor == X86_VENDOR_AMD && !c->x86_cache_mbm_width_offset)
-			c->x86_cache_mbm_width_offset = MBM_CNTR_WIDTH_OFFSET_AMD;
+		if (!c->x86_cache_mbm_width_offset) {
+			switch (c->x86_vendor) {
+			case X86_VENDOR_AMD:
+				c->x86_cache_mbm_width_offset = MBM_CNTR_WIDTH_OFFSET_AMD;
+				break;
+			case X86_VENDOR_HYGON:
+				c->x86_cache_mbm_width_offset = MBM_CNTR_WIDTH_OFFSET_HYGON;
+				break;
+			default:
+				/* Leave c->x86_cache_mbm_width_offset as 0 */
+				break;
+			}
+		}
 	}
 }
 

--- a/arch/x86/kernel/cpu/resctrl/core.c
+++ b/arch/x86/kernel/cpu/resctrl/core.c
@@ -759,7 +759,8 @@ static __init bool get_mem_config(void)
 
 	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL)
 		return __get_mem_config_intel(&hw_res->r_resctrl);
-	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD)
+	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD ||
+		 boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
 		return __rdt_get_mem_config_amd(&hw_res->r_resctrl);
 
 	return false;
@@ -910,7 +911,8 @@ static __init void rdt_init_res_defs(void)
 {
 	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL)
 		rdt_init_res_defs_intel();
-	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD)
+	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD ||
+		 boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
 		rdt_init_res_defs_amd();
 }
 

--- a/arch/x86/kernel/cpu/resctrl/core.c
+++ b/arch/x86/kernel/cpu/resctrl/core.c
@@ -759,8 +759,7 @@ static __init bool get_mem_config(void)
 
 	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL)
 		return __get_mem_config_intel(&hw_res->r_resctrl);
-	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD ||
-		 boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
+	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD)
 		return __rdt_get_mem_config_amd(&hw_res->r_resctrl);
 
 	return false;
@@ -911,8 +910,7 @@ static __init void rdt_init_res_defs(void)
 {
 	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL)
 		rdt_init_res_defs_intel();
-	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD ||
-		 boot_cpu_data.x86_vendor == X86_VENDOR_HYGON)
+	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD)
 		rdt_init_res_defs_amd();
 }
 
@@ -943,9 +941,7 @@ void resctrl_cpu_detect(struct cpuinfo_x86 *c)
 		c->x86_cache_occ_scale = ebx;
 		c->x86_cache_mbm_width_offset = eax & 0xff;
 
-		if ((c->x86_vendor == X86_VENDOR_AMD ||
-		     c->x86_vendor == X86_VENDOR_HYGON) &&
-		    !c->x86_cache_mbm_width_offset)
+		if (c->x86_vendor == X86_VENDOR_AMD && !c->x86_cache_mbm_width_offset)
 			c->x86_cache_mbm_width_offset = MBM_CNTR_WIDTH_OFFSET_AMD;
 	}
 }

--- a/arch/x86/kernel/cpu/resctrl/internal.h
+++ b/arch/x86/kernel/cpu/resctrl/internal.h
@@ -20,6 +20,9 @@
 #define MBA_IS_LINEAR			0x4
 #define MBM_CNTR_WIDTH_OFFSET_AMD	20
 
+/* Hygon MBM counter width as an offset from MBM_CNTR_WIDTH_BASE */
+#define MBM_CNTR_WIDTH_OFFSET_HYGON	8
+
 #define RMID_VAL_ERROR			BIT_ULL(63)
 #define RMID_VAL_UNAVAIL		BIT_ULL(62)
 /*


### PR DESCRIPTION
Tianxiang Peng (1):
  x86/cpu/hygon: Add missing resctrl_cpu_detect() in bsp_init helper

Wentao Guan (1):
  Revert "x86/resctrl: Add Hygon QoS support"

Xiaochen Shen (2):
  x86/resctrl: Add missing resctrl initialization for Hygon
  x86/resctrl: Fix memory bandwidth counter width for Hygon

 arch/x86/kernel/cpu/hygon.c            |  1 +
 arch/x86/kernel/cpu/resctrl/core.c     | 17 +++++++++++++----
 arch/x86/kernel/cpu/resctrl/internal.h |  3 +++
 3 files changed, 17 insertions(+), 4 deletions(-)

## Summary by Sourcery

Update Hygon resctrl QoS support and detection to align with upstream behavior.

Bug Fixes:
- Correctly initialize Hygon resctrl support during BSP CPU setup.
- Fix Hygon memory bandwidth monitoring counter width by using a Hygon-specific width offset instead of sharing the AMD value.

Enhancements:
- Refine resctrl CPU detection logic to select vendor-specific MBM counter width offsets for AMD and Hygon, leaving others unchanged.