### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [Deepin] scsi: leapraid: correct LEAPRAID_REPLY_SIZE macro

### DIFF
--- a/drivers/scsi/leapraid/leapraid_app.c
+++ b/drivers/scsi/leapraid/leapraid_app.c
@@ -305,7 +305,7 @@ static long leapraid_ctl_do_command(struct leapraid_adapter *adapter,
 
 	adapter->driver_cmds.ctl_cmd.status = LEAPRAID_CMD_PENDING;
 	memset((void *)(&adapter->driver_cmds.ctl_cmd.reply), 0,
-	       LEAPRAID_REPLY_SIEZ);
+	       LEAPRAID_REPLY_SIZE);
 	ctl_sp_mpi_req = leapraid_get_task_desc(adapter, taskid);
 	memset(ctl_sp_mpi_req, 0, LEAPRAID_REQUEST_SIZE);
 	memcpy(ctl_sp_mpi_req,
@@ -428,7 +428,7 @@ static long leapraid_ctl_do_command(struct leapraid_adapter *adapter,
 		}
 	}
 	if (karg->max_rep_bytes) {
-		sz = min_t(u32, karg->max_rep_bytes, LEAPRAID_REPLY_SIEZ);
+		sz = min_t(u32, karg->max_rep_bytes, LEAPRAID_REPLY_SIZE);
 		if (copy_to_user(karg->rep_msg_buf_ptr,
 				 (void *)&adapter->driver_cmds.ctl_cmd.reply,
 				 sz)) {

--- a/drivers/scsi/leapraid/leapraid_func.c
+++ b/drivers/scsi/leapraid/leapraid_func.c
@@ -5347,7 +5347,7 @@ static void leapraid_request_descript_handler(struct leapraid_adapter *adapter,
 	case LEAPRAID_RPY_DESC_FLG_ADDRESS_REPLY:
 		rep = le32_to_cpu(rpf->addr_rep.rep_frame_addr);
 		if (rep > ((u32)adapter->mem_desc.rep_msg_dma +
-			   adapter->adapter_attr.rep_msg_qd * LEAPRAID_REPLY_SIEZ) ||
+			   adapter->adapter_attr.rep_msg_qd * LEAPRAID_REPLY_SIZE) ||
 		    rep < ((u32)adapter->mem_desc.rep_msg_dma))
 			rep = 0;
 		if (taskid) {
@@ -7292,7 +7292,7 @@ static void leapraid_free_host_memory(struct leapraid_adapter *adapter)
 	if (adapter->mem_desc.rep_msg) {
 		dma_free_coherent(
 			&adapter->pdev->dev,
-			adapter->adapter_attr.rep_msg_qd * LEAPRAID_REPLY_SIEZ,
+			adapter->adapter_attr.rep_msg_qd * LEAPRAID_REPLY_SIZE,
 			adapter->mem_desc.rep_msg,
 			adapter->mem_desc.rep_msg_dma);
 		adapter->mem_desc.rep_msg = NULL;
@@ -7545,7 +7545,7 @@ try_again:
 	adapter->mem_desc.rep_msg =
 		 dma_alloc_coherent(&adapter->pdev->dev,
 				    adapter->adapter_attr.rep_msg_qd *
-				    LEAPRAID_REPLY_SIEZ,
+				    LEAPRAID_REPLY_SIZE,
 				    &adapter->mem_desc.rep_msg_dma,
 				    GFP_KERNEL);
 	if (!adapter->mem_desc.rep_msg) {
@@ -7556,7 +7556,7 @@ try_again:
 	}
 	if (!leapraid_is_in_same_4g_seg(adapter->mem_desc.rep_msg_dma,
 					adapter->adapter_attr.rep_msg_qd *
-					LEAPRAID_REPLY_SIEZ)) {
+					LEAPRAID_REPLY_SIZE)) {
 		dev_warn(&adapter->pdev->dev,
 			 "use 32 bit dma due to rep msg is not in same 4g!\n");
 		rc = -EAGAIN;
@@ -8125,7 +8125,7 @@ static void leapraid_init_rep_msg_addr(struct leapraid_adapter *adapter)
 
 	for (i = 0, reply_address = (u32)adapter->mem_desc.rep_msg_dma;
 	     i < adapter->adapter_attr.rep_msg_qd;
-	     i++, reply_address += LEAPRAID_REPLY_SIEZ) {
+	     i++, reply_address += LEAPRAID_REPLY_SIZE) {
 		adapter->mem_desc.rep_msg_addr[i] = cpu_to_le32(reply_address);
 	}
 }

--- a/drivers/scsi/leapraid/leapraid_func.h
+++ b/drivers/scsi/leapraid/leapraid_func.h
@@ -29,7 +29,7 @@
 
 /* some requset and reply buffer size */
 #define LEAPRAID_REQUEST_SIZE                   128
-#define LEAPRAID_REPLY_SIEZ                     128
+#define LEAPRAID_REPLY_SIZE                     128
 #define LEAPRAID_CHAIN_SEG_SIZE                 128
 #define LEAPRAID_MAX_SGES_IN_CHAIN              7
 #define LEAPRAID_DEFAULT_CHAINS_PER_IO          19
@@ -425,7 +425,7 @@ enum LEAPRAID_CB_INDEX {
 };
 
 struct leapraid_default_reply {
-	u8 pad[LEAPRAID_REPLY_SIEZ];
+	u8 pad[LEAPRAID_REPLY_SIZE];
 };
 
 struct leapraid_sense_buffer {


### PR DESCRIPTION
#1470 

deepin inclusion
category: other

fix the typo.

Fixes: 08c6c3c5c5fc ("scsi: leapraid: supports LeapRaid controller")

## Summary by Sourcery

Bug Fixes:
- Fix incorrect LEAPRAID reply size macro name used in reply buffer allocation, initialization, and bounds checking in the LeapRaid driver.