### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [HISI] Sync sdei_watchdog code with openEuler OLK-6.6

### DIFF
--- a/arch/arm64/kernel/watchdog_sdei.c
+++ b/arch/arm64/kernel/watchdog_sdei.c
@@ -25,6 +25,7 @@ static int sdei_watchdog_event_num;
 bool disable_sdei_nmi_watchdog;
 static bool sdei_watchdog_registered;
 static DEFINE_PER_CPU(ktime_t, last_check_time);
+static DEFINE_PER_CPU(bool, sdei_usr_en);
 
 void sdei_watchdog_hardlockup_enable(unsigned int cpu)
 {
@@ -44,6 +45,7 @@ void sdei_watchdog_hardlockup_enable(unsigned int cpu)
 		pr_err("Enable NMI Watchdog failed on cpu%d\n",
 				smp_processor_id());
 	}
+	__this_cpu_write(sdei_usr_en, 1);
 }
 
 void sdei_watchdog_hardlockup_disable(unsigned int cpu)
@@ -54,6 +56,7 @@ void sdei_watchdog_hardlockup_disable(unsigned int cpu)
 		return;
 
 	ret = sdei_api_event_disable(sdei_watchdog_event_num);
+	__this_cpu_write(sdei_usr_en, 0);
 	if (ret)
 		pr_err("Disable NMI Watchdog failed on cpu%d\n",
 				smp_processor_id());
@@ -110,16 +113,18 @@ void sdei_watchdog_clear_eoi(void)
 static int sdei_watchdog_pm_notifier(struct notifier_block *nb,
 				unsigned long action, void *data)
 {
-	int rv;
+	int rv = 0;
 
 	WARN_ON_ONCE(preemptible());
 
 	switch (action) {
 	case CPU_PM_ENTER:
-		rv = sdei_api_event_disable(sdei_watchdog_event_num);
+		if (per_cpu(sdei_usr_en, smp_processor_id()))
+			rv = sdei_api_event_disable(sdei_watchdog_event_num);
 		break;
 	case CPU_PM_EXIT:
-		rv = sdei_api_event_enable(sdei_watchdog_event_num);
+		if (per_cpu(sdei_usr_en, smp_processor_id()))
+			rv = sdei_api_event_enable(sdei_watchdog_event_num);
 		break;
 	default:
 		return NOTIFY_DONE;

--- a/arch/arm64/kernel/watchdog_sdei.c
+++ b/arch/arm64/kernel/watchdog_sdei.c
@@ -114,9 +114,27 @@ static int sdei_watchdog_pm_notifier(struct notifier_block *nb,
 				unsigned long action, void *data)
 {
 	int rv = 0;
+	u64 result;
 
 	WARN_ON_ONCE(preemptible());
 
+	/*
+	 * Judge event status before disable or enable to prevent
+	 * incorrect state transitions, e.g., disabling after
+	 * unregistering.
+	 */
+	rv = sdei_api_event_status(sdei_watchdog_event_num, &result);
+	if (rv)
+		goto error;
+	if (!result)
+		goto success;
+
+	/*
+	 * After powering on/off the LPI (Low Power Idle),
+	 * the enable function must be called to enable the
+	 * EL3 Secure Timer, ensuring proper handling of
+	 * secure timer functionality.
+	 */
 	switch (action) {
 	case CPU_PM_ENTER:
 		if (per_cpu(sdei_usr_en, smp_processor_id()))
@@ -131,9 +149,10 @@ static int sdei_watchdog_pm_notifier(struct notifier_block *nb,
 		return NOTIFY_DONE;
 	}
 
+error:
 	if (rv)
 		return notifier_from_errno(rv);
-
+success:
 	return NOTIFY_OK;
 }
 

--- a/arch/arm64/kernel/watchdog_sdei.c
+++ b/arch/arm64/kernel/watchdog_sdei.c
@@ -123,6 +123,7 @@ static int sdei_watchdog_pm_notifier(struct notifier_block *nb,
 			rv = sdei_api_event_disable(sdei_watchdog_event_num);
 		break;
 	case CPU_PM_EXIT:
+	case CPU_PM_ENTER_FAILED:
 		if (per_cpu(sdei_usr_en, smp_processor_id()))
 			rv = sdei_api_event_enable(sdei_watchdog_event_num);
 		break;

--- a/arch/arm64/kernel/watchdog_sdei.c
+++ b/arch/arm64/kernel/watchdog_sdei.c
@@ -65,7 +65,6 @@ static int sdei_watchdog_callback(u32 event,
 	ktime_t delta, now = ktime_get_mono_fast_ns();
 
 	delta = now - __this_cpu_read(last_check_time);
-	__this_cpu_write(last_check_time, now);
 
 	/*
 	 * Set delta to 4/5 of the actual watchdog threshold period so the
@@ -79,6 +78,7 @@ static int sdei_watchdog_callback(u32 event,
 	}
 
 	watchdog_hardlockup_check(smp_processor_id(), regs);
+	__this_cpu_write(last_check_time, now);
 
 	return 0;
 }


### PR DESCRIPTION
## Summary by Sourcery

Guard SDEI watchdog power-management transitions with event status checks and per-CPU user enable state tracking.

Bug Fixes:
- Prevent invalid SDEI watchdog event enable/disable transitions during CPU power management by checking event status before acting.
- Avoid disabling or re-enabling the SDEI watchdog around CPU low-power states when it was not explicitly enabled by the user.
- Ensure watchdog timestamps are only updated after successful hard lockup checks to maintain correct monitoring intervals across events.

Enhancements:
- Track per-CPU SDEI watchdog user enablement state to coordinate behavior across hardlockup control and power-management notifiers.