### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12-y] bpf: fix recent three come up with bugs from upstream

### DIFF
--- a/kernel/bpf/trampoline.c
+++ b/kernel/bpf/trampoline.c
@@ -653,15 +653,22 @@ static void bpf_shim_tramp_link_release(struct bpf_link *link)
 		return;
 
 	WARN_ON_ONCE(bpf_trampoline_unlink_prog(&shim_link->link, shim_link->trampoline, NULL));
-	bpf_trampoline_put(shim_link->trampoline);
 }
 
 static void bpf_shim_tramp_link_dealloc(struct bpf_link *link)
 {
 	struct bpf_shim_tramp_link *shim_link =
 		container_of(link, struct bpf_shim_tramp_link, link.link);
+	struct bpf_trampoline *tr = shim_link->trampoline;
+	if (!tr) {
+		kfree(shim_link);
+		return;
+	}
 
+	mutex_lock(&tr->mutex);
 	kfree(shim_link);
+	mutex_unlock(&tr->mutex);
+	bpf_trampoline_put(tr);
 }
 
 static const struct bpf_link_ops bpf_shim_tramp_link_lops = {
@@ -749,10 +756,8 @@ int bpf_trampoline_link_cgroup_shim(struct bpf_prog *prog,
 	mutex_lock(&tr->mutex);
 
 	shim_link = cgroup_shim_find(tr, bpf_func);
-	if (shim_link) {
+	if (shim_link && atomic64_inc_not_zero(&shim_link->link.link.refcnt)) {
 		/* Reusing existing shim attached by the other program. */
-		bpf_link_inc(&shim_link->link.link);
-
 		mutex_unlock(&tr->mutex);
 		bpf_trampoline_put(tr); /* bpf_trampoline_get above */
 		return 0;

--- a/net/bpf/test_run.c
+++ b/net/bpf/test_run.c
@@ -101,11 +101,9 @@ reset:
 struct xdp_page_head {
 	struct xdp_buff orig_ctx;
 	struct xdp_buff ctx;
-	union {
-		/* ::data_hard_start starts here */
-		DECLARE_FLEX_ARRAY(struct xdp_frame, frame);
-		DECLARE_FLEX_ARRAY(u8, data);
-	};
+	/* ::data_hard_start starts here */
+	struct xdp_frame frame;
+	DECLARE_FLEX_ARRAY(u8, data);
 };
 
 struct xdp_test_data {
@@ -142,10 +140,11 @@ static void xdp_test_run_init_page(netmem_ref netmem, void *arg)
 	frm_len = orig_ctx->data_end - orig_ctx->data_meta;
 	meta_len = orig_ctx->data - orig_ctx->data_meta;
 	headroom -= meta_len;
+	headroom += sizeof(head->frame);
 
 	new_ctx = &head->ctx;
-	frm = head->frame;
-	data = head->data;
+	frm = &head->frame;
+	data = frm;
 	memcpy(data + headroom, orig_ctx->data_meta, frm_len);
 
 	xdp_init_buff(new_ctx, TEST_XDP_FRAME_SIZE, &xdp->rxq);
@@ -226,8 +225,8 @@ static bool frame_was_changed(const struct xdp_page_head *head)
 	 * i.e. has the highest chances to be overwritten. If those two are
 	 * untouched, it's most likely safe to skip the context reset.
 	 */
-	return head->frame->data != head->orig_ctx.data ||
-	       head->frame->flags != head->orig_ctx.flags;
+	return head->frame.data != head->orig_ctx.data ||
+	       head->frame.flags != head->orig_ctx.flags;
 }
 
 static bool ctx_was_changed(struct xdp_page_head *head)
@@ -245,8 +244,8 @@ static void reset_ctx(struct xdp_page_head *head)
 	head->ctx.data = head->orig_ctx.data;
 	head->ctx.data_meta = head->orig_ctx.data_meta;
 	head->ctx.data_end = head->orig_ctx.data_end;
-	xdp_update_frame_from_buff(&head->ctx, head->frame);
-	head->frame->mem = head->orig_ctx.rxq->mem;
+	xdp_update_frame_from_buff(&head->ctx, &head->frame);
+	head->frame.mem = head->orig_ctx.rxq->mem;
 }
 
 static int xdp_recv_frames(struct xdp_frame **frames, int nframes,
@@ -312,7 +311,7 @@ static int xdp_test_run_batch(struct xdp_test_data *xdp, struct bpf_prog *prog,
 		head = phys_to_virt(page_to_phys(page));
 		reset_ctx(head);
 		ctx = &head->ctx;
-		frm = head->frame;
+		frm = &head->frame;
 		xdp->frame_cnt++;
 
 		act = bpf_prog_run_xdp(prog, ctx);

--- a/net/core/lwt_bpf.c
+++ b/net/core/lwt_bpf.c
@@ -615,9 +615,12 @@ int bpf_lwt_push_ip_encap(struct sk_buff *skb, void *hdr, u32 len, bool ingress)
 
 	if (ingress)
 		err = skb_cow_head(skb, len + skb->mac_len);
-	else
+	else {
+		if (unlikely(!skb_dst(skb)))
+			return -EINVAL;
 		err = skb_cow_head(skb,
 				   len + LL_RESERVED_SPACE(skb_dst(skb)->dev));
+	}
 	if (unlikely(err))
 		return err;
 

--- a/tools/testing/selftests/bpf/prog_tests/xdp_do_redirect.c
+++ b/tools/testing/selftests/bpf/prog_tests/xdp_do_redirect.c
@@ -58,12 +58,12 @@ static int attach_tc_prog(struct bpf_tc_hook *hook, int fd)
 
 /* The maximum permissible size is: PAGE_SIZE - sizeof(struct xdp_page_head) -
  * SKB_DATA_ALIGN(sizeof(struct skb_shared_info)) - XDP_PACKET_HEADROOM =
- * 3408 bytes for 64-byte cacheline and 3216 for 256-byte one.
+ * 3368 bytes for 64-byte cacheline and 3216 for 256-byte one.
  */
 #if defined(__s390x__)
-#define MAX_PKT_SIZE 3216
+#define MAX_PKT_SIZE 3176
 #else
-#define MAX_PKT_SIZE 3408
+#define MAX_PKT_SIZE 3368
 #endif
 static void test_max_pkt_size(int fd)
 {


### PR DESCRIPTION
bug1: https://lore.kernel.org/all/fa2be179-bad7-4ee3-8668-4903d1853461@hust.edu.cn/
bug2: https://lore.kernel.org/all/de98e423-a113-4a11-853d-9706cbc07e37@hust.edu.cn/
bug3: https://lore.kernel.org/all/3c4ebb0b.46ff8.19abab8abe2.Coremail.kaiyanm@hust.edu.cn/

fix1(a86d5ab): from [upstream](https://lore.kernel.org/all/20260104162350.347403-2-kafai.wan@linux.dev/)
fix2(4a98882): is a temporary fix
fix3(c923ab1): is being commited to upstream

## Summary by Sourcery

Fix multiple BPF-related bugs in XDP test infrastructure, trampoline shim link management, and LWT IP encapsulation handling.

Bug Fixes:
- Correct XDP page head layout and context/frame handling in BPF XDP test runner to avoid incorrect frame pointer usage and sizing issues.
- Fix BPF shim trampoline link lifetime management by guarding deallocation with the trampoline mutex and safe refcount checks when reusing existing shims.
- Adjust XDP redirect selftest maximum packet sizes to match the revised XDP page layout and avoid exceeding buffer limits.
- Prevent null-dst dereference in BPF LWT IP encapsulation on egress by validating skb_dst before using LL_RESERVED_SPACE.