### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [CI] CI: add check depend all workflow

### DIFF
--- a/.github/tools/check_kernel_commits.sh
+++ b/.github/tools/check_kernel_commits.sh
@@ -11,9 +11,9 @@ log_error() { echo -e "\033[31m[ERROR]\033[0m $*" >&2; }
 
 main() {
     [ $# -lt 1 ] && { echo "Usage: $0 <range> [branch]" >&2; exit 1; }
-    
+
     local range="$1"
-    
+
     if ! git remote get-url torvalds >/dev/null 2>&1; then
         git remote add torvalds "${REMOTE_URL}"
     else
@@ -64,10 +64,6 @@ main() {
         # 处理完一个commit
         if (hash != "") {
             processed++
-            if (processed % 10 == 0) {
-                printf "\r[INFO] 进度: %d/%d | 匹配:%d 重复:%d 无Fixes:%d 缺依赖:%d", 
-                       processed, total, matched, dup, no_fixes, no_ref > "/dev/stderr"
-            }
             
             # 条件1：标题是否已存在？
             if (subject in target) {
@@ -112,7 +108,6 @@ main() {
                 } else {
                     # 符合条件：有Fixes且引用存在，且标题不重复
                     matched++
-                    printf "\r\033[K" > "/dev/stderr"  # 清行
                     print hash " " subject
                 }
             }

--- a/.github/tools/check_kernel_commits.sh
+++ b/.github/tools/check_kernel_commits.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REMOTE_NAME="${REMOTE_NAME:-torvalds}"
+REMOTE_URL="${REMOTE_URL:-https://github.com/torvalds/linux.git}"
+TARGET_BRANCH="${2:-master}"
+
+log_info() { echo -e "\033[32m[INFO]\033[0m $*" >&2; }
+log_error() { echo -e "\033[31m[ERROR]\033[0m $*" >&2; }
+
+main() {
+    [ $# -lt 1 ] && { echo "Usage: $0 <range> [branch]" >&2; exit 1; }
+    
+    local range="$1"
+    
+    if ! git remote get-url torvalds >/dev/null 2>&1; then
+        git remote add torvalds "${REMOTE_URL}"
+    else
+        git remote set-url torvalds "${REMOTE_URL}"
+    fi
+
+    git fetch torvalds
+
+    if ! git rev-parse --verify "$TARGET_BRANCH^{commit}" >/dev/null 2>&1; then
+        log_error "目标分支不存在: $TARGET_BRANCH"
+        exit 1
+    fi
+    
+    local tmp_target=$(mktemp)
+    
+    log_info "正在导出 $TARGET_BRANCH 标题..."
+    git log --format="%s" "$TARGET_BRANCH" 2>/dev/null > "$tmp_target"
+    local target_count=$(wc -l < "$tmp_target")
+    log_info "目标分支共 $target_count 个标题"
+    
+    local total=$(git rev-list --count "$range" 2>/dev/null || echo "0")
+    log_info "检查范围 $range (共 $total 个提交)..."
+    
+    log_info "开始筛选..."
+    echo "========================================"
+    
+    # 使用标准AWK（兼容mawk/gawk），避免match()数组捕获
+    git log --format="%H%n%s%n%b%n---COMMIT_END---" --reverse "$range" 2>/dev/null | \
+    awk -v target_file="$tmp_target" -v total="$total" '
+    BEGIN {
+        # 加载目标分支标题到数组
+        while ((getline line < target_file) > 0) {
+            if (length(line) > 0) target[line] = 1
+        }
+        close(target_file)
+        
+        matched = 0
+        dup = 0
+        no_fixes = 0
+        no_ref = 0
+        processed = 0
+        
+        # 读取状态：0=读hash, 1=读subject, 2=读body
+        state = 0
+    }
+    
+     /---COMMIT_END---/ {
+        # 处理完一个commit
+        if (hash != "") {
+            processed++
+            if (processed % 10 == 0) {
+                printf "\r[INFO] 进度: %d/%d | 匹配:%d 重复:%d 无Fixes:%d 缺依赖:%d", 
+                       processed, total, matched, dup, no_fixes, no_ref > "/dev/stderr"
+            }
+            
+            # 条件1：标题是否已存在？
+            if (subject in target) {
+                dup++
+            } else {
+                # 条件2：查找 Fixes: 行
+                has_fixes = 0
+                ref_found = 0
+                
+                # 分割body行查找 Fixes:
+                n = split(body, lines, /\n/)
+                for (i=1; i<=n; i++) {
+                    if (lines[i] ~ /^Fixes:/) {
+                        has_fixes = 1
+                        
+                        # 提取 ("...") 中的内容（兼容所有awk版本）
+                        line_content = lines[i]
+                        start_pos = index(line_content, "(\"") 
+                        
+                        if (start_pos > 0) {
+                            # 找到 (" 的位置，提取到 ") 结束
+                            temp = substr(line_content, start_pos + 2)
+                            end_pos = index(temp, "\")")
+                            
+                            if (end_pos > 0) {
+                                ref_title = substr(temp, 1, end_pos - 1)
+                                
+                                # 检查引用是否在目标分支
+                                if (ref_title in target) {
+                                    ref_found = 1
+                                    break
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                if (!has_fixes) {
+                    no_fixes++
+                } else if (!ref_found) {
+                    no_ref++
+                } else {
+                    # 符合条件：有Fixes且引用存在，且标题不重复
+                    matched++
+                    printf "\r\033[K" > "/dev/stderr"  # 清行
+                    print hash " " subject
+                }
+            }
+        }
+        
+        state = 0
+        hash = ""
+        subject = ""
+        body = ""
+        next
+    }
+    
+    state == 0 {
+        hash = $0
+        state = 1
+        next
+    }
+    
+    state == 1 {
+        subject = $0
+        state = 2
+        next
+    }
+    
+    state == 2 {
+        # 累积body行
+        if (body == "") body = $0
+        else body = body "\n" $0
+        next
+    }
+    
+    END {
+        printf "\r\033[K" > "/dev/stderr"
+        print "[INFO] 完成: 总计 " processed " | 匹配 " matched " | 重复 " dup " | 无Fixes " no_fixes " | 缺依赖 " no_ref > "/dev/stderr"
+    }
+    '
+    
+    echo "========================================" >&2
+    
+    rm -f "$tmp_target"
+}
+
+main "$@"

--- a/.github/workflows/check-depend-all.yml
+++ b/.github/workflows/check-depend-all.yml
@@ -2,8 +2,6 @@ name: check depend all
 on:
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * *"
 
 env:
   KBUILD_BUILD_USER: deepin-kernel-sig

--- a/.github/workflows/check-depend-all.yml
+++ b/.github/workflows/check-depend-all.yml
@@ -1,0 +1,36 @@
+name: check depend all
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+env:
+  KBUILD_BUILD_USER: deepin-kernel-sig
+  KBUILD_BUILD_HOST: deepin-kernel-builder
+  email: support@deepin.org
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-depend-all:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: '0'
+      - name: "Install Deps"
+        run: |
+          git config --global user.email $email
+          git config --global user.name $KBUILD_BUILD_USER
+
+      - name: "Check Depend for all commit"
+        run: |
+          # Use commits in v6.6..torvalds which has Fixes Tag to check (0,pr_sha) to checkdepends
+          bash .github/tools/check_kernel_commits.sh v6.6..torvalds/master ${{ github.event.pull_request.head.sha }}
+


### PR DESCRIPTION
deepin inclusion
category: other

check if upstream have someone fix which commits in our tree.

## Summary by Sourcery

Add an automated CI workflow to detect kernel commits in this tree that correspond to upstream fixes and ensure their dependencies are satisfied against the upstream Linux master branch.

Build:
- Add a helper script to scan local kernel commit range, compare against upstream Linux titles, and identify non-duplicate commits whose Fixes: references exist upstream but may be missing in this tree.

CI:
- Introduce a scheduled and PR-triggered GitHub Actions workflow that runs on self-hosted runners to check dependency coverage for all kernel commits against torvalds/linux.