### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Intel] Backport for i915 fixes

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_color.c
+++ b/drivers/gpu/drm/i915/display/intel_color.c
@@ -3689,6 +3689,7 @@ static const struct intel_color_funcs vlv_color_funcs = {
 	.read_luts = i965_read_luts,
 	.lut_equal = i965_lut_equal,
 	.read_csc = vlv_read_csc,
+	.get_config = i9xx_get_config,
 };
 
 static const struct intel_color_funcs i965_color_funcs = {

--- a/drivers/gpu/drm/i915/display/intel_display.c
+++ b/drivers/gpu/drm/i915/display/intel_display.c
@@ -3662,8 +3662,8 @@ static bool hsw_get_pipe_config(struct intel_crtc *crtc,
 	if (!active)
 		goto out;
 
-	intel_dsc_get_config(pipe_config);
 	intel_bigjoiner_get_config(pipe_config);
+	intel_dsc_get_config(pipe_config);
 
 	if (!transcoder_is_dsi(pipe_config->cpu_transcoder) ||
 	    DISPLAY_VER(dev_priv) >= 11)

--- a/drivers/gpu/drm/i915/display/intel_vdsc.c
+++ b/drivers/gpu/drm/i915/display/intel_vdsc.c
@@ -874,7 +874,7 @@ static void intel_dsc_get_pps_config(struct intel_crtc_state *crtc_state)
 	/* PPS 2 */
 	pps_temp = intel_dsc_pps_read_and_verify(crtc_state, 2);
 
-	vdsc_cfg->pic_width = REG_FIELD_GET(DSC_PPS2_PIC_WIDTH_MASK, pps_temp) / num_vdsc_instances;
+	vdsc_cfg->pic_width = REG_FIELD_GET(DSC_PPS2_PIC_WIDTH_MASK, pps_temp) * num_vdsc_instances;
 	vdsc_cfg->pic_height = REG_FIELD_GET(DSC_PPS2_PIC_HEIGHT_MASK, pps_temp);
 
 	/* PPS 3 */

--- a/drivers/gpu/drm/i915/display/intel_vdsc_regs.h
+++ b/drivers/gpu/drm/i915/display/intel_vdsc_regs.h
@@ -51,8 +51,8 @@
 #define DSCC_PICTURE_PARAMETER_SET_0		_MMIO(0x6BA00)
 #define _DSCA_PPS_0				0x6B200
 #define _DSCC_PPS_0				0x6BA00
-#define DSCA_PPS(pps)				_MMIO(_DSCA_PPS_0 + (pps) * 4)
-#define DSCC_PPS(pps)				_MMIO(_DSCC_PPS_0 + (pps) * 4)
+#define DSCA_PPS(pps)				_MMIO(_DSCA_PPS_0 + ((pps) < 12 ? (pps) : (pps) + 12) * 4)
+#define DSCC_PPS(pps)				_MMIO(_DSCC_PPS_0 + ((pps) < 12 ? (pps) : (pps) + 12) * 4)
 #define _ICL_DSC0_PICTURE_PARAMETER_SET_0_PB	0x78270
 #define _ICL_DSC1_PICTURE_PARAMETER_SET_0_PB	0x78370
 #define _ICL_DSC0_PICTURE_PARAMETER_SET_0_PC	0x78470


### PR DESCRIPTION
#65 
#327 

Ankit Nautiyal (1):
  drm/i915/display: Get bigjoiner config before dsc config during
    readout

Manasi Navare (1):
  drm/i915/dsc: Fix the macro that calculates DSCC_/DSCA_ PPS reg
    address

Suraj Kandpal (1):
  drm/i915/dsc: Fix pic_width readout

Ville Syrjälä (1):
  drm/i915: Fix VLV color state readout

 drivers/gpu/drm/i915/display/intel_color.c     | 1 +
 drivers/gpu/drm/i915/display/intel_display.c   | 2 +-
 drivers/gpu/drm/i915/display/intel_vdsc.c      | 2 +-
 drivers/gpu/drm/i915/display/intel_vdsc_regs.h | 4 ++--
 4 files changed, 5 insertions(+), 4 deletions(-)

## Summary by Sourcery

Backport i915 display driver fixes for DSC PPS handling, pipe configuration readout ordering, picture width calculation, and VLV color configuration.

Bug Fixes:
- Correct DSC PPS register address calculation for DSCA/DSCC blocks to match hardware layout.
- Fix pipe configuration readout ordering by obtaining bigjoiner state before DSC configuration on Haswell.
- Correct DSC picture width readout by multiplying by the number of DSC instances instead of dividing.
- Ensure VLV color state readout is wired to the generic i9xx get_config implementation.