### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] pwm: loongson: Fix LOONGSON_PWM_FREQ_DEFAULT

### DIFF
--- a/drivers/pwm/pwm-loongson.c
+++ b/drivers/pwm/pwm-loongson.c
@@ -49,7 +49,7 @@
 #define LOONGSON_PWM_CTRL_REG_DZONE	BIT(10) /* Anti-dead Zone Enable Bit */
 
 /* default input clk frequency for the ACPI case */
-#define LOONGSON_PWM_FREQ_DEFAULT	50000 /* Hz */
+#define LOONGSON_PWM_FREQ_DEFAULT	50000000 /* Hz */
 
 struct pwm_loongson_ddata {
 	struct pwm_chip	chip;


### PR DESCRIPTION
mainline inclusion
from mainline-v6.18-rc1
category: bugfix

Per the 7A1000 and 7A2000 user manual, the clock frequency of their PWM controllers is 50 MHz, not 50 kHz.

Fixes: 2b62c89448dd ("pwm: Add Loongson PWM controller support")

Reviewed-by: Binbin Zhou <zhoubinbin@loongson.cn>
Reviewed-by: Huacai Chen <chenhuacai@loongson.cn>
Link: https://lore.kernel.org/r/20250816104904.4779-2-xry111@xry111.site
Cc: stable@vger.kernel.org

(cherry picked from commit 75604e9a5b60707722028947d6dc6bdacb42282e)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect default PWM clock frequency used for Loongson controllers in ACPI-based configurations.