### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] accel/ivpu: Fix Qemu crash when running in passthrough

### DIFF
--- a/drivers/accel/ivpu/ivpu_pm.c
+++ b/drivers/accel/ivpu/ivpu_pm.c
@@ -72,8 +72,8 @@ static int ivpu_resume(struct ivpu_device *vdev)
 	int ret;
 
 retry:
-	pci_restore_state(to_pci_dev(vdev->drm.dev));
 	pci_set_power_state(to_pci_dev(vdev->drm.dev), PCI_D0);
+	pci_restore_state(to_pci_dev(vdev->drm.dev));
 
 	ret = ivpu_hw_power_up(vdev);
 	if (ret) {


### PR DESCRIPTION
mainline inclusion
from mainline-v6.14-rc1
category: bugfix

Restore PCI state after putting the NPU in D0.
Restoring state before powering up the device caused a Qemu crash if NPU was running in passthrough mode and recovery was performed.

Fixes: 3534eacbf101 ("accel/ivpu: Fix PCI D0 state entry in resume")
Cc: stable@vger.kernel.org # v6.8+
Reviewed-by: Karol Wachowski <karol.wachowski@linux.intel.com>

Link: https://patchwork.freedesktop.org/patch/msgid/20241106105549.2757115-1-jacek.lawrynowicz@linux.intel.com (cherry picked from commit 901dd2617c9c3554b2449c8844b6338009112fcf)

## Summary by Sourcery

Bug Fixes:
- Fix QEMU crash during ivpu device recovery in PCI passthrough by restoring PCI state only after transitioning the device to D0 power state.