### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] mm: page_alloc: remove redundant READ_ONCE

### DIFF
--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -2521,7 +2521,7 @@ static void free_unref_page_commit(struct zone *zone, struct per_cpu_pages *pcp,
 		free_high = (pcp->free_count >= batch &&
 			     (pcp->flags & PCPF_PREV_FREE_HIGH_ORDER) &&
 			     (!(pcp->flags & PCPF_FREE_HIGH_BATCH) ||
-			      pcp->count >= READ_ONCE(batch)));
+			      pcp->count >= batch));
 		pcp->flags |= PCPF_PREV_FREE_HIGH_ORDER;
 	} else if (pcp->flags & PCPF_PREV_FREE_HIGH_ORDER) {
 		pcp->flags &= ~PCPF_PREV_FREE_HIGH_ORDER;


### PR DESCRIPTION
mainline inclusion
from mainline-v6.16-rc1
category: bugfix

In the current code, batch is a local variable, and it cannot be concurrently modified.  It's unnecessary to use READ_ONCE here, so remove it.

Link: https://lkml.kernel.org/r/CAA=HWd1kn01ym8YuVFuAqK2Ggq3itEGkqX8T6eCXs_C7tiv-Jw@mail.gmail.com
Fixes: 51a755c56dc0 ("mm: tune PCP high automatically")

Reviewed-by: Qi Zheng <zhengqi.arch@bytedance.com>
Reviewed-by: Huang Ying <ying.huang@linux.alibaba.com>
Reviewed-by: Anshuman Khandual <anshuman.khandual@arm.com>
Reviewed-by: Pankaj Gupta <pankaj.gupta@amd.com>
Reviewed-by: Oscar Salvador <osalvador@suse.de>
Reviewed-by: Vishal Moola (Oracle) <vishal.moola@gmail.com>
Cc: Muchun Song <songmuchun@bytedance.com>

(cherry picked from commit cd348c5e6af3b4220eb37a08fdaf9c924a2e1c19)

## Summary by Sourcery

Enhancements:
- Remove redundant READ_ONCE from the per-CPU page allocator free path where the batch variable is only locally used.