### PR TITLE
Revert "[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net: Fix kabi breakage for skbuff by exclude header"

### DIFF
--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -67,12 +67,7 @@
 #include <net/dst.h>
 #include <net/sock.h>
 #include <net/checksum.h>
-#ifndef CONFIG_DEEPIN_KABI_RESERVE
 #include <net/gro.h>
-#else  /* !CONFIG_DEEPIN_KABI_RESERVE */
-/* This should be increased if a protocol with a bigger head is added. */
-#define GRO_MAX_HEAD (MAX_HEADER + 128)
-#endif /* CONFIG_DEEPIN_KABI_RESERVE */
 #include <net/gso.h>
 #include <net/ip6_checksum.h>
 #include <net/xfrm.h>


### PR DESCRIPTION
Reverts deepin-community/kernel#1379

## Summary by Sourcery

Enhancements:
- Remove Deepin KABI reserve conditional logic and custom GRO_MAX_HEAD definition from skbuff, relying on the upstream GRO header behavior again.