### PR TITLE
Revert "[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net/ipv6: Fix KABI for Remove expired routes with a separated list of…"

### DIFF
--- a/include/net/ip6_fib.h
+++ b/include/net/ip6_fib.h
@@ -186,6 +186,8 @@ struct fib6_info {
 	refcount_t			fib6_ref;
 	unsigned long			expires;
 
+	struct hlist_node		gc_link;
+
 	struct dst_metrics		*fib6_metrics;
 #define fib6_pmtu		fib6_metrics->metrics[RTAX_MTU-1]
 
@@ -211,7 +213,8 @@ struct fib6_info {
 	struct rcu_head			rcu;
 	struct nexthop			*nh;
 
-	DEEPIN_KABI_USE(1, 2, struct hlist_node		gc_link)
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	struct fib6_nh			fib6_nh[];
 };
@@ -411,7 +414,7 @@ struct fib6_table {
 	struct inet_peer_base	tb6_peers;
 	unsigned int		flags;
 	unsigned int		fib_seq;
-	DEEPIN_KABI_EXTEND(struct hlist_head       tb6_gc_hlist)	/* GC candidates */
+	struct hlist_head       tb6_gc_hlist;	/* GC candidates */
 #define RT6_TABLE_HAS_DFLT_ROUTER	BIT(0)
 };
 


### PR DESCRIPTION
Reverts deepin-community/kernel#1452

## Summary by Sourcery

Revert previous IPv6 route garbage-collection KABI change and restore the original gc linkage and table GC list definitions.

Enhancements:
- Restore fib6_info.gc_link as a standard field and revert it from KABI-specific usage.
- Revert fib6_table.tb6_gc_hlist back to a regular garbage-collection candidate list instead of a KABI extension.