### PR TITLE
Revert "[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] bpf: Fix kabi in bpf_map_owner by using KABI_EXTEND"

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -276,7 +276,7 @@ struct bpf_map_owner {
 	bool xdp_has_frags;
 	u64 storage_cookie[MAX_BPF_CGROUP_STORAGE_TYPE];
 	const struct btf_type *attach_func_proto;
-	DEEPIN_KABI_EXTEND(enum bpf_attach_type expected_attach_type)
+	enum bpf_attach_type expected_attach_type;
 };
 
 struct bpf_map {


### PR DESCRIPTION
Reverts deepin-community/kernel#1368

## Summary by Sourcery

Bug Fixes:
- Align the bpf_map_owner structure layout with the original ABI by removing the DEEPIN_KABI_EXTEND wrapper from expected_attach_type.