### PR TITLE
Revert "[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] net: netpoll: Fix kabi in netpoll by using KABI_EXTEND"

### DIFF
--- a/include/linux/netpoll.h
+++ b/include/linux/netpoll.h
@@ -32,10 +32,10 @@ struct netpoll {
 	bool ipv6;
 	u16 local_port, remote_port;
 	u8 remote_mac[ETH_ALEN];
+	struct sk_buff_head skb_pool;
 
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
-	DEEPIN_KABI_EXTEND(struct sk_buff_head skb_pool)
 };
 
 struct netpoll_info {


### PR DESCRIPTION
Reverts deepin-community/kernel#1367

## Summary by Sourcery

Enhancements:
- Simplify netpoll KABI handling by making skb_pool a regular struct member instead of using DEEPIN_KABI_EXTEND.