### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Deepin] Revert KABI fix changes.

### DIFF
--- a/arch/x86/events/core.c
+++ b/arch/x86/events/core.c
@@ -675,7 +675,7 @@ static int __x86_pmu_event_init(struct perf_event *event)
 	event->hw.idx = -1;
 	event->hw.last_cpu = -1;
 	event->hw.last_tag = ~0ULL;
-	event->hw_ext->dyn_constraint = ~0ULL;
+	event->hw.dyn_constraint = ~0ULL;
 
 	/* mark unused */
 	event->hw.extra_reg.idx = EXTRA_REG_NONE;

--- a/arch/x86/events/intel/core.c
+++ b/arch/x86/events/intel/core.c
@@ -2927,7 +2927,6 @@ static void intel_pmu_config_acr(int idx, u64 mask, u32 reload)
 static void intel_pmu_enable_acr(struct perf_event *event)
 {
 	struct hw_perf_event *hwc = &event->hw;
-	struct hw_perf_event_ext *hw_ext = event->hw_ext;
 
 	if (!is_acr_event_group(event) || !event->attr.config2) {
 		/*
@@ -2938,7 +2937,7 @@ static void intel_pmu_enable_acr(struct perf_event *event)
 		return;
 	}
 
-	intel_pmu_config_acr(hwc->idx, hw_ext->config1, -hwc->sample_period);
+	intel_pmu_config_acr(hwc->idx, hwc->config1, -hwc->sample_period);
 }
 
 DEFINE_STATIC_CALL_NULL(intel_pmu_enable_acr_event, intel_pmu_enable_acr);
@@ -2999,7 +2998,7 @@ static void intel_pmu_acr_late_setup(struct cpu_hw_events *cpuc)
 				if (i + idx >= cpuc->n_events ||
 				    !is_acr_event_group(cpuc->event_list[i + idx]))
 					return;
-				__set_bit(cpuc->assign[i + idx], (unsigned long *)&event->hw_ext->config1);
+				__set_bit(cpuc->assign[i + idx], (unsigned long *)&event->hw.config1);
 			}
 		}
 		i = j - 1;
@@ -3845,9 +3844,9 @@ intel_get_event_constraints(struct cpu_hw_events *cpuc, int idx,
 	if (cpuc->excl_cntrs)
 		return intel_get_excl_constraints(cpuc, event, idx, c2);
 
-	if (event->hw_ext->dyn_constraint != ~0ULL) {
+	if (event->hw.dyn_constraint != ~0ULL) {
 		c2 = dyn_constraint(cpuc, c2, idx);
-		c2->idxmsk64 &= event->hw_ext->dyn_constraint;
+		c2->idxmsk64 &= event->hw.dyn_constraint;
 		c2->weight = hweight64(c2->idxmsk64);
 	}
 
@@ -4211,7 +4210,7 @@ static bool intel_pmu_is_acr_group(struct perf_event *event)
 static inline void intel_pmu_set_acr_cntr_constr(struct perf_event *event,
 						 u64 *cause_mask, int *num)
 {
-	event->hw_ext->dyn_constraint &= hybrid(event->pmu, acr_cntr_mask64);
+	event->hw.dyn_constraint &= hybrid(event->pmu, acr_cntr_mask64);
 	*cause_mask |= event->attr.config2;
 	*num += 1;
 }
@@ -4220,7 +4219,7 @@ static inline void intel_pmu_set_acr_caused_constr(struct perf_event *event,
 						   int idx, u64 cause_mask)
 {
 	if (test_bit(idx, (unsigned long *)&cause_mask))
-		event->hw_ext->dyn_constraint &= hybrid(event->pmu, acr_cause_mask64);
+		event->hw.dyn_constraint &= hybrid(event->pmu, acr_cause_mask64);
 }
 
 static int intel_pmu_hw_config(struct perf_event *event)
@@ -4286,7 +4285,7 @@ static int intel_pmu_hw_config(struct perf_event *event)
 			return -EINVAL;
 		if (branch_sample_counters(leader)) {
 			num++;
-			leader->hw_ext->dyn_constraint &= x86_pmu.lbr_counters;
+			leader->hw.dyn_constraint &= x86_pmu.lbr_counters;
 		}
 		leader->hw.flags |= PERF_X86_EVENT_BRANCH_COUNTERS;
 
@@ -4295,7 +4294,7 @@ static int intel_pmu_hw_config(struct perf_event *event)
 				return -EINVAL;
 			if (branch_sample_counters(sibling)) {
 				num++;
-				sibling->hw_ext->dyn_constraint &= x86_pmu.lbr_counters;
+				sibling->hw.dyn_constraint &= x86_pmu.lbr_counters;
 			}
 		}
 

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -276,7 +276,7 @@ struct bpf_map_owner {
 	bool xdp_has_frags;
 	u64 storage_cookie[MAX_BPF_CGROUP_STORAGE_TYPE];
 	const struct btf_type *attach_func_proto;
-	DEEPIN_KABI_EXTEND(enum bpf_attach_type expected_attach_type)
+	enum bpf_attach_type expected_attach_type;
 };
 
 struct bpf_map {

--- a/include/linux/fwnode.h
+++ b/include/linux/fwnode.h
@@ -171,10 +171,11 @@ struct fwnode_operations {
 	void __iomem *(*iomap)(struct fwnode_handle *fwnode, int index);
 	int (*irq_get)(const struct fwnode_handle *fwnode, unsigned int index);
 	int (*add_links)(struct fwnode_handle *fwnode);
-
-	DEEPIN_KABI_USE(1, int (*property_count_reference_with_args)(
+	int (*property_count_reference_with_args)(
 		const struct fwnode_handle *fwnode, const char *list_name,
-		const char *cells_name))
+		const char *cells_name);
+
+	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)

--- a/include/linux/netpoll.h
+++ b/include/linux/netpoll.h
@@ -32,10 +32,10 @@ struct netpoll {
 	bool ipv6;
 	u16 local_port, remote_port;
 	u8 remote_mac[ETH_ALEN];
+	struct sk_buff_head skb_pool;
 
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
-	DEEPIN_KABI_EXTEND(struct sk_buff_head skb_pool)
 };
 
 struct netpoll_info {

--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -150,17 +150,6 @@ struct hw_perf_event_extra {
 
 static_assert((PERF_EVENT_FLAG_USER_READ_CNT & PERF_EVENT_FLAG_ARCH) == 0);
 
-struct hw_perf_event_ext {
-#ifdef CONFIG_PERF_EVENTS
-	union {
-		struct {
-			u64 config1;
-			u64 dyn_constraint;
-		};
-	};
-#endif
-};
-
 /**
  * struct hw_perf_event - performance event hardware details:
  */
@@ -169,7 +158,9 @@ struct hw_perf_event {
 	union {
 		struct { /* hardware */
 			u64		config;
+			u64		config1;
 			u64		last_tag;
+			u64		dyn_constraint;
 			unsigned long	config_base;
 			unsigned long	event_base;
 			int		event_base_rdpmc;
@@ -863,7 +854,7 @@ struct perf_event {
 	 */
 	__u32				orig_type;
 
-	DEEPIN_KABI_USE(1, struct hw_perf_event_ext *hw_ext)
+	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)

--- a/include/net/ip6_fib.h
+++ b/include/net/ip6_fib.h
@@ -186,6 +186,8 @@ struct fib6_info {
 	refcount_t			fib6_ref;
 	unsigned long			expires;
 
+	struct hlist_node		gc_link;
+
 	struct dst_metrics		*fib6_metrics;
 #define fib6_pmtu		fib6_metrics->metrics[RTAX_MTU-1]
 
@@ -211,7 +213,8 @@ struct fib6_info {
 	struct rcu_head			rcu;
 	struct nexthop			*nh;
 
-	DEEPIN_KABI_USE(1, 2, struct hlist_node		gc_link)
+	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_RESERVE(2)
 
 	struct fib6_nh			fib6_nh[];
 };
@@ -411,7 +414,7 @@ struct fib6_table {
 	struct inet_peer_base	tb6_peers;
 	unsigned int		flags;
 	unsigned int		fib_seq;
-	DEEPIN_KABI_EXTEND(struct hlist_head       tb6_gc_hlist)	/* GC candidates */
+	struct hlist_head       tb6_gc_hlist;	/* GC candidates */
 #define RT6_TABLE_HAS_DFLT_ROUTER	BIT(0)
 };
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -425,7 +425,6 @@ static DEFINE_MUTEX(pmus_lock);
 static struct srcu_struct pmus_srcu;
 static cpumask_var_t perf_online_mask;
 static struct kmem_cache *perf_event_cache;
-static struct kmem_cache *perf_hw_event_cache;
 
 /*
  * perf event paranoia level:
@@ -5013,7 +5012,6 @@ static void free_event_rcu(struct rcu_head *head)
 	if (event->ns)
 		put_pid_ns(event->ns);
 	perf_event_free_filter(event);
-	kmem_cache_free(perf_hw_event_cache, event->hw_ext);
 	kmem_cache_free(perf_event_cache, event);
 }
 
@@ -12069,14 +12067,6 @@ perf_event_alloc(struct perf_event_attr *attr, int cpu,
 	if (!event)
 		return ERR_PTR(-ENOMEM);
 
-	event->hw_ext = kmem_cache_alloc_node(perf_hw_event_cache,
-					      GFP_KERNEL | __GFP_ZERO,
-					      node);
-	if (!event->hw_ext) {
-		kmem_cache_free(perf_event_cache, event);
-		return ERR_PTR(-ENOMEM);
-	}
-
 	/*
 	 * Single events are their own group leaders, with an
 	 * empty sibling list:
@@ -13939,7 +13929,6 @@ void __init perf_event_init(void)
 	WARN(ret, "hw_breakpoint initialization failed with: %d", ret);
 
 	perf_event_cache = KMEM_CACHE(perf_event, SLAB_PANIC);
-	perf_hw_event_cache = KMEM_CACHE(hw_perf_event_ext, SLAB_PANIC);
 
 	/*
 	 * Build time assertion that we keep the data_head at the intended

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -67,12 +67,7 @@
 #include <net/dst.h>
 #include <net/sock.h>
 #include <net/checksum.h>
-#ifndef CONFIG_DEEPIN_KABI_RESERVE
 #include <net/gro.h>
-#else  /* !CONFIG_DEEPIN_KABI_RESERVE */
-/* This should be increased if a protocol with a bigger head is added. */
-#define GRO_MAX_HEAD (MAX_HEADER + 128)
-#endif /* CONFIG_DEEPIN_KABI_RESERVE */
 #include <net/gso.h>
 #include <net/ip6_checksum.h>
 #include <net/xfrm.h>


### PR DESCRIPTION
We release new kabi version, revert them.

## Summary by Sourcery

Revert previous Deepin KABI-related extensions and allocations, restoring in-tree kernel interfaces and structures for perf events, firmware nodes, IPv6 FIB GC, GRO handling, BPF map owner, and netpoll to their upstream layouts.

Bug Fixes:
- Restore use of core hw_perf_event fields for ACR configuration and dynamic constraints in the Intel x86 perf subsystem.

Enhancements:
- Remove auxiliary hw_perf_event_ext allocation and related slab cache, simplifying perf event lifetime management.
- Reinstate direct function pointer and struct members in fwnode_operations, fib6_info, fib6_table, bpf_map_owner, and netpoll instead of Deepin KABI macros, aligning with upstream kernels.