### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [Deepin] scripts: adapt to UOS/deepin scripting

### DIFF
--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -162,7 +162,7 @@ if [ "${KDEB_PKGVERSION:+set}" ]; then
 else
 	upstream_version=$("${srctree}/scripts/setlocalversion" --no-local "${srctree}" | sed 's/-\(rc[1-9]\)/~\1/')
 	debian_revision=$("${srctree}/scripts/build-version")
-	packageversion=${upstream_version}-${debian_revision}
+	packageversion=${debian_revision}
 fi
 sourcename=${KDEB_SOURCENAME:-linux-upstream}
 


### PR DESCRIPTION
Update scripts for use with build_kernel.sh.



[ Port to v6.18: remove useless logic and only remove such linux-{headers/image/libc}-dev_"-gx12x-xx.xx.xx.xx to -xx.xx.xx.xx".deb ] (cherry picked from commit 83e7cdc6aad1a6c85cc4b777b8f8e37207e7b30a)

## Summary by Sourcery

Update Debian packaging script mkdebian to adapt kernel build scripts for Deepin/UOS integration and simplify handling of generated linux-* dev .deb packages.

Enhancements:
- Adjust Debian packaging logic in mkdebian for compatibility with build_kernel.sh and Deepin/UOS-specific package naming.
- Remove obsolete logic around filtering linux-{headers,image,libc}-dev Debian packages, keeping only the minimal handling needed for the new naming scheme.