### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [Deepin] [AOSC] arm64: disable mpam in tsv110

### DIFF
--- a/arch/arm64/kernel/pi/idreg-override.c
+++ b/arch/arm64/kernel/pi/idreg-override.c
@@ -215,6 +215,17 @@ static const struct ftr_set_desc sw_features __prel64_initconst = {
 	},
 };
 
+static struct arm64_ftr_override __read_mostly aosc_feature_override;
+
+static const struct ftr_set_desc aosc_features __prel64_initconst = {
+	.name		= "aosc",
+	.override	= &aosc_feature_override,
+	.fields		= {
+		FIELD("try_mpam", 0, NULL),
+		{}
+	},
+};
+
 static const
 PREL64(const struct ftr_set_desc, reg) regs[] __prel64_initconst = {
 	{ &mmfr0	},
@@ -226,6 +237,7 @@ PREL64(const struct ftr_set_desc, reg) regs[] __prel64_initconst = {
 	{ &isar2	},
 	{ &smfr0	},
 	{ &sw_features	},
+	{ &aosc_features	},
 };
 
 static const struct {
@@ -390,6 +402,14 @@ static __init void parse_cmdline(const void *fdt, int chosen)
 
 	if (!IS_ENABLED(CONFIG_CMDLINE_FORCE) && prop)
 		__parse_cmdline(prop, true);
+
+	/*
+	 * Sorry but we have to work OotB on some platforms with broken
+	 * firmware, notably W510.  Use "aosc.try_mpam=1" if you really need
+	 * MPAM on AOSC.
+	 */
+	if (!arm64_apply_feature_override(0, 0, 4, &aosc_feature_override))
+		__parse_cmdline("arm64.nompam", true);
 }
 
 void __init init_feature_override(u64 boot_status, const void *fdt,

--- a/arch/arm64/kernel/pi/idreg-override.c
+++ b/arch/arm64/kernel/pi/idreg-override.c
@@ -408,8 +408,21 @@ static __init void parse_cmdline(const void *fdt, int chosen)
 	 * firmware, notably W510.  Use "aosc.try_mpam=1" if you really need
 	 * MPAM on AOSC.
 	 */
-	if (!arm64_apply_feature_override(0, 0, 4, &aosc_feature_override))
-		__parse_cmdline("arm64.nompam", true);
+	static const struct midr_range mpam_disable_list[] __initconst = {
+		MIDR_ALL_VERSIONS(MIDR_HISI_TSV110),
+		{ /* sentinel */ }
+	};
+
+	for (const struct midr_range *r = mpam_disable_list; r->model; r++) {
+		if (midr_is_cpu_model_range(read_cpuid_id(), r->model,
+					    r->rv_min, r->rv_max)) {
+			if (!arm64_apply_feature_override(0, 0, 4, &aosc_feature_override)) {
+				__parse_cmdline("arm64.nompam", true);
+				break;
+			}
+		}
+	}
+
 }
 
 void __init init_feature_override(u64 boot_status, const void *fdt,


### PR DESCRIPTION
If you really need it , use aosc.try_mpam=1.
If you really noneed it, use arm64.nompam=1.

Log:

[    0.000000] CPU features: SYS_ID_AA64PFR0_EL1[43:40]: forced to 0
[    0.000000] CPU features: SYS_ID_AA64PFR1_EL1[19:16]: already set to 0
[    0.000000] CPU features: detected: GICv3 CPU interface
[    0.000000] CPU features: detected: Virtualization Host Extensions
[    0.000000] CPU features: detected: Spectre-v4
[    0.000000] CPU features: detected: Spectre-BHB
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: BOOT_IMAGE=/vmlinuz-6.18.13-arm64-desktop-rolling root=UUID=c2f3cdb4-f919-43ba-bd32-172c2744dfb2 ro splash quiet console=tty plymouth.ignore-serial-consoles DEEPIN_GFXMODE= luks.crypttab=n
[    0.000000] Unknown kernel command line parameters "splash DEEPIN_GFXMODE=", will be passed to user space.
[    0.000000] printk: log_buf_len individual max cpu contribution: 32768 bytes
[    0.000000] printk: log_buf_len total cpu_extra contributions: 753664 bytes
[    0.000000] printk: log_buf_len min size: 131072 bytes
[    0.000000] printk: log buffer data + meta data: 1048576 + 3670016 = 4718592 bytes
[    0.000000] printk: early log buf free: 125224(95%)
[    0.000000] Dentry cache hash table entries: 4194304 (order: 13, 33554432 bytes, linear)
[    0.000000] Inode-cache hash table entries: 2097152 (order: 12, 16777216 bytes, linear)
[    0.000000] software IO TLB: area num 32.
[    0.000000] software IO TLB: mapped [mem 0x000000007b000000-0x000000007f000000] (64MB)
[    0.000000] Fallback order for Node 0: 0 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 8387568
[    0.000000] Policy zone: Normal
[    0.000000] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
