### PR TITLE
HAOC: IEE_SIP: Fix kdump failure in native_idt_invalidate()

### DIFF
--- a/arch/x86/include/asm/desc.h
+++ b/arch/x86/include/asm/desc.h
@@ -261,7 +261,15 @@ static inline void native_idt_invalidate(void)
 		.size = 0
 	};
 
+#ifdef CONFIG_IEE_SIP
+	// The native_idt_invalidate() is only called by machine_kexec(). 
+	// In the kdump path, IEE_SIP should not be used, so we directly
+	// call iee_load_idt_early(), which is the original version of
+	// native_load_idt() to load an invalid IDT.
+	iee_load_idt_early(&invalid_idt);
+#else
 	native_load_idt(&invalid_idt);
+#endif
 }
 
 /*


### PR DESCRIPTION
kdump 生成 vmcore 的路径中会通过 machine_kexec() 调用 native_idt_invalidate() 。当启用 IEE_SIP 时，native_idt_invalidate() 最终会调用 iee_rwx_gate，其试图切换函数栈时发生错误。

因此，我们修改了 native_idt_invalidate() 函数，它只被 machine_kexec() 调用，使其始终直接调用 lidt，避免访问 iee_rwx_gate。

## Summary by Sourcery

Bug Fixes:
- Prevent kdump failures in native_idt_invalidate() under IEE_SIP by loading an invalid IDT via the early IDT loader instead of the IEE-enabled path.