### PR TITLE
Linux 6.6.y macb update 6603

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -2013,7 +2013,8 @@ static void macb_tx_restart(struct macb_queue *queue)
 	if (queue->tx_head == queue->tx_tail)
 		goto out_tx_ptr_unlock;
 
-	tbqp = queue_readl(queue, TBQP) / macb_dma_desc_get_size(bp);
+	tbqp = queue_readl(queue, TBQP) - lower_32_bits(queue->tx_ring_dma);
+	tbqp = tbqp / macb_dma_desc_get_size(bp);
 	tbqp = macb_adj_dma_desc_idx(bp, macb_tx_ring_wrap(bp, tbqp));
 	head_idx = macb_adj_dma_desc_idx(bp, macb_tx_ring_wrap(bp, queue->tx_head));
 

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -4788,7 +4788,6 @@ static const struct macb_config phytium_gem1p0_config = {
 	.usrio = &macb_default_usrio,
 };
 
-#if defined(CONFIG_OF)
 /* 1518 rounded up */
 #define AT91ETHER_MAX_RBUFF_SZ	0x600
 /* max number of receive buffers */
@@ -5491,6 +5490,7 @@ static const struct macb_config phytium_gem2p0_config = {
 	.usrio = &macb_default_usrio,
 };
 
+#if defined(CONFIG_OF)
 static const struct of_device_id macb_dt_ids[] = {
 	{ .compatible = "cdns,at91sam9260-macb", .data = &at91sam9260_config },
 	{ .compatible = "cdns,macb" },

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -640,7 +640,7 @@ static int macb_usx_pcs_config(struct phylink_pcs *pcs,
 	struct macb *bp = container_of(pcs, struct macb, phylink_usx_pcs);
 
 	gem_writel(bp, USX_CONTROL, gem_readl(bp, USX_CONTROL) |
-		   GEM_BIT(SIGNAL_OK));
+		   GEM_BIT(SIGNAL_OK) | GEM_BIT(TX_EN));
 
 	return 0;
 }

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -926,7 +926,6 @@ static void phytium_gem1p0_sel_clk(struct macb *bp, int speed)
 							gem_readl(bp, HS_MAC_CONFIG)));
 }
 
-#if defined(CONFIG_OF)
 static void phytium_gem2p0_sel_clk(struct macb *bp, int speed)
 {
 	if (bp->phy_interface == PHY_INTERFACE_MODE_SGMII) {
@@ -946,7 +945,6 @@ static void phytium_gem2p0_sel_clk(struct macb *bp, int speed)
 		gem_writel(bp, HS_MAC_CONFIG, GEM_BFINS(HS_MAC_SPEED, HS_SPEED_2500M,
 							gem_readl(bp, HS_MAC_CONFIG)));
 }
-#endif /* CONFIG_OF */
 
 static void macb_mac_link_up(struct phylink_config *config,
 			     struct phy_device *phy,


### PR DESCRIPTION
phytium:update to version 6.6.0.3 patchs

## Summary by Sourcery

Update Phytium macb driver integration and fix USX and TX queue handling.

Bug Fixes:
- Ensure USX PCS configuration also enables transmit when marking signal OK.
- Correct transmit buffer queue pointer calculation during TX restart to avoid descriptor index errors.

Enhancements:
- Adjust CONFIG_OF guarding so Phytium macb configurations are always built while only the device tree match table remains conditional on OF support.