### PR TITLE
PCI: Add ACS quirk for phytium root and switch ports

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -5358,6 +5358,10 @@ static const struct pci_dev_acs_enabled {
 	{ PCI_VENDOR_ID_MUCSE, 0x1c21, pci_quirk_mf_endpoint_acs },
 	{ PCI_VENDOR_ID_MUCSE, 0x1061, pci_quirk_mf_endpoint_acs },
 	{ PCI_VENDOR_ID_MUCSE, 0x1c61, pci_quirk_mf_endpoint_acs },
+	/* Phytium Technology */
+	{ PCI_VENDOR_ID_PLX, PCI_ANY_ID, pci_quirk_xgene_acs },
+	{ PCI_VENDOR_ID_CDNS, PCI_ANY_ID, pci_quirk_xgene_acs },
+	{ PCI_VENDOR_ID_PHYTIUM, PCI_ANY_ID, pci_quirk_xgene_acs },
 	{ 0 }
 };
 


### PR DESCRIPTION
The phytium PCIe root ports and X100 switch do not support ACS at this point. However, the hardware provides isolation and source validation through the SMMU. The stream ID generated by the PCIe ports contain both the bus/device/function number as well as the port ID in its 3 most significant bits. Turn on ACS but disable all the peer-to-peer features.

## Summary by Sourcery

Enhancements:
- Add ACS quirk entries for Phytium-related PCIe devices to treat them as ACS-capable while disabling peer-to-peer features.