### PR TITLE
spi: phytium: update phytium spi controller driver support

### DIFF
--- a/drivers/spi/spi-phytium-common.c
+++ b/drivers/spi/spi-phytium-common.c
@@ -102,6 +102,9 @@ int spi_phytium_print_status(struct phytium_spi *fts, u8 status0,
 		break;
 	}
 
+	if (fts->debug_enabled)
+		fts->handle_debug_err(fts);
+
 	return -1;
 }
 

--- a/drivers/spi/spi-phytium-plat-v2.c
+++ b/drivers/spi/spi-phytium-plat-v2.c
@@ -26,7 +26,7 @@
 #include "spi-phytium.h"
 
 #define DRIVER_NAME_PHYT "phytium_spi_2.0"
-#define DRIVER_VERSION	"1.0.7"
+#define DRIVER_VERSION	"1.0.8"
 
 #define PHYTIUM_CPU_PART_FTC872		0x872
 
@@ -130,7 +130,7 @@ static int spi_phyt_probe(struct platform_device *pdev)
 	int ret;
 	int num_cs;
 	int cs_gpio;
-	int global_cs = 0;
+	int global_cs = 1;
 	int i;
 	u32 clk_rate = SPI_DEFAULT_CLK;
 

--- a/drivers/spi/spi-phytium-plat-v2.c
+++ b/drivers/spi/spi-phytium-plat-v2.c
@@ -26,7 +26,7 @@
 #include "spi-phytium.h"
 
 #define DRIVER_NAME_PHYT "phytium_spi_2.0"
-#define DRIVER_VERSION	"1.0.6"
+#define DRIVER_VERSION	"1.0.7"
 
 #define PHYTIUM_CPU_PART_FTC872		0x872
 

--- a/drivers/spi/spi-phytium-qspi.c
+++ b/drivers/spi/spi-phytium-qspi.c
@@ -267,28 +267,28 @@ static int phytium_qspi_flash_capacity_encode_new(u32 size,
 
 	switch (size) {
 	case SZ_4M:
-		*cap |= (0x0 >> (4 * i));
+		*cap |= (0x0 << (4 * i));
 		break;
 	case SZ_8M:
-		*cap |= (0x1 >> (4 * i));
+		*cap |= (0x1 << (4 * i));
 		break;
 	case SZ_16M:
-		*cap |= (0x2 >> (4 * i));
+		*cap |= (0x2 << (4 * i));
 		break;
 	case SZ_32M:
-		*cap |= (0x3 >> (4 * i));
+		*cap |= (0x3 << (4 * i));
 		break;
 	case SZ_64M:
-		*cap |= (0x4 >> (4 * i));
+		*cap |= (0x4 << (4 * i));
 		break;
 	case SZ_128M:
-		*cap |= (0x5 >> (4 * i));
+		*cap |= (0x5 << (4 * i));
 		break;
 	case SZ_256M:
-		*cap |= (0x6 >> (4 * i));
+		*cap |= (0x6 << (4 * i));
 		break;
 	case SZ_512M:
-		*cap |= (0x7 >> (4 * i));
+		*cap |= (0x7 << (4 * i));
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/spi/spi-phytium-qspi.c
+++ b/drivers/spi/spi-phytium-qspi.c
@@ -21,7 +21,7 @@
 #include <linux/spi/spi-mem.h>
 #include <linux/mtd/spi-nor.h>
 
-#define DRIVER_VERSION	"1.0.2"
+#define DRIVER_VERSION	"1.0.3"
 
 #define PHYTIUM_CPU_PART_FTC862		0x862
 
@@ -463,8 +463,8 @@ static int phytium_qspi_exec_op(struct spi_mem *mem,
 
 	if (op->dummy.nbytes) {
 		cmd |= QSPI_CMD_PORT_LATENCY_MASK;
-		cmd |= ((op->dummy.nbytes * 8) / op->dummy.buswidth) <<
-			QSPI_CMD_PORT_LATENCY_SHIFT;
+		cmd |= ((op->dummy.nbytes * 8 - 1) / op->dummy.buswidth) <<
+			QSPI_CMD_PORT_DUMMY_SHIFT;
 	}
 
 	if (op->data.nbytes) {

--- a/drivers/spi/spi-phytium-qspi.c
+++ b/drivers/spi/spi-phytium-qspi.c
@@ -793,7 +793,7 @@ static int phytium_qspi_probe(struct platform_device *pdev)
 		goto probe_setup_failed;
 	}
 
-	if (!qspi->nodirmap) {
+	if (!qspi->nodirmap && qspi->fnum != 0) {
 		/*
 		 * The controller supports direct mapping access only if all
 		 * flashes are of same size.

--- a/drivers/spi/spi-phytium-v2.c
+++ b/drivers/spi/spi-phytium-v2.c
@@ -15,6 +15,8 @@
 #include <linux/platform_device.h>
 #include <linux/slab.h>
 #include <linux/spi/spi.h>
+#include <linux/spi/spi-mem.h>
+#include <linux/mtd/spi-nor.h>
 #include <linux/scatterlist.h>
 #include <linux/module.h>
 #include <linux/of.h>
@@ -24,10 +26,6 @@
 #include <linux/acpi.h>
 #include <linux/mtd/spi-nor.h>
 #include "spi-phytium.h"
-
-#define MCP251x_READ		0x03
-#define MCP251x_READ_RXB0	0x90
-#define MCP251x_READ_RXB1	0x94
 
 static inline void spi_phyt_enable_chip(struct phytium_spi *fts, u8 enable)
 {
@@ -99,13 +97,6 @@ static void spi_phyt_set_cs(struct spi_device *spi, bool enable)
 	u32 origin;
 	u16 cs;
 
-	if (fts->tx || fts->rx)
-		return;
-
-	if (fts->msg->cmd_id == PHYTSPI_MSG_CMD_DATA &&
-			fts->msg->cmd_subid == PHYTSPI_MSG_CMD_DATA_TX)
-		return;
-
 	if (chip && chip->cs_control)
 		chip->cs_control(!enable);
 
@@ -145,7 +136,12 @@ static int spi_phyt_transfer_one(struct spi_master *master,
 {
 	struct phytium_spi *fts = spi_master_get_devdata(master);
 	struct chip_data *chip = spi_get_ctldata(spi);
+	struct spi_mem *mem = spi_get_drvdata(spi);
+	struct spi_nor *nor = NULL;
 	int ret;
+
+	if (mem)
+		nor = spi_mem_get_drvdata(mem);
 
 	fts->tx = (void *)transfer->tx_buf;
 	fts->tx_end = fts->tx + transfer->len;
@@ -162,7 +158,7 @@ static int spi_phyt_transfer_one(struct spi_master *master,
 			chip->tmode = TMOD_TO;
 	}
 
-	if (fts->tx && fts->len == 1) {
+	if (mem == nor->spimem && fts->tx && fts->len == 1) {
 		if ((*(u8 *)fts->tx == SPINOR_OP_WREN) && fts->spi_write_flag == 0) {
 			spi_phytium_write_pre(fts, spi->chip_select,
 					transfer->bits_per_word, spi->mode,
@@ -262,11 +258,7 @@ static int spi_phyt_transfer_one(struct spi_master *master,
 			}
 			fts->flash_erase = 0;
 		} else {
-			fts->flags = 1;
-			if (fts->spi_write_flag == 0 && *(u8 *)(fts->tx) != MCP251x_READ
-					&& *(u8 *)(fts->tx) != MCP251x_READ_RXB0
-					&& *(u8 *)(fts->tx) != MCP251x_READ_RXB1)
-				fts->flags = 3;
+			fts->flags = 0;
 
 			ret = spi_phytium_write(fts, spi->chip_select, transfer->bits_per_word,
 					spi->mode, chip->tmode, fts->flags, fts->spi_write_flag);

--- a/drivers/spi/spi-phytium-v2.c
+++ b/drivers/spi/spi-phytium-v2.c
@@ -403,9 +403,50 @@ static void spi_phyt_timer_handle(struct timer_list *t)
 	mod_timer(&fts->timer, jiffies + msecs_to_jiffies(10));
 }
 
+void spi_handle_debug_err(struct phytium_spi *fts)
+{
+	struct device *dev = &fts->master->dev;
+	u32 reg, len, i;
+
+	reg = phytium_read_regfile(fts, SPI_REGFILE_DEBUG);
+
+	if (reg & SPI_REGFILE_HAVE_LOG) {
+		len = strnlen(fts->log, fts->log_size);
+		dev_info(dev, "log len :%d,addr: 0x%llx,size:%d\n",
+				len, (u64)fts->log, fts->log_size);
+		if (len > SPI_LOG_LINE_MAX_LEN) {
+			for (i = 0; i + SPI_LOG_LINE_MAX_LEN < len; i += SPI_LOG_LINE_MAX_LEN)
+				dev_info(dev, "(log)%.*s\n", SPI_LOG_LINE_MAX_LEN, &fts->log[i]);
+		} else {
+			dev_info(dev, "(log)%.*s\n", SPI_LOG_LINE_MAX_LEN, &fts->log[0]);
+		}
+
+		for (i = 0; i < fts->log_size; i++)
+			fts->log[i] = 0;
+	}
+
+	reg &= ~SPI_REGFILE_HAVE_LOG;
+	phytium_write_regfile(fts, SPI_REGFILE_DEBUG, reg);
+}
+
 static void spi_phyt_hw_init(struct device *dev, struct phytium_spi *fts)
 {
+	u32 reg, i;
+
 	spi_phytium_default(fts);
+
+	reg = phytium_read_regfile(fts, SPI_REGFILE_DEBUG);
+	fts->ddr_paddr = ((reg & SPI_REGFILE_ADDR_MASK) >> 8) << SPI_DDR_ADDR_HIGH;
+	fts->log_size = ((reg & SPI_REGFILE_SIZE_MASK) >> 4) * SPI_DEBUG_LOG_SIZE;
+	fts->log = devm_ioremap(dev, fts->ddr_paddr, fts->log_size);
+
+	if (IS_ERR(fts->log)) {
+		dev_err(dev, "log_addr is err\n");
+		return;
+	}
+
+	for (i = 0; i < fts->log_size; i++)
+		fts->log[i] = 0;
 }
 
 int spi_phyt_add_host(struct device *dev, struct phytium_spi *fts)
@@ -452,6 +493,7 @@ int spi_phyt_add_host(struct device *dev, struct phytium_spi *fts)
 	fts->alive_enabled = false;
 
 	fts->watchdog = spi_watchdog;
+	fts->handle_debug_err = spi_handle_debug_err;
 
 	fts->timer.expires = jiffies + msecs_to_jiffies(50);
 	timer_setup(&fts->timer, spi_phyt_timer_handle, 0);

--- a/drivers/spi/spi-phytium-v2.c
+++ b/drivers/spi/spi-phytium-v2.c
@@ -25,6 +25,10 @@
 #include <linux/mtd/spi-nor.h>
 #include "spi-phytium.h"
 
+#define MCP251x_READ		0x03
+#define MCP251x_READ_RXB0	0x90
+#define MCP251x_READ_RXB1	0x94
+
 static inline void spi_phyt_enable_chip(struct phytium_spi *fts, u8 enable)
 {
 	u8 val = enable ? 1 : 2;
@@ -158,7 +162,7 @@ static int spi_phyt_transfer_one(struct spi_master *master,
 			chip->tmode = TMOD_TO;
 	}
 
-	if (fts->tx) {
+	if (fts->tx && fts->len == 1) {
 		if ((*(u8 *)fts->tx == SPINOR_OP_WREN) && fts->spi_write_flag == 0) {
 			spi_phytium_write_pre(fts, spi->chip_select,
 					transfer->bits_per_word, spi->mode,
@@ -258,8 +262,14 @@ static int spi_phyt_transfer_one(struct spi_master *master,
 			}
 			fts->flash_erase = 0;
 		} else {
+			fts->flags = 1;
+			if (fts->spi_write_flag == 0 && *(u8 *)(fts->tx) != MCP251x_READ
+					&& *(u8 *)(fts->tx) != MCP251x_READ_RXB0
+					&& *(u8 *)(fts->tx) != MCP251x_READ_RXB1)
+				fts->flags = 3;
+
 			ret = spi_phytium_write(fts, spi->chip_select, transfer->bits_per_word,
-					spi->mode, chip->tmode, 1, fts->spi_write_flag);
+					spi->mode, chip->tmode, fts->flags, fts->spi_write_flag);
 			if (ret) {
 				dev_err(&master->dev, "write command failed\n");
 				return ret;
@@ -483,6 +493,7 @@ int spi_phyt_add_host(struct device *dev, struct phytium_spi *fts)
 	master->dev.of_node = dev->of_node;
 	master->dev.fwnode = dev->fwnode;
 	master->flags = SPI_CONTROLLER_GPIO_SS;
+	master->flags |= SPI_CONTROLLER_HALF_DUPLEX;
 
 	spi_master_set_devdata(master, fts);
 

--- a/drivers/spi/spi-phytium-v2.c
+++ b/drivers/spi/spi-phytium-v2.c
@@ -168,7 +168,7 @@ static int spi_phyt_transfer_one(struct spi_master *master,
 		}
 
 		if ((*(u8 *)fts->tx == SPINOR_OP_BE_4K) && (fts->spi_write_flag == 1) &&
-				fts->flash_read == 0 && fts->flash_erase == 0) {
+				fts->flash_read == 0 && fts->flash_erase != 1) {
 			fts->spi_write_flag++;
 			fts->flash_erase = 1;
 			return 0;

--- a/drivers/spi/spi-phytium.h
+++ b/drivers/spi/spi-phytium.h
@@ -194,6 +194,7 @@ struct phytium_spi {
 	u32			cur_tx_tail;
 	struct completion	cmd_completion;
 
+	u8			flags;
 	u8			spi_write_flag;
 	u8			flash_erase;
 	u8			flash_read;

--- a/drivers/spi/spi-phytium.h
+++ b/drivers/spi/spi-phytium.h
@@ -65,6 +65,14 @@
 #define SPI_REGFILE_DEBUG_VAL		BIT(0)
 #define SPI_REGFILE_ALIVE_VAL		BIT(1)
 #define SPI_REGFILE_HEARTBIT_VAL	BIT(2)
+#define SPI_REGFILE_HAVE_LOG		BIT(3)
+#define SPI_REGFILE_SIZE_MASK		GENMASK(7, 4)
+#define SPI_REGFILE_ADDR_MASK		GENMASK(27, 8)
+
+#define SPI_DDR_ADDR_HIGH		12
+#define SPI_DEBUG_LOG_SIZE		4096
+
+#define SPI_LOG_LINE_MAX_LEN		400
 
 #define SPI_MODULE_OPT_CMD		0x20
 
@@ -197,7 +205,11 @@ struct phytium_spi {
 	bool			alive_enabled;
 	struct timer_list	timer;
 	u32			runtimes; // for debug
+	u64			ddr_paddr;
+	char			*log;
+	u32			log_size;
 	void			(*watchdog)(struct phytium_spi *fts);
+	void			(*handle_debug_err)(struct phytium_spi *fts);
 
 	/* DMA info */
 	u32			current_freq; /* frequency in hz */


### PR DESCRIPTION
This patch updates the support for phytium spi controller driver.

## Summary by Sourcery

Update Phytium SPI and QSPI controller drivers with improved SPI-NOR handling, debugging/logging support, and configuration fixes.

New Features:
- Add debug log buffer discovery and dumping for Phytium SPI controllers using regfile configuration.

Bug Fixes:
- Correct QSPI flash capacity encoding by using left shifts instead of right shifts.
- Fix QSPI dummy-cycle configuration when executing operations to use the proper shift and value calculation.
- Prevent enabling direct mapping when there are zero flashes attached to the QSPI controller.
- Adjust SPI-NOR write/erase handling to correctly recognize erase operations and gate write commands based on the associated spi_mem instance.
- Ensure chip select can toggle even when transfer state is active, avoiding premature returns that block CS changes.

Enhancements:
- Mark the Phytium SPI master as half-duplex capable and wire up a debug error handler hook.
- Increment driver version numbers for the Phytium SPI and QSPI platform drivers.
- Change the default global chip-select configuration for the Phytium SPI v2 platform driver.