### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] r8169: add support for RTL8168M

### DIFF
--- a/drivers/net/ethernet/realtek/r8169_main.c
+++ b/drivers/net/ethernet/realtek/r8169_main.c
@@ -2119,6 +2119,8 @@ static enum mac_version rtl8169_get_mac_version(u16 xid, bool gmii)
 		 * the wild. Let's disable detection.
 		 * { 0x7cf, 0x540,	RTL_GIGA_MAC_VER_45 },
 		 */
+		/* Realtek calls it RTL8168M, but it's handled like RTL8168H */
+		{ 0x7cf, 0x6c0,	RTL_GIGA_MAC_VER_46 },
 
 		/* 8168G family. */
 		{ 0x7cf, 0x5c8,	RTL_GIGA_MAC_VER_44 },


### PR DESCRIPTION
Log:
r8169 0000:01:00.0: error -ENODEV: unknown chip XID 6c0, contact r8169 maintainers (see MAINTAINERS file)
Link: https://lore.kernel.org/all/8bacfc9f-7194-4376-acf7-38a935d735be@gmail.com/

mainline inclusion
from mainline-v6.10-rc1
category: feature

A user reported an unknown chip version. According to the r8168 vendor driver it's called RTL8168M, but handling is identical to RTL8168H. So let's simply treat it as RTL8168H.

Tested-by: Евгений <octobergun@gmail.com>


(cherry picked from commit 39f59c72ad3a1eaab9a60f0671bc94d2bc826d21)

## Summary by Sourcery

New Features:
- Recognize the RTL8168M (XID 0x6c0) Realtek r8169 Ethernet controller and treat it as RTL8168H for driver handling.