### PR TITLE
media: phytium-jpeg: Reduce the latency introduced by IRQ threads

### DIFF
--- a/drivers/media/platform/phytium/phytium_jpeg_core.c
+++ b/drivers/media/platform/phytium/phytium_jpeg_core.c
@@ -1123,8 +1123,8 @@ static int phytium_jpeg_parser_timer31_irq(struct phytium_jpeg_dev *jpeg_dev)
 		return -ENODEV;
 	}
 
-	ret = devm_request_threaded_irq(dev, irq, NULL, phytium_jpeg_timer31_irq,
-			IRQF_ONESHOT, PHYTIUM_JPEG_NAME, jpeg_dev);
+	ret = devm_request_irq(dev, irq, phytium_jpeg_timer31_irq,
+			IRQF_TIMER, PHYTIUM_JPEG_NAME, jpeg_dev);
 	if (ret < 0)
 		dev_err(dev, "Failed to request timer31 IRQ %d\n", irq);
 
@@ -1177,8 +1177,8 @@ static int phytium_jpeg_parser_timer30_irq(struct phytium_jpeg_dev *jpeg_dev)
 		return -ENODEV;
 	}
 
-	ret = devm_request_threaded_irq(dev, irq, NULL, phytium_jpeg_timer30_irq,
-			IRQF_ONESHOT, PHYTIUM_JPEG_NAME, jpeg_dev);
+	ret = devm_request_irq(dev, irq, phytium_jpeg_timer30_irq,
+			IRQF_TIMER, PHYTIUM_JPEG_NAME, jpeg_dev);
 	if (ret < 0)
 		dev_err(dev, "Failed to request timer30 IRQ %d\n", irq);
 


### PR DESCRIPTION
When OS is under heavy load, there is a high probability that the IRQ thread will not get invoked immediately. In the scenario, scheduling IRQ threads generate latency. Therefore, the legacy IRQ method is used to mitigate this latency.

## Summary by Sourcery

Bug Fixes:
- Avoid delayed handling of JPEG parser timer interrupts by replacing threaded IRQs with direct IRQ handlers for timer30 and timer31.