### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] PCI: Add ARCH_PHYTIUM check for phytium root and switch ports

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -5381,8 +5381,10 @@ static const struct pci_dev_acs_enabled {
 	{ PCI_VENDOR_ID_MUCSE, 0x1061, pci_quirk_mf_endpoint_acs },
 	{ PCI_VENDOR_ID_MUCSE, 0x1c61, pci_quirk_mf_endpoint_acs },
 	/* Phytium Technology */
+#ifdef CONFIG_ARCH_PHYTIUM
 	{ PCI_VENDOR_ID_PLX, PCI_ANY_ID, pci_quirk_xgene_acs },
 	{ PCI_VENDOR_ID_CDNS, PCI_ANY_ID, pci_quirk_xgene_acs },
+#endif /* CONFIG_ARCH_PHYTIUM */
 	{ PCI_VENDOR_ID_PHYTIUM, PCI_ANY_ID, pci_quirk_xgene_acs },
 	{ 0 }
 };


### PR DESCRIPTION
deepin inclusion
category: bugfix

To prevent affect other platform or use a runtime check, use ARCH_PHYTIUM  to limit the quirk in our arm64 platform kernel.

Fixes: 66d26941f982 ("PCI: Add ACS quirk for phytium root and switch ports")

## Summary by Sourcery

Bug Fixes:
- Prevent unintended impact of the Phytium PCI ACS quirk on non-Phytium platforms by guarding it with an ARCH_PHYTIUM configuration check.