### PR TITLE
mmc: phytium: Add driver version information for mmc

### DIFF
--- a/drivers/mmc/host/phytium-mci-pci.c
+++ b/drivers/mmc/host/phytium-mci-pci.c
@@ -173,3 +173,4 @@ module_pci_driver(phytium_mci_pci_driver);
 MODULE_DESCRIPTION("Phytium Multimedia Card Interface PCI driver");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Cheng Quan <chengquan@phytium.com.cn>");
+MODULE_VERSION(PHYTIUM_MMC_DRIVER_VERSION);

--- a/drivers/mmc/host/phytium-mci-plat-v2.c
+++ b/drivers/mmc/host/phytium-mci-plat-v2.c
@@ -258,3 +258,4 @@ module_platform_driver(phytium_mci_driver);
 MODULE_DESCRIPTION("Phytium Multimedia Card Interface driver");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Lai Xueyu <laixueyu1280@phytium.com.cn>");
+MODULE_VERSION(PHYTIUM_MMC_V2_DRIVER_VERSION);

--- a/drivers/mmc/host/phytium-mci-plat.c
+++ b/drivers/mmc/host/phytium-mci-plat.c
@@ -192,3 +192,4 @@ module_platform_driver(phytium_mci_driver);
 MODULE_DESCRIPTION("Phytium Multimedia Card Interface driver");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Cheng Quan <chengquan@phytium.com.cn>");
+MODULE_VERSION(PHYTIUM_MMC_DRIVER_VERSION);

--- a/drivers/mmc/host/phytium-mci-v2.c
+++ b/drivers/mmc/host/phytium-mci-v2.c
@@ -1074,3 +1074,4 @@ EXPORT_SYMBOL(phyt_mci_common_probe);
 MODULE_DESCRIPTION("Phytium Multimedia Card Interface driver");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Lai Xueyu <laixueyu1280@phytium.com.cn>");
+MODULE_VERSION(PHYTIUM_MMC_V2_DRIVER_VERSION);

--- a/drivers/mmc/host/phytium-mci-v2.h
+++ b/drivers/mmc/host/phytium-mci-v2.h
@@ -19,6 +19,8 @@
 /*------------------------------------------------------*/
 /* Common Definition					*/
 /*------------------------------------------------------*/
+#define PHYTIUM_MMC_V2_DRIVER_VERSION "1.1.0"
+
 #define SD_BLOCK_SIZE		512
 #define MAX_BD_NUM		128
 #define MCI_CLK			1200000000

--- a/drivers/mmc/host/phytium-mci.c
+++ b/drivers/mmc/host/phytium-mci.c
@@ -1575,3 +1575,4 @@ EXPORT_SYMBOL(phytium_mci_common_probe);
 MODULE_DESCRIPTION("Phytium Multimedia Card Interface driver");
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Cheng Quan <chengquan@phytium.com.cn>");
+MODULE_VERSION(PHYTIUM_MMC_DRIVER_VERSION);

--- a/drivers/mmc/host/phytium-mci.h
+++ b/drivers/mmc/host/phytium-mci.h
@@ -19,6 +19,8 @@
 /*------------------------------------------------------*/
 /* Common Definition					*/
 /*------------------------------------------------------*/
+#define PHYTIUM_MMC_DRIVER_VERSION "1.0.0"
+
 #define MAX_BD_NUM		128
 #define SD_BLOCK_SIZE		512
 

--- a/drivers/mmc/host/phytium-sdci.c
+++ b/drivers/mmc/host/phytium-sdci.c
@@ -39,6 +39,8 @@
 
 #include "phytium-sdci.h"
 
+#define PHYTIUM_SDCI_DRIVER_VERSION "1.0.0"
+
 static const u32 cmd_ints_mask = SDCI_SDCI_NORMAL_ISER_ECC_EN | SDCI_SDCI_NORMAL_ISER_EEI_EN;
 static const u32 data_ints_mask = SDCI_BD_ISER_ETRS_EN;
 static const u32 err_ints_mask = SDCI_ERROR_ISER_ECTE_EN | SDCI_ERROR_ISR_CCRCE_EN |
@@ -1438,3 +1440,4 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Cheng Quan <chengquan@phytium.com.cn>");
 MODULE_AUTHOR("Chen Baozi <chenbaozi@phytium.com.cn>");
 MODULE_DESCRIPTION("Phytium SD Card Interface driver");
+MODULE_VERSION(PHYTIUM_SDCI_DRIVER_VERSION);


### PR DESCRIPTION
This patch add driver version information, which will be used to synchronize and manage driver patches in the future.

## Summary by Sourcery

Add explicit version metadata to Phytium MMC/SDCI drivers for tracking and managing driver revisions.

New Features:
- Expose version information for the Phytium SDCI MMC host driver via a defined driver version string and MODULE_VERSION.
- Expose version information for the Phytium MMC host drivers (legacy and v2, PCI and platform variants) via dedicated driver version macros and MODULE_VERSION entries.