### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Deepin] arm64: entry: inline cortex_a76_erratum_1463225_svc_handler

### DIFF
--- a/arch/arm64/kernel/entry-common.c
+++ b/arch/arm64/kernel/entry-common.c
@@ -189,7 +189,7 @@ asmlinkage void noinstr el##_##regsize##_##vector##_handler(struct pt_regs *regs
 #ifdef CONFIG_ARM64_ERRATUM_1463225
 static DEFINE_PER_CPU(int, __in_cortex_a76_erratum_1463225_wa);
 
-static void cortex_a76_erratum_1463225_svc_handler(void)
+static __always_inline void cortex_a76_erratum_1463225_svc_handler(void)
 {
 	u64 reg, val;
 


### PR DESCRIPTION
deepin inclusion
category: performance

enable CONFIG_ARM64_ERRATUM_1463225 causes 4% in noaffected cpu unixbench syscall test, before we decide to disable it, test inline it bring up ~1%, cortex_a76_erratum_1463225_debug_handler had been inlined, so it should not bring any functional change.


(cherry picked from commit b7a24f94c29192f6e92b4deec13b60de1642442c)

## Summary by Sourcery

Enhancements:
- Mark the cortex_a76_erratum_1463225_svc_handler as always inline to align with the already inlined debug handler and avoid additional call overhead.