### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Deepin] ALSA: hda: Add FTHD0001 match for Phytium

### DIFF
--- a/sound/hda/controllers/phytium.c
+++ b/sound/hda/controllers/phytium.c
@@ -1058,6 +1058,7 @@ MODULE_DEVICE_TABLE(of, hda_ft_of_match);
 #ifdef CONFIG_ACPI
 static const struct acpi_device_id hda_ft_acpi_match[] = {
 	{ .id = "PHYT0006" },
+	{ .id = "FTHD0001" },
 	{}
 };
 MODULE_DEVICE_TABLE(acpi, hda_ft_acpi_match);


### PR DESCRIPTION
Some Phytium ALSA HDA devices declare their ID as FTHD0001 instead of PHYT0006 (following Phytium's deprecated older ACPI specification).

Add the old ID to the ACPI match list so that the audio driver for these devices can be loaded correctly.

Similar to ("ALSA: hda: Resolving the issue of the ALC662 sound card failing to load.") in openKylin tree.

Link: https://gitee.com/openkylin/linux/commit/6ad24efc4daecb54c99e31862d3cc0220e5d8a72
Codeveloped-by: wangdicheng <wangdicheng@kylinos.cn>


(cherry picked from commit 555481f035ced671de4f819362ce590cd91a25fe)

## Summary by Sourcery

Bug Fixes:
- Allow Phytium HDA audio devices advertising the deprecated FTHD0001 ACPI ID to be recognized and handled by the existing ALSA HDA Phytium driver.