### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Upstream] drm/amdgpu: ensure no_hw_access is visible before MMIO

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
@@ -5743,6 +5743,9 @@ int amdgpu_device_mode1_reset(struct amdgpu_device *adev)
 	/* enable mmio access after mode 1 reset completed */
 	adev->no_hw_access = false;
 
+	/* ensure no_hw_access is updated before we access hw */
+	smp_mb();
+
 	amdgpu_device_load_pci_state(adev->pdev);
 	ret = amdgpu_psp_wait_for_bootloader(adev);
 	if (ret)


### PR DESCRIPTION
mainline inclusion
from mainline-v7.0-rc1
category: bugfix

Add a full memory barrier after clearing no_hw_access in amdgpu_device_mode1_reset() so subsequent PCI state restore access cannot observe stale state on other CPUs.

Fixes: 7edb503fe4b6 ("drm/amd/pm: Disable MMIO access during SMU Mode 1 reset")

Reviewed-by: Yifan Zhang <yifan1.zhang@amd.com>

(cherry picked from commit 31b153315b8702d0249aa44d83d9fbf42c5c7a79)

## Summary by Sourcery

Bug Fixes:
- Prevent races where MMIO or PCI state restore may observe stale no_hw_access state after an AMDGPU Mode 1 reset by enforcing proper memory ordering.