### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Deepin] deepin: arm64: acpi: hisi: Fix Revert disallow AML memory opregions t…

### DIFF
--- a/arch/arm64/kernel/acpi.c
+++ b/arch/arm64/kernel/acpi.c
@@ -326,18 +326,19 @@ pgprot_t __acpi_get_mem_attribute(phys_addr_t addr)
 void __iomem *acpi_os_ioremap(acpi_physical_address phys, acpi_size size)
 {
 #ifdef CONFIG_ARM64
-       if (read_cpuid_implementor() == ARM_CPU_IMP_HISI) {
-               /* For normal memory we already have a cacheable mapping. */
-               if (memblock_is_map_memory(phys))
-	               return (void __iomem *)__phys_to_virt(phys);
+	if ((read_cpuid_implementor() == ARM_CPU_IMP_HISI) &&
+		(read_cpuid_part_number() == HISI_CPU_PART_TSV110)) {
+		/* For normal memory we already have a cacheable mapping. */
+		if (memblock_is_map_memory(phys))
+			return (void __iomem *)__phys_to_virt(phys);
 
-               /*
-               * We should still honor the memory's attribute here because
-               * crash dump kernel possibly excludes some ACPI (reclaim)
-               * regions from memblock list.
-               */
-               return ioremap_prot(phys, size, __acpi_get_mem_attribute(phys));
-       }
+		/*
+		 * We should still honor the memory's attribute here because
+		 * crash dump kernel possibly excludes some ACPI (reclaim)
+		 * regions from memblock list.
+		 */
+		return __ioremap_prot(phys, size, __acpi_get_mem_attribute(phys));
+	}
 #endif
 	efi_memory_desc_t *md, *region = NULL;
 	pgprot_t prot;


### PR DESCRIPTION
…o access kernel memory

deepin inclusion
category: bugfix

use __ioremap_prot() instead of ioremap_prot(),
and use read_cpuid_part_number() to limit it to TSV110(core of kp920).

Log:
------------[ cut here ]------------
WARNING: CPU: 0 PID: 0 at ./arch/arm64/include/asm/io.h:275 acpi_os_ioremap+0x>
Modules linked in:
CPU: 0 UID: 0 PID: 0 Comm: swapper/0 Not tainted 6.18.18-arm64-desktop-rolling>
pstate: 60000009 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--) pc : acpi_os_ioremap+0x320/0x32c
lr : acpi_os_ioremap+0x25c/0x32c
sp : ffff800082fa3ce0
x29: ffff800082fa3ce0 x28: 0000000030a8974c x27: ffff800082fc2310 x26: ffff0027fbffb080 x25: ffff800081c43d50 x24: 0000000000000000 x23: ffff8000831ab638 x22: 0000000039680000 x21: 0000000000001000 x20: 0000000000000040 x19: 0000000039680000 x18: ffff800082fc4140 x17: 000000003a6e63c7 x16: 000000007eedd586 x15: ffff800082fa39f0 x14: 0000000000000000 x13: ffff0027db7f8000 x12: 0000000000000186 x11: 0000000000000082 x10: ffff0027fbe34400 x9 : 0000000000000000 x8 : ffffffffffffffe8 x7 : fffffffffe4334c0 x6 : fffffffffe4340c0 x5 : ffffffffffffffd8 x4 : 0000000000000030 x3 : 0000000000000020 x2 : 0000000000000000 x1 : 00e8000000000f03 x0 : 00e8000000000703 Call trace:
 acpi_os_ioremap+0x320/0x32c (P)
 acpi_os_map_iomem+0xc0/0x194
 acpi_os_map_memory+0x14/0x24
 acpi_tb_validate_table+0x9c/0xbc
 acpi_tb_verify_temp_table+0x54/0x23c
 acpi_reallocate_root_table+0x118/0x1d4
 acpi_early_init+0x58/0xac
 start_kernel+0x4dc/0x694
 __primary_switched+0x90/0x98
---[ end trace 0000000000000000 ]---

ACPI: Interpreter enabled
ACPI: Using GIC for interrupt routing
ACPI: MCFG table detected, 1 entries
ACPI Error: Could not map memory at 0x0000000039690019, size 4095 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PCI6._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x0000000039690019, size 4095 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PCI7._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x0000000039690019, size 4095 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PCI9._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x0000000039690019, size 4095 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PCIA._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x0000000039690019, size 4095 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PCIB._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001E, size 4090 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.SPI0.TPM._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001A, size 4094 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.POE0._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001A, size 4094 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.POE2._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001A, size 4094 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.POE3._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001B, size 4093 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PSTA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Aborting method \_SB.MB36._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001B, size 4093 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PSTA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Aborting method \_SB.MB37._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001B, size 4093 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PSTA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Aborting method \_SB.L306._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Could not map memory at 0x000000003969001B, size 4093 (20250807/exregion-147)
ACPI Error: AE_NO_MEMORY, Returned by Handler for [SystemMemory] (20250807/evregion-303)
ACPI Error: Aborting method \_SB.PSTA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)
ACPI Error: Aborting method \_SB.L307._STA due to previous error (AE_NO_MEMORY) (20250807/psparse-529)

## Summary by Sourcery

Bug Fixes:
- Fix ACPI SystemMemory region mapping failures and associated kernel warnings on Hisilicon arm64 systems by correctly handling normal memory and using the proper ioremap helper for TSV110 cores only.