### PR TITLE
Linux 6.6.y i2s

### DIFF
--- a/sound/soc/phytium/pmdk_dp.c
+++ b/sound/soc/phytium/pmdk_dp.c
@@ -128,6 +128,7 @@ static struct snd_soc_dai_link pmdk_dai0 = {
 	.dai_fmt = SMDK_DAI_FMT,
 	.init = pmdk_dp0_init,
 	SND_SOC_DAILINK_REG(pmdk_dp0_dai),
+	.playback_only = 1,
 };
 
 static struct snd_soc_dai_link pmdk_dai1 = {
@@ -136,6 +137,7 @@ static struct snd_soc_dai_link pmdk_dai1 = {
 	.dai_fmt = SMDK_DAI_FMT,
 	.init = pmdk_dp1_init,
 	SND_SOC_DAILINK_REG(pmdk_dp1_dai),
+	.playback_only = 1,
 };
 
 static struct snd_soc_dai_link pmdk_dai2 = {
@@ -144,6 +146,7 @@ static struct snd_soc_dai_link pmdk_dai2 = {
 	.dai_fmt = SMDK_DAI_FMT,
 	.init = pmdk_dp2_init,
 	SND_SOC_DAILINK_REG(pmdk_dp2_dai),
+	.playback_only = 1,
 };
 
 static struct snd_soc_card pmdk = {

--- a/sound/soc/phytium/pmdk_dp.c
+++ b/sound/soc/phytium/pmdk_dp.c
@@ -167,20 +167,35 @@ static int pmdk_sound_probe(struct platform_device *pdev)
 	struct pmdk_dp_private *priv;
 	struct snd_soc_dai_link *pmdk_dai;
 	int num_dp = 2;
+	int dp_mask = 3;
 
 	card->dev = &pdev->dev;
 	device_property_read_u32(&pdev->dev, "num-dp", &num_dp);
+	device_property_read_u32(&pdev->dev, "dp-mask", &dp_mask);
 	pmdk_dai = devm_kzalloc(&pdev->dev, num_dp * sizeof(*pmdk_dai), GFP_KERNEL);
 	if (!pmdk_dai)
 		return -ENOMEM;
 
 	switch (num_dp) {
 	case 1:
-		pmdk_dai[0] = pmdk_dai0;
+		if (dp_mask == 1)
+			pmdk_dai[0] = pmdk_dai0;
+		else if (dp_mask == 2)
+			pmdk_dai[0] = pmdk_dai1;
+		else if (dp_mask == 4)
+			pmdk_dai[0] = pmdk_dai2;
 		break;
 	case 2:
-		pmdk_dai[0] = pmdk_dai0;
-		pmdk_dai[1] = pmdk_dai1;
+		if (dp_mask == 3) {
+			pmdk_dai[0] = pmdk_dai0;
+			pmdk_dai[1] = pmdk_dai1;
+		} else if (dp_mask == 5) {
+			pmdk_dai[0] = pmdk_dai0;
+			pmdk_dai[1] = pmdk_dai2;
+		} else if (dp_mask == 6) {
+			pmdk_dai[0] = pmdk_dai1;
+			pmdk_dai[1] = pmdk_dai2;
+		}
 		break;
 	case 3:
 		pmdk_dai[0] = pmdk_dai0;

--- a/sound/soc/phytium/pmdk_dp.c
+++ b/sound/soc/phytium/pmdk_dp.c
@@ -178,23 +178,23 @@ static int pmdk_sound_probe(struct platform_device *pdev)
 
 	switch (num_dp) {
 	case 1:
-		if (dp_mask == 1)
-			pmdk_dai[0] = pmdk_dai0;
-		else if (dp_mask == 2)
+		if (dp_mask == 2)
 			pmdk_dai[0] = pmdk_dai1;
 		else if (dp_mask == 4)
 			pmdk_dai[0] = pmdk_dai2;
+		else
+			pmdk_dai[0] = pmdk_dai0;
 		break;
 	case 2:
-		if (dp_mask == 3) {
-			pmdk_dai[0] = pmdk_dai0;
-			pmdk_dai[1] = pmdk_dai1;
-		} else if (dp_mask == 5) {
+		if (dp_mask == 5) {
 			pmdk_dai[0] = pmdk_dai0;
 			pmdk_dai[1] = pmdk_dai2;
 		} else if (dp_mask == 6) {
 			pmdk_dai[0] = pmdk_dai1;
 			pmdk_dai[1] = pmdk_dai2;
+		} else {
+			pmdk_dai[0] = pmdk_dai0;
+			pmdk_dai[1] = pmdk_dai1;
 		}
 		break;
 	case 3:


### PR DESCRIPTION
Change default dp_mask value.
Use dp-mask to choose pmdk_dai.
Add playback only in pmdk_dai.

## Summary by Sourcery

Configure Phytium PMDK DisplayPort audio routing based on a dp-mask property and restrict the PMDK DAI links to playback-only operation.

Enhancements:
- Add a dp-mask device property with a default value to select which PMDK DAI links are instantiated for one- and two-port configurations.
- Mark all PMDK DisplayPort DAI links as playback-only to disable capture on these interfaces.