### PR TITLE
i2c: phytium: Fix some interrupt bugs and support MCTP

### DIFF
--- a/drivers/i2c/busses/i2c-phytium-common.c
+++ b/drivers/i2c/busses/i2c-phytium-common.c
@@ -117,7 +117,7 @@ EXPORT_SYMBOL_GPL(i2c_phytium_prepare_clk);
 
 int i2c_phytium_check_bus_not_busy(struct phytium_i2c_dev *dev)
 {
-	if (dev->slave_state != SLAVE_STATE_IDLE)
+	if (dev->slave_status != SLAVE_STATE_IDLE)
 		return -EAGAIN;
 	if (phytium_readl(dev, IC_STATUS) & IC_STATUS_ACTIVITY)
 		return -ETIMEDOUT;

--- a/drivers/i2c/busses/i2c-phytium-core.h
+++ b/drivers/i2c/busses/i2c-phytium-core.h
@@ -11,7 +11,7 @@
 
 #include <linux/types.h>
 
-#define I2C_PHYTIUM_DRV_VERSION "1.0.0"
+#define I2C_PHYTIUM_DRV_VERSION "1.0.1"
 
 #define IC_DEFAULT_FUNCTIONALITY (I2C_FUNC_I2C |		\
 				  I2C_FUNC_SMBUS_BYTE |		\
@@ -141,13 +141,13 @@
 #define PHYTIUM_IC_SLAVE		1
 
 #if IS_ENABLED(CONFIG_I2C_SLAVE)
-enum i2c_slave_state {
-	SLAVE_STATE_IDLE,
-	SLAVE_STATE_RECV,
-	SLAVE_STATE_SEND,
-	SLAVE_STATE_REQUEST,
-	SLAVE_STATE_RESPONSE
-};
+/* Slave status */
+#define	SLAVE_STATE_IDLE		0x0
+#define	SLAVE_WRITE_IN_PROGRESS		BIT(0)
+#define	SLAVE_READ_IN_PROGRESS		BIT(1)
+#define	SLAVE_STATE_ACTIVE		BIT(2)
+
+#define REQ_MIN_LEN			6
 #endif
 #define ABRT_7B_ADDR_NOACK		0
 #define ABRT_10ADDR1_NOACK		1
@@ -199,7 +199,8 @@ struct phytium_i2c_dev {
 
 	u32			capability;
 #if IS_ENABLED(CONFIG_I2C_SLAVE)
-	enum i2c_slave_state	slave_state;
+	u32			slave_status;
+	struct completion	slave_complete;
 #endif
 	spinlock_t		i2c_lock;
 	struct i2c_client	*slave;

--- a/drivers/i2c/busses/i2c-phytium-mix.c
+++ b/drivers/i2c/busses/i2c-phytium-mix.c
@@ -24,6 +24,9 @@
 #define I2C_QUICK_CMD_BIT_SET			BIT(13)
 #define DEFAULT_TIMEOUT				(DEFAULT_CLOCK_FREQUENCY / 1000 * 35)
 
+static int i2c_phytium_init_master(struct phytium_i2c_dev *dev);
+static void i2c_phytium_change_mode(int target_mode, struct phytium_i2c_dev *dev);
+
 static int i2c_phytium_recover_controller(struct phytium_i2c_dev *dev)
 {
 	unsigned long flags;
@@ -31,14 +34,20 @@ static int i2c_phytium_recover_controller(struct phytium_i2c_dev *dev)
 	spin_lock_irqsave(&dev->i2c_lock, flags);
 
 	reset_control_reset(dev->rst);
-#if IS_ENABLED(CONFIG_I2C_SLAVE)
-	dev->slave_state = SLAVE_STATE_IDLE;
-	dev->status = STATUS_IDLE;
-	if (dev->slave)
-		phytium_writel(dev, dev->slave->addr, IC_SAR);
-#endif
 
+	if (!dev->slave) {
+		i2c_phytium_init_master(dev);
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+	} else {
+		dev->slave_status = SLAVE_STATE_IDLE;
+		phytium_writel(dev, dev->slave->addr, IC_SAR);
+		i2c_phytium_change_mode(PHYTIUM_IC_SLAVE, dev);
+#endif
+	}
+
+	dev->status = STATUS_IDLE;
 	spin_unlock_irqrestore(&dev->i2c_lock, flags);
+
 	return 0;
 }
 
@@ -131,7 +140,6 @@ static int i2c_phytium_init_master(struct phytium_i2c_dev *dev)
 static void i2c_phytium_change_mode(int target_mode, struct phytium_i2c_dev *dev)
 {
 	if (target_mode == PHYTIUM_IC_MASTER) {
-		dev->disable_int(dev);
 		dev->disable(dev);
 		i2c_phytium_init_master(dev);
 	} else {
@@ -371,30 +379,40 @@ static int i2c_phytium_xfer(struct i2c_adapter *adapter, struct i2c_msg msgs[],
 	ret = pm_runtime_get_sync(dev->dev);
 	if (ret < 0) {
 		dev_err(dev->dev, "pm runtime get sync err.\n");
-		goto pm_exit;
+		goto done;
 	}
 
 	spin_lock_irqsave(&dev->i2c_lock, flags);
-	reinit_completion(&dev->cmd_complete);
 
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+	if (dev->slave && dev->slave_status != SLAVE_STATE_IDLE) {
+		reinit_completion(&dev->slave_complete);
+		spin_unlock_irqrestore(&dev->i2c_lock, flags);
+
+		/* Waiting for slave to complete. */
+		if (!wait_for_completion_timeout(&dev->slave_complete,
+				adapter->timeout)) {
+			dev_err(dev->dev, "Slave is timeout, recover\n");
+			i2c_phytium_recover_controller(dev);
+			ret = -ETIMEDOUT;
+			goto done;
+		}
+		spin_lock_irqsave(&dev->i2c_lock, flags);
+	}
+
+	if (dev->mode == PHYTIUM_IC_SLAVE)
+		i2c_phytium_change_mode(PHYTIUM_IC_MASTER, dev);
+#endif
+
+	reinit_completion(&dev->cmd_complete);
 	dev->msgs = msgs;
 	dev->msgs_num = num;
 	dev->cmd_err = 0;
 	dev->msg_write_idx = 0;
 	dev->msg_read_idx = 0;
 	dev->msg_err = 0;
-	dev->status = STATUS_IDLE;
 	dev->abort_source = 0;
 	dev->rx_outstanding = 0;
-
-	ret = i2c_phytium_check_bus_not_busy(dev);
-	if (ret < 0)
-		goto done;
-
-#if IS_ENABLED(CONFIG_I2C_SLAVE)
-	if (dev->slave_cfg)
-		i2c_phytium_change_mode(PHYTIUM_IC_MASTER, dev);
-#endif
 
 	/* Start the transfers */
 	i2c_phytium_xfer_init(dev);
@@ -404,15 +422,19 @@ static int i2c_phytium_xfer(struct i2c_adapter *adapter, struct i2c_msg msgs[],
 					 adapter->timeout)) {
 		dev_err(dev->dev, "controller timed out\n");
 		i2c_phytium_recover_controller(dev);
-		spin_lock_irqsave(&dev->i2c_lock, flags);
-		if (!dev->slave_cfg)
-			i2c_phytium_init_master(dev);
 		ret = -ETIMEDOUT;
 		goto done;
 	}
-	spin_lock_irqsave(&dev->i2c_lock, flags);
-	__i2c_phytium_disable_nowait(dev);
 
+	if (!dev->slave)
+		__i2c_phytium_disable_nowait(dev);
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+	/* Do nothing. */
+	if (dev->slave && dev->msgs->len >= REQ_MIN_LEN) {
+		reinit_completion(&dev->slave_complete);
+		wait_for_completion_timeout(&dev->slave_complete, adapter->timeout);
+	}
+#endif
 	if (dev->msg_err) {
 		ret = dev->msg_err;
 		goto done;
@@ -425,25 +447,13 @@ static int i2c_phytium_xfer(struct i2c_adapter *adapter, struct i2c_msg msgs[],
 
 	/* We have got an error */
 	if (dev->cmd_err == IC_ERR_TX_ABRT) {
-		spin_unlock_irqrestore(&dev->i2c_lock, flags);
 		ret = i2c_phytium_handle_tx_abort(dev);
-		spin_lock_irqsave(&dev->i2c_lock, flags);
 		goto done;
 	}
 
 	ret = -EIO;
 
 done:
-#if IS_ENABLED(CONFIG_I2C_SLAVE)
-	if (dev->slave_cfg)
-		i2c_phytium_change_mode(PHYTIUM_IC_SLAVE, dev);
-	dev->status = STATUS_IDLE;
-	dev->slave_state = SLAVE_STATE_IDLE;
-#endif
-	spin_unlock_irqrestore(&dev->i2c_lock, flags);
-
-pm_exit:
-
 	pm_runtime_mark_last_busy(dev->dev);
 	pm_runtime_put_autosuspend(dev->dev);
 
@@ -483,7 +493,7 @@ static int i2c_phytium_reg_slave(struct i2c_client *slave)
 	dev->msg_write_idx = 0;
 	dev->msg_read_idx = 0;
 	dev->msg_err = 0;
-	dev->status = STATUS_IDLE;
+	dev->slave_status = SLAVE_STATE_IDLE;
 	dev->abort_source = 0;
 	dev->rx_outstanding = 0;
 
@@ -603,8 +613,7 @@ static int i2c_phytium_irq_handler_master(struct phytium_i2c_dev *dev)
 			phytium_readl(dev, IC_CLR_TX_ABRT);
 			phytium_writel(dev, 0, IC_INTR_MASK);
 
-			complete(&dev->cmd_complete);
-			return 0;
+			goto abort;
 		}
 	}
 
@@ -617,6 +626,10 @@ static int i2c_phytium_irq_handler_master(struct phytium_i2c_dev *dev)
 abort:
 	if ((stat & IC_INTR_TX_ABRT) || (stat & IC_INTR_STOP_DET) || dev->msg_err) {
 		complete(&dev->cmd_complete);
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+		if (dev->slave)
+			i2c_phytium_change_mode(PHYTIUM_IC_SLAVE, dev);
+#endif
 	} else if (unlikely(dev->flags & ACCESS_INTR_MASK)) {
 		/* Workaround to trigger pending interrupt */
 		stat = phytium_readl(dev, IC_INTR_MASK);
@@ -644,11 +657,10 @@ static int i2c_phytium_irq_handler_slave(struct phytium_i2c_dev *dev)
 	stat = i2c_phytium_read_clear_intrbits(dev);
 
 	if (stat & IC_INTR_RX_FULL) {
-		if (dev->status != STATUS_WRITE_IN_PROGRESS) {
-			dev->status = STATUS_WRITE_IN_PROGRESS;
+		if (dev->slave_status != SLAVE_WRITE_IN_PROGRESS) {
+			dev->slave_status = SLAVE_WRITE_IN_PROGRESS;
 			i2c_slave_event(dev->slave, I2C_SLAVE_WRITE_REQUESTED,
 					&val);
-			dev->slave_state = SLAVE_STATE_RECV;
 		}
 		do {
 			val = phytium_readl(dev, IC_DATA_CMD);
@@ -662,13 +674,11 @@ static int i2c_phytium_irq_handler_slave(struct phytium_i2c_dev *dev)
 		if (slave_activity) {
 			phytium_readl(dev, IC_CLR_RD_REQ);
 
-			if (!(dev->status & STATUS_READ_IN_PROGRESS)) {
+			if (!(dev->slave_status & SLAVE_READ_IN_PROGRESS)) {
 				i2c_slave_event(dev->slave,
 						I2C_SLAVE_READ_REQUESTED, &val);
-				dev->status |= STATUS_READ_IN_PROGRESS;
-				dev->status &= ~STATUS_WRITE_IN_PROGRESS;
-				dev->slave_state = SLAVE_STATE_SEND;
-
+				dev->slave_status |= SLAVE_READ_IN_PROGRESS;
+				dev->slave_status &= ~SLAVE_WRITE_IN_PROGRESS;
 			} else {
 				i2c_slave_event(dev->slave,
 						I2C_SLAVE_READ_PROCESSED, &val);
@@ -680,8 +690,8 @@ static int i2c_phytium_irq_handler_slave(struct phytium_i2c_dev *dev)
 	if (stat & IC_INTR_STOP_DET) {
 		i2c_slave_event(dev->slave, I2C_SLAVE_STOP, &val);
 #if IS_ENABLED(CONFIG_I2C_SLAVE)
-		dev->status = STATUS_IDLE;
-		dev->slave_state = SLAVE_STATE_IDLE;
+		dev->slave_status = SLAVE_STATE_IDLE;
+		complete(&dev->slave_complete);
 #endif
 	}
 
@@ -697,6 +707,8 @@ static irqreturn_t i2c_phytium_isr(int this_irq, void *dev_id)
 
 #if IS_ENABLED(CONFIG_I2C_SLAVE)
 	if (dev->mode == PHYTIUM_IC_SLAVE) {
+		if (dev->slave_status == SLAVE_STATE_IDLE)
+			dev->slave_status = SLAVE_STATE_ACTIVE;
 		i2c_phytium_irq_handler_slave(dev);
 		spin_unlock(&dev->i2c_lock);
 		return IRQ_HANDLED;
@@ -829,6 +841,10 @@ int i2c_phytium_probe(struct phytium_i2c_dev *dev)
 					"Phytium I2C Slave Adapter");
 		dev->init = i2c_phytium_init_slave;
 	}
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+	init_completion(&dev->slave_complete);
+	dev->slave_status = SLAVE_STATE_IDLE;
+#endif
 
 	dev->disable = i2c_phytium_disable;
 	dev->disable_int = i2c_phytium_disable_int;

--- a/drivers/i2c/busses/i2c-phytium-pci.c
+++ b/drivers/i2c/busses/i2c-phytium-pci.c
@@ -184,7 +184,7 @@ static int i2c_phytium_pci_probe(struct pci_dev *pdev,
 	dev->flags |= controller->flags;
 
 #if IS_ENABLED(CONFIG_I2C_SLAVE)
-	dev->slave_state = SLAVE_STATE_IDLE;
+	dev->slave_status = SLAVE_STATE_IDLE;
 #endif
 	spin_lock_init(&dev->i2c_lock);
 	dev->functionality = controller->functionality | IC_DEFAULT_FUNCTIONALITY;

--- a/drivers/i2c/busses/i2c-phytium-platform.c
+++ b/drivers/i2c/busses/i2c-phytium-platform.c
@@ -153,7 +153,7 @@ static int phytium_i2c_plat_probe(struct platform_device *pdev)
 	dev->irq = irq;
 	dev->first_time_init_master = false;
 #if IS_ENABLED(CONFIG_I2C_SLAVE)
-	dev->slave_state = SLAVE_STATE_IDLE;
+	dev->slave_status = SLAVE_STATE_IDLE;
 #endif
 	spin_lock_init(&dev->i2c_lock);
 	platform_set_drvdata(pdev, dev);

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-common.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-common.c
@@ -159,7 +159,7 @@ void i2c_phyt_show_log(struct i2c_phyt_dev *dev)
 		dev_info(dev->dev, "log len :%d,addr: 0x%llx,size:%d\n", len, (u64)dev->log_addr,
 					dev->log_size);
 		if (len > FT_LOG_LINE_MAX_LEN) {
-			for (i = 0; i < len; i += FT_LOG_LINE_MAX_LEN)
+			for (i = 0; i + FT_LOG_LINE_MAX_LEN < len; i += FT_LOG_LINE_MAX_LEN)
 				dev_info(dev->dev, "(log)%.*s\n", FT_LOG_LINE_MAX_LEN, &plog[i]);
 		} else {
 			dev_info(dev->dev, "(log)%.*s\n", FT_LOG_LINE_MAX_LEN, &plog[0]);

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-common.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-common.c
@@ -20,7 +20,7 @@
 #include "i2c-phyt-core.h"
 
 #define FT_LOG_LINE_MAX_LEN		400
-#define FT_LOG_MAX_SIZE			8192
+#define FT_LOG_MAX_SIZE			32768
 
 static void i2c_phyt_send_msg(struct i2c_phyt_dev *dev,
 				struct phyt_msg_info *set_msg, bool complete_flag);
@@ -32,6 +32,11 @@ static char *i2c_ft_abort_sources[] = {
 	[FT_I2C_INT_ERR] = "Interrupt error",
 	[FT_I2C_BLOCK_SIZE] = "smbus block error",
 	[FT_I2C_INVALID_ADDR] = "slave address invalid",
+	[FT_I2C_TRANS_PACKET_FAIL] = "Packet transfer fail",
+	[FT_I2C_PACKET_NOT_START] = "Packet not start",
+	[FT_I2C_PARA_ERR] = "Para error",
+	[FT_I2C_INTR_XFER_INIT] = "Intr mode xfer init",
+	[FT_I2C_TRANS_WAIT] = "Trans wait",
 	[FT_I2C_CHECK_STATUS_ERR] = "Uncomplete status",
 };
 
@@ -183,7 +188,7 @@ int  i2c_phyt_malloc_log_mem(struct i2c_phyt_dev *dev)
 	reg = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_DEBUG);
 	phy_addr = ((reg & FT_I2C_LOG_ADDR_MASK) >> FT_I2C_LOG_ADDR_LOW_SHIFT) <<
 							FT_I2C_LOG_ADDR_SHIFT;
-	dev->log_size = ((reg & FT_I2C_LOG_SIZE_MASK) >> FT_I2C_LOG_SIZE_LOW_SHIFT) * 1024;
+	dev->log_size = ((reg & FT_I2C_LOG_SIZE_MASK) >> FT_I2C_LOG_SIZE_LOW_SHIFT) * 4096;
 
 	dev->log_addr = devm_ioremap(dev->dev, phy_addr, dev->log_size);
 
@@ -293,6 +298,7 @@ void i2c_phyt_default_cfg(struct i2c_phyt_dev *dev,
 	struct phyt_msg_info i2c_mng_msg;
 
 	memset(&i2c_mng_msg, 0, sizeof(i2c_mng_msg));
+	memset(dev->rx_shmem_addr, 0xFF, sizeof(struct phyt_msg_info));
 
 	i2c_phyt_common_set_cmd(dev, &i2c_mng_msg, PHYTI2C_MSG_CMD_DEFAULT,
 					PHYTI2C_MSG_CMD_DEFAULT_RESUME);
@@ -370,9 +376,12 @@ int i2c_phyt_check_status(struct i2c_phyt_dev *dev,
 	if (msg->head.status0 != FT_I2C_MSG_COMPLETE_UNKNOW) {
 		if (!dev->mng.is_need_check ||
 		    ((msg->head.status0 == FT_I2C_MSG_COMPLETE_OK) &&
-		     (msg->head.status1 == FT_I2C_SUCCESS))) {
+		    ((msg->head.status1 == FT_I2C_SUCCESS) ||
+		     (msg->head.status1 == FT_I2C_TRANS_WAIT)))) {
 			dev->abort_source = 0;
 			result = FT_I2C_SUCCESS;
+			if (msg->head.status1 == FT_I2C_TRANS_WAIT)
+				dev->flags = FT_I2C_TRANS_WAIT;
 		} else {
 			i2c_phyt_show_log(dev);
 			dev->abort_source = 1 << msg->head.status1;

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-core.h
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-core.h
@@ -14,7 +14,7 @@
 #include <linux/interrupt.h>
 #include <linux/kernel.h>
 
-#define I2C_PHYTIUM_V2_DRV_VERSION		"1.0.1"
+#define I2C_PHYTIUM_V2_DRV_VERSION		"1.0.2"
 
 #define FT_I2C_MSG_UNIT_SIZE			10
 #define FT_I2C_DATA_RESV_LEN			2

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-core.h
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-core.h
@@ -14,7 +14,7 @@
 #include <linux/interrupt.h>
 #include <linux/kernel.h>
 
-#define I2C_PHYTIUM_V2_DRV_VERSION		"1.0.2"
+#define I2C_PHYTIUM_V2_DRV_VERSION		"1.0.3"
 
 #define FT_I2C_MSG_UNIT_SIZE			10
 #define FT_I2C_DATA_RESV_LEN			2
@@ -38,9 +38,9 @@
 #define FT_I2C_REGFILE_HEARTBIT_VAL		BIT(2)
 #define FT_I2C_LOG_SIZE_LOW_SHIFT		4
 #define FT_I2C_LOG_SIZE_MASK			GENMASK(7, FT_I2C_LOG_SIZE_LOW_SHIFT)
-#define FT_I2C_LOG_ADDR_SHIFT			10
+#define FT_I2C_LOG_ADDR_SHIFT			12
 #define FT_I2C_LOG_ADDR_LOW_SHIFT		8
-#define FT_I2C_LOG_ADDR_MASK			GENMASK(29, FT_I2C_LOG_ADDR_LOW_SHIFT)
+#define FT_I2C_LOG_ADDR_MASK			GENMASK(27, FT_I2C_LOG_ADDR_LOW_SHIFT)
 #define FT_I2C_LOG_ADDR_LOCK_VAL		BIT(31)
 #define FT_I2C_LOG_ADDR_LOG_FLAG		BIT(3)
 #define FT_I2C_LOG_ADDR_LOG_ALIVE		BIT(1)
@@ -267,6 +267,10 @@ enum phyti2c_status_code {
 	FT_I2C_BLOCK_SIZE,
 	FT_I2C_INVALID_ADDR,
 	FT_I2C_TRANS_PACKET_FAIL,
+	FT_I2C_PACKET_NOT_START,
+	FT_I2C_PARA_ERR,
+	FT_I2C_INTR_XFER_INIT,
+	FT_I2C_TRANS_WAIT,
 	/*The RV result must put above*/
 	FT_I2C_RUNNING,
 	FT_I2C_CHECK_STATUS_ERR
@@ -389,6 +393,7 @@ struct i2c_phyt_dev {
 	u32 master_cfg;
 	u32 slave_cfg;
 	u32 functionality;
+	spinlock_t	i2c_lock;
 
 	u8 real_index[FT_I2C_SINGLE_FRAME_CNT];
 	struct i2c_timings timings;
@@ -509,4 +514,5 @@ void i2c_phyt_notify_rv(struct i2c_phyt_dev *dev, bool need_check);
 int i2c_phyt_check_status(struct i2c_phyt_dev *dev, struct phyt_msg_info *msg);
 void i2c_phyt_set_int_interrupt(struct i2c_phyt_dev *dev,
 				u32 is_enable, u32 intr_mask);
+void i2c_phyt_trig_rv_intr(struct i2c_phyt_dev *dev);
 #endif

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
@@ -444,7 +444,7 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 {
 	struct i2c_phyt_dev *dev = (struct i2c_phyt_dev *)dev_id;
 	struct phyt_msg_info *rx_msg = (struct phyt_msg_info *)dev->rx_shmem_addr;
-	u32 stat;
+	u32 stat, head, tail;
 	int ret;
 
 	stat = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_RV2AP_INTR_STAT);
@@ -456,21 +456,31 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 
 	i2c_phyt_common_regfile_clear_rv2ap_int(dev, stat);
 
-	if (dev->complete_flag) {
-		if (rx_msg->head.cmd_type == PHYTI2C_MSG_CMD_REPORT)
-			goto done;
-
-		ret = i2c_phyt_master_handle(dev);
-		if (ret == FT_I2C_RUNNING)
-			return IRQ_HANDLED;
-
-		dev->complete_flag = false;
-		dev->mng.cur_cmd_cnt = 0;
-		i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_HEAD, 0);
-		i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_TAIL, 0);
-		complete(&dev->cmd_complete);
-		return IRQ_HANDLED;
+	if (!dev->mng.tx_ring_cnt) {
+		dev_err(dev->dev, "tx_ring_cnt is zero\n");
+		return IRQ_NONE;
 	}
+	head = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_TX_HEAD) % dev->mng.tx_ring_cnt;
+	tail = dev->mng.cur_cmd_cnt % dev->mng.tx_ring_cnt;
+	do {
+		tail++;
+		tail %= dev->mng.tx_ring_cnt;
+		if (dev->complete_flag) {
+			if (rx_msg->head.cmd_type == PHYTI2C_MSG_CMD_REPORT)
+				goto done;
+
+			ret = i2c_phyt_master_handle(dev);
+			if (ret == FT_I2C_RUNNING)
+				continue;
+
+			dev->complete_flag = false;
+			dev->mng.cur_cmd_cnt = 0;
+			i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_HEAD, 0);
+			i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_TAIL, 0);
+			complete(&dev->cmd_complete);
+			return IRQ_HANDLED;
+		}
+	} while (tail != head);
 done:
 	i2c_phyt_master_isr_handle(dev);
 

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
@@ -345,9 +345,11 @@ static int i2c_phyt_master_xfer(struct i2c_adapter *adapter,
 {
 	struct i2c_phyt_dev *dev = i2c_get_adapdata(adapter);
 	int ret;
+	unsigned long flags;
 
 	pm_runtime_get_sync(dev->dev);
 
+	spin_lock_irqsave(&dev->i2c_lock, flags);
 	dev->msgs = msgs;
 	dev->msgs_num = num;
 	dev->msg_err = 0;
@@ -356,12 +358,13 @@ static int i2c_phyt_master_xfer(struct i2c_adapter *adapter,
 	dev->mng.tx_cmd_cnt = 0;
 	dev->mng.cur_cmd_cnt = 0;
 	dev->mng.is_last_frame = false;
+	dev->flags = ~FT_I2C_TRANS_WAIT;
 
 	i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_HEAD, 0);
 	i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_TAIL, 0);
 
 	i2c_phyt_master_xfer_single_frame(dev);
-
+	spin_unlock_irqrestore(&dev->i2c_lock, flags);
 	ret = i2c_phyt_check_result(dev);
 	if (!ret) {
 		ret = num;
@@ -369,7 +372,8 @@ static int i2c_phyt_master_xfer(struct i2c_adapter *adapter,
 		if (dev->abort_source != FT_I2C_SUCCESS) {
 			i2c_phyt_handle_tx_abort(dev);
 			if ((dev->abort_source & BIT(FT_I2C_TIMEOUT)) ||
-			    (dev->abort_source & BIT(FT_I2C_TRANS_PACKET_FAIL))) {
+			    (dev->abort_source & BIT(FT_I2C_TRANS_PACKET_FAIL)) ||
+			    (dev->abort_source & BIT(FT_I2C_INTR_XFER_INIT))) {
 				i2c_phyt_set_module_en(
 					dev, FT_I2C_ADAPTER_MODULE_RESET);
 				i2c_phyt_check_result(dev);
@@ -447,10 +451,12 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 	u32 stat, head, tail;
 	int ret;
 
+	spin_lock(&dev->i2c_lock);
 	stat = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_RV2AP_INTR_STAT);
 
 	if (!(stat & FT_I2C_RV2AP_INTR_BIT4)) {
 		dev_warn(dev->dev, "unexpect i2c_phyt regfile intr, stat:%#x\n", stat);
+		spin_unlock(&dev->i2c_lock);
 		return IRQ_NONE;
 	}
 
@@ -458,6 +464,7 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 
 	if (!dev->mng.tx_ring_cnt) {
 		dev_err(dev->dev, "tx_ring_cnt is zero\n");
+		spin_unlock(&dev->i2c_lock);
 		return IRQ_NONE;
 	}
 	head = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_TX_HEAD) % dev->mng.tx_ring_cnt;
@@ -465,10 +472,10 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 	do {
 		tail++;
 		tail %= dev->mng.tx_ring_cnt;
-		if (dev->complete_flag) {
-			if (rx_msg->head.cmd_type == PHYTI2C_MSG_CMD_REPORT)
-				goto done;
+		if (rx_msg->head.cmd_type == PHYTI2C_MSG_CMD_REPORT)
+			i2c_phyt_master_isr_handle(dev);
 
+		if (dev->complete_flag) {
 			ret = i2c_phyt_master_handle(dev);
 			if (ret == FT_I2C_RUNNING)
 				continue;
@@ -478,12 +485,17 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 			i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_HEAD, 0);
 			i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_TAIL, 0);
 			complete(&dev->cmd_complete);
+			spin_unlock(&dev->i2c_lock);
 			return IRQ_HANDLED;
 		}
 	} while (tail != head);
-done:
-	i2c_phyt_master_isr_handle(dev);
 
+	if (dev->flags == FT_I2C_TRANS_WAIT) {
+		dev->flags = ~FT_I2C_TRANS_WAIT;
+		i2c_phyt_trig_rv_intr(dev);
+	}
+
+	spin_unlock(&dev->i2c_lock);
 	return IRQ_HANDLED;
 }
 

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-platform.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-platform.c
@@ -305,6 +305,7 @@ static int i2c_phyt_plat_probe(struct platform_device *pdev)
 			    dev->mng.tx_ring_cnt * sizeof(struct phyt_msg_info);
 
 	dev->dev = &pdev->dev;
+	spin_lock_init(&dev->i2c_lock);
 	platform_set_drvdata(pdev, dev);
 
 	ret = i2c_phyt_malloc_log_mem(dev);


### PR DESCRIPTION
The revised content is as follows:
1.Fixed the bug of combining two interrupts.
2.Support MCTP over I2C
3.Fixed the bug of delayed response to interrupts

## Summary by Sourcery

Refine Phytium I2C master/slave handling and interrupt flows, extend status and logging support, and update driver versions for improved reliability and MCTP-over-I2C operation.

Bug Fixes:
- Fix Phytium I2C mixed-mode driver to correctly separate master and slave interrupt handling and avoid combined or delayed completions.
- Ensure master transfers properly wait for in-progress slave activity to complete before switching modes, preventing timeouts and bus errors.
- Correct v2 master regfile interrupt processing to handle empty or unexpected conditions safely and reset the hardware on additional abort sources.
- Fix log output iteration and log memory sizing/mapping so hardware-provided logs are read and printed correctly.

Enhancements:
- Introduce a bitmask-based slave_status state machine and completion for Phytium I2C slave mode to better track active, read, and write phases and coordinate with master transfers.
- Add new v2 status codes and flag handling (including TRANS_WAIT and interrupt-init transfer) to support MCTP-style transactions and more detailed abort diagnostics.
- Increase v2 log buffer capacity and adjust address/size decoding, along with clearing shared-memory RX structures on default configuration for more robust debugging.
- Guard critical sections in the v2 master path and ISR with a dedicated I2C spinlock to improve concurrency safety in interrupt-driven transfers.
- Update Phytium I2C v1 and v2 driver version strings to reflect the new behaviour and capabilities.