### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Deepin] Revert "deepin: arm64: cpufeature: disable LSE on some cpus"

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3501,21 +3501,6 @@
 			unlikely, in the extreme case this might damage your
 			hardware.
 
-	lse_disable_check [ARM64]
-			Disable LSE (Large System Extensions) atomic instructions
-			on some systems to improve performance of per-CPU atomic
-			operations. LSE atomics can exhibit significant overhead
-			on certain microarchitectures (e.g., TSV110) due
-			to "far atomic" implementations bypassing L1 cache. LL/SC
-			(Load-Link/Store-Conditional) is substantially faster.
-
-			The default value is 0 (enabled), which automatically
-			disables LSE on some systems. Set to 1 to bypass
-			the automatic disabling of LSE on affected systems.
-
-			When this feature is active, the kernel logs:
-			"LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature."
-
 	lsm.debug	[SECURITY] Enable LSM initialization debugging output.
 
 	lsm=lsm1,...,lsmN

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1716,33 +1716,6 @@ static bool has_32bit_el0(const struct arm64_cpu_capabilities *entry, int scope)
 	return true;
 }
 
-static bool lse_disable_check __read_mostly;
-
-static int __init arm64_lse_disable_check(char *str)
-{
-	return kstrtobool(str, &lse_disable_check);
-}
-early_param("lse_disable_check", arm64_lse_disable_check);
-
-static bool has_lse_capability_check(const struct arm64_cpu_capabilities *cap,
-										 int scope)
-{
-	/* List of CPUs that LSE are slow more than llsc */
-	static const struct midr_range lse_disable_list[] = {
-		MIDR_ALL_VERSIONS(MIDR_HISI_TSV110),
-		{ /* sentinel */ }
-	};
-
-	/* Disable LSE when lse_disable_check is 0 and in lse_disable_list */
-	if (lse_disable_check == 0 && is_midr_in_range_list(lse_disable_list)) {
-		if (scope == SCOPE_SYSTEM)
-			pr_info("LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature.\n");
-		return false;
-	}
-
-	return has_cpuid_feature(cap, scope);
-}
-
 static bool has_useable_gicv3_cpuif(const struct arm64_cpu_capabilities *entry, int scope)
 {
 	bool has_sre;
@@ -2555,7 +2528,7 @@ static const struct arm64_cpu_capabilities arm64_features[] = {
 		.desc = "LSE atomic instructions",
 		.capability = ARM64_HAS_LSE_ATOMICS,
 		.type = ARM64_CPUCAP_SYSTEM_FEATURE,
-		.matches = has_lse_capability_check,
+		.matches = has_cpuid_feature,
 		ARM64_CPUID_FIELDS(ID_AA64ISAR0_EL1, ATOMIC, IMP)
 	},
 #endif /* CONFIG_ARM64_LSE_ATOMICS */


### PR DESCRIPTION
deepin inclusion
category: bugfix

This reverts commit 14918ea9f9ef66e3216a9f5dd58acc500c5baca3. It will cause UnixBench syscall regression in linux-6.18.y which based in v6.18.19.

## Summary by Sourcery

Bug Fixes:
- Remove the runtime parameter and CPU model blacklist that forced LSE atomics off on certain arm64 CPUs, addressing observed syscall performance regressions.