### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Deepin] Revert "deepin: arm64: cpufeature: disable LSE on some cpus"

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3501,21 +3501,6 @@
 			unlikely, in the extreme case this might damage your
 			hardware.
 
-	lse_disable_check [ARM64]
-			Disable LSE (Large System Extensions) atomic instructions
-			on some systems to improve performance of per-CPU atomic
-			operations. LSE atomics can exhibit significant overhead
-			on certain microarchitectures (e.g., TSV110) due
-			to "far atomic" implementations bypassing L1 cache. LL/SC
-			(Load-Link/Store-Conditional) is substantially faster.
-
-			The default value is 0 (enabled), which automatically
-			disables LSE on some systems. Set to 1 to bypass
-			the automatic disabling of LSE on affected systems.
-
-			When this feature is active, the kernel logs:
-			"LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature."
-
 	lsm.debug	[SECURITY] Enable LSM initialization debugging output.
 
 	lsm=lsm1,...,lsmN

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1716,33 +1716,6 @@ static bool has_32bit_el0(const struct arm64_cpu_capabilities *entry, int scope)
 	return true;
 }
 
-static bool lse_disable_check __read_mostly;
-
-static int __init arm64_lse_disable_check(char *str)
-{
-	return kstrtobool(str, &lse_disable_check);
-}
-early_param("lse_disable_check", arm64_lse_disable_check);
-
-static bool has_lse_capability_check(const struct arm64_cpu_capabilities *cap,
-										 int scope)
-{
-	/* List of CPUs that LSE are slow more than llsc */
-	static const struct midr_range lse_disable_list[] = {
-		MIDR_ALL_VERSIONS(MIDR_HISI_TSV110),
-		{ /* sentinel */ }
-	};
-
-	/* Disable LSE when lse_disable_check is 0 and in lse_disable_list */
-	if (lse_disable_check == 0 && is_midr_in_range_list(lse_disable_list)) {
-		if (scope == SCOPE_SYSTEM)
-			pr_info("LSE atomics: use llsc for performance, use lse_disable_check=1 to disable the feature.\n");
-		return false;
-	}
-
-	return has_cpuid_feature(cap, scope);
-}
-
 static bool has_useable_gicv3_cpuif(const struct arm64_cpu_capabilities *entry, int scope)
 {
 	bool has_sre;
@@ -2555,7 +2528,7 @@ static const struct arm64_cpu_capabilities arm64_features[] = {
 		.desc = "LSE atomic instructions",
 		.capability = ARM64_HAS_LSE_ATOMICS,
 		.type = ARM64_CPUCAP_SYSTEM_FEATURE,
-		.matches = has_lse_capability_check,
+		.matches = has_cpuid_feature,
 		ARM64_CPUID_FIELDS(ID_AA64ISAR0_EL1, ATOMIC, IMP)
 	},
 #endif /* CONFIG_ARM64_LSE_ATOMICS */


### PR DESCRIPTION
deepin inclusion
category: bugfix

This reverts commit 14918ea9f9ef66e3216a9f5dd58acc500c5baca3. It will cause UnixBench syscall regression in linux-6.18.y which based in v6.18.19.

With the revert,in 24c 920 1x from 1126 to 988,24x from 9434 to 9715.

Log:
[Before 1x]
System Benchmarks Index Values               BASELINE       RESULT    INDEX
Dhrystone 2 using register variables         116700.0   30346943.3   2600.4
Double-Precision Whetstone                       55.0       4514.6    820.8
Execl Throughput                                 43.0       2824.0    656.7
File Copy 1024 bufsize 2000 maxblocks          3960.0     719139.0   1816.0
File Copy 256 bufsize 500 maxblocks            1655.0     212030.0   1281.1
File Copy 4096 bufsize 8000 maxblocks          5800.0    1766100.0   3045.0
Pipe Throughput                               12440.0    1405369.5   1129.7
Pipe-based Context Switching                   4000.0     144187.5    360.5
Process Creation                                126.0       3560.0    282.5
Shell Scripts (1 concurrent)                     42.4       5050.5   1191.1
Shell Scripts (8 concurrent)                      6.0       2947.7   4912.8
System Call Overhead                          15000.0     935986.4    624.0
System Benchmarks Index Score                                        1126.4
[After 1x]
Dhrystone 2 using register variables         116700.0   29462063.4   2524.6
Double-Precision Whetstone                       55.0       4507.6    819.6
Execl Throughput                                 43.0       2477.1    576.1
File Copy 1024 bufsize 2000 maxblocks          3960.0     564461.0   1425.4
File Copy 256 bufsize 500 maxblocks            1655.0     163496.0    987.9
File Copy 4096 bufsize 8000 maxblocks          5800.0    1554620.0   2680.4
Pipe Throughput                               12440.0    1405593.5   1129.9
Pipe-based Context Switching                   4000.0     100530.2    251.3
Process Creation                                126.0       2263.4    179.6
Shell Scripts (1 concurrent)                     42.4       5208.7   1228.5
Shell Scripts (8 concurrent)                      6.0       3082.5   5137.5
System Call Overhead                          15000.0     897115.7    598.1
System Benchmarks Index Score                                         988.1
[Before 24x]
24 CPUs in system; running 24 parallel copies of tests
System Benchmarks Index Values               BASELINE       RESULT    INDEX
Dhrystone 2 using register variables         116700.0  710228109.0  60859.3
Double-Precision Whetstone                       55.0     106511.4  19365.7
Execl Throughput                                 43.0      42370.0   9853.5
File Copy 1024 bufsize 2000 maxblocks          3960.0    1114497.0   2814.4
File Copy 256 bufsize 500 maxblocks            1655.0     337201.0   2037.5
File Copy 4096 bufsize 8000 maxblocks          5800.0    3287750.0   5668.5
Pipe Throughput                               12440.0   33199012.2  26687.3
Pipe-based Context Switching                   4000.0    5091924.6  12729.8
Process Creation                                126.0      52588.8   4173.7
Shell Scripts (1 concurrent)                     42.4      84831.4  20007.4
Shell Scripts (8 concurrent)                      6.0      10579.0  17631.6
System Call Overhead                          15000.0    3953070.4   2635.4
System Benchmarks Index Score                                        9434.9
[After 24x]
Dhrystone 2 using register variables         116700.0  722390878.1  61901.5
Double-Precision Whetstone                       55.0     108414.1  19711.6
Execl Throughput                                 43.0      41266.4   9596.8
File Copy 1024 bufsize 2000 maxblocks          3960.0     819510.0   2069.5
File Copy 256 bufsize 500 maxblocks            1655.0     242870.0   1467.5
File Copy 4096 bufsize 8000 maxblocks          5800.0    2694030.0   4644.9
Pipe Throughput                               12440.0   33836303.4  27199.6
Pipe-based Context Switching                   4000.0    5268669.0  13171.7
Process Creation                                126.0      59271.5   4704.1
Shell Scripts (1 concurrent)                     42.4      81581.5  19240.9
Shell Scripts (8 concurrent)                      6.0      10202.7  17004.4
System Call Overhead                          15000.0   11647922.9   7765.3
System Benchmarks Index Score                                        9715.5

## Summary by Sourcery

Revert the Deepin-specific logic that conditionally disabled ARM64 LSE atomics on certain CPUs and restore the upstream cpufeature handling for LSE detection.

Bug Fixes:
- Remove the run-time knob and CPU MIDR-based check that forced LSE atomics off on some arm64 systems, resolving observed syscall performance regressions in UnixBench on linux-6.18.y.

Documentation:
- Drop the kernel parameter documentation tied to the removed LSE disabling mechanism, keeping admin-guide options aligned with available functionality.