### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Deepin] loongarch: disable kaslr when hibernate is supported

### DIFF
--- a/arch/loongarch/kernel/relocate.c
+++ b/arch/loongarch/kernel/relocate.c
@@ -164,6 +164,9 @@ static inline __init bool kaslr_disabled(void)
 	str = strstr(boot_command_line, "resume=");
 	if (str == boot_command_line || (str > boot_command_line && *(str - 1) == ' '))
 		return true;
+
+	pr_info("KASLR is disabled by hibernate enabled.\n");
+	return true;
 #endif
 
 	str = strstr(boot_command_line, "kexec_file");


### PR DESCRIPTION
Link: https://github.com/deepin-community/kernel/pull/338

deepin inclusion
category: feature

[ !broken ] kaslr is disabled !

When kaslr is enabled and no 'resume=' in cmdline (see 71344f2b0), loongarch cannot resume from a hibernated kernel. Console log stops at:

	PM: Image loading progress: 100%
	PM: Image loading done
	PM: hibernation: Read 2669152 kbytes in 4.26 seconds (626.56 MB/s)
	ata1.00: Entering standby power mode
	radeon 0000:06:00.0: GPU pci config reset
	Disabling non-boot CPUs ...

However, resume still fails after using nokaslr in cmdline. Log says:

	PM: Image loading progress: 100%
	PM: Image loading done
	PM: hibernation: Read 2669152 kbytes in 4.26 seconds (626.56 MB/s)
	ata1.00: Entering standby power mode
	radeon 0000:06:00.0: GPU pci config reset
	Disabling non-boot CPUs ...
	ACPI: PM: Restoring platform NVS memory
	Enabling non-boot CPUs ...
	Booting CPU#1...
	CPU1: failed to start
	Error taking CPU1 up: -5
	Booting CPU#2...
	CPU2: failed to start
	Error taking CPU2 up: -5
	Booting CPU#3...
	CPU3: failed to start
	Error taking CPU3 up: -5
	Booting CPU#4...
	64-bit Loongson Processor probed (LA664 Core)
	CPU4 revision is: 0014d000 (Loongson-64bit)
	FPU4 revision is: 00000000
	CPU#4 finished
	CPU4 is up
	Booting CPU#5...
	CPU5: failed to start
	Error taking CPU5 up: -5
	Booting CPU#6...
	Kernel ade access[#5738]:
	CPU: 0 PID: 0 Comm: swapper/0 Tainted: G      D            6.6.0-loong64-desktop #25.00.2000.002
	Hardware name: KaiTian 90Y4A08AKX/KL3A60007A2000DTMB1, BIOS W0MKT0DA 11/25/2024
	pc 9000000000304160 ra 900000000030415c tp 900000000341c000 sp 9000000100403f90
	a0 24001c4c5676979d a1 0000000000000000 a2 0000000000000000 a3 0000000000000000
	a4 90000000040aef08 a5 90000000040aedd0 a6 9000000003d78118 a7 0000000000000000
	t0 0000000000000000 t1 0000000000000000 t2 0000000000000000 t3 0000000000000000
	t4 0000000000000000 t5 0000000000000000 t6 0000000000000000 t7 0000000000000000
	t8 0000000000000000 u0 0000000000000003 s9 00000000fd180638 s0 0000000000000000
	s1 9000000004108cf0 s2 ffffffffffffffff s3 0000000000000001 s4 0000000000000000
	s5 9000000008233481 s6 0000000000000000 s7 9000000002bd4d10 s8 9000000003d72910
	   ra: 900000000030415c generic_handle_domain_irq+0x1c/0x80
	  ERA: 9000000000304160 generic_handle_domain_irq+0x20/0x80
	 CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)
	 PRMD: 00000008 (PPLV0 -PIE +PWE)
	 EUEN: 00000000 (-FPE -SXE -ASXE -BTE)
	 ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)
	ESTAT: 00480800 [ADEM] (IS=11 ECode=8 EsubCode=1)
	 BADV: 24001c4c56769835
	 PRID: 0014d000 (Loongson-64bit, Loongson-3A6000-HV)
	Modules linked in: snd_seq_dummy snd_hrtimer snd_seq snd_seq_device bnep st sr_mod cdrom bluetooth rfkill qrtr nls_iso8859_1 nls_cp4t
	Process swapper/0 (pid: 0, threadinfo=00000000cf4196b1, task=000000007aa949f6)
	Stack : 00000000000002b0 9000000000facff8 900000000344b000 9000000100403ff0
	        0000000000000001 0000000000000000 900000000341fc90 9000000001b1f590
	        90000001006f8000 900000000341fc90 900000000341fc60 9000000001b1f664
	        900000000341fc90 0000000000000000
	Call Trace:
	[<9000000000304160>] generic_handle_domain_irq+0x20/0x80
	[<9000000000facff8>] handle_cpu_irq+0x78/0xc0
	[<9000000001b1f590>] handle_loongarch_irq+0x30/0x60
	[<9000000001b1f664>] do_vint+0xa4/0xe0
	[<90000000002225e0>] __arch_cpu_idle+0x20/0x24
	[<9000000001b21f1c>] arch_cpu_idle+0x1c/0x40
	[<9000000001b22180>] default_idle_call+0xa0/0x158
	[<90000000002cb9c8>] do_idle+0x108/0x160
	[<90000000002cbc84>] cpu_startup_entry+0x44/0x60
	[<9000000001b23234>] kernel_init+0x0/0x14c
	[<9000000001b411c4>] arch_post_acpi_subsys_init+0x0/0xc

This is caused by RANDOM_KMALLOC_CACHES, if this option is enabled, secondary CPUs may fail at "Error taking CPUx up: -5". System may stuck with the above calltrace, or can still enter graphic desktop with only CPU0.

To enable S4, disable kaslr and RANDOM_KMALLOC_CHACHES for now.

## Summary by Sourcery

Bug Fixes:
- Address hibernation resume failures and secondary CPU bring-up errors on LoongArch systems caused by KASLR and randomized kmalloc caches when resuming from S4.