### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Hygon] x86/crypto: fix scatterwalk_unmap issue in cis sm4 driver

### DIFF
--- a/arch/x86/crypto/sm4_cis_glue.c
+++ b/arch/x86/crypto/sm4_cis_glue.c
@@ -773,12 +773,11 @@ static int sm4_gcm_do_crypt(struct aead_request *req, bool encrypt)
 		if (zfilled)
 			crypto_shash_update(cis_ctx->ghash_desc, pad, zfilled);
 
+		if (!assocmem)
+			scatterwalk_unmap(assoc);
+		else
+			kfree(assocmem);
 	}
-
-	if (!assocmem)
-		scatterwalk_unmap(assoc);
-	else
-		kfree(assocmem);
 
 	err = encrypt ? skcipher_walk_aead_encrypt(&walk, req, false)
 		  : skcipher_walk_aead_decrypt(&walk, req, false);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure associated data buffers in the SM4 CIS GCM driver are unmapped or freed only when they have been processed, preventing incorrect scatterwalk_unmap usage.