### PR TITLE
[Deepin-Kernel-SIG][linux-6.6-y][Deepin] Input: Add Kconfig depend for PixArt PS/2 touchpad

### DIFF
--- a/drivers/input/mouse/Kconfig
+++ b/drivers/input/mouse/Kconfig
@@ -72,7 +72,7 @@ config MOUSE_PS2_LOGIPS2PP
 config MOUSE_PS2_PIXART
 	bool "PixArt PS/2 touchpad protocol extension" if EXPERT
 	default y
-	depends on MOUSE_PS2
+	depends on MOUSE_PS2 && (MACH_LOONGSON32 || MACH_LOONGSON64 || COMPILE_TEST)
 	help
 	  This driver supports the PixArt PS/2 touchpad found in some
 	  laptops.


### PR DESCRIPTION
deepin inclusion
categroy: bugfix

With the patch v5, still cause false detect in some no pixart touchpads, so limit it in loongson config.

Link: https://lore.kernel.org/all/tbhy6xk4tjuza7rgsv55xss5woysyv4wlg46m6sxfq6y5nk7da@7hyl7cf5ehus/
Reported-by: wenlunpeng <wenlunpeng@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Limit PixArt PS/2 touchpad detection to Loongson configurations to prevent false positives on other hardware.