### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] sched: Simplify code sync from v6.9-rc1

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -1766,7 +1766,6 @@ static void cpu_util_update_eff(struct cgroup_subsys_state *css);
 #endif
 
 #ifdef CONFIG_SYSCTL
-#ifdef CONFIG_UCLAMP_TASK
 #ifdef CONFIG_UCLAMP_TASK_GROUP
 static void uclamp_update_root_tg(void)
 {
@@ -1872,7 +1871,6 @@ undo:
 	return result;
 }
 #endif
-#endif
 
 static void uclamp_fork(struct task_struct *p)
 {
@@ -1938,7 +1936,7 @@ static void __init init_uclamp(void)
 	}
 }
 
-#else /* CONFIG_UCLAMP_TASK */
+#else /* !CONFIG_UCLAMP_TASK */
 static inline void uclamp_rq_inc(struct rq *rq, struct task_struct *p, int flags) { }
 static inline void uclamp_rq_dec(struct rq *rq, struct task_struct *p) { }
 static inline void uclamp_fork(struct task_struct *p) { }

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -9500,10 +9500,10 @@ static inline bool cfs_rq_has_blocked(struct cfs_rq *cfs_rq)
 
 static inline bool others_have_blocked(struct rq *rq)
 {
-	if (READ_ONCE(rq->avg_rt.util_avg))
+	if (cpu_util_rt(rq))
 		return true;
 
-	if (READ_ONCE(rq->avg_dl.util_avg))
+	if (cpu_util_dl(rq))
 		return true;
 
 	if (thermal_load_avg(rq))
@@ -9769,8 +9769,8 @@ static unsigned long scale_rt_capacity(int cpu)
 	 * avg_thermal.load_avg tracks thermal pressure and the weighted
 	 * average uses the actual delta max capacity(load).
 	 */
-	used = READ_ONCE(rq->avg_rt.util_avg);
-	used += READ_ONCE(rq->avg_dl.util_avg);
+	used = cpu_util_rt(rq);
+	used += cpu_util_dl(rq);
 	used += thermal_load_avg(rq);
 
 	if (unlikely(used >= max))

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -9509,10 +9509,8 @@ static inline bool others_have_blocked(struct rq *rq)
 	if (thermal_load_avg(rq))
 		return true;
 
-#ifdef CONFIG_HAVE_SCHED_AVG_IRQ
-	if (READ_ONCE(rq->avg_irq.util_avg))
+	if (cpu_util_irq(rq))
 		return true;
-#endif
 
 	return false;
 }

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -10443,10 +10443,8 @@ static int idle_cpu_without(int cpu, struct task_struct *p)
 	 * be computed and tested before calling idle_cpu_without().
 	 */
 
-#ifdef CONFIG_SMP
 	if (rq->ttwu_pending)
 		return 0;
-#endif
 
 	return 1;
 }

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -3388,7 +3388,7 @@ static inline bool uclamp_rq_is_idle(struct rq *rq)
 
 static inline unsigned long cpu_util_irq(struct rq *rq)
 {
-	return rq->avg_irq.util_avg;
+	return READ_ONCE(rq->avg_irq.util_avg);
 }
 
 static inline


### PR DESCRIPTION
## Summary by Sourcery

Simplify scheduler utilization accounting and configuration conditionals for better consistency with upstream.

Enhancements:
- Replace direct access to per-rq RT/DL/IRQ utilization fields with cpu_util_* helper functions in fair scheduler paths.
- Simplify idle CPU checks by removing an unnecessary CONFIG_SMP conditional around rq->ttwu_pending.
- Clean up uclamp-related configuration conditionals and comments in the scheduler core to match upstream organization.
- Guard IRQ utilization reads with READ_ONCE via cpu_util_irq for safer concurrent access.