### PR TITLE
kbuild: Keep .config in linux-headers for old dkms

### DIFF
--- a/scripts/package/install-extmod-build
+++ b/scripts/package/install-extmod-build
@@ -37,6 +37,7 @@ mkdir -p "${destdir}"
 	echo include/config/auto.conf
 	echo include/config/kernel.release
 	echo include/generated
+	echo .config
 	find_in_scripts
 
 	if is_enabled CONFIG_GCC_PLUGINS; then


### PR DESCRIPTION
This was removed in 43eaad8716("kbuild: slim down package for building external modules"). But old versions of dkms still want the .config file, so keep it.

## Summary by Sourcery

Enhancements:
- Retain the kernel .config file in linux-headers packages used for building external modules to support legacy dkms tooling.