### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Fromlist] KVM: x86: Advertise AVX512 Bit Matrix Multiply (BMM) to userspace

### DIFF
--- a/arch/x86/include/asm/cpufeatures.h
+++ b/arch/x86/include/asm/cpufeatures.h
@@ -488,6 +488,7 @@
 #define X86_FEATURE_GP_ON_USER_CPUID	(20*32+17) /* User CPUID faulting */
 
 #define X86_FEATURE_PREFETCHI		(20*32+20) /* Prefetch Data/Instruction to Cache Level */
+#define X86_FEATURE_AVX512_BMM		(20*32+23) /* AVX512 Bit Matrix Multiply instructions */
 #define X86_FEATURE_SBPB		(20*32+27) /* Selective Branch Prediction Barrier */
 #define X86_FEATURE_IBPB_BRTYPE		(20*32+28) /* MSR_PRED_CMD[IBPB] flushes all branch type predictions */
 #define X86_FEATURE_SRSO_NO		(20*32+29) /* CPU is not affected by SRSO */

--- a/arch/x86/kvm/cpuid.c
+++ b/arch/x86/kvm/cpuid.c
@@ -1217,11 +1217,12 @@ void kvm_set_cpu_caps(void)
 		F(NULL_SEL_CLR_BASE),
 		/* UpperAddressIgnore */
 		F(AUTOIBRS),
-		F(PREFETCHI),
 		EMULATED_F(NO_SMM_CTL_MSR),
 		/* PrefetchCtlMsr */
 		/* GpOnUserCpuid */
 		/* EPSF */
+		F(PREFETCHI),
+		F(AVX512_BMM),
 		SYNTHESIZED_F(SBPB),
 		SYNTHESIZED_F(IBPB_BRTYPE),
 		SYNTHESIZED_F(SRSO_NO),


### PR DESCRIPTION
Advertise AVX512 Bit Matrix Multiply (BMM) and Bit Reversal instructions to userspace via CPUID leaf 0x80000021_EAX[23]. This feature enables bit matrix multiply operations and bit reversal.

While at it, reorder PREFETCHI to match the bit position order in CPUID leaf 0x80000021_EAX for better organization.


Link: https://github.com/kvm-x86/linux/commit/de0bfdc7137d

## Summary by Sourcery

Advertise the AVX512 Bit Matrix Multiply capability to KVM userspace via CPUID while keeping CPUID feature bit ordering aligned with the architectural specification.

New Features:
- Expose AVX512 Bit Matrix Multiply instructions to userspace through a new CPUID feature bit.

Enhancements:
- Reorder the PREFETCHI CPUID feature bit to match the documented bit position layout in leaf 0x80000021_EAX.