### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] deepin: extra ci: add i386_defconfig

### DIFF
--- a/.github/workflows/build-kernel-extra.yml
+++ b/.github/workflows/build-kernel-extra.yml
@@ -26,6 +26,18 @@ jobs:
           git config --global user.email $email
           git config --global user.name $KBUILD_BUILD_USER
 
+      - name: "Compile kernel i386_defconfig"
+        run: |
+          # .config
+          make i386_defconfig
+          make -j$(nproc)
+
+      - name: "Clang build kernel i386_defconfig"
+        run: |
+          # .config
+          make LLVM=-18 i386_defconfig
+          make LLVM=-18 -j$(nproc)
+
       - name: "Compile kernel x86_64_defconfig"
         run: |
           # .config

--- a/drivers/cpufreq/acpi-cpufreq.c
+++ b/drivers/cpufreq/acpi-cpufreq.c
@@ -627,6 +627,7 @@ static int acpi_cpufreq_blacklist(struct cpuinfo_x86 *c)
 }
 #endif
 
+#ifdef CONFIG_ACPI_CPPC_LIB
 /* The work item is needed to avoid CPU hotplug locking issues */
 static void sched_itmt_work_fn(struct work_struct *work)
 {
@@ -640,7 +641,6 @@ static void sched_set_itmt(void)
 	schedule_work(&sched_itmt_work);
 }
 
-#ifdef CONFIG_ACPI_CPPC_LIB
 /*
  * get_max_boost_ratio: Computes the max_boost_ratio as the ratio
  * between the highest_perf and the nominal_perf.

--- a/sound/pci/hda/hda_intel.c
+++ b/sound/pci/hda/hda_intel.c
@@ -423,7 +423,7 @@ static int gf_init_pci(struct azx *chip)
 			gf_chip->diu_fb_bdl_ofs[1] = diu_fb_bdl[1] - diu_fb_base; // stream offset = fb_size -4M-16M+7M*2+4K
 			gf_chip->diu_fb_bdl_vaddr[1] = ioremap_wc(diu_fb_bdl[1], BDL_SIZE); // size = 4K
 
-			dev_info(chip->card->dev, "gf_hda diu fb base=0x%llx, size=%dM.\n", diu_fb_base, (unsigned int)(fb_size >> 20));
+			dev_info(chip->card->dev, "gf_hda diu fb base=%pa, size=%dM.\n", &diu_fb_base, (unsigned int)(fb_size >> 20));
 		}
 	}
 	return 0;


### PR DESCRIPTION
1. It seems our peers also check for build success under this configuration.

2. At this moment, the code in the deepin linux-6.6.y branch indeed fails to build under that branch.

## Summary by Sourcery

Extend extra kernel CI to cover i386_defconfig and fix related build issues.

Bug Fixes:
- Guard sched_itmt_work_fn and sched_set_itmt with CONFIG_ACPI_CPPC_LIB to avoid build failures when CPPC support is disabled.
- Fix HDA Intel diagnostic logging to use phys_addr formatting for the DIU framebuffer base address on 32-bit builds.

CI:
- Update the extra kernel GitHub Actions workflow to build the kernel with i386_defconfig.