### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [deepin] Input: evdev - Modify the process of closing the evdev device to use …

### DIFF
--- a/drivers/input/evdev.c
+++ b/drivers/input/evdev.c
@@ -383,7 +383,13 @@ static void evdev_detach_client(struct evdev *evdev,
 	spin_lock(&evdev->client_lock);
 	list_del_rcu(&client->node);
 	spin_unlock(&evdev->client_lock);
-	synchronize_rcu();
+
+	if (system_state == SYSTEM_HALT ||
+		system_state == SYSTEM_POWER_OFF ||
+		system_state == SYSTEM_RESTART)
+		synchronize_rcu_expedited();
+	else
+		synchronize_rcu();
 }
 
 static int evdev_open_device(struct evdev *evdev)


### PR DESCRIPTION
…the synchronize_rcu_expedited interface to speed up the shutdown process.

deepin inclusion
categroy: performace

As Documentations saied:
	synchronize_rcu_expedited() instead
	of synchronize_rcu().  This reduces latency,
	but can increase CPU utilization, degrade
	real-time latency, and degrade energy efficiency.
use it to optimize the shutdown process by
our system developer report where some input dev shutdown cost many XXms.
With the patched kernel, shutdown cost time from 5.96 to 5.11.

Tested-by: qiancheng <qiancheng@uniontech.com>

## Summary by Sourcery

Enhancements:
- Conditionally use synchronize_rcu_expedited() instead of synchronize_rcu() during evdev client cleanup when the system is halting, powering off, or restarting to reduce shutdown latency.