### PR TITLE
[linux 6.18.y] [deepin] LoongArch: Export some signal functions

### DIFF
--- a/arch/loongarch/include/asm/fpu.h
+++ b/arch/loongarch/include/asm/fpu.h
@@ -29,22 +29,22 @@ void kernel_fpu_end(void);
 asmlinkage void _init_fpu(unsigned int);
 asmlinkage void _save_fp(struct loongarch_fpu *);
 asmlinkage void _restore_fp(struct loongarch_fpu *);
-asmlinkage int _save_fp_context(void __user *fpregs, void __user *fcc, void __user *csr);
-asmlinkage int _restore_fp_context(void __user *fpregs, void __user *fcc, void __user *csr);
+extern int _save_fp_context(void __user *fpregs, void __user *fcc, void __user *csr);
+extern int _restore_fp_context(void __user *fpregs, void __user *fcc, void __user *csr);
 
 asmlinkage void _save_lsx(struct loongarch_fpu *fpu);
 asmlinkage void _restore_lsx(struct loongarch_fpu *fpu);
 asmlinkage void _init_lsx_upper(void);
 asmlinkage void _restore_lsx_upper(struct loongarch_fpu *fpu);
-asmlinkage int _save_lsx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
-asmlinkage int _restore_lsx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
+extern int _save_lsx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
+extern int _restore_lsx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
 
 asmlinkage void _save_lasx(struct loongarch_fpu *fpu);
 asmlinkage void _restore_lasx(struct loongarch_fpu *fpu);
 asmlinkage void _init_lasx_upper(void);
 asmlinkage void _restore_lasx_upper(struct loongarch_fpu *fpu);
-asmlinkage int _save_lasx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
-asmlinkage int _restore_lasx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
+extern int _save_lasx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
+extern int _restore_lasx_context(void __user *fpregs, void __user *fcc, void __user *fcsr);
 
 static inline void enable_lsx(void);
 static inline void disable_lsx(void);

--- a/arch/loongarch/include/asm/lbt.h
+++ b/arch/loongarch/include/asm/lbt.h
@@ -15,10 +15,10 @@
 asmlinkage void _init_lbt(void);
 asmlinkage void _save_lbt(struct loongarch_lbt *);
 asmlinkage void _restore_lbt(struct loongarch_lbt *);
-asmlinkage int _save_lbt_context(void __user *regs, void __user *eflags);
-asmlinkage int _restore_lbt_context(void __user *regs, void __user *eflags);
-asmlinkage int _save_ftop_context(void __user *ftop);
-asmlinkage int _restore_ftop_context(void __user *ftop);
+extern int _save_lbt_context(void __user *regs, void __user *eflags);
+extern int _restore_lbt_context(void __user *regs, void __user *eflags);
+extern int _save_ftop_context(void __user *ftop);
+extern int _restore_ftop_context(void __user *ftop);
 
 static inline int is_lbt_enabled(void)
 {

--- a/arch/loongarch/kernel/Makefile
+++ b/arch/loongarch/kernel/Makefile
@@ -7,6 +7,7 @@ OBJECT_FILES_NON_STANDARD_head.o := y
 
 always-$(KBUILD_BUILTIN)	:= vmlinux.lds
 
+obj-y		+= extern.o
 obj-y		+= head.o cpu-probe.o cacheinfo.o env.o setup.o entry.o genex.o \
 		   traps.o irq.o idle.o process.o dma.o mem.o reset.o switch.o \
 		   elf.o syscall.o signal.o time.o topology.o inst.o ptrace.o vdso.o \

--- a/arch/loongarch/kernel/extern.c
+++ b/arch/loongarch/kernel/extern.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/signal.h>
+
+void loongarch_set_current_blocked(sigset_t *newset);
+int loongarch_copy_siginfo_to_user(siginfo_t __user *to, const kernel_siginfo_t *from);
+int loongarch___save_altstack(stack_t __user *uss, unsigned long sp);
+int loongarch_restore_altstack(const stack_t __user *uss);
+
+void loongarch_set_current_blocked(sigset_t *newset)
+{
+	return set_current_blocked(newset);
+}
+EXPORT_SYMBOL_GPL(loongarch_set_current_blocked);
+
+int loongarch_copy_siginfo_to_user(siginfo_t __user *to, const kernel_siginfo_t *from)
+{
+	return copy_siginfo_to_user(to, from);
+}
+EXPORT_SYMBOL_GPL(loongarch_copy_siginfo_to_user);
+
+int loongarch___save_altstack(stack_t __user *uss, unsigned long sp)
+{
+	return __save_altstack(uss, sp);
+}
+EXPORT_SYMBOL_GPL(loongarch___save_altstack);
+
+int loongarch_restore_altstack(const stack_t __user *uss)
+{
+	return restore_altstack(uss);
+}
+EXPORT_SYMBOL_GPL(loongarch_restore_altstack);

--- a/arch/loongarch/kernel/ptrace.c
+++ b/arch/loongarch/kernel/ptrace.c
@@ -72,9 +72,13 @@ void ptrace_disable(struct task_struct *child)
 
 /* regset get/set implementations */
 
-static int gpr_get(struct task_struct *target,
-		   const struct user_regset *regset,
-		   struct membuf to)
+int gpr_get(struct task_struct *target,
+	    const struct user_regset *regset,
+	    struct membuf to);
+
+int gpr_get(struct task_struct *target,
+	    const struct user_regset *regset,
+	    struct membuf to)
 {
 	int r;
 	struct pt_regs *regs = task_pt_regs(target);
@@ -87,10 +91,15 @@ static int gpr_get(struct task_struct *target,
 	return r;
 }
 
-static int gpr_set(struct task_struct *target,
-		   const struct user_regset *regset,
-		   unsigned int pos, unsigned int count,
-		   const void *kbuf, const void __user *ubuf)
+int gpr_set(struct task_struct *target,
+	    const struct user_regset *regset,
+	    unsigned int pos, unsigned int count,
+	    const void *kbuf, const void __user *ubuf);
+
+int gpr_set(struct task_struct *target,
+	    const struct user_regset *regset,
+	    unsigned int pos, unsigned int count,
+	    const void *kbuf, const void __user *ubuf)
 {
 	int err;
 	int a0_start = sizeof(u64) * GPR_NUM;
@@ -950,8 +959,11 @@ const struct user_regset_view *task_user_regset_view(struct task_struct *task)
 	return &user_loongarch64_view;
 }
 
-static inline int read_user(struct task_struct *target, unsigned long addr,
-			    unsigned long __user *data)
+int read_user(struct task_struct *target, unsigned long addr,
+	      unsigned long __user *data);
+
+int read_user(struct task_struct *target, unsigned long addr,
+	      unsigned long __user *data)
 {
 	unsigned long tmp = 0;
 
@@ -975,8 +987,11 @@ static inline int read_user(struct task_struct *target, unsigned long addr,
 	return put_user(tmp, data);
 }
 
-static inline int write_user(struct task_struct *target, unsigned long addr,
-			    unsigned long data)
+int write_user(struct task_struct *target, unsigned long addr,
+	       unsigned long data);
+
+int write_user(struct task_struct *target, unsigned long addr,
+	       unsigned long data)
 {
 	switch (addr) {
 	case 0 ... 31:

--- a/arch/loongarch/kernel/signal.c
+++ b/arch/loongarch/kernel/signal.c
@@ -932,8 +932,11 @@ badframe:
 	return 0;
 }
 
-static int setup_rt_frame(void *sig_return, struct ksignal *ksig,
-			  struct pt_regs *regs, sigset_t *set)
+int setup_rt_frame(void *sig_return, struct ksignal *ksig,
+		   struct pt_regs *regs, sigset_t *set);
+
+int setup_rt_frame(void *sig_return, struct ksignal *ksig,
+		   struct pt_regs *regs, sigset_t *set)
 {
 	int err = 0;
 	struct extctx_layout extctx;


### PR DESCRIPTION
Export some signal functions

## Summary by Sourcery

Export LoongArch signal and register helper functions for use by external code and modules.

New Features:
- Add a new LoongArch extern.c module providing wrapper symbols around core signal and altstack helpers.

Enhancements:
- Make LoongArch ptrace register accessors, user read/write helpers, and signal frame setup functions globally visible instead of file-local.
- Adjust LoongArch FPU and LBT context management function declarations to be externally visible C symbols.
- Wire the new extern.o object into the LoongArch kernel build.