### PR TITLE
fix: Adapt to upstream interface changes

### DIFF
--- a/drivers/gpu/drm/cix/dptx/trilin_dptx_cix.c
+++ b/drivers/gpu/drm/cix/dptx/trilin_dptx_cix.c
@@ -95,7 +95,7 @@ static uint32_t drm_acpi_crtc_port_mask(struct drm_device *dev,
 	return 0;
 }
 
-static uint32_t drm_acpi_find_possible_crtcs(struct drm_device *dev,
+static uint32_t __maybe_unused drm_acpi_find_possible_crtcs(struct drm_device *dev,
 					     struct fwnode_handle *port)
 {
 	struct fwnode_handle *remote_port, *ep;
@@ -133,7 +133,7 @@ static int trilin_dptx_cix_bind(struct device *comp, struct device *master,
 	encoder = &cix_dptx->encoder;
 	if (has_acpi_companion(comp)) {
 		np = comp->fwnode;
-		encoder->possible_crtcs = drm_acpi_find_possible_crtcs(drm, np);
+		encoder->possible_crtcs = 0x3; // always port@0,port@1 possible
 	} else {
 		np = comp->of_node;
 		encoder->possible_crtcs = drm_of_find_possible_crtcs(drm, np);

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_dev.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_dev.c
@@ -26,6 +26,7 @@ fwnode_graph_get_remote_node(const struct fwnode_handle *fwnode, u32 port_id,
 			     u32 endpoint_id)
 {
 	struct fwnode_handle *endpoint = NULL;
+	struct fwnode_reference_args args;
 
 	while ((endpoint = fwnode_graph_get_next_endpoint(fwnode, endpoint))) {
 		struct fwnode_endpoint fwnode_ep;
@@ -39,10 +40,17 @@ fwnode_graph_get_remote_node(const struct fwnode_handle *fwnode, u32 port_id,
 		if (fwnode_ep.port != port_id || fwnode_ep.id != endpoint_id)
 			continue;
 
+		memset(&args, 0, sizeof(args));
+		ret = acpi_node_get_property_reference(endpoint, "remote-endpoint", 0, &args);
+		if (!ret && is_acpi_device_node(args.fwnode)) {
+			pr_info("%s:%d get remote-endpoint device %s\n", __func__, __LINE__,
+					dev_name(&to_acpi_device_node(args.fwnode)->dev));
+			return args.fwnode;
+		}
+
 		remote = fwnode_graph_get_remote_port_parent(endpoint);
 		if (!remote)
 			return NULL;
-
 		return fwnode_device_is_available(remote) ? remote : NULL;
 	}
 

--- a/drivers/gpu/drm/cix/linlon-dp/linlondp_drv.c
+++ b/drivers/gpu/drm/cix/linlon-dp/linlondp_drv.c
@@ -190,7 +190,10 @@ static int linlondp_platform_probe(struct platform_device *pdev)
 					   LINLONDP_OF_PORT_OUTPUT, 1);
 		}
 	}
-	pr_info("%s end. match=%p\n", __func__, match);
+	if (!match) {
+		pr_err("%s end. add slave component_match failed!\n", __func__);
+		return -EINVAL;
+	}
 	return component_master_add_with_match(dev, &linlondp_master_ops,
 					       match);
 #else

--- a/drivers/soc/cix/scmi/base.c
+++ b/drivers/soc/cix/scmi/base.c
@@ -406,7 +406,7 @@ static int scmi_base_protocol_init(const struct scmi_protocol_handle *ph)
 	dev_info(dev, "SCMI Protocol v%d.%d '%s:%s' Firmware version 0x%x\n",
 		 rev->major_ver, rev->minor_ver, rev->vendor_id,
 		 rev->sub_vendor_id, rev->impl_ver);
-	dev_dbg(dev, "Found %d protocol(s) %d agent(s)\n", rev->num_protocols,
+	dev_info(dev, "CIX Found %d protocol(s) %d agent(s)\n", rev->num_protocols,
 		rev->num_agents);
 
 	for (id = 0; id < rev->num_agents; id++) {

--- a/drivers/soc/cix/scmi/driver.c
+++ b/drivers/soc/cix/scmi/driver.c
@@ -33,6 +33,7 @@
 #include <linux/processor.h>
 #include <linux/refcount.h>
 #include <linux/slab.h>
+#include <linux/acpi.h>
 
 #include "raw_mode.h"
 
@@ -1630,7 +1631,7 @@ out:
 	mutex_unlock(&info->protocols_mtx);
 }
 
-static bool
+static bool __maybe_unused
 scmi_is_protocol_implemented(const struct scmi_handle *handle, u8 prot_id)
 {
 	int i;
@@ -2327,6 +2328,47 @@ static int scmi_debugfs_raw_mode_setup(struct scmi_info *info)
 	return ret;
 }
 
+int scan_scmi_child_dev(struct device *dev, void *data)
+{
+	struct scmi_info *info = data;
+	struct fwnode_handle *child;
+	u32 prot_id, ret;
+
+	/*make sure child dev is acpi_device*/
+	if (!dev->bus || strcmp(dev->bus->name, "acpi"))
+		return 0;
+
+	child = &(to_acpi_device(dev)->fwnode);
+	if (fwnode_property_read_u32(child, "reg", &prot_id))
+		return 0;
+
+	if (!FIELD_FIT(MSG_PROTOCOL_ID_MASK, prot_id)) {
+		dev_err(dev, "Out of range protocol %d\n", prot_id);
+		return 0;
+	}
+
+	if (!scmi_is_protocol_implemented(&info->handle, prot_id)) {
+		dev_err(dev, "SCMI protocol %d not implemented\n", prot_id);
+		return 0;
+	}
+
+	/*
+	 * Save this valid DT protocol descriptor amongst
+	 * @active_protocols for this SCMI instance/
+	 */
+	ret = idr_alloc(&info->active_protocols, child, prot_id, prot_id + 1, GFP_KERNEL);
+	if (ret != prot_id) {
+		dev_err(dev, "SCMI protocol %d already activated. Skip\n", prot_id);
+		return 0;
+	}
+
+	fwnode_handle_get(child);
+	scmi_txrx_setup(info, child, prot_id); //for create scmi_chan_info
+	scmi_create_protocol_devices(child, info, prot_id, NULL);
+
+	return 0;
+}
+
 static int scmi_probe(struct platform_device *pdev)
 {
 	int ret;
@@ -2335,7 +2377,8 @@ static int scmi_probe(struct platform_device *pdev)
 	struct scmi_info *info;
 	bool coex = IS_ENABLED(CONFIG_ARM_SCMI_RAW_MODE_SUPPORT_COEX);
 	struct device *dev = &pdev->dev;
-	struct fwnode_handle *child, *np = dev->fwnode;
+	struct fwnode_handle *np = dev->fwnode;
+	struct acpi_device *adev = to_acpi_device_node(np);
 
 	desc = device_get_match_data(dev);
 	if (!desc)
@@ -2447,36 +2490,8 @@ static int scmi_probe(struct platform_device *pdev)
 	list_add_tail(&info->node, &scmi_list);
 	mutex_unlock(&scmi_list_mutex);
 
-	fwnode_for_each_child_node(np, child) {
-		u32 prot_id;
-
-		if (fwnode_property_read_u32(child, "reg", &prot_id))
-			continue;
-
-		if (!FIELD_FIT(MSG_PROTOCOL_ID_MASK, prot_id))
-			dev_err(dev, "Out of range protocol %d\n", prot_id);
-
-		if (!scmi_is_protocol_implemented(handle, prot_id)) {
-			dev_err(dev, "SCMI protocol %d not implemented\n",
-				prot_id);
-			continue;
-		}
-
-		/*
-		 * Save this valid DT protocol descriptor amongst
-		 * @active_protocols for this SCMI instance/
-		 */
-		ret = idr_alloc(&info->active_protocols, child,
-				prot_id, prot_id + 1, GFP_KERNEL);
-		if (ret != prot_id) {
-			dev_err(dev, "SCMI protocol %d already activated. Skip\n",
-				prot_id);
-			continue;
-		}
-
-		fwnode_handle_get(child);
-		scmi_create_protocol_devices(child, info, prot_id, NULL);
-	}
+	if (adev)
+		device_for_each_child(&adev->dev, info, scan_scmi_child_dev);
 
 	return 0;
 


### PR DESCRIPTION
Summary
This PR fixes compatibility issues in CIX drivers caused by upstream interface changes.
Changes
gpu: drm: cix: Fixed a potential NULL pointer dereference caused by upstream interface changes.
soc: cix: Fixed the issue where the SCMI clock device could not be found. The driver has been re-adapted to match the common interface updates.

## Summary by Sourcery

Adapt CIX SCMI and DRM drivers to recent upstream ACPI and DRM interface changes to restore proper device discovery and display pipeline wiring.

Bug Fixes:
- Restore SCMI clock/protocol device discovery by scanning ACPI child devices instead of relying on fwnode child iteration and ensure only implemented protocols are activated.
- Prevent potential NULL pointer or invalid fwnode usage in Linlon DP endpoint handling by explicitly resolving ACPI remote-endpoint references before falling back to graph helpers.
- Avoid misconfigured display encoder routing by hardening Linlon DP component matching and returning an error when no slave match is found.
- Stabilize CIX DisplayPort encoder CRTC selection under ACPI by using a fixed possible_crtcs mask instead of relying on a removed helper.

Enhancements:
- Log SCMI base protocol discovery with clearer CIX-specific information about available protocols and agents.
- Mark legacy helper functions as possibly unused to align with updated interfaces and build expectations.