### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] Revert "LoongArch: Workaround LS2K/LS7A GPU DMA hang bug"

### DIFF
--- a/arch/loongarch/pci/pci.c
+++ b/arch/loongarch/pci/pci.c
@@ -6,11 +6,9 @@
 #include <linux/export.h>
 #include <linux/init.h>
 #include <linux/acpi.h>
-#include <linux/delay.h>
 #include <linux/types.h>
 #include <linux/pci.h>
 #include <linux/vgaarb.h>
-#include <linux/io-64-nonatomic-lo-hi.h>
 #include <asm/cacheflush.h>
 #include <asm/loongson.h>
 
@@ -18,9 +16,6 @@
 #define PCI_DEVICE_ID_LOONGSON_DC1      0x7a06
 #define PCI_DEVICE_ID_LOONGSON_DC2      0x7a36
 #define PCI_DEVICE_ID_LOONGSON_DC3      0x7a46
-#define PCI_DEVICE_ID_LOONGSON_GPU1     0x7a15
-#define PCI_DEVICE_ID_LOONGSON_GPU2     0x7a25
-#define PCI_DEVICE_ID_LOONGSON_GPU3     0x7a35
 
 int raw_pci_read(unsigned int domain, unsigned int bus, unsigned int devfn,
 						int reg, int len, u32 *val)
@@ -105,78 +100,3 @@ static void pci_fixup_vgadev(struct pci_dev *pdev)
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_DC1, pci_fixup_vgadev);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_DC2, pci_fixup_vgadev);
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_DC3, pci_fixup_vgadev);
-
-#define CRTC_NUM_MAX		2
-#define CRTC_OUTPUT_ENABLE	0x100
-
-static void loongson_gpu_fixup_dma_hang(struct pci_dev *pdev, bool on)
-{
-	u32 i, val, count, crtc_offset, device;
-	void __iomem *crtc_reg, *base, *regbase;
-	static u32 crtc_status[CRTC_NUM_MAX] = { 0 };
-
-	base = pdev->bus->ops->map_bus(pdev->bus, pdev->devfn + 1, 0);
-	device = readw(base + PCI_DEVICE_ID);
-
-	regbase = ioremap(readq(base + PCI_BASE_ADDRESS_0) & ~0xffull, SZ_64K);
-	if (!regbase) {
-		pci_err(pdev, "Failed to ioremap()\n");
-		return;
-	}
-
-	switch (device) {
-	case PCI_DEVICE_ID_LOONGSON_DC2:
-		crtc_reg = regbase + 0x1240;
-		crtc_offset = 0x10;
-		break;
-	case PCI_DEVICE_ID_LOONGSON_DC3:
-		crtc_reg = regbase;
-		crtc_offset = 0x400;
-		break;
-	}
-
-	for (i = 0; i < CRTC_NUM_MAX; i++, crtc_reg += crtc_offset) {
-		val = readl(crtc_reg);
-
-		if (!on)
-			crtc_status[i] = val;
-
-		/* No need to fixup if the status is off at startup. */
-		if (!(crtc_status[i] & CRTC_OUTPUT_ENABLE))
-			continue;
-
-		if (on)
-			val |= CRTC_OUTPUT_ENABLE;
-		else
-			val &= ~CRTC_OUTPUT_ENABLE;
-
-		mb();
-		writel(val, crtc_reg);
-
-		for (count = 0; count < 40; count++) {
-			val = readl(crtc_reg) & CRTC_OUTPUT_ENABLE;
-			if ((on && val) || (!on && !val))
-				break;
-			udelay(1000);
-		}
-
-		pci_info(pdev, "DMA hang fixup at reg[0x%lx]: 0x%x\n",
-				(unsigned long)crtc_reg & 0xffff, readl(crtc_reg));
-	}
-
-	iounmap(regbase);
-}
-
-static void pci_fixup_dma_hang_early(struct pci_dev *pdev)
-{
-	loongson_gpu_fixup_dma_hang(pdev, false);
-}
-DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU2, pci_fixup_dma_hang_early);
-DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU3, pci_fixup_dma_hang_early);
-
-static void pci_fixup_dma_hang_final(struct pci_dev *pdev)
-{
-	loongson_gpu_fixup_dma_hang(pdev, true);
-}
-DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU2, pci_fixup_dma_hang_final);
-DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_LOONGSON, PCI_DEVICE_ID_LOONGSON_GPU3, pci_fixup_dma_hang_final);


### PR DESCRIPTION
deepin incluion
category: bugfix

This reverts commit 955dad2a7a91c52731f07dce1ce7434f3eb2ae56. It confirmed the commit caused kernel crash with extra GPU, such as arise and amdgpu.

Log:
[    0.805731] Kernel ade access[#1]:
[    0.809103] CPU: 1 PID: 1 Comm: swapper/0 Not tainted 6.6.134-loong64-desktop-hwe #25.01.00.23
[    0.817833] Hardware name: Loongson Loongson-3A6000-HV-7A2000-1w-V0.1-EVB/Loongson-3A6000-HV-7A2000-1w-EVB-V1.21, BIOS Loongson-UDK2018-V4.0.05756-prestab
[    0.831573] pc 9000000001839bd4 ra 9000000001839b60 tp 90000001002d0000 sp 90000001002d36a0
[    0.839869] a0 80000efe00003100 a1 0000000000003100 a2 0000000000000000 a3 0000000000000002
[    0.848166] a4 90000001002d3694 a5 900000010087714d a6 90000000032a4000 a7 0000000000000001
[    0.856463] t0 00000000000085b9 t1 000000000000ffff t2 0000000000000000 t3 0000000000000000
[    0.864759] t4 fffffffffffffffd t5 00000000fffb6e7c t6 0000000000f06001 t7 00388a0001000090
[    0.873056] t8 9000000100877234 u0 900000010087714d s9 90000001002d3806 s0 90000000041cab88
[    0.881352] s1 7fffffffffffff00 s2 90000000041cab90 s3 0000000000002710 s4 0000000000000000
[    0.889648] s5 0000000000000000 s6 90000001008a3000 s7 7fffffffffffff00 s8 9000000004074000
[    0.897944]    ra: 9000000001839b60 loongson_gpu_fixup_dma_hang+0x40/0x210
[    0.904774]   ERA: 9000000001839bd4 loongson_gpu_fixup_dma_hang+0xb4/0x210
[    0.911602]  CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)
[    0.917744]  PRMD: 00000004 (PPLV0 +PIE -PWE)
[    0.922068]  EUEN: 00000000 (-FPE -SXE -ASXE -BTE)
[    0.926825]  ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)
[    0.931581] ESTAT: 00480000 [ADEM] (IS= ECode=8 EsubCode=1)
[    0.937114]  BADV: 7fffffffffffff00
[    0.940571]  PRID: 0014d000 (Loongson-64bit, Loongson-3A6000-HV)
[    0.946535] Modules linked in:
[    0.949561] Process swapper/0 (pid: 1, threadinfo=(____ptrval____), task=(____ptrval____))
[    0.957771] Stack : 0000000000000006 90000001002d3758 90000001002d36e4 0000000000000007
[    0.965726]         0000000024004f00 9000000001839d30 000000000000ffff ffffffffffffffff
[    0.973679]         9000000002b080a0 90000001008a3000 9000000002b08088 9000000000f2a7c8
[    0.981632]         0000000000000000 0000000000000000 0000000000000006 90000001002d3758
[    0.989586]         90000001008a30b8 90000000032a4000 0000000000000000 90000001008a4000
[    0.997539]         90000001008a3000 9000000000efa02c 9000000100004c00 9000000004000001
[    1.005492]         90000001002d37c4 a5f4111bbd94bf0d 0000000000000000 0000000000000000
[    1.013445]         0000000000000006 90000000032a4000 0000000000000030 90000000032a4000
[    1.021398]         900000087c994000 90000001008a3000 0000000000000000 9000000000efae80
[    1.029351]         7a2500147c84b060 a5f4111bbd94bf0d 0000000000000001 0000000000000030
[    1.037304]         ...
[    1.039726] Call Trace:
[    1.039727] [<9000000001839bd4>] loongson_gpu_fixup_dma_hang+0xb4/0x210
[    1.048717] [<9000000000f2a7c4>] pci_fixup_device+0x104/0x280
[    1.054425] [<9000000000efa028>] pci_setup_device+0x248/0x690
[    1.060133] [<9000000000efae7c>] pci_scan_single_device+0xdc/0x140
[    1.066272] [<9000000000efafa0>] pci_scan_slot+0xc0/0x280
[    1.071632] [<9000000000efc61c>] pci_scan_child_bus_extend+0x5c/0x3f0
[    1.078030] [<9000000000f9b6b0>] acpi_pci_root_create+0x2b0/0x420
[    1.084083] [<900000000183a530>] pci_acpi_scan_root+0x2e0/0x490
[    1.089962] [<9000000000f9aa48>] acpi_pci_root_add+0x218/0x3a0
[    1.095754] [<9000000000f8e7d0>] acpi_bus_attach+0x1a0/0x3c0
[    1.101374] [<900000000112b488>] device_for_each_child+0x68/0xe0
[    1.107342] [<9000000000f8b570>] acpi_dev_for_each_child+0x40/0x70
[    1.113481] [<9000000000f8e8bc>] acpi_bus_attach+0x28c/0x3c0
[    1.119099] [<900000000112b488>] device_for_each_child+0x68/0xe0
[    1.125065] [<9000000000f8b570>] acpi_dev_for_each_child+0x40/0x70
[    1.131202] [<9000000000f8e8bc>] acpi_bus_attach+0x28c/0x3c0
[    1.136820] [<9000000000f91a98>] acpi_bus_scan+0x68/0x280
[    1.142180] [<90000000018cef4c>] acpi_scan_init+0x190/0x310
[    1.147716] [<90000000018ceb8c>] acpi_init+0xcc/0x148
[    1.152731] [<9000000000244cd8>] do_one_initcall+0x48/0x310
[    1.158265] [<90000000018918f0>] kernel_init_freeable+0x254/0x2d4
[    1.164319] [<9000000001875280>] kernel_init+0x24/0x134
[    1.169509] [<9000000001873d08>] ret_from_kernel_thread+0x28/0xc0
[    1.175561] [<9000000000246164>] ret_from_kernel_thread_asm+0xc/0x88
[    1.181872]
[    1.183342] Code: 0015001b  02c022f9  0010efd8 <2400030c> 0040818c  38720005  40006380  240002ed  034401ad
[    1.193028]
[    1.194500] ---[ end trace 0000000000000000 ]---
[    1.199084] Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b

## Summary by Sourcery

Bug Fixes:
- Remove the Loongson GPU PCI DMA hang fixup logic that caused kernel panics during PCI device initialization with certain discrete GPUs.