### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] LoongArch: Fix potential ade in loongson_gpu_fixup_dma_hang()

### DIFF
--- a/arch/loongarch/pci/pci.c
+++ b/arch/loongarch/pci/pci.c
@@ -133,6 +133,9 @@ static void loongson_gpu_fixup_dma_hang(struct pci_dev *pdev, bool on)
 		crtc_reg = regbase;
 		crtc_offset = 0x400;
 		break;
+	default:
+		iounmap(regbase);
+		return;
 	}
 
 	for (i = 0; i < CRTC_NUM_MAX; i++, crtc_reg += crtc_offset) {


### PR DESCRIPTION
deepin inclusion
category: bugfix

The switch case in loongson_gpu_fixup_dma_hang() may not DC2 or DC3, and readl(crtc_reg) will access with random address, because device is from base+PCI_DEVICE_ID, base is from pdev->devfn+1, it is wrong when my platform inserts a gpu:
lspci -tv
-[0000:00]-+-00.0  Loongson Technology LLC Hyper Transport Bridge Controller ...
           +-06.0  Loongson Technology LLC LG100 GPU
           +-06.2  Loongson Technology LLC Device 7a37
...

Add a default switch case to fix it.

Before:
[    0.807099] Kernel ade access[#1]:
[    0.810472] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 6.6.136-loong64-desktop-hwe+ #4
[    0.818252] Hardware name: Loongson Loongson-3A6000-HV-7A2000-1w-V0.1-EVB/Loongson-3A6000-HV-7A2000-1w-EVB-V1.21, BIOS Loongson-UDK2018-V4.0.05756-prestab
[    0.831992] pc 90000000017e5534 ra 90000000017e54c0 tp 90000001002f8000 sp 90000001002fb6c0
[    0.840289] a0 80000efe00003100 a1 0000000000003100 a2 0000000000000000 a3 0000000000000002
[    0.848585] a4 90000001002fb6b4 a5 900000087cdb58fd a6 90000000027af000 a7 0000000000000001
[    0.856882] t0 00000000000085b9 t1 000000000000ffff t2 0000000000000000 t3 0000000000000000
[    0.865179] t4 fffffffffffffffd t5 00000000fffb6d9c t6 0000000000083b00 t7 00000000000070c0
[    0.873475] t8 900000087cdb4d94 u0 900000087cdb58fd s9 90000001002fb826 s0 90000000031c12c8
[    0.881771] s1 7fffffffffffff00 s2 90000000031c12d0 s3 0000000000002710 s4 0000000000000000
[    0.890067] s5 0000000000000000 s6 9000000100053000 s7 7fffffffffffff00 s8 90000000030d4000
[    0.898364]    ra: 90000000017e54c0 loongson_gpu_fixup_dma_hang+0x40/0x210
[    0.905195]   ERA: 90000000017e5534 loongson_gpu_fixup_dma_hang+0xb4/0x210
[    0.912023]  CRMD: 000000b0 (PLV0 -IE -DA +PG DACF=CC DACM=CC -WE)
[    0.918165]  PRMD: 00000004 (PPLV0 +PIE -PWE)
[    0.922489]  EUEN: 00000000 (-FPE -SXE -ASXE -BTE)
[    0.927246]  ECFG: 00071c1d (LIE=0,2-4,10-12 VS=7)
[    0.932002] ESTAT: 00480000 [ADEM] (IS= ECode=8 EsubCode=1)
[    0.937535]  BADV: 7fffffffffffff00
[    0.940992]  PRID: 0014d000 (Loongson-64bit, Loongson-3A6000-HV)
[    0.946956] Modules linked in:
[    0.949982] Process swapper/0 (pid: 1, threadinfo=(____ptrval____), task=(____ptrval____))
[    0.958193] Stack : 0000000000000006 90000001002fb778 90000001002fb704 0000000000000007
[    0.966147]         0000000016a65700 90000000017e5690 000000000000ffff ffffffffffffffff
[    0.974100]         900000000209f7c0 9000000100053000 900000000209f7a8 9000000000eebc08
[    0.982053]         0000000000000000 0000000000000000 0000000000000006 90000001002fb778
[    0.990006]         90000001000530b8 90000000027af000 0000000000000000 9000000100054000
[    0.997959]         9000000100053000 9000000000ebb70c 9000000100004c00 9000000004000001
[    1.005913]         90000001002fb7e4 bae765461f31cb12 0000000000000000 0000000000000000
[    1.013866]         0000000000000006 90000000027af000 0000000000000030 90000000027af000
[    1.021819]         900000087cd6f800 9000000100053000 0000000000000000 9000000000ebc560
[    1.029772]         7a2500147cdaf720 bae765461f31cb12 0000000000000001 0000000000000030
[    1.037725]         ...
[    1.040146] Call Trace:
[    1.040148] [<90000000017e5534>] loongson_gpu_fixup_dma_hang+0xb4/0x210
[    1.049138] [<9000000000eebc08>] pci_fixup_device+0x108/0x280
[    1.054846] [<9000000000ebb70c>] pci_setup_device+0x24c/0x690
[    1.060551] [<9000000000ebc560>] pci_scan_single_device+0xe0/0x140
[    1.066688] [<9000000000ebc684>] pci_scan_slot+0xc4/0x280
[    1.072048] [<9000000000ebdd00>] pci_scan_child_bus_extend+0x60/0x3f0
[    1.078444] [<9000000000f5bc94>] acpi_pci_root_create+0x2b4/0x420
[    1.084498] [<90000000017e5e74>] pci_acpi_scan_root+0x2d4/0x440
[    1.090376] [<9000000000f5b02c>] acpi_pci_root_add+0x21c/0x3a0
[    1.096168] [<9000000000f4ee54>] acpi_bus_attach+0x1a4/0x3c0
[    1.101788] [<90000000010e200c>] device_for_each_child+0x6c/0xe0
[    1.107755] [<9000000000f4bbf4>] acpi_dev_for_each_child+0x44/0x70
[    1.113892] [<9000000000f4ef40>] acpi_bus_attach+0x290/0x3c0
[    1.119511] [<90000000010e200c>] device_for_each_child+0x6c/0xe0
[    1.125476] [<9000000000f4bbf4>] acpi_dev_for_each_child+0x44/0x70
[    1.131612] [<9000000000f4ef40>] acpi_bus_attach+0x290/0x3c0
[    1.137231] [<9000000000f5211c>] acpi_bus_scan+0x6c/0x280
[    1.142591] [<900000000189c028>] acpi_scan_init+0x194/0x310
[    1.148125] [<900000000189bc6c>] acpi_init+0xcc/0x140
[    1.153139] [<9000000000220cdc>] do_one_initcall+0x4c/0x310
[    1.158672] [<90000000018618fc>] kernel_init_freeable+0x258/0x2d4
[    1.164726] [<900000000184326c>] kernel_init+0x28/0x13c
[    1.169914] [<9000000000222008>] ret_from_kernel_thread+0xc/0xa4
[    1.175878]
[    1.177349] Code: 0015001b  02c022f9  0010efd8 <2400030c> 0040818c  38720005  40006380  240002ed  034401ad
[    1.187034]

After:
[    0.808160] pci 0000:00:06.0: Not find match device
[    0.813002] pci 0000:00:06.0: [0014:7a25] type 00 class 0x040000
[    0.818970] pci 0000:00:06.0: BAR 0 [mem 0xe8025162000-0xe80251620ff 64bit]
[    0.825887] pci 0000:00:06.0: BAR 2 [mem 0xe8010000000-0xe801fffffff 64bit]
[    0.832804] pci 0000:00:06.0: BAR 4 [mem 0xe8025120000-0xe802512ffff 64bit]
[    0.839750] pci 0000:00:06.2: [0014:7a37] type 00 class 0x040300
[    0.845718] pci 0000:00:06.2: BAR 0 [mem 0xe8025110000-0xe802511ffff 64bit]

Cc: stable@vger.kernel.org
Fixes: 95db0c9f526d ("LoongArch: Workaround LS2K/LS7A GPU DMA hang bug")
Link: https://gist.github.com/opsiff/ebf2dac51b4013d22462f2124c55f807

## Summary by Sourcery

Bug Fixes:
- Add a default case in loongson_gpu_fixup_dma_hang() to unmap the register base and exit early if the GPU device does not match known types, avoiding accesses to random addresses.