### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Hygon] pwm: dwc: Add support for Hygon pwm controller

### DIFF
--- a/drivers/pwm/pwm-dwc.c
+++ b/drivers/pwm/pwm-dwc.c
@@ -301,6 +301,7 @@ static SIMPLE_DEV_PM_OPS(dwc_pwm_pm_ops, dwc_pwm_suspend, dwc_pwm_resume);
 
 static const struct pci_device_id dwc_pwm_id_table[] = {
 	{ PCI_VDEVICE(INTEL, 0x4bb7) }, /* Elkhart Lake */
+	{ PCI_VDEVICE(HYGON, 0x7910) },
 	{  }	/* Terminating Entry */
 };
 MODULE_DEVICE_TABLE(pci, dwc_pwm_id_table);


### PR DESCRIPTION
Link: https://gitcode.com/deepin-community/kernel/pull/16

ANBZ: #30097

Add PCI ID for Hygon pwm controller.

Hygon-SIG: commit none hygon anolis: pwm: dwc: Add support for Hygon pwm controller

Hygon-SIG: commit 0a8df9c4bd74 anolis anolis: pwm: dwc: Add support for Hygon pwm controller
Backport from anolis to support Hygon family 18h model 18h


Cc: hygon-arch@list.openanolis.cn
Reviewed-by: Xiaochen Shen <shenxiaochen@hygon.cn>
Reviewed-by: Yuanhe Shu <xiangzao@linux.alibaba.com>
Reviewed-by: Guixin Liu <kanie@linux.alibaba.com>
Link: https://gitee.com/anolis/cloud-kernel/pulls/6545
[ YuntongJin : amend commit log ]

## Summary by Sourcery

New Features:
- Recognize and handle the Hygon PWM controller via its PCI device ID in the dwc PWM driver.