### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [FROMLIST] USB: cdc-acm: Fix bit overlap and move quirk definitions to header

### DIFF
--- a/drivers/usb/class/cdc-acm.c
+++ b/drivers/usb/class/cdc-acm.c
@@ -114,8 +114,6 @@ static int acm_ctrl_msg(struct acm *acm, int request, int value,
 	int retval;
 
 	retval = usb_autopm_get_interface(acm->control);
-#define VENDOR_CLASS_DATA_IFACE		BIT(9)  /* data interface uses vendor-specific class */
-#define ALWAYS_POLL_CTRL		BIT(10) /* keep ctrl URB active even without an open TTY */
 	if (retval)
 		return retval;
 

--- a/drivers/usb/class/cdc-acm.h
+++ b/drivers/usb/class/cdc-acm.h
@@ -115,3 +115,5 @@ struct acm {
 #define DISABLE_ECHO			BIT(7)
 #define MISSING_CAP_BRK			BIT(8)
 #define NO_UNION_12			BIT(9)
+#define VENDOR_CLASS_DATA_IFACE		BIT(10)  /* data interface uses vendor-specific class */
+#define ALWAYS_POLL_CTRL		BIT(11) /* keep ctrl URB active even without an open TTY */


### PR DESCRIPTION
The VENDOR_CLASS_DATA_IFACE and ALWAYS_POLL_CTRL quirk flags added in commit f58752ebcb35 ("USB: cdc-acm: Add quirks for Yoga Book 9 14IAH10 INGENIC touchscreen") were placed inside the acm_ctrl_msg() function rather than in the header with the other quirk flags.  Worse, their values (BIT(9) and BIT(10)) collided with NO_UNION_12 which is already BIT(9).

Move the definitions to drivers/usb/class/cdc-acm.h where they belong and shift them to BIT(10) and BIT(11) to avoid the overlap.

Fixes: f58752ebcb35 ("USB: cdc-acm: Add quirks for Yoga Book 9 14IAH10 INGENIC touchscreen")
Cc: stable@vger.kernel.org

(cherry picked from commit 12b9827785b0afcea0005dc0d13c13a187176113)

## Summary by Sourcery

Fix cdc-acm USB quirk flag definitions to avoid bit overlap and centralize them in the shared header.

Bug Fixes:
- Resolve overlapping quirk bit definitions between NO_UNION_12 and newly added cdc-acm quirks.

Enhancements:
- Move VENDOR_CLASS_DATA_IFACE and ALWAYS_POLL_CTRL quirk flags from the source file into the cdc-acm header alongside other quirk flags.