### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] Update kernel base to 6.6.137

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 6
-SUBLEVEL = 136
+SUBLEVEL = 137
 EXTRAVERSION =
 NAME = Pinguïn Aangedreven
 

--- a/drivers/xen/privcmd.c
+++ b/drivers/xen/privcmd.c
@@ -1213,6 +1213,12 @@ static void privcmd_close(struct vm_area_struct *vma)
 	kvfree(pages);
 }
 
+static int privcmd_may_split(struct vm_area_struct *area, unsigned long addr)
+{
+	/* Forbid splitting, avoids double free via privcmd_close(). */
+	return -EINVAL;
+}
+
 static vm_fault_t privcmd_fault(struct vm_fault *vmf)
 {
 	printk(KERN_DEBUG "privcmd_fault: vma=%p %lx-%lx, pgoff=%lx, uv=%p\n",
@@ -1224,6 +1230,7 @@ static vm_fault_t privcmd_fault(struct vm_fault *vmf)
 
 static const struct vm_operations_struct privcmd_vm_ops = {
 	.close = privcmd_close,
+	.may_split = privcmd_may_split,
 	.fault = privcmd_fault
 };
 

--- a/drivers/xen/sys-hypervisor.c
+++ b/drivers/xen/sys-hypervisor.c
@@ -366,6 +366,8 @@ static ssize_t buildid_show(struct hyp_sysfs_attr *attr, char *buffer)
 			ret = sprintf(buffer, "<denied>");
 		return ret;
 	}
+	if (ret > PAGE_SIZE)
+		return -ENOSPC;
 
 	buildid = kmalloc(sizeof(*buildid) + ret, GFP_KERNEL);
 	if (!buildid)
@@ -373,8 +375,10 @@ static ssize_t buildid_show(struct hyp_sysfs_attr *attr, char *buffer)
 
 	buildid->len = ret;
 	ret = HYPERVISOR_xen_version(XENVER_build_id, buildid);
-	if (ret > 0)
-		ret = sprintf(buffer, "%s", buildid->buf);
+	if (ret > 0) {
+		/* Build id is binary, not a string. */
+		memcpy(buffer, buildid->buf, ret);
+	}
 	kfree(buildid);
 
 	return ret;


### PR DESCRIPTION
Update kernel base to 6.6.137.

git log --oneline v6.6.136..v6.6.137 |wc
     11      95     761

Merged(8):
https://github.com/deepin-community/kernel/pull/1658
crypto: af_alg - Fix page reassignment overflow in af_alg_pull_tsgl
crypto: authencesn - Fix src offset when decrypting in-place
crypto: authencesn - Do not place hiseq at end of dst for out-of-place decryption
crypto: authenc - use memcpy_sglist() instead of null skcipher
crypto: algif_aead - snapshot IV for async AEAD requests
crypto: algif_aead - Revert to operating out-of-place
crypto: algif_aead - use memcpy_sglist() instead of null skcipher
crypto: scatterwalk - Backport memcpy_sglist()

## Summary by Sourcery

Update Xen hypervisor sysfs build ID handling and prevent VMA splitting for Xen privcmd mappings while bumping the kernel base version to 6.6.137.

Bug Fixes:
- Ensure Xen hypervisor build ID sysfs output handles binary data safely and respects page size limits.
- Prevent Xen privcmd VMAs from being split to avoid potential double-free issues in privcmd_close().

Build:
- Bump kernel SUBLEVEL from 136 to 137 to track Linux 6.6.137 base release.