### PR TITLE
i3c: phytium: update phytium i3c controller driver support to 6.6.0.4

### DIFF
--- a/drivers/i3c/i3c_master_acpi.c
+++ b/drivers/i3c/i3c_master_acpi.c
@@ -6,7 +6,6 @@
  */
 
 #include <linux/acpi.h>
-#include <acpi/acpi_bus.h>
 #include <linux/device.h>
 #include <linux/export.h>
 #include <linux/kernel.h>

--- a/drivers/i3c/i3c_master_acpi.h
+++ b/drivers/i3c/i3c_master_acpi.h
@@ -9,7 +9,6 @@
 #define __I3C_MASTER_ACPI_H
 
 #include <linux/acpi.h>
-#include <acpi/acpi_bus.h>
 
 int i3c_master_acpi_get_params(acpi_handle handle, char *method, u32 *value);
 void i3c_master_acpi_clk_params(acpi_handle handle, char *method,

--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -6,7 +6,6 @@
  */
 
 #include <linux/acpi.h>
-#include <acpi/acpi_bus.h>
 #include <linux/atomic.h>
 #include <linux/bug.h>
 #include <linux/device.h>

--- a/drivers/i3c/master/Kconfig
+++ b/drivers/i3c/master/Kconfig
@@ -62,6 +62,7 @@ config PHYTIUM_I3C_MASTER
 	tristate "Phytium I3C master driver"
 	depends on I3C
 	depends on HAS_IOMEM
+	depends on ARCH_PHYTIUM
 	depends on !(ALPHA || PARISC)
 	help
 	  Enable this driver if you want to support phytium I3C master block.

--- a/drivers/i3c/master/i3c-master-phytium.c
+++ b/drivers/i3c/master/i3c-master-phytium.c
@@ -26,6 +26,7 @@
 #include <linux/pm_runtime.h>
 #include "../i3c_master_acpi.h"
 
+#define I3C_PHYTIUM_DRV_VERSION		"1.0.0"
 #define DEV_ID				0x0
 #define DEV_ID_I3C_MASTER		0x5034
 
@@ -1847,3 +1848,4 @@ MODULE_AUTHOR("Feng Jun <fengjun@phytium.com.cn>");
 MODULE_DESCRIPTION("Phytium I3C master driver");
 MODULE_LICENSE("GPL");
 MODULE_ALIAS("platform:phytium-i3c-master");
+MODULE_VERSION(I3C_PHYTIUM_DRV_VERSION);


### PR DESCRIPTION
This patches updates the support for phytium i3c controller driver.
1. Add dependency ARCH_PHYTIUM
2. Add driver version information
3. Resolve compilation errors when disabling ACPI configuration

## Summary by Sourcery

Update the Phytium I3C master driver with version metadata and clean up ACPI dependencies to keep the I3C subsystem building correctly across configurations.

New Features:
- Expose a driver version string for the Phytium I3C master via MODULE_VERSION.

Bug Fixes:
- Remove direct acpi_bus.h dependencies from I3C ACPI support and core to avoid build issues when ACPI configurations change.