### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Hygon] x86/opcode: Fix sm4rand/sm4rk operand types in x86-opcode-map.txt

### DIFF
--- a/arch/x86/lib/x86-opcode-map.txt
+++ b/arch/x86/lib/x86-opcode-map.txt
@@ -891,8 +891,8 @@ AVXcode: 3
 73: vpshrdd/q Vx,Hx,Wx,Ib (66),(ev)
 88: vsm3randa Vx,Hx,Wx,Ib (66),(v1)
 89: vsm3msga Vx,Hx,Wx,Ib (66),(v1)
-8a: vsm4rand Vx,Hx,Wx,Ib (66),(v1) | sm4rand Vk,Wx,Ib (66)
-8b: vsm4rk Vx,Hx,Wx,Ib (66),(v1) | sm4rk Vk,Wx,Ib (66)
+8a: vsm4rand Vx,Hx,Wx,Ib (66),(v1) | sm4rand Vx,Wx,Ib (66)
+8b: vsm4rk Vx,Hx,Wx,Ib (66),(v1) | sm4rk Vx,Wx,Ib (66)
 c2: vcmpph Vx,Hx,Wx,Ib (ev) | vcmpsh Vx,Hx,Wx,Ib (F3),(ev)
 cc: sha1rnds4 Vdq,Wdq,Ib
 ce: vgf2p8affineqb Vx,Wx,Ib (66)

--- a/tools/arch/x86/lib/x86-opcode-map.txt
+++ b/tools/arch/x86/lib/x86-opcode-map.txt
@@ -891,8 +891,8 @@ AVXcode: 3
 73: vpshrdd/q Vx,Hx,Wx,Ib (66),(ev)
 88: vsm3randa Vx,Hx,Wx,Ib (66),(v1)
 89: vsm3msga Vx,Hx,Wx,Ib (66),(v1)
-8a: vsm4rand Vx,Hx,Wx,Ib (66),(v1) | sm4rand Vk,Wx,Ib (66)
-8b: vsm4rk Vx,Hx,Wx,Ib (66),(v1) | sm4rk Vk,Wx,Ib (66)
+8a: vsm4rand Vx,Hx,Wx,Ib (66),(v1) | sm4rand Vx,Wx,Ib (66)
+8b: vsm4rk Vx,Hx,Wx,Ib (66),(v1) | sm4rk Vx,Wx,Ib (66)
 c2: vcmpph Vx,Hx,Wx,Ib (ev) | vcmpsh Vx,Hx,Wx,Ib (F3),(ev)
 cc: sha1rnds4 Vdq,Wdq,Ib
 ce: vgf2p8affineqb Vx,Wx,Ib (66)


### PR DESCRIPTION
The legacy forms (non-VEX) of the sm4rand and sm4rk instructions should use Vx instead of Vk (avx512 register) for their
destination operand. Update both the kernel and tools copies.

Fixes: 43fdbdb7ef06 ("x86: add hygon cis opcode map")
Closes: https://github.com/deepin-community/kernel/issues/1659

## Summary by Sourcery

Bug Fixes:
- Fix incorrect use of AVX-512 Vk registers instead of Vx registers for legacy (non-VEX) sm4rand and sm4rk instruction destinations in the x86 opcode maps for both kernel and tools.