### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Upstream] Update kernel base to 6.6.138

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 6
-SUBLEVEL = 137
+SUBLEVEL = 138
 EXTRAVERSION =
 NAME = Pinguïn Aangedreven
 

--- a/net/ipv4/esp4.c
+++ b/net/ipv4/esp4.c
@@ -873,7 +873,8 @@ static int esp_input(struct xfrm_state *x, struct sk_buff *skb)
 			nfrags = 1;
 
 			goto skip_cow;
-		} else if (!skb_has_frag_list(skb)) {
+		} else if (!skb_has_frag_list(skb) &&
+			   !skb_has_shared_frag(skb)) {
 			nfrags = skb_shinfo(skb)->nr_frags;
 			nfrags++;
 

--- a/net/ipv4/ip_output.c
+++ b/net/ipv4/ip_output.c
@@ -1230,6 +1230,8 @@ alloc_new_skb:
 			if (err < 0)
 				goto error;
 			copy = err;
+			if (!(flags & MSG_NO_SHARED_FRAGS))
+				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
 			wmem_alloc_delta += copy;
 		} else if (!zc) {
 			int i = skb_shinfo(skb)->nr_frags;

--- a/net/ipv6/esp6.c
+++ b/net/ipv6/esp6.c
@@ -921,7 +921,8 @@ static int esp6_input(struct xfrm_state *x, struct sk_buff *skb)
 			nfrags = 1;
 
 			goto skip_cow;
-		} else if (!skb_has_frag_list(skb)) {
+		} else if (!skb_has_frag_list(skb) &&
+			   !skb_has_shared_frag(skb)) {
 			nfrags = skb_shinfo(skb)->nr_frags;
 			nfrags++;
 

--- a/net/ipv6/ip6_output.c
+++ b/net/ipv6/ip6_output.c
@@ -1829,6 +1829,8 @@ alloc_new_skb:
 			if (err < 0)
 				goto error;
 			copy = err;
+			if (!(flags & MSG_NO_SHARED_FRAGS))
+				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
 			wmem_alloc_delta += copy;
 		} else if (!zc) {
 			int i = skb_shinfo(skb)->nr_frags;


### PR DESCRIPTION
Update kernel base to 6.6.138.

git log --oneline v6.6.137..v6.6.138 |wc
      2      13      96

## Summary by Sourcery

Update the kernel base to 6.6.138 and adjust IPv4/IPv6 ESP and output handling for shared SKB fragments.

Bug Fixes:
- Prevent ESP IPv4 and IPv6 input paths from treating SKBs with shared fragments as non-fragmented payloads.

Enhancements:
- Mark IPv4 and IPv6 output SKBs that use linearized copy as having shared fragments unless explicitly disabled by MSG_NO_SHARED_FRAGS.
- Bump kernel sublevel from 6.6.137 to 6.6.138.