### PR TITLE
i2s: phytium: update phytium i2s controller driver support to 6.6.0.4

### DIFF
--- a/sound/soc/phytium/Kconfig
+++ b/sound/soc/phytium/Kconfig
@@ -27,18 +27,19 @@ config SND_PMDK_ES8336
 	 ES8336 codecs.
 
 config SND_SOC_PHYTIUM_I2S_V2
-        tristate "Phytium I2S V2 Device Driver"
-        help
-         Say Y or M if you want to add support for I2S v2 driver for
-         Phytium I2S device . The device supports 2 channels each
-         for play and record.
+	tristate "Phytium I2S V2 Device Driver"
+	depends on ARCH_PHYTIUM
+	help
+	 Say Y or M if you want to add support for I2S v2 driver for
+	 Phytium I2S device . The device supports 2 channels each
+	 for play and record.
 
 config SND_SOC_PHYTIUM_MACHINE_V2
-        tristate "Phytium Machine V2 Driver"
-        depends on SND_SOC_PHYTIUM_I2S_V2
-        help
-         Say Y or M if you want to add Phytium machine v2 support for
-         codecs.
+	tristate "Phytium Machine V2 Driver"
+	depends on SND_SOC_PHYTIUM_I2S_V2
+	help
+	 Say Y or M if you want to add Phytium machine v2 support for
+	 codecs.
 
 config SND_PMDK_DP
 	tristate "Phytium machine support with DP"

--- a/sound/soc/phytium/phytium-i2s-v2.c
+++ b/sound/soc/phytium/phytium-i2s-v2.c
@@ -30,7 +30,7 @@
 #include <sound/jack.h>
 #include "phytium-i2s-v2.h"
 
-#define PHYT_I2S_V2_VERSION "1.0.8"
+#define PHYT_I2S_V2_VERSION "1.0.9"
 
 static struct snd_soc_jack hs_jack;
 static irqreturn_t phyt_i2s_gpio_interrupt(int irq, void *dev_id);
@@ -540,6 +540,7 @@ static int phyt_pcm_component_probe(struct snd_soc_component *component)
 static const struct snd_soc_component_driver phytium_i2s_component = {
 	.name = "phytium-i2s",
 	.use_dai_pcm_id = true,
+	.probe_order = SND_SOC_COMP_ORDER_LATE,
 	.pcm_construct = phyt_pcm_new,
 	.pcm_destruct = phyt_pcm_free,
 	.suspend = phyt_pcm_suspend,

--- a/sound/soc/phytium/phytium-i2s-v2.c
+++ b/sound/soc/phytium/phytium-i2s-v2.c
@@ -30,7 +30,7 @@
 #include <sound/jack.h>
 #include "phytium-i2s-v2.h"
 
-#define PHYT_I2S_V2_VERSION "1.0.6"
+#define PHYT_I2S_V2_VERSION "1.0.8"
 
 static struct snd_soc_jack hs_jack;
 static irqreturn_t phyt_i2s_gpio_interrupt(int irq, void *dev_id);
@@ -539,6 +539,7 @@ static int phyt_pcm_component_probe(struct snd_soc_component *component)
 
 static const struct snd_soc_component_driver phytium_i2s_component = {
 	.name = "phytium-i2s",
+	.use_dai_pcm_id = true,
 	.pcm_construct = phyt_pcm_new,
 	.pcm_destruct = phyt_pcm_free,
 	.suspend = phyt_pcm_suspend,
@@ -951,8 +952,54 @@ error:
 
 static DEVICE_ATTR_RW(phyt_i2s_debug);
 
+static ssize_t phyt_i2s_control_store(struct device *dev,
+		struct device_attribute *attr,
+		const char *buf, size_t size)
+{
+	struct phytium_i2s *priv = dev_get_drvdata(dev);
+	char *p, *token;
+	u8 loc;
+	int ret;
+	long value;
+
+	p = kmalloc(size, GFP_KERNEL);
+	if (p == NULL)
+		return -EINVAL;
+	strscpy(p, buf, sizeof(p));
+
+	token = strsep(&p, " ");
+	if (!token) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = kstrtol(token, 0, &value);
+	if (ret)
+		goto error;
+	loc = (u8)value;
+
+	if (loc == 1) {
+		//Enable I2S and DMA
+		phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CTL, 1);
+		phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_ITER, TX_EN);
+	} else if (loc == 0) {
+		//Disable I2S and DMA
+		phyt_writel_reg(priv->regfile_base, PHYTIUM_REGFILE_ITER, TX_DIS);
+		phyt_writel_reg(priv->dma_reg_base, PHYTIUM_DMA_CTL, 0);
+	}
+
+	kfree(p);
+	return size;
+error:
+	kfree(p);
+	return ret;
+}
+
+static DEVICE_ATTR_WO(phyt_i2s_control);
+
 static struct attribute *phyt_i2s_device_attrs[] = {
 	&dev_attr_phyt_i2s_debug.attr,
+	&dev_attr_phyt_i2s_control.attr,
 	NULL,
 };
 

--- a/sound/soc/phytium/phytium-machine-v2.c
+++ b/sound/soc/phytium/phytium-machine-v2.c
@@ -48,6 +48,7 @@ SND_SOC_DAILINK_DEFS(phyt_machine,
 static struct snd_soc_dai_link phyt_machine_dai[] = {
 	{
 		.name = "PHYTIUM HIFI V2",
+		.id = 0,
 		.stream_name = "PHYTIUM HIFT V2",
 		.dai_fmt = PMDK_DAI_FMT,
 		SND_SOC_DAILINK_REG(phyt_machine),

--- a/sound/soc/phytium/pmdk_dp.c
+++ b/sound/soc/phytium/pmdk_dp.c
@@ -67,7 +67,8 @@ static int pmdk_dp0_init(struct snd_soc_pcm_runtime *runtime)
 		dev_err(card->dev, "Jack creation failed %d\n", ret);
 		return ret;
 	}
-	snd_soc_component_set_jack(component, &priv->jack0, NULL);
+	ret = snd_soc_component_set_jack(component, &priv->jack0, NULL);
+
 	return ret;
 }
 
@@ -85,7 +86,8 @@ static int pmdk_dp1_init(struct snd_soc_pcm_runtime *runtime)
 		dev_err(card->dev, "Jack creation failed %d\n", ret);
 		return ret;
 	}
-	snd_soc_component_set_jack(component, &priv->jack1, NULL);
+	ret = snd_soc_component_set_jack(component, &priv->jack1, NULL);
+
 	return ret;
 }
 
@@ -103,7 +105,8 @@ static int pmdk_dp2_init(struct snd_soc_pcm_runtime *runtime)
 		dev_err(card->dev, "Jack creation failed %d\n", ret);
 		return ret;
 	}
-	snd_soc_component_set_jack(component, &priv->jack2, NULL);
+	ret = snd_soc_component_set_jack(component, &priv->jack2, NULL);
+
 	return ret;
 }
 
@@ -124,6 +127,7 @@ SND_SOC_DAILINK_DEFS(pmdk_dp2_dai,
 
 static struct snd_soc_dai_link pmdk_dai0 = {
 	.name = "Phytium dp0-audio",
+	.id = 0,
 	.stream_name = "Playback",
 	.dai_fmt = SMDK_DAI_FMT,
 	.init = pmdk_dp0_init,
@@ -133,6 +137,7 @@ static struct snd_soc_dai_link pmdk_dai0 = {
 
 static struct snd_soc_dai_link pmdk_dai1 = {
 	.name = "Phytium dp1-audio",
+	.id = 1,
 	.stream_name = "Playback",
 	.dai_fmt = SMDK_DAI_FMT,
 	.init = pmdk_dp1_init,
@@ -142,6 +147,7 @@ static struct snd_soc_dai_link pmdk_dai1 = {
 
 static struct snd_soc_dai_link pmdk_dai2 = {
 	.name = "Phytium dp2-audio",
+	.id = 2,
 	.stream_name = "Playback",
 	.dai_fmt = SMDK_DAI_FMT,
 	.init = pmdk_dp2_init,


### PR DESCRIPTION
This patches updates the support for phytium i2s controller driver.

1.Add audio control node
2.Add use_dai_pcm_id attribute
3.Restricted adaptation platform
4.Defer I2S probe procedure

## Summary by Sourcery

Update Phytium I2S v2 and related machine drivers to improve control, jack handling, and DAI linkage against the 6.6.0.4 audio stack.

New Features:
- Expose a sysfs control node to enable or disable the Phytium I2S controller and its DMA engine.
- Assign explicit DAI link IDs for Phytium DP and machine DAI links to support PCM-ID-based routing.

Bug Fixes:
- Propagate the result of snd_soc_component_set_jack in the Phytium DP init paths to correctly report jack setup failures.

Enhancements:
- Enable use_dai_pcm_id and defer the Phytium I2S component probe to the late phase for better integration with the ASoC core.
- Bump the Phytium I2S v2 driver version string to 1.0.9.