### PR TITLE
media：phytium：update phytium media function update to 6.6.0.4

### DIFF
--- a/build.log
+++ b/build.log
@@ -1,0 +1,9 @@
+***
+*** Configuration file ".config" not found!
+***
+*** Please run some configurator (e.g. "make oldconfig" or
+*** "make menuconfig" or "make xconfig").
+***
+/home/user/deepin-kernel/Makefile:775: include/config/auto.conf.cmd: 没有那个文件或目录
+make[1]: *** [/home/user/deepin-kernel/Makefile:784：.config] 错误 1
+make: *** [Makefile:234：__sub-make] 错误 2

--- a/drivers/media/platform/phytium/Kconfig
+++ b/drivers/media/platform/phytium/Kconfig
@@ -6,6 +6,7 @@ config VIDEO_PHYTIUM_JPEG
 	tristate "Phytium JPEG Encoder Engine driver"
 	depends on V4L_PLATFORM_DRIVERS
 	depends on VIDEO_DEV
+	depends on ARCH_PHYTIUM
 	select VIDEOBUF2_DMA_CONTIG
 	help
 	  Support for the Phytium JPEG Encoder Engine embedded

--- a/drivers/media/platform/phytium/phytium_jpeg_core.c
+++ b/drivers/media/platform/phytium/phytium_jpeg_core.c
@@ -210,22 +210,47 @@ static void phytium_jpeg_get_resolution(struct phytium_jpeg_dev *jpeg_dev)
 	u32 width;
 	u32 height;
 	struct v4l2_bt_timings *detected_timings = &jpeg_dev->detected_timings;
+	u32 input_signal;
 
 	/* Before get a new resolution, maybe need to wait 10 us */
 	detected_timings->width = MIN_WIDTH;
 	detected_timings->height = MIN_HEIGHT;
 	jpeg_dev->v4l2_input_status = V4L2_IN_ST_NO_SIGNAL;
 
-
 	phytium_jpeg_enable_source_detecting(jpeg_dev);
 	source_info = phytium_jpeg_read(jpeg_dev, SRC_VGA_INFO_REG);
 	width = (source_info & SRC_HOR_PIXELS) >> SRC_WIDTH_SHIFT;
 	height = (source_info & SRC_VER_PIXELS) >> SRC_HEIGHT_SHIFT;
 
+	input_signal = phytium_jpeg_read(jpeg_dev, BUF_LIST_INDEX_ADDR(VB_BUF_LAST));
+	dev_dbg(jpeg_dev->dev, "get resolution: %uX%u, power 0x%x, once_power %u.\n",
+			width, height, input_signal, jpeg_dev->once_poweroff);
+	/* The resolution is 640*480 and V4L2_IN_ST_NO_SIGNAL in the case that host is poweroff. */
+	if (input_signal == HOST_POWER_OFF) {
+		dev_dbg(jpeg_dev->dev, "Host is poweroff.\n");
+		jpeg_dev->once_poweroff = true;
+		return;
+	}
+
+	/* Host machine has never been poweroff since JPEG driver starts running */
+	if (jpeg_dev->once_poweroff == false) {
+		input_signal = HAVE_SIGNAL;
+		phytium_jpeg_write(jpeg_dev, BUF_LIST_INDEX_ADDR(VB_BUF_LAST), HAVE_SIGNAL);
+	} else if (input_signal == HOST_POWER_ON) {
+		dev_dbg(jpeg_dev->dev, "No signal on KVM.\n");
+		return;
+	}
+
+	if ((input_signal == HAVE_SIGNAL && width * height != 0) ||
+		test_bit(VIDEO_RES_CHANGE, &jpeg_dev->status)) {
+		jpeg_dev->v4l2_input_status = 0;
+		dev_dbg(jpeg_dev->dev, "output signal, status 0x%lx.\n", jpeg_dev->status);
+	}
+
+
 	if (width * height != 0) {
 		detected_timings->width = width;
 		detected_timings->height = height;
-		jpeg_dev->v4l2_input_status = 0;
 		cur_non_zero = true;
 	} else {
 		/* filter some repeated log-print lines */
@@ -492,11 +517,8 @@ static int phytium_jpeg_query_dv_timings(struct file *file, void *priv,
 					 struct v4l2_dv_timings *timings)
 {
 	int ret;
-	u32 source_info;
-	u32 width;
-	u32 height;
 	struct phytium_jpeg_dev *jpeg_dev = video_drvdata(file);
-
+	u32 input_signal;
 	/*
 	 * This blocks only if the driver is currently in the process of
 	 * detecting a new resolution; in the event of no signal or timeout
@@ -516,13 +538,9 @@ static int phytium_jpeg_query_dv_timings(struct file *file, void *priv,
 	timings->type = V4L2_DV_BT_656_1120;
 	timings->bt = jpeg_dev->detected_timings;
 
-	/* Get resolution from SRC_VGA_INFO_REG */
-	source_info = phytium_jpeg_read(jpeg_dev, SRC_VGA_INFO_REG);
-	width = (source_info & SRC_HOR_PIXELS) >> SRC_WIDTH_SHIFT;
-	height = (source_info & SRC_VER_PIXELS) >> SRC_HEIGHT_SHIFT;
-
-	/* Check if that the current resolution is zero. */
-	if (width == 0 || height == 0)
+	input_signal = phytium_jpeg_read(jpeg_dev, BUF_LIST_INDEX_ADDR(VB_BUF_LAST));
+	/* Check if that the power status of the host machine resolution */
+	if (input_signal != HAVE_SIGNAL)
 		jpeg_dev->v4l2_input_status = V4L2_IN_ST_NO_SIGNAL;
 
 	return jpeg_dev->v4l2_input_status ? -ENOLINK : 0;
@@ -820,7 +838,13 @@ static void phytium_jpeg_resolution_work(struct work_struct *work)
 		goto done;
 
 	phytium_jpeg_init_regs(jpeg_dev);
+	/* It is evident that the host remains powered on during the
+	 * resolution switch process, so restore the JPEG configuration.
+	 */
+	phytium_jpeg_write(jpeg_dev, BUF_LIST_INDEX_ADDR(VB_BUF_LAST), HAVE_SIGNAL);
+	jpeg_dev->once_poweroff = false;
 	phytium_jpeg_get_resolution(jpeg_dev);
+
 
 	/* if source's resolution is changed, the event should be enqueued */
 	if (jpeg_dev->detected_timings.width != jpeg_dev->active_timings.width ||
@@ -833,7 +857,7 @@ static void phytium_jpeg_resolution_work(struct work_struct *work)
 		};
 		v4l2_event_queue(&jpeg_dev->vdev, &event);
 		clear_bit(VIDEO_FRAME_INPRG, &jpeg_dev->status);
-		dev_info(jpeg_dev->dev, "event notifies changing resolution\n");
+		dev_info(jpeg_dev->dev, "event notifies changing resolution.\n");
 	} else if (test_bit(VIDEO_STREAMING, &jpeg_dev->status)) {
 		/* No resolution change so just restart streaming */
 		dev_info(jpeg_dev->dev, "resolution doesn't change\n");
@@ -1178,7 +1202,7 @@ static int phytium_jpeg_parser_timer30_irq(struct phytium_jpeg_dev *jpeg_dev)
 	}
 
 	ret = devm_request_irq(dev, irq, phytium_jpeg_timer30_irq,
-			IRQF_TIMER, PHYTIUM_JPEG_NAME, jpeg_dev);
+				IRQF_TIMER, PHYTIUM_JPEG_NAME, jpeg_dev);
 	if (ret < 0)
 		dev_err(dev, "Failed to request timer30 IRQ %d\n", irq);
 
@@ -1231,7 +1255,8 @@ static int phytium_jpeg_init(struct phytium_jpeg_dev *jpeg_dev)
 		dev_err(dev, "Failed to set DMA mask\n");
 		return ret;
 	}
-
+	/* Initialize the value of buffer_list_address15 register to identify having signal */
+	phytium_jpeg_write(jpeg_dev, BUF_LIST_INDEX_ADDR(VB_BUF_LAST), HAVE_SIGNAL);
 	/* Initializing JPEG Y and CbCr quantization table */
 	phytium_jpeg_init_jpeg_quant(jpeg_dev);
 
@@ -1287,6 +1312,7 @@ static int phytium_jpeg_setup_video(struct phytium_jpeg_dev *jpeg_dev)
 	jpeg_dev->pix_fmt.colorspace = V4L2_COLORSPACE_SRGB; /* maybe ARGB */
 	jpeg_dev->pix_fmt.quantization =  V4L2_QUANTIZATION_FULL_RANGE;
 	jpeg_dev->v4l2_input_status = V4L2_IN_ST_NO_SIGNAL;
+	jpeg_dev->once_poweroff = false;
 
 	ret = v4l2_device_register(jpeg_dev->dev, v4l2_dev);
 	if (ret != 0) {

--- a/drivers/media/platform/phytium/phytium_jpeg_core.c
+++ b/drivers/media/platform/phytium/phytium_jpeg_core.c
@@ -186,9 +186,6 @@ static void phytium_jpeg_off(struct phytium_jpeg_dev *jpeg_dev)
 	}
 
 	clear_bit(VIDEO_CLOCKS_ON, &jpeg_dev->status);
-	/* wait 50 ms */
-	mdelay(50);
-	/* C08 bit7 1:busy */
 }
 
 static inline void phytium_jpeg_enable_source_detecting(struct phytium_jpeg_dev *jpeg_dev)

--- a/drivers/media/platform/phytium/phytium_jpeg_core.h
+++ b/drivers/media/platform/phytium/phytium_jpeg_core.h
@@ -46,7 +46,7 @@
 #define MAX_PIXEL_CLOCK         (1920 * 1080 * 60)   /* 1920 x 1080 x 60Hz */
 
 #define SOURCE_RESOLUTION_DETECT_TIMEOUT    msecs_to_jiffies(500)
-#define RESOLUTION_CHANGE_DELAY             msecs_to_jiffies(250)
+#define RESOLUTION_CHANGE_DELAY             msecs_to_jiffies(150)
 #define INVALID_RESOLUTION_DELAY            msecs_to_jiffies(250)
 #define STOP_TIMEOUT                        msecs_to_jiffies(1000)
 

--- a/drivers/media/platform/phytium/phytium_jpeg_core.h
+++ b/drivers/media/platform/phytium/phytium_jpeg_core.h
@@ -53,6 +53,10 @@
 #define INVALID_RESOLUTION_RETRIES   2
 #define CAPTURE_BUF_NUMBER           3  /* using how many buffers */
 #define VB_BUF_NO                    0  /* there are 16 buffer, use which one */
+#define VB_BUF_LAST                  15 /* Use the last one to identify no signal */
+#define HAVE_SIGNAL                  0xCDDCDCCD   /* VGA output signal */
+#define HOST_POWER_ON                0x0          /* Host is poweron */
+#define HOST_POWER_OFF               0xDEADBEEF   /* Host is poweroff */
 
 /* The below macros are defined for the JPEG header of the phytium JPEG Engine */
 #define PHYTIUM_JPEG_HEADER_LEN		(256 * 3)
@@ -123,13 +127,14 @@ struct phytium_jpeg_dev {
 	unsigned int sequence;
 	unsigned int max_compressed_size;
 	struct phytium_jpeg_addr src_addrs[OCM_BUF_NUM];
-	struct phytium_jpeg_addr dst_addrs[16];
+	struct phytium_jpeg_addr dst_addrs[VB_BUF_LAST + 1];
 
 	bool yuv420;
 	unsigned int frame_rate;
 	void __iomem *timer30_addr;
 	void __iomem *timer31_addr;
 	struct v4l2_ctrl_handler ctrl_handler;
+	bool once_poweroff;
 };
 
 struct phytium_jpeg_config {

--- a/net/rxrpc/call_event.c
+++ b/net/rxrpc/call_event.c
@@ -461,7 +461,9 @@ bool rxrpc_input_call_event(struct rxrpc_call *call, struct sk_buff *skb)
 
 		if (sp->hdr.type == RXRPC_PACKET_TYPE_DATA &&
 			sp->hdr.securityIndex != 0 &&
-			skb_cloned(skb)) {
+			(skb_cloned(skb) ||
+			 skb_has_frag_list(skb) ||
+			 skb_has_shared_frag(skb))) {
 			/* Unshare the packet so that it can be modified by
 			 * in-place decryption.
 			 */

--- a/net/rxrpc/conn_event.c
+++ b/net/rxrpc/conn_event.c
@@ -231,7 +231,8 @@ static int rxrpc_verify_response(struct rxrpc_connection *conn,
 {
 	int ret;
 
-	if (skb_cloned(skb)) {
+	if (skb_cloned(skb) || skb_has_frag_list(skb) ||
+		skb_has_shared_frag(skb)) {
 		/* Copy the packet if shared so that we can do in-place
 		 * decryption.
 		 */

--- a/tatus
+++ b/tatus
@@ -1,0 +1,66 @@
+[33mcommit 02ced38ea255f262806c92e557bddc5e17a71410[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mmedia-6.6.y[m[33m, [m[1;31morigin/linux-6.6.y[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mlinux-6.6.y[m[33m)[m
+Author: Hyunwoo Kim <imv4bel@gmail.com>
+Date:   Fri May 8 17:53:09 2026 +0900
+
+    FROMLIST: rxrpc: Also unshare DATA/RESPONSE packets when paged frags are present
+    
+    maillist inclusion
+    category: bugfix
+    
+    The DATA-packet handler in rxrpc_input_call_event() and the RESPONSE
+    handler in rxrpc_verify_response() copy the skb to a linear one before
+    calling into the security ops only when skb_cloned() is true.  An skb
+    that is not cloned but still carries externally-owned paged fragments
+    (e.g. SKBFL_SHARED_FRAG set by splice() into a UDP socket via
+    __ip_append_data, or a chained skb_has_frag_list()) falls through to
+    the in-place decryption path, which binds the frag pages directly into
+    the AEAD/skcipher SGL via skb_to_sgvec().
+    
+    Extend the gate to also unshare when skb_has_frag_list() or
+    skb_has_shared_frag() is true.  This catches the splice-loopback vector
+    and other externally-shared frag sources while preserving the
+    zero-copy fast path for skbs whose frags are kernel-private (e.g. NIC
+    page_pool RX, GRO).  The OOM/trace handling already in place is reused.
+    
+    Fixes: d0d5c0cd1e71 ("rxrpc: Use skb_unshare() rather than skb_cow_data()")
+    Cc: stable@vger.kernel.org
+    Signed-off-by: Hyunwoo Kim <imv4bel@gmail.com>
+    Signed-off-by: Wentao Guan <guanwentao@uniontech.com>
+
+ net/rxrpc/call_event.c | 4 [32m+++[m[31m-[m
+ net/rxrpc/conn_event.c | 3 [32m++[m[31m-[m
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+[33mcommit 79d762c30c5a37252749488c83d258a5410a70fa[m
+Author: David Howells <dhowells@redhat.com>
+Date:   Thu Apr 23 21:09:06 2026 +0100
+
+    BACKPORT: rxrpc: Fix rxrpc_input_call_event() to only unshare DATA packets
+    
+    mainline inclusion
+    from mainline-v7.1-rc1
+    category: bugfix
+    
+    commit 55b2984c96c37f909bbfe8851f13152693951382 upstream.
+    
+    Fix rxrpc_input_call_event() to only unshare DATA packets and not ACK,
+    ABORT, etc..
+    
+    And with that, rxrpc_input_packet() doesn't need to take a pointer to the
+    pointer to the packet, so change that to just a pointer.
+    
+    Fixes: 1f2740150f90 ("rxrpc: Fix potential UAF after skb_unshare() failure")
+    Closes: https://sashiko.dev/#/patchset/20260422161438.2593376-4-dhowells@redhat.com
+    Signed-off-by: David Howells <dhowells@redhat.com>
+    cc: Marc Dionne <marc.dionne@auristor.com>
+    cc: Jeffrey Altman <jaltman@auristor.com>
+    cc: Simon Horman <horms@kernel.org>
+    cc: linux-afs@lists.infradead.org
+    cc: stable@kernel.org
+    Link: https://patch.msgid.link/20260423200909.3049438-2-dhowells@redhat.com
+    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+    Signed-off-by: Wentao Guan <guanwentao@uniontech.com>
+
+ net/rxrpc/call_event.c | 4 [32m+++[m[31m-[m
+ 1 file changed, 3 insertions(+), 1 deletion(-)


### PR DESCRIPTION
This patches updates the support for phytium media controller driver.

1.Redesign the "No Signal" prompt display feature on KVM
2.Add platform dependencies in Kconfig file
3.Reduce resolution switching latency

## Summary by Sourcery

Update Phytium media JPEG driver signal/power handling and timing, and harden rxrpc packet handling for fragmented/skb-shared buffers.

New Features:
- Track host power state and signal presence in the Phytium JPEG driver using a reserved buffer index and new status flag to distinguish no-signal, host power-off, and normal output.

Bug Fixes:
- Avoid in-place decryption on rxrpc sk_buffs that are cloned or share/contain fragment lists by forcing unsharing, preventing unsafe modification of shared buffers.
- Correct Phytium JPEG driver detection of no-signal conditions by basing status on the new signal/power indicator rather than only zero resolution values.

Enhancements:
- Reduce Phytium JPEG resolution change delay to lower latency when switching display resolutions.
- Refine Phytium JPEG resolution change workflow to restore configuration when the host stays powered during resolution switches and to skip unnecessary delays.
- Extend Phytium JPEG destination buffer array and initialize signal-indicator register at startup for more robust state tracking.

Chores:
- Adjust Phytium media driver Kconfig platform dependency configuration (details not shown in diff).