### PR TITLE
[linux-6.6.y] hwmon: zhaoxin-cputemp: Update for KX-8000

### DIFF
--- a/drivers/hwmon/zhaoxin-cputemp.c
+++ b/drivers/hwmon/zhaoxin-cputemp.c
@@ -122,7 +122,7 @@ static int zhaoxin_cputemp_probe(struct platform_device *pdev)
 	data->id = pdev->id;
 	data->name = "zhaoxin_cputemp";
 	data->msr_temp = 0x1423;
-	if (c->x86_model == 0x6b || c->x86_model == 0x7b) {
+	if (c->x86_model == 0x6b || c->x86_model == 0x7b || c->x86_model == 0x8b) {
 		data->msr_crit = 0x175b;
 		data->msr_max = 0x175a;
 	} else {
@@ -265,6 +265,8 @@ static const struct x86_cpu_id __initconst cputemp_ids[] = {
 	X86_MATCH_VENDOR_FAM_MODEL(ZHAOXIN, 7, 0x6b, NULL),
 	X86_MATCH_VENDOR_FAM_MODEL(CENTAUR, 7, 0x7b, NULL),
 	X86_MATCH_VENDOR_FAM_MODEL(ZHAOXIN, 7, 0x7b, NULL),
+	X86_MATCH_VENDOR_FAM_MODEL(CENTAUR, 7, 0x8b, NULL),
+	X86_MATCH_VENDOR_FAM_MODEL(ZHAOXIN, 7, 0x8b, NULL),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, cputemp_ids);


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

This patch extends temperature monitoring support to include the new Zhaoxin KX-8000 FMS CPU family by:

1. Adding model 0x8b to the MSR register mapping condition, so it uses the same temperature critical and maximum MSR addresses (0x175b and 0x175a) as the existing 0x6b and 0x7b models.

2. Registering both CENTAUR and ZHAOXIN vendor variants of the 0x8b model in the CPU ID matching table to enable driver probe on these systems.

## Summary by Sourcery

New Features:
- Enable temperature monitoring for Zhaoxin/Centaur family 7 model 0x8b CPUs using the existing critical and maximum temperature MSR layout.