### PR TITLE
[linux-6.6.y] ACPI: APEI: GHES: Add ghes_edac support for __ZX__ and _BYO_ systems

### DIFF
--- a/drivers/acpi/apei/ghes.c
+++ b/drivers/acpi/apei/ghes.c
@@ -1611,6 +1611,8 @@ void __init acpi_ghes_init(void)
  */
 static struct acpi_platform_list plat_list[] = {
 	{"HPE   ", "Server  ", 0, ACPI_SIG_FADT, all_versions},
+	{"__ZX__", "EDK2    ", 3, ACPI_SIG_FADT, greater_than_or_equal},
+	{"_BYO_ ", "BYOSOFT ", 3, ACPI_SIG_FADT, greater_than_or_equal},
 	{ } /* End */
 };
 


### PR DESCRIPTION
Let ghes_edac be the preferred driver to load on  __ZX__ and _BYO_ systems by extending the platform detection list in ghes.c


Tested-by: Lyle Li <LyleLi@zhaoxin.com>
Acked-by: Borislav Petkov (AMD) <bp@alien8.de>
[ rjw: Subject and changelog edits ]
Link: https://patch.msgid.link/20260128025216.12564-1-TonyWWang-oc@zhaoxin.com

## Summary by Sourcery

New Features:
- Treat __ZX__ EDK2 and _BYO_ BYOSOFT systems as platforms where ghes_edac is the preferred EDAC driver.