### PR TITLE
[linux-6.6.y] efi/cper: Print correctable AER information

### DIFF
--- a/drivers/firmware/efi/cper.c
+++ b/drivers/firmware/efi/cper.c
@@ -547,12 +547,17 @@ static void cper_print_pcie(const char *pfx, const struct cper_sec_pcie *pcie,
 	"%s""bridge: secondary_status: 0x%04x, control: 0x%04x\n",
 	pfx, pcie->bridge.secondary_status, pcie->bridge.control);
 
-	/* Fatal errors call __ghes_panic() before AER handler prints this */
-	if ((pcie->validation_bits & CPER_PCIE_VALID_AER_INFO) &&
-	    (gdata->error_severity & CPER_SEV_FATAL)) {
+	/*
+	 * Print all valid AER info. Record may be from BERT (boot-time) or GHES (run-time).
+	 *
+	 * Fatal errors call __ghes_panic() before AER handler prints this.
+	 */
+	if (pcie->validation_bits & CPER_PCIE_VALID_AER_INFO) {
 		struct aer_capability_regs *aer;
 
 		aer = (struct aer_capability_regs *)pcie->aer_info;
+		printk("%saer_cor_status: 0x%08x, aer_cor_mask: 0x%08x\n",
+		       pfx, aer->cor_status, aer->cor_mask);
 		printk("%saer_uncor_status: 0x%08x, aer_uncor_mask: 0x%08x\n",
 		       pfx, aer->uncor_status, aer->uncor_mask);
 		printk("%saer_uncor_severity: 0x%08x\n",


### PR DESCRIPTION
Currently, cper_print_pcie() only logs Uncorrectable Error Status, Mask and Severity registers along with the TLP header.

If a correctable error is received immediately preceding or following an Uncorrectable Fatal Error, its information is lost since Correctable Error Status and Mask registers are not logged.

As such, to avoid skipping any possible error information, Correctable Error Status and Mask registers should also be logged.

Additionally, ensure that AER information is also available through cper_print_pcie() for Correctable and Uncorrectable Non-Fatal Errors.


Tested-by: Avadhut Naik <avadhut.naik@amd.com>

## Summary by Sourcery

Bug Fixes:
- Preserve and expose correctable PCIe AER error information in CPER logs that was previously omitted for non-fatal and adjacent errors.