### PR TITLE
[linux-6.6.y] CI: arm64: disable debuginfo to speed up build test

### DIFF
--- a/.github/workflows/build-kernel-arm64.yml
+++ b/.github/workflows/build-kernel-arm64.yml
@@ -30,10 +30,16 @@ jobs:
         run: |
           # .config
           make deepin_arm64_desktop_defconfig
+          scripts/config --enable CONFIG_DEBUG_INFO_NONE
+          scripts/config --disable CONFIG_DEBUG_INFO_DWARF5
+          make olddefconfig
           make -j$(nproc)
 
       - name: 'Clang build kernel'
         run: |
           # .config
           make LLVM=-18 deepin_arm64_desktop_defconfig
+          scripts/config --enable CONFIG_DEBUG_INFO_NONE
+          scripts/config --disable CONFIG_DEBUG_INFO_DWARF5
+          make LLVM=-18 olddefconfig
           make LLVM=-18 -j$(nproc)


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update arm64 kernel GitHub Actions workflow to enable CONFIG_DEBUG_INFO_NONE and disable CONFIG_DEBUG_INFO_DWARF5 for both GCC and Clang builds before running olddefconfig.