### PR TITLE
[Deepin-Kernel-SIG] [linux 6.12.y] [deepin] net: stmmac: phytium: remove support for lpi_intr_o

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
@@ -194,7 +194,6 @@ static int phytium_dwmac_probe(struct platform_device *pdev)
 		return -ENXIO;
 	}
 	stmmac_res.wol_irq = stmmac_res.irq;
-	stmmac_res.lpi_irq = -1;
 
 	return  stmmac_dvr_probe(&pdev->dev, plat, &stmmac_res);
 }


### PR DESCRIPTION
[net: stmmac: phytium: remove lpi_irq
        commit 8096f0383425 ("net: stmmac: remove support for lpi_intr_o") upstream,
        so remove it.
        Log:
        drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c: In function ‘phytium_dwmac_probe’:
        drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c:188:19: error: ‘struct stmmac_resources’ has no member named ‘lpi_irq’
        188 |         stmmac_res.lpi_irq = -1;]
Log:
drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c:197:19: error: ‘struct stmmac_resources’ has no member named ‘lpi_irq’
  197 |         stmmac_res.lpi_irq = -1;

## Summary by Sourcery

Bug Fixes:
- Fix build failure in the Phytium stmmac driver by dropping assignment to the removed lpi_irq resource field.