### PR TITLE
[linux-6.6.y] x86/microcode: Serialize cpu startup during early updates

### DIFF
--- a/arch/x86/kernel/cpu/microcode/zhaoxin.c
+++ b/arch/x86/kernel/cpu/microcode/zhaoxin.c
@@ -495,6 +495,7 @@ void __init load_ucode_zhaoxin_bsp(struct early_load_data *ed)
 
 	if (uci.mc && apply_microcode_early(&uci) == UCODE_UPDATED) {
 		zhaoxin_ucode_patch = UCODE_BSP_LOADED;
+		x86_cpuinit.parallel_bringup = false;
 		ed->new_rev = uci.cpu_sig.rev;
 	} else if (uci.mc) {
 		pr_debug("%s: BSP CPU %d early update failed due to application failure\n",


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

Due to hardware limitations, it is necessary to avoid situations where some cores are waiting to receive startup while other cores are updating microcode. Therefore, cpu startup must be serialized when microcode updates are required.

## Summary by Sourcery

Enhancements:
- Disable parallel CPU bringup when the BSP successfully performs an early Zhaoxin microcode update, ensuring serialized CPU startup during microcode updates.