### PR TITLE
[linux-6.6.y] ata: ahci: Fix Zhaoxin SATA LED quirk pci_dev refcount handling

### DIFF
--- a/drivers/ata/ahci.c
+++ b/drivers/ata/ahci.c
@@ -1840,12 +1840,16 @@ static void ahci_zx_led_remove_quirk(struct pci_dev *pdev)
 		if (target_p0_dev && p1_mmio_tmp)
 			break;
 	}
+
 	if (target_p0_dev) {
 		sata_host = pci_get_drvdata(target_p0_dev);
 		sata_hpriv = sata_host ? sata_host->private_data : NULL;
 		if (sata_hpriv)
 			sata_hpriv->p1_mmio = p1_mmio_tmp;
 	}
+
+	if (sata_pdev)
+		pci_dev_put(sata_pdev);
 }
 
 static void ahci_zx_led_init_quirk(struct pci_dev *pdev, struct ahci_host_priv *hpriv)
@@ -1864,6 +1868,8 @@ static void ahci_zx_led_init_quirk(struct pci_dev *pdev, struct ahci_host_priv *
 	val = native_read_msr_safe(ZX_GET_BUS_NUMBER_QUIRK, &err);
 	if (err) /* MSR read failed */
 		return;
+
+	pr_info("ahci: zx led quirk init\n");
 
 	hpriv->sx_index = 0xFF;
 	hpriv->px_index = 0xFF;
@@ -1906,6 +1912,8 @@ static void ahci_zx_led_init_quirk(struct pci_dev *pdev, struct ahci_host_priv *
 			break;
 		}
 	}
+	if (sata_pdev)
+		pci_dev_put(sata_pdev);
 }
 #else
 static inline void ahci_zx_led_remove_quirk(struct pci_dev *pdev) { }


### PR DESCRIPTION
This patch fixes the Zhaoxin SATA LED quirk support by ensuring the pci_dev reference obtained from pci_get_device() is released in both ahci_zx_led_remove_quirk() and ahci_zx_led_init_quirk().

It also adds a pr_info() log when the Zhaoxin LED quirk is initialized, improving diagnostic visibility.

## Summary by Sourcery

Fix Zhaoxin AHCI SATA LED quirk PCI device reference handling and improve logging for initialization diagnostics.

Bug Fixes:
- Release pci_dev references acquired for Zhaoxin SATA LED quirks in both initialization and removal paths to avoid refcount leaks.

Enhancements:
- Log a pr_info message when the Zhaoxin AHCI LED quirk is initialized to aid debugging.