### PR TITLE
[linux-6.6.y] x86/microcode: Simplify Zhaoxin microcode patch saving

### DIFF
--- a/arch/x86/kernel/cpu/microcode/zhaoxin.c
+++ b/arch/x86/kernel/cpu/microcode/zhaoxin.c
@@ -176,7 +176,6 @@ static int zhaoxin_microcode_sanity_check(void *mc, bool print_err, int hdr_type
 static void save_microcode_patch(struct microcode_zhaoxin *patch)
 {
 	unsigned int size = patch->hdr.total_size;
-	struct microcode_zhaoxin *mc = NULL;
 	struct page *pg = NULL;
 	void *dst = NULL;
 
@@ -186,18 +185,14 @@ static void save_microcode_patch(struct microcode_zhaoxin *patch)
 	 * the memory allocation to this range.
 	 */
 	pg = alloc_pages(GFP_DMA32 | GFP_KERNEL, get_order(size));
-
-	if (pg) {
-		dst = page_address(pg);
-		memcpy(dst, patch, size);
-		mc = dst;
-		if (mc) {
-			zhaoxin_ucode_patch = mc;
-			return;
-		}
+	if (!pg) {
+		pr_err("Unable to allocate microcode memory size: %u\n", size);
+		return;
 	}
 
-	pr_err("Unable to allocate microcode memory size: %u\n", size);
+	dst = page_address(pg);
+	memcpy(dst, patch, size);
+	zhaoxin_ucode_patch = dst;
 }
 
 static inline u32


### PR DESCRIPTION
This patch simplifies the save_microcode_patch() function in the Zhaoxin microcode driver by removing unnecessary variables and streamlining the memory allocation and copying logic.

The changes include:
- Remove the unused local variable 'mc'.
- Directly handle memory allocation failure without redundant checks.
- Simplify the memcpy and assignment to zhaoxin_ucode_patch.

This improves code readability and reduces complexity without changing functionality.

## Summary by Sourcery

Enhancements:
- Streamline save_microcode_patch() in the Zhaoxin microcode driver by removing redundant variables and simplifying allocation failure handling and patch assignment logic.