### PR TITLE
[linux-6.6.y] ALSA: hda: Add support of Zhaoxin SB HDAC

### DIFF
--- a/sound/pci/hda/hda_intel.c
+++ b/sound/pci/hda/hda_intel.c
@@ -1646,7 +1646,8 @@ static int check_position_fix(struct azx *chip, int fix)
 	}
 
 	/* Check VIA/ATI HD Audio Controller exist */
-	if (chip->driver_type == AZX_DRIVER_VIA) {
+	if (chip->driver_type == AZX_DRIVER_VIA ||
+	    chip->driver_type == AZX_DRIVER_ZHAOXIN) {
 		dev_dbg(chip->card->dev, "Using VIACOMBO position fix\n");
 		return POS_FIX_VIACOMBO;
 	}
@@ -1800,7 +1801,8 @@ static void azx_check_snoop_available(struct azx *chip)
 
 	snoop = true;
 	if (azx_get_snoop_type(chip) == AZX_SNOOP_TYPE_NONE &&
-	    chip->driver_type == AZX_DRIVER_VIA) {
+	    (chip->driver_type == AZX_DRIVER_VIA ||
+	     chip->driver_type == AZX_DRIVER_ZHAOXIN)) {
 		/* force to non-snoop mode for a new VIA controller
 		 * when BIOS is set
 		 */


### PR DESCRIPTION
zhaoxin inclusion
category: feature

-------------------

Add some special initialization for Zhaoxin SB HDAC.

## Summary by Sourcery

New Features:
- Treat Zhaoxin SB HDAC controllers as VIA-compatible for position fix selection and non-snoop mode handling.