### PR TITLE
irq: phytium: update phytium irq controller driver support to 6.6.0.4

### DIFF
--- a/drivers/iommu/arm/arm-smmu/arm-smmu.c
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu.c
@@ -1374,6 +1374,19 @@ static struct iommu_device *arm_smmu_probe_device(struct device *dev)
 		return ERR_PTR(-ENODEV);
 	}
 
+#ifdef CONFIG_ARCH_PHYTIUM
+	/* Phytium Ps17064 workaround patch */
+	if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) == MIDR_PHYTIUM_PS17064) {
+		int num = fwspec->num_ids;
+
+		for (i = 0; i < num; i++) {
+			u32 fwid = FWID_READ(fwspec->ids[i]);
+
+			iommu_fwspec_add_ids(dev, &fwid, 1);
+		}
+	}
+#endif
+
 	ret = -EINVAL;
 	for (i = 0; i < fwspec->num_ids; i++) {
 		u16 sid = FIELD_GET(ARM_SMMU_SMR_ID, fwspec->ids[i]);

--- a/drivers/iommu/arm/arm-smmu/arm-smmu.h
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu.h
@@ -10,6 +10,7 @@
 #ifndef _ARM_SMMU_H
 #define _ARM_SMMU_H
 
+#include <asm/cputype.h>
 #include <linux/atomic.h>
 #include <linux/bitfield.h>
 #include <linux/bits.h>
@@ -22,6 +23,10 @@
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
 #include <linux/types.h>
+
+#ifdef CONFIG_ARCH_PHYTIUM
+#define FWID_READ(id) (((u16)(id) >> 3) | (((id) >> 16 | 0x7000) << 16))
+#endif
 
 /* Configuration registers */
 #define ARM_SMMU_GR0_sCR0		0x0

--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -32,6 +32,9 @@
 #include <trace/events/iommu.h>
 #include <linux/sched/mm.h>
 #include <linux/msi.h>
+#ifdef CONFIG_ARCH_PHYTIUM
+#include <asm/cputype.h>
+#endif
 
 #include "dma-iommu.h"
 #include "iommu-priv.h"
@@ -198,6 +201,15 @@ static int __init iommu_subsys_init(void)
 			iommu_set_default_passthrough(false);
 		else
 			iommu_set_default_translated(false);
+#ifdef CONFIG_ARCH_PHYTIUM
+		/*
+		 * Always set default iommu type to IOMMU_DOMAIN_IDENTITY
+		 * on Phytium Ps17064 SoC to avoid unnecessary troubles
+		 * introduced by the SMMU workaround.
+		 */
+		if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) == MIDR_PHYTIUM_PS17064)
+			iommu_set_default_passthrough(true);
+#endif
 
 		if (iommu_default_passthrough() && cc_platform_has(CC_ATTR_MEM_ENCRYPT)) {
 			pr_info("Memory encryption detected - Disabling default IOMMU Passthrough\n");
@@ -659,6 +671,19 @@ static int __init iommu_set_def_domain_type(char *str)
 	ret = kstrtobool(str, &pt);
 	if (ret)
 		return ret;
+
+#ifdef CONFIG_ARCH_PHYTIUM
+	/*
+	 * Always set default iommu type to IOMMU_DOMAIN_IDENTITY
+	 * on Phytium Ps17064 SoC to avoid unnecessary troubles
+	 * introduced by the SMMU workaround.
+	 */
+	if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) == MIDR_PHYTIUM_PS17064) {
+		iommu_def_domain_type = IOMMU_DOMAIN_IDENTITY;
+		iommu_set_default_passthrough(true);
+		return 0;
+	}
+#endif
 
 	if (pt)
 		iommu_set_default_passthrough(true);

--- a/drivers/irqchip/irq-gic-v3-its.c
+++ b/drivers/irqchip/irq-gic-v3-its.c
@@ -1736,7 +1736,8 @@ static void its_irq_compose_msi_msg(struct irq_data *d, struct msi_msg *msg)
 	msg->address_hi		= upper_32_bits(addr);
 	msg->data		= its_get_event_id(d);
 
-	iommu_dma_compose_msi_msg(irq_data_get_msi_desc(d), msg);
+	if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) != MIDR_PHYTIUM_PS17064)
+		iommu_dma_compose_msi_msg(irq_data_get_msi_desc(d), msg);
 }
 
 static int its_irq_set_irqchip_state(struct irq_data *d,

--- a/drivers/irqchip/irq-gic-v3-its.c
+++ b/drivers/irqchip/irq-gic-v3-its.c
@@ -1736,8 +1736,10 @@ static void its_irq_compose_msi_msg(struct irq_data *d, struct msi_msg *msg)
 	msg->address_hi		= upper_32_bits(addr);
 	msg->data		= its_get_event_id(d);
 
+#ifdef CONFIG_ARCH_PHYTIUM
 	if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) != MIDR_PHYTIUM_PS17064)
 		iommu_dma_compose_msi_msg(irq_data_get_msi_desc(d), msg);
+#endif
 }
 
 static int its_irq_set_irqchip_state(struct irq_data *d,

--- a/drivers/irqchip/irq-gic-v3-its.c
+++ b/drivers/irqchip/irq-gic-v3-its.c
@@ -1737,9 +1737,10 @@ static void its_irq_compose_msi_msg(struct irq_data *d, struct msi_msg *msg)
 	msg->data		= its_get_event_id(d);
 
 #ifdef CONFIG_ARCH_PHYTIUM
-	if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) != MIDR_PHYTIUM_PS17064)
-		iommu_dma_compose_msi_msg(irq_data_get_msi_desc(d), msg);
+	if ((read_cpuid_id() & MIDR_CPU_MODEL_MASK) == MIDR_PHYTIUM_PS17064)
+		return;
 #endif
+	iommu_dma_compose_msi_msg(irq_data_get_msi_desc(d), msg);
 }
 
 static int its_irq_set_irqchip_state(struct irq_data *d,


### PR DESCRIPTION
This patches updates the support for phytium irq controller driver.

1.iommu/arm-smmu: Add SMMU workaround for Phytium Ps17064
2.arm64: Phytium: Slove the error on aarch32 compiler
3.arm64: Phytium: Fix incorrect MSI compose logic on Phytium PS17064 SoCs

## Summary by Sourcery

Update IOMMU, SMMU, and GICv3 ITS handling to apply Phytium PS17064-specific workarounds and defaults.

Bug Fixes:
- Force IOMMU default domain to identity and enable passthrough on Phytium PS17064 SoCs to avoid issues introduced by the SMMU workaround.
- Adjust SMMU device probing on Phytium PS17064 by rewriting firmware IDs to match expected stream IDs.
- Prevent incorrect MSI message composition on Phytium PS17064 by skipping the IOMMU-backed MSI composition path for that CPU model.

Enhancements:
- Introduce Phytium-specific CPU model checks and helper macro wiring in the IOMMU and SMMU drivers to support PS17064 workarounds.