### PR TITLE
qspi: phytium: update phytium qspi controller driver support to 6.6.0.4

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -818,7 +818,7 @@ config SPI_PHYTIUM_PCI
 
 config SPI_PHYTIUM_QSPI
 	tristate "Phytium Quad SPI controller"
-	depends on ARCH_PHYTIUM || COMPILE_TEST
+	depends on ARCH_PHYTIUM && COMPILE_TEST
 	depends on OF
 	depends on SPI_MEM
 	help

--- a/drivers/spi/spi-phytium-qspi.c
+++ b/drivers/spi/spi-phytium-qspi.c
@@ -181,8 +181,8 @@ struct phytium_qspi {
 	u8 fnum;
 	bool nodirmap;
 
-	u32 wr_cfg_reg;
-	u32 rd_cfg_reg;
+	u32 wr_cfg_reg[PHYTIUM_QSPI_MAX_NORCHIP];
+	u32 rd_cfg_reg[PHYTIUM_QSPI_MAX_NORCHIP];
 	u32 flash_cap;
 };
 
@@ -538,7 +538,7 @@ static int phytium_qspi_dirmap_create(struct spi_mem_dirmap_desc *desc)
 		cmd |= flash->clk_div & QSPI_RD_CFG_RD_SCK_SEL_MASK;
 
 		writel_relaxed(cmd, qspi->io_base + QSPI_RD_CFG_REG);
-		qspi->rd_cfg_reg = cmd;
+		qspi->rd_cfg_reg[spi->chip_select] = cmd;
 
 		dev_dbg(qspi->dev, "Create read dirmap and setup RD_CFG_REG [%#x].\n", cmd);
 	} else if (desc->info.op_tmpl.data.dir == SPI_MEM_DATA_OUT) {
@@ -555,7 +555,7 @@ static int phytium_qspi_dirmap_create(struct spi_mem_dirmap_desc *desc)
 
 		cmd |= QSPI_WR_CFG_WR_MODE_MASK;
 		cmd |= flash->clk_div & QSPI_WR_CFG_WR_SCK_SEL_MASK;
-		qspi->wr_cfg_reg = cmd;
+		qspi->wr_cfg_reg[spi->chip_select] = cmd;
 	} else {
 		ret = -EINVAL;
 	}
@@ -574,6 +574,7 @@ static ssize_t phytium_qspi_dirmap_read(struct spi_mem_dirmap_desc *desc,
 	void __iomem *src = flash->base + offs;
 	u8 *buf_rx = buf;
 
+	writel_relaxed(qspi->rd_cfg_reg[spi->chip_select], qspi->io_base + QSPI_RD_CFG_REG);
 	memcpy_fromio(buf_rx, src, len);
 
 	return len;
@@ -593,7 +594,7 @@ static ssize_t phytium_qspi_dirmap_write(struct spi_mem_dirmap_desc *desc,
 	u_char tmp[4] = {0};
 
 	/* set wr_cfg for drimap write */
-	writel_relaxed(qspi->wr_cfg_reg, qspi->io_base + QSPI_WR_CFG_REG);
+	writel_relaxed(qspi->wr_cfg_reg[spi->chip_select], qspi->io_base + QSPI_WR_CFG_REG);
 
 	if (offs & 0x03) {
 		dev_err(qspi->dev, "Addr not four-byte aligned!\n");
@@ -889,7 +890,6 @@ static int __maybe_unused phytium_qspi_resume(struct device *dev)
 
 	if (!qspi->nodirmap) {
 		/* set rd_cfg reg and flash_capacity reg after resume */
-		writel_relaxed(qspi->rd_cfg_reg, qspi->io_base + QSPI_RD_CFG_REG);
 		writel_relaxed(qspi->flash_cap, qspi->io_base + QSPI_FLASH_CAP_REG);
 	} else {
 		writel_relaxed(WR_CFG_NODIR_VALUE, qspi->io_base + QSPI_WR_CFG_REG);


### PR DESCRIPTION
This patches updates the support for phytium qspi controller driver.
1. Use the corresponding configurations for each chip
2. Strict QSPI compile dependency

## Summary by Sourcery

Update the Phytium QSPI controller driver to track per-chip configuration and correctly program controller registers for dirmap transfers.

Bug Fixes:
- Store read and write configuration registers per chip select instead of globally to avoid conflicts when multiple flashes are attached.
- Reprogram the read configuration register before each dirmap read to ensure correct controller state after other operations or power transitions.

Enhancements:
- Simplify resume handling by only restoring the flash capacity register when dirmap is enabled, relying on per-chip configuration to be set during access.