### PR TITLE
ras: phytium: update phytium ras controller driver support to 6.6.0.4

### DIFF
--- a/drivers/acpi/apei/ghes.c
+++ b/drivers/acpi/apei/ghes.c
@@ -150,6 +150,9 @@ static DEFINE_MUTEX(ghes_list_mutex);
 static LIST_HEAD(ghes_devs);
 static DEFINE_MUTEX(ghes_devs_mutex);
 
+ATOMIC_NOTIFIER_HEAD(ghes_mem_err_chain);
+EXPORT_SYMBOL_GPL(ghes_mem_err_chain);
+
 /*
  * Because the memory area used to transfer hardware error information
  * from BIOS to Linux can be determined only in NMI, IRQ or timer
@@ -702,6 +705,11 @@ static bool ghes_do_proc(struct ghes *ghes,
 
 		if (guid_equal(sec_type, &CPER_SEC_PLATFORM_MEM)) {
 			struct cper_sec_mem_err *mem_err = acpi_hest_get_payload(gdata);
+			struct ghes_mem_err mem;
+
+			mem.notify_type = ghes->generic->notify.type;
+			mem.severity = gdata->error_severity;
+			mem.mem_err = mem_err;
 
 			atomic_notifier_call_chain(&ghes_report_chain, sev, mem_err);
 

--- a/drivers/acpi/apei/ghes.c
+++ b/drivers/acpi/apei/ghes.c
@@ -711,6 +711,7 @@ static bool ghes_do_proc(struct ghes *ghes,
 			mem.severity = gdata->error_severity;
 			mem.mem_err = mem_err;
 
+			atomic_notifier_call_chain(&ghes_mem_err_chain, 0, &mem);
 			atomic_notifier_call_chain(&ghes_report_chain, sev, mem_err);
 
 			arch_apei_report_mem_error(sev, mem_err);

--- a/include/acpi/ghes.h
+++ b/include/acpi/ghes.h
@@ -131,6 +131,14 @@ int ghes_notify_sea(void);
 static inline int ghes_notify_sea(void) { return -ENOENT; }
 #endif
 
+struct ghes_mem_err {
+	int notify_type;
+	int severity;
+	struct cper_sec_mem_err *mem_err;
+};
+
+extern struct atomic_notifier_head ghes_mem_err_chain;
+
 struct notifier_block;
 extern void ghes_register_report_chain(struct notifier_block *nb);
 extern void ghes_unregister_report_chain(struct notifier_block *nb);


### PR DESCRIPTION
This patches updates the support for phytium ras controller driver.

1.GHES: Add a notify chain for process memory section.
2.GHES: Add ghes_mem_err_chain notify chain for process memory section

## Summary by Sourcery

Extend GHES memory error handling to expose richer contextual information via a new notifier chain for platform memory error sections.

New Features:
- Introduce a dedicated atomic notifier chain for GHES platform memory errors to allow external consumers to subscribe to memory error events.

Enhancements:
- Include notification type and severity alongside CPER memory error records when invoking the new memory error notifier chain.