### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Update kernel base to 6.12.89

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 12
-SUBLEVEL = 88
+SUBLEVEL = 89
 EXTRAVERSION =
 NAME = Baby Opossum Posse
 


### PR DESCRIPTION
Update kernel base to 6.12.89.

git log --oneline v6.12.88..v6.12.89 |wc
2

Merged:
https://github.com/deepin-community/kernel/pull/1731
(cherry picked from commit 51eba7e6c91ada319dc9ebee3f88e4472b5efbc4)

## Summary by Sourcery

Update the kernel version metadata to 6.12.89.