### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] r8152: fix incorrect register write to USB_UPHY_XTAL

### DIFF
--- a/drivers/net/usb/r8152.c
+++ b/drivers/net/usb/r8152.c
@@ -3859,7 +3859,7 @@ static void r8156_ups_en(struct r8152 *tp, bool enable)
 		case RTL_VER_15:
 			ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_UPHY_XTAL);
 			ocp_data &= ~OOBS_POLLING;
-			ocp_write_byte(tp, MCU_TYPE_USB, USB_UPHY_XTAL, ocp_data);
+			ocp_write_word(tp, MCU_TYPE_USB, USB_UPHY_XTAL, ocp_data);
 			break;
 		default:
 			break;


### PR DESCRIPTION
[Upstream commit 48afd5124fd6129c46fd12cb06155384b1c4a0c4]

The old code used ocp_write_byte() to clear the OOBS_POLLING bit (BIT(8)) in the USB_UPHY_XTAL register, but this doesn't correctly clear a bit in the upper byte of the 16-bit register.

Fix this by using ocp_write_word() instead.

Fixes: 195aae321c82 ("r8152: support new chips")

Reviewed-by: Hayes Wang <hayeswang@realtek.com>
Link: https://patch.msgid.link/20260326073925.32976-454-nic_swsd@realtek.com

## Summary by Sourcery

Bug Fixes:
- Correct USB_UPHY_XTAL OOBS_POLLING bit clearing by writing the full 16-bit word instead of a single byte.