### PR TITLE
i2c: phytium: update phytium i2c controller driver support to 6.6.0.4

### DIFF
--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-core.h
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-core.h
@@ -14,7 +14,7 @@
 #include <linux/interrupt.h>
 #include <linux/kernel.h>
 
-#define I2C_PHYTIUM_V2_DRV_VERSION		"1.0.3"
+#define I2C_PHYTIUM_V2_DRV_VERSION		"1.0.4"
 
 #define FT_I2C_MSG_UNIT_SIZE			10
 #define FT_I2C_DATA_RESV_LEN			2
@@ -348,6 +348,7 @@ struct i2c_phyt_tranfer {
 	u32 tx_cmd_cnt;
 	u32 cur_cmd_cnt;
 	u32 cur_index;
+	u32 last_index;
 	u32 opt_finish_len;
 	u32 tx_ring_cnt;
 	bool is_need_check;

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
@@ -358,6 +358,7 @@ static int i2c_phyt_master_xfer(struct i2c_adapter *adapter,
 	dev->mng.tx_cmd_cnt = 0;
 	dev->mng.cur_cmd_cnt = 0;
 	dev->mng.is_last_frame = false;
+	dev->mng.last_index = 0xffffffff;
 	dev->flags = ~FT_I2C_TRANS_WAIT;
 
 	i2c_phyt_write_reg(dev, FT_I2C_REGFILE_TX_HEAD, 0);
@@ -369,6 +370,7 @@ static int i2c_phyt_master_xfer(struct i2c_adapter *adapter,
 	if (!ret) {
 		ret = num;
 	} else {
+		dev->mng.cur_cmd_cnt = 0;
 		if (dev->abort_source != FT_I2C_SUCCESS) {
 			i2c_phyt_handle_tx_abort(dev);
 			if ((dev->abort_source & BIT(FT_I2C_TIMEOUT)) ||
@@ -460,20 +462,29 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 		return IRQ_NONE;
 	}
 
+	head = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_TX_HEAD) % dev->mng.tx_ring_cnt;
 	i2c_phyt_common_regfile_clear_rv2ap_int(dev, stat);
-
 	if (!dev->mng.tx_ring_cnt) {
 		dev_err(dev->dev, "tx_ring_cnt is zero\n");
 		spin_unlock(&dev->i2c_lock);
 		return IRQ_NONE;
 	}
-	head = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_TX_HEAD) % dev->mng.tx_ring_cnt;
+
 	tail = dev->mng.cur_cmd_cnt % dev->mng.tx_ring_cnt;
 	do {
 		tail++;
 		tail %= dev->mng.tx_ring_cnt;
 		if (rx_msg->head.cmd_type == PHYTI2C_MSG_CMD_REPORT)
 			i2c_phyt_master_isr_handle(dev);
+		/*
+		 *cur_cmd_cnt > 0 means in data transfer,when this contion happens,this data
+		 *has been processed in last interrupt handler,so do nothing this time.
+		 */
+		if (dev->mng.cur_cmd_cnt && dev->mng.last_index == head) {
+			dev_info(dev->dev, "===RV dose not update==\n");
+			spin_unlock(&dev->i2c_lock);
+			return IRQ_HANDLED;
+		}
 
 		if (dev->complete_flag) {
 			ret = i2c_phyt_master_handle(dev);
@@ -490,6 +501,7 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 		}
 	} while (tail != head);
 
+	dev->mng.last_index = head;
 	if (dev->flags == FT_I2C_TRANS_WAIT) {
 		dev->flags = ~FT_I2C_TRANS_WAIT;
 		i2c_phyt_trig_rv_intr(dev);

--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-platform.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-platform.c
@@ -398,7 +398,7 @@ static int i2c_phyt_plat_probe(struct platform_device *pdev)
 	adap->class = I2C_CLASS_DEPRECATED;
 	ACPI_COMPANION_SET(&adap->dev, ACPI_COMPANION(&pdev->dev));
 	adap->dev.of_node = pdev->dev.of_node;
-	adap->timeout = HZ;
+	adap->timeout = 2 * HZ;
 	adap->dev.fwnode = pdev->dev.fwnode;
 	dev_pm_set_driver_flags(&pdev->dev,
 				DPM_FLAG_SMART_PREPARE |


### PR DESCRIPTION
This patches updates the support for phytium i2c controller driver.
1.Fixed the bug that processed unupdated data

## Summary by Sourcery

Update Phytium I2C v2 master driver behavior and version to improve robustness and align with newer kernel support.

Bug Fixes:
- Prevent reprocessing of already-handled transfer data when the TX head register is not updated between interrupts.
- Reset current command count on transfer failure to avoid using stale state.

Enhancements:
- Track and use the last processed TX ring index in the interrupt handler to detect unchanged hardware state.
- Increase the I2C adapter timeout to better accommodate longer transfers.
- Bump the Phytium I2C v2 driver version from 1.0.3 to 1.0.4.