### PR TITLE
SNOOP:phytium:update phytium SNOOP driver support to 6.6.0.4

### DIFF
--- a/Documentation/devicetree/bindings/misc/phytium,snoop-ctrl.yaml
+++ b/Documentation/devicetree/bindings/misc/phytium,snoop-ctrl.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/misc/phytium,snoop-ctrl.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Phytium BMC Snoop Controller
+
+maintainers:
+  - Lan Hengyu <lanhengyu1395@phytium.com.cn>
+
+description:
+        The snoop controller allows the BMC to listen on and record the data
+        bytes written by the Host to the target I/O ports.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - phytium,snoop-ctrl
+  reg:
+    maxItems: 1
+
+  interrupts:
+    maxItems: 1
+
+  snoop-ports:
+    $ref: /schemas/types.yaml#/definitions/uint32-array
+    description: Ports to snoop
+
+required:
+  - compatible
+  - interrupts
+  - snoop-ports
+
+examples:
+  - |
+      snoop: snoop@28010000 {
+          compatible = "phytium,snoop-ctrl";
+          reg = <0x0 0x28010000 0x1000>;
+          interrupts = <GIC_SPI 144 IRQ_TYPE_LEVEL_HIGH>;
+
+          snoop-ports = <0x80>;
+      };

--- a/Documentation/devicetree/bindings/misc/phytium,snoop-ctrl.yaml
+++ b/Documentation/devicetree/bindings/misc/phytium,snoop-ctrl.yaml
@@ -36,9 +36,8 @@ required:
 examples:
   - |
       snoop: snoop@28010000 {
-          compatible = "phytium,snoop-ctrl";
-          reg = <0x0 0x28010000 0x1000>;
+          compatible = "phytium,snoop-ctrl", "syscon";
+          reg = <0x0 0x28010000 0x0 0x1000>;
           interrupts = <GIC_SPI 144 IRQ_TYPE_LEVEL_HIGH>;
-
-          snoop-ports = <0x80>;
+          snoop-ports = <0x80 0x81>;
       };

--- a/arch/arm64/boot/dts/phytium/pe220x.dtsi
+++ b/arch/arm64/boot/dts/phytium/pe220x.dtsi
@@ -251,6 +251,13 @@
 			status = "disabled";
 		};
 
+		snoop: snoop@28010000 {
+			compatible = "phytium,snoop-ctrl";
+			reg = <0x0 0x28010000 0x1000>;
+			interrupts = <GIC_SPI 88 IRQ_TYPE_LEVEL_HIGH>;
+			snoop-ports = <0x80>;
+		};
+
 		lpc: lpc@28010000 {
 			compatible = "simple-mfd", "syscon";
 			reg = <0x0 0x28010000 0x0 0x1000>;

--- a/arch/arm64/boot/dts/phytium/pe220x.dtsi
+++ b/arch/arm64/boot/dts/phytium/pe220x.dtsi
@@ -252,10 +252,11 @@
 		};
 
 		snoop: snoop@28010000 {
-			compatible = "phytium,snoop-ctrl";
-			reg = <0x0 0x28010000 0x1000>;
+			compatible = "phytium,snoop-ctrl", "syscon";
+			reg = <0x0 0x28010000 0x0 0x1000>;
 			interrupts = <GIC_SPI 88 IRQ_TYPE_LEVEL_HIGH>;
-			snoop-ports = <0x80>;
+			snoop-ports = <0x80 0x81>;
+			status = "disabled";
 		};
 
 		lpc: lpc@28010000 {


### PR DESCRIPTION
This patches update the support for phytium SNOOP driver.

1.update the DT description for the Phytium snoop controller.
2.add snoop description for pe220x platforms, which usually used as BMC cards.
3.update the snoop node description for pe220x platforms to ensure its driver is functioning normally.

## Summary by Sourcery

Documentation:
- Add a Devicetree binding document for the Phytium BMC snoop controller, describing its properties and usage on supported platforms.