### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [deepin] i2c: phytium: Fix potential divided by zero in i2c_phyt_master_regfil…

### DIFF
--- a/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
+++ b/drivers/i2c/busses/phytium_i2c_v2/i2c-phyt-master.c
@@ -462,13 +462,14 @@ static irqreturn_t i2c_phyt_master_regfile_isr(int this_irq, void *dev_id)
 		return IRQ_NONE;
 	}
 
-	head = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_TX_HEAD) % dev->mng.tx_ring_cnt;
+	head = i2c_phyt_read_reg(dev, FT_I2C_REGFILE_TX_HEAD);
 	i2c_phyt_common_regfile_clear_rv2ap_int(dev, stat);
 	if (!dev->mng.tx_ring_cnt) {
 		dev_err(dev->dev, "tx_ring_cnt is zero\n");
 		spin_unlock(&dev->i2c_lock);
 		return IRQ_NONE;
 	}
+	head = head % dev->mng.tx_ring_cnt;
 
 	tail = dev->mng.cur_cmd_cnt % dev->mng.tx_ring_cnt;
 	do {


### PR DESCRIPTION
…e_isr()

deepin inclusion
category: bugfix

Fixes: 7db4ed0a96d3 ("i2c: phytium: Fixed the bug that processed unupdated data")

## Summary by Sourcery

Bug Fixes:
- Avoid potential divide-by-zero when computing TX ring buffer indices if tx_ring_cnt is zero in the Phytium I2C controller driver.