### PR TITLE
tlb: phytium: update phytium tlb controller driver support to 6.6.0.4

### DIFF
--- a/arch/arm64/include/asm/tlbflush.h
+++ b/arch/arm64/include/asm/tlbflush.h
@@ -340,7 +340,7 @@ static inline void arch_tlbbatch_flush(struct arch_tlbflush_unmap_batch *batch)
  * This is meant to avoid soft lock-ups on large TLB flushing ranges and not
  * necessarily a performance improvement.
  */
-#define MAX_TLBI_OPS	PTRS_PER_PTE
+#define MAX_DVM_OPS	PTRS_PER_PTE
 
 /*
  * __flush_tlb_range_op - Perform TLBI operation upon a range
@@ -418,12 +418,12 @@ static inline void __flush_tlb_range(struct vm_area_struct *vma,
 
 	/*
 	 * When not uses TLB range ops, we can handle up to
-	 * (MAX_TLBI_OPS - 1) pages;
+	 * (MAX_DVM_OPS - 1) pages;
 	 * When uses TLB range ops, we can handle up to
 	 * (MAX_TLBI_RANGE_PAGES - 1) pages.
 	 */
 	if ((!system_supports_tlb_range() &&
-	     (end - start) >= (MAX_TLBI_OPS * stride)) ||
+	     (end - start) >= (MAX_DVM_OPS * stride)) ||
 	    pages >= MAX_TLBI_RANGE_PAGES) {
 		flush_tlb_mm(vma->vm_mm);
 		return;
@@ -456,7 +456,7 @@ static inline void flush_tlb_kernel_range(unsigned long start, unsigned long end
 {
 	unsigned long addr;
 
-	if ((end - start) > (MAX_TLBI_OPS * PAGE_SIZE)) {
+	if ((end - start) > (MAX_DVM_OPS * PAGE_SIZE)) {
 		flush_tlb_all();
 		return;
 	}

--- a/arch/arm64/include/asm/tlbflush.h
+++ b/arch/arm64/include/asm/tlbflush.h
@@ -405,6 +405,23 @@ do {									\
 #define __flush_s2_tlb_range_op(op, start, pages, stride, tlb_level) \
 	__flush_tlb_range_op(op, start, pages, stride, 0, tlb_level, false)
 
+static inline bool __flush_tlb_range_limit_excess(unsigned long start,
+               unsigned long end, unsigned long pages, unsigned long stride)
+{
+       /*
+        * When the system does not support TLB range based flush
+        * operation, (MAX_DVM_OPS - 1) pages can be handled. But
+        * with TLB range based operation, MAX_TLBI_RANGE_PAGES
+        * pages can be handled.
+        */
+       if ((!system_supports_tlb_range() &&
+            (end - start) >= (MAX_DVM_OPS * stride)) ||
+           pages > MAX_TLBI_RANGE_PAGES)
+               return true;
+
+       return false;
+}
+
 static inline void __flush_tlb_range(struct vm_area_struct *vma,
 				     unsigned long start, unsigned long end,
 				     unsigned long stride, bool last_level,
@@ -416,15 +433,7 @@ static inline void __flush_tlb_range(struct vm_area_struct *vma,
 	end = round_up(end, stride);
 	pages = (end - start) >> PAGE_SHIFT;
 
-	/*
-	 * When not uses TLB range ops, we can handle up to
-	 * (MAX_DVM_OPS - 1) pages;
-	 * When uses TLB range ops, we can handle up to
-	 * MAX_TLBI_RANGE_PAGES pages.
-	 */
-	if ((!system_supports_tlb_range() &&
-	     (end - start) >= (MAX_DVM_OPS * stride)) ||
-	    pages > MAX_TLBI_RANGE_PAGES) {
+	if (__flush_tlb_range_limit_excess(start, end, pages, stride)) {
 		flush_tlb_mm(vma->vm_mm);
 		return;
 	}

--- a/arch/arm64/include/asm/tlbflush.h
+++ b/arch/arm64/include/asm/tlbflush.h
@@ -463,19 +463,20 @@ static inline void flush_tlb_range(struct vm_area_struct *vma,
 
 static inline void flush_tlb_kernel_range(unsigned long start, unsigned long end)
 {
-	unsigned long addr;
+	const unsigned long stride = PAGE_SIZE;
+	unsigned long pages;
 
-	if ((end - start) > (MAX_DVM_OPS * PAGE_SIZE)) {
+	start = round_down(start, stride);
+	end = round_up(end, stride);
+	pages = (end - start) >> PAGE_SHIFT;
+
+	if (__flush_tlb_range_limit_excess(start, end, pages, stride)) {
 		flush_tlb_all();
 		return;
 	}
 
-	start = __TLBI_VADDR(start, 0);
-	end = __TLBI_VADDR(end, 0);
-
 	dsb(ishst);
-	for (addr = start; addr < end; addr += 1 << (PAGE_SHIFT - 12))
-		__tlbi(vaale1is, addr);
+	__flush_tlb_range_op(vaale1is, start, pages, stride, 0, 0, false);
 	dsb(ish);
 	isb();
 }

--- a/arch/arm64/include/asm/tlbflush.h
+++ b/arch/arm64/include/asm/tlbflush.h
@@ -420,11 +420,11 @@ static inline void __flush_tlb_range(struct vm_area_struct *vma,
 	 * When not uses TLB range ops, we can handle up to
 	 * (MAX_DVM_OPS - 1) pages;
 	 * When uses TLB range ops, we can handle up to
-	 * (MAX_TLBI_RANGE_PAGES - 1) pages.
+	 * MAX_TLBI_RANGE_PAGES pages.
 	 */
 	if ((!system_supports_tlb_range() &&
 	     (end - start) >= (MAX_DVM_OPS * stride)) ||
-	    pages >= MAX_TLBI_RANGE_PAGES) {
+	    pages > MAX_TLBI_RANGE_PAGES) {
 		flush_tlb_mm(vma->vm_mm);
 		return;
 	}


### PR DESCRIPTION
This patches updates the support for phytium tbl controller driver.
1. Rename MAX_TLBI_OPS
2. Allow range operation for MAX_TLBI_RANGE_PAGES
3. add __flush_tlb_range_limit_excess()
4. optimize flush tlb kernel range

## Summary by Sourcery

Update Phytium ARM64 platform support with improved TLB range handling, new SoC identification and frequency-scaling drivers, and refinements to audio codec drivers.

New Features:
- Add unified Phytium DMU devfreq driver to manage DDR memory controller frequency via ACPI on multiple hardware versions.
- Add unified Phytium NOC devfreq driver to manage interconnect frequency with utilization-based scaling and suspend/resume support.
- Introduce Phytium SoC identification infrastructure using SMCCC, system registers, and CPU part IDs, exposing a global SoC type for platform code.

Bug Fixes:
- Correct TLB range flush limits for large mappings and align kernel-range flushing logic with the generic range helper to avoid excessive full TLB invalidations.
- Fix Phytium codec v2 status handling by using named error codes and clearer messages, and ensure shared command memory is cleared before control operations to avoid stale requests.
- Improve ES8388 codec probe to handle register write failures and adjust initial control register programming to a safe configuration.

Enhancements:
- Rename ARM64 TLB operation macro to better reflect DVM usage and reuse a common helper in kernel-range flushing for consistency and maintainability.
- Track Phytium codec v2 channel count in the driver state and reuse it for DAI configuration instead of repeatedly querying hardware.
- Update ES8388 codec driver version metadata and refine its default initialization sequence.
- Rename the Phytium FTC303 CPU part to FTC310 and update associated MIDR-based feature and mitigation tables to match the new identifier.

Build:
- Wire up the new Phytium DMU and NOC devfreq drivers in Kconfig and the devfreq Makefile so they can be built when enabled.

Chores:
- Extend ARM64 setup to initialize and export the detected Phytium SoC type for other subsystems.
- Touch MAINTAINERS, platform defconfig, and codec Kconfig entries to include the new Phytium-related components.