### PR TITLE
[linux-6.6.y] cpufreq: Add CPU frequency policy change notification support

### DIFF
--- a/drivers/cpufreq/cpufreq.c
+++ b/drivers/cpufreq/cpufreq.c
@@ -2701,6 +2701,8 @@ static int cpufreq_set_policy(struct cpufreq_policy *policy,
 		ret = cpufreq_start_governor(policy);
 		if (!ret) {
 			pr_debug("governor change\n");
+			blocking_notifier_call_chain(&cpufreq_policy_notifier_list,
+						     CPUFREQ_CHANGE_POLICY, policy);
 			sched_cpufreq_governor_change(policy, old_gov);
 			return 0;
 		}

--- a/include/linux/cpufreq.h
+++ b/include/linux/cpufreq.h
@@ -509,6 +509,7 @@ static inline void cpufreq_resume(void) {}
 /* Policy Notifiers  */
 #define CPUFREQ_CREATE_POLICY		(0)
 #define CPUFREQ_REMOVE_POLICY		(1)
+#define CPUFREQ_CHANGE_POLICY		(2)
 
 #ifdef CONFIG_CPU_FREQ
 int cpufreq_register_notifier(struct notifier_block *nb, unsigned int list);


### PR DESCRIPTION
zhaoxin inclusion
category: feature

--------------------

Implemented CPUFREQ_CHANGE_POLICY notification in cpufreq subsystem. This enhancement allows kernel modules to be notified when a CPU frequency policy is modified, facilitating more integrated system management. The notification is dispatched after a successful governor switch during policy updates.

## Summary by Sourcery

Add notification support for CPU frequency policy changes to the cpufreq subsystem.

New Features:
- Introduce a CPUFREQ_CHANGE_POLICY event type for cpufreq policy notifiers.
- Notify registered listeners after a successful governor switch when a CPU frequency policy is updated.