### PR TITLE
fork: normalize copy_process() error return before ERR_PTR().

### DIFF
--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -2854,6 +2854,13 @@ fork_out:
 	spin_lock_irq(&current->sighand->siglock);
 	hlist_del_init(&delayed.node);
 	spin_unlock_irq(&current->sighand->siglock);
+	/*
+	 * The error path returns ERR_PTR(retval), which requires retval to be a
+	 * negative errno in the range [-MAX_ERRNO, -1]. Normalize unexpected
+	 * values to avoid returning non-error pointers to callers.
+	 */
+	if (unlikely(retval >= 0 || retval < -MAX_ERRNO))
+		retval = -EINVAL;
 	return ERR_PTR(retval);
 }
 


### PR DESCRIPTION
copy_process() returns ERR_PTR(retval) from its error path, so retval must be a negative errno. If retval is zero or positive, ERR_PTR(retval) produces a non-error pointer that is not caught by IS_ERR() in kernel_clone().

A BPF_MODIFY_RETURN program attached to security_task_alloc() can return a positive value. copy_process() treats the non-zero return as a failure and then returns ERR_PTR(1). kernel_clone() does not treat that as an error and later dereferences the pointer, causing a kernel crash.

Normalize unexpected non-negative values before returning ERR_PTR() from copy_process(). This keeps the fix local to the fork error path and does not change BPF_MODIFY_RETURN verifier behavior.

The issue has been reported and discussed upstream, but the verifier-side fix attempt has not been accepted. Carry this targeted fix in deepin-kernel to prevent the reported denial-of-service.

Link: https://lore.kernel.org/bpf/973a1b7b-8ee7-407a-890a-11455d9cc5bf@std.uestc.edu.cn/
Link: https://lore.kernel.org/all/20260411163556.8567-1-yangfeng59949@163.com/
Reported-by: Quan Sun <2022090917019@std.uestc.edu.cn>
Reported-by: Yinhao Hu <dddddd@hust.edu.cn>
Reported-by: Kaiyan Mei <M202472210@hust.edu.cn>

## Summary by Sourcery

Bug Fixes:
- Ensure copy_process() converts unexpected non-negative retval values into -EINVAL before returning ERR_PTR() to avoid kernel_clone() dereferencing non-error pointers and crashing.