### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [FROMLIST] [AMD] x86/CPU/AMD: Add family 0x1a models 0xd0 through 0xef

### DIFF
--- a/arch/x86/kernel/cpu/amd.c
+++ b/arch/x86/kernel/cpu/amd.c
@@ -518,7 +518,7 @@ static void bsp_init_amd(struct cpuinfo_x86 *c)
 			break;
 		case 0x50 ... 0x5f:
 		case 0x80 ... 0xaf:
-		case 0xc0 ... 0xcf:
+		case 0xc0 ... 0xef:
 			setup_force_cpu_cap(X86_FEATURE_ZEN6);
 			break;
 		default:


### PR DESCRIPTION
Family 0x1a model 0xd0, 0xe0 should have X86_FEATURE_ZEN6


Link: https://lore.kernel.org/lkml/20260530061819.9721-1-Pratik.Vishwakarma@amd.com/

## Summary by Sourcery

Bug Fixes:
- Ensure AMD family 0x1a models 0xd0 through 0xef are correctly marked with the X86_FEATURE_ZEN6 capability.