### PR TITLE
GHES: Add a notify chain for process memory section.

### DIFF
--- a/drivers/acpi/apei/ghes.c
+++ b/drivers/acpi/apei/ghes.c
@@ -150,6 +150,9 @@ static DEFINE_MUTEX(ghes_list_mutex);
 static LIST_HEAD(ghes_devs);
 static DEFINE_MUTEX(ghes_devs_mutex);
 
+ATOMIC_NOTIFIER_HEAD(ghes_mem_err_chain);
+EXPORT_SYMBOL_GPL(ghes_mem_err_chain);
+
 /*
  * Because the memory area used to transfer hardware error information
  * from BIOS to Linux can be determined only in NMI, IRQ or timer
@@ -702,6 +705,11 @@ static bool ghes_do_proc(struct ghes *ghes,
 
 		if (guid_equal(sec_type, &CPER_SEC_PLATFORM_MEM)) {
 			struct cper_sec_mem_err *mem_err = acpi_hest_get_payload(gdata);
+			struct ghes_mem_err mem;
+
+			mem.notify_type = ghes->generic->notify.type;
+			mem.severity = gdata->error_severity;
+			mem.mem_err = mem_err;
 
 			atomic_notifier_call_chain(&ghes_report_chain, sev, mem_err);
 

--- a/include/acpi/ghes.h
+++ b/include/acpi/ghes.h
@@ -131,6 +131,14 @@ int ghes_notify_sea(void);
 static inline int ghes_notify_sea(void) { return -ENOENT; }
 #endif
 
+struct ghes_mem_err {
+	int notify_type;
+	int severity;
+	struct cper_sec_mem_err *mem_err;
+};
+
+extern struct atomic_notifier_head ghes_mem_err_chain;
+
 struct notifier_block;
 extern void ghes_register_report_chain(struct notifier_block *nb);
 extern void ghes_unregister_report_chain(struct notifier_block *nb);


### PR DESCRIPTION
Add a notify chain for process memory section, with which other modules might do error recovery.

## Summary by Sourcery

Introduce a notifier chain for reporting GHES platform memory errors so other modules can react to process memory error events.

New Features:
- Expose a new atomic notifier chain for GHES memory errors via a globally exported symbol.

Enhancements:
- Extend GHES processing of platform memory error sections to populate and pass structured context about the notification type and severity to listeners via the new notifier chain.