### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [FROMLIST] dmaengine: qcom: gpi: set DMA_PRIVATE capability

### DIFF
--- a/drivers/dma/qcom/gpi.c
+++ b/drivers/dma/qcom/gpi.c
@@ -2253,6 +2253,7 @@ static int gpi_probe(struct platform_device *pdev)
 	/* clear and Set capabilities */
 	dma_cap_zero(gpi_dev->dma_device.cap_mask);
 	dma_cap_set(DMA_SLAVE, gpi_dev->dma_device.cap_mask);
+	dma_cap_set(DMA_PRIVATE, gpi_dev->dma_device.cap_mask);
 
 	/* configure dmaengine apis */
 	gpi_dev->dma_device.directions = BIT(DMA_DEV_TO_MEM) | BIT(DMA_MEM_TO_DEV);


### PR DESCRIPTION
The GPI DMA controller is only responsible for QUP peripherals, and cannot work as a general-purpose DMA accelerator.

Set DMA_PRIVATE capability for it.

This fixes error messages about GPI being shown when an async-tx consumer is loaded.

Fixes: 5d0c3533a19f ("dmaengine: qcom: Add GPI dma driver")

Link: https://lore.kernel.org/all/20260602070344.3707256-1-zhengxingda@iscas.ac.cn/
Suggested-by: Icenowy Zheng <zhengxingda@iscas.ac.cn>

## Summary by Sourcery

Bug Fixes:
- Prevent spurious error messages and misuse by marking the Qualcomm GPI DMA controller with the DMA_PRIVATE capability instead of exposing it as a general-purpose DMA engine.