### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [SW64] sw: Adapt to upstream xor_unlock_is_negative_byte

### DIFF
--- a/.github/workflows/build-kernel-sw64.yml
+++ b/.github/workflows/build-kernel-sw64.yml
@@ -20,7 +20,7 @@ jobs:
   build-kernel-sw6b:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email
@@ -35,6 +35,12 @@ jobs:
   build-kernel-sw8a:
     runs-on: [self-hosted, linux, x64]
     steps:
+      - uses: actions/checkout@v6
+      - name: "Install Deps"
+        run: |
+          git config --global user.email $email
+          git config --global user.name $KBUILD_BUILD_USER
+
       - name: "Compile kernel"
         run: |
           # .config

--- a/arch/sw_64/include/asm/bitops.h
+++ b/arch/sw_64/include/asm/bitops.h
@@ -561,6 +561,14 @@ sched_find_first_bit(const unsigned long b[2])
 
 #include <asm-generic/bitops/ext2-atomic-setbit.h>
 
+#define clear_bit_unlock          __sw64_clear_bit_unlock
+#define __clear_bit_unlock        __sw64___clear_bit_unlock
+#define test_and_set_bit_lock     __sw64_test_and_set_bit_lock
+#include <asm-generic/bitops/lock.h>
+#undef clear_bit_unlock
+#undef __clear_bit_unlock
+#undef test_and_set_bit_lock
+
 #endif /* __KERNEL__ */
 
 #endif /* _ASM_SW64_BITOPS_H */


### PR DESCRIPTION
## Summary by Sourcery

Update sw64 kernel bit operations and CI workflow configuration for lock bitops compatibility and checkout action version.

Enhancements:
- Wire sw64 architecture bitops to generic lock bitops helpers to support unlocked clear and test-and-set operations.

Build:
- Update GitHub Actions checkout step to version 6 in sw64 kernel build workflow.