### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] CI: Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/build-kernel-arm64.yml
+++ b/.github/workflows/build-kernel-arm64.yml
@@ -16,7 +16,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/build-kernel-loong64.yml
+++ b/.github/workflows/build-kernel-loong64.yml
@@ -20,7 +20,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/build-kernel-riscv64.yml
+++ b/.github/workflows/build-kernel-riscv64.yml
@@ -20,7 +20,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/build-kernel-s390.yml
+++ b/.github/workflows/build-kernel-s390.yml
@@ -16,7 +16,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, S390]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -20,7 +20,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/check-config.yml
+++ b/.github/workflows/check-config.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/package-kernel-amd64-daily.yml
+++ b/.github/workflows/package-kernel-amd64-daily.yml
@@ -15,7 +15,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, x64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/package-kernel-arm64-daily.yml
+++ b/.github/workflows/package-kernel-arm64-daily.yml
@@ -15,7 +15,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, ARM64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email

--- a/.github/workflows/package-kernel-loong64-daily.yml
+++ b/.github/workflows/package-kernel-loong64-daily.yml
@@ -15,7 +15,7 @@ jobs:
   build-kernel:
     runs-on: [self-hosted, linux, loong64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: "Install Deps"
         run: |
           git config --global user.email $email


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump actions/checkout from v3/v4 to v6 in all kernel build, packaging, and config-check workflows.