### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [deepin] cix: gpu: arm: midgard: add missing ACPI dependency

### DIFF
--- a/drivers/soc/cix/gpu/arm/midgard/Kconfig
+++ b/drivers/soc/cix/gpu/arm/midgard/Kconfig
@@ -24,7 +24,7 @@ menuconfig MALI_MIDGARD
 	select PM_DEVFREQ
 	select DEVFREQ_THERMAL
 	select FW_LOADER
-	select THERMAL_ACPI
+	select THERMAL_ACPI if ACPI
 	depends on ARM64
 	default y
 	help


### PR DESCRIPTION
deepin inclusion
category: bugfix

Log:
WARNING: unmet direct dependencies detected for THERMAL_ACPI
  Depends on [n]: THERMAL [=y] && ACPI [=n]
  Selected by [y]:
  - MALI_MIDGARD [=y] && ARM64 [=y]

## Summary by Sourcery

Bug Fixes:
- Fix unmet direct dependency warning for THERMAL_ACPI when MALI_MIDGARD is enabled without ACPI.