### PR TITLE
PSWIOTLB: phytium: update phytium PSWIOTLB controller driver support to 6.6.0.4

### DIFF
--- a/arch/arm64/mm/init.c
+++ b/arch/arm64/mm/init.c
@@ -503,9 +503,10 @@ void __init mem_init(void)
 	swiotlb_init(swiotlb, SWIOTLB_VERBOSE);
 
 #ifdef CONFIG_PSWIOTLB
-	/* enable pswiotlb default */
+	/* enable pswiotlb default, but skip in kdump kernel to save memory*/
 	if ((pswiotlb_force_disable != true) &&
-		is_phytium_ps_socs())
+		is_phytium_ps_socs() &&
+		!is_kdump_kernel())
 		pswiotlb_init(1, PSWIOTLB_VERBOSE);
 #endif
 

--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -6517,10 +6517,8 @@ void pci_configure_pswiotlb(struct pci_dev *dev, struct pci_bus *bus)
 {
 #ifdef CONFIG_PSWIOTLB
        if ((pswiotlb_force_disable != true) &&
-               is_phytium_ps_socs()) {
+               is_phytium_ps_socs())
                pswiotlb_store_local_node(dev, bus);
-               dma_set_seg_boundary(&dev->dev, 0xffffffffffff);
-       }
 #endif
 }
 

--- a/kernel/dma/phytium/pswiotlb-dma.h
+++ b/kernel/dma/phytium/pswiotlb-dma.h
@@ -149,7 +149,8 @@ void pswiotlb_iommu_dma_free(struct device *dev, size_t size, void *cpu_addr,
 static inline bool check_if_pswiotlb_is_applicable(struct device *dev)
 {
 	if (!pswiotlb_force_disable && is_phytium_ps_socs()
-				&& dev && dev->can_use_pswiotlb) {
+				&& dev && dev->can_use_pswiotlb
+				&& is_pswiotlb_active(dev)) {
 		if (dev->numa_node == NUMA_NO_NODE ||
 			dev->numa_node != dev->local_node)
 			dev->numa_node = dev->local_node;

--- a/kernel/dma/phytium/pswiotlb-iommu.c
+++ b/kernel/dma/phytium/pswiotlb-iommu.c
@@ -59,14 +59,28 @@ enum iommu_dma_cookie_type {
 	IOMMU_DMA_MSI_COOKIE,
 };
 
+enum iommu_dma_queue_type {
+	IOMMU_DMA_OPTS_PER_CPU_QUEUE,
+	IOMMU_DMA_OPTS_SINGLE_QUEUE,
+};
+
+struct iommu_dma_options {
+	enum iommu_dma_queue_type qt;
+	size_t		fq_size;
+	unsigned int	fq_timeout;
+};
+
 struct iommu_dma_cookie {
 	enum iommu_dma_cookie_type	type;
 	union {
 		/* Full allocator for IOMMU_DMA_IOVA_COOKIE */
 		struct {
 			struct iova_domain	iovad;
-
-			struct iova_fq __percpu *fq;	/* Flush queue */
+			/* Flush queue */
+			union {
+				struct iova_fq	*single_fq;
+				struct iova_fq	__percpu *percpu_fq;
+			};
 			/* Number of TLB flushes that have been started */
 			atomic64_t		fq_flush_start_cnt;
 			/* Number of TLB flushes that have been finished */
@@ -83,6 +97,8 @@ struct iommu_dma_cookie {
 
 	/* Domain for flush queue callback; NULL if flush queue not in use */
 	struct iommu_domain		*fq_domain;
+	/* Options for dma-iommu use */
+	struct iommu_dma_options	options;
 	struct mutex			mutex;
 };
 
@@ -104,9 +120,10 @@ struct iova_fq_entry {
 
 /* Per-CPU flush queue structure */
 struct iova_fq {
-	struct iova_fq_entry entries[IOVA_FQ_SIZE];
-	unsigned int head, tail;
 	spinlock_t lock;
+	unsigned int head, tail;
+	unsigned int mod_mask;
+	struct iova_fq_entry entries[];
 };
 
 #define fq_ring_for_each(i, fq) \
@@ -119,7 +136,7 @@ struct iova_fq {
  * static inline bool fq_full(struct iova_fq *fq);
  * static void fq_flush_iotlb(struct iommu_dma_cookie *cookie);
  * static inline unsigned int fq_ring_add(struct iova_fq *fq);
- * static void fq_ring_free(struct iommu_dma_cookie *cookie, struct iova_fq *fq);
+ * static void fq_ring_free_locked(struct iommu_dma_cookie *cookie, struct iova_fq *fq);
  * static size_t iommu_pgsize(struct iommu_domain *domain, unsigned long iova,
  *		phys_addr_t paddr, size_t size, size_t *count);
  * static int __iommu_map_pages(struct iommu_domain *domain, unsigned long iova,
@@ -164,7 +181,7 @@ static inline unsigned int fq_ring_add(struct iova_fq *fq)
 	return idx;
 }
 
-static void fq_ring_free(struct iommu_dma_cookie *cookie, struct iova_fq *fq)
+static void fq_ring_free_locked(struct iommu_dma_cookie *cookie, struct iova_fq *fq)
 {
 	u64 counter = atomic64_read(&cookie->fq_flush_finish_cnt);
 	unsigned int idx;
@@ -181,7 +198,7 @@ static void fq_ring_free(struct iommu_dma_cookie *cookie, struct iova_fq *fq)
 			       fq->entries[idx].iova_pfn,
 			       fq->entries[idx].pages);
 
-		fq->head = (fq->head + 1) % IOVA_FQ_SIZE;
+		fq->head = (fq->head + 1) & fq->mod_mask;
 	}
 }
 
@@ -461,7 +478,11 @@ static void queue_iova(struct iommu_dma_cookie *cookie,
 	 */
 	smp_mb();
 
-	fq = raw_cpu_ptr(cookie->fq);
+	if (cookie->options.qt == IOMMU_DMA_OPTS_SINGLE_QUEUE)
+		fq = cookie->single_fq;
+	else
+		fq = raw_cpu_ptr(cookie->percpu_fq);
+
 	spin_lock_irqsave(&fq->lock, flags);
 
 	/*
@@ -469,11 +490,11 @@ static void queue_iova(struct iommu_dma_cookie *cookie,
 	 * flushed out on another CPU. This makes the fq_full() check below less
 	 * likely to be true.
 	 */
-	fq_ring_free(cookie, fq);
+	fq_ring_free_locked(cookie, fq);
 
 	if (fq_full(fq)) {
 		fq_flush_iotlb(cookie);
-		fq_ring_free(cookie, fq);
+		fq_ring_free_locked(cookie, fq);
 	}
 
 	idx = fq_ring_add(fq);

--- a/kernel/dma/phytium/pswiotlb-iommu.c
+++ b/kernel/dma/phytium/pswiotlb-iommu.c
@@ -100,15 +100,11 @@ struct iommu_dma_cookie {
 	/* Options for dma-iommu use */
 	struct iommu_dma_options	options;
 	struct mutex			mutex;
+
+	struct work_struct free_iova_work;
 };
 
 static DEFINE_STATIC_KEY_FALSE(iommu_deferred_attach_enabled);
-
-/* Number of entries per flush queue */
-#define IOVA_FQ_SIZE	256
-
-/* Timeout (in ms) after which entries are flushed from the queue */
-#define IOVA_FQ_TIMEOUT	10
 
 /* Flush queue entry for deferred flushing */
 struct iova_fq_entry {
@@ -127,8 +123,7 @@ struct iova_fq {
 };
 
 #define fq_ring_for_each(i, fq) \
-	for ((i) = (fq)->head; (i) != (fq)->tail; (i) = ((i) + 1) % IOVA_FQ_SIZE)
-
+	for ((i) = (fq)->head; (i) != (fq)->tail; (i) = ((i) + 1) & (fq)->mod_mask)
 /*
  * The following functions are ported from
  * ./drivers/iommu/dma-iommu.c
@@ -167,7 +162,7 @@ struct iova_fq {
 static inline bool fq_full(struct iova_fq *fq)
 {
 	assert_spin_locked(&fq->lock);
-	return (((fq->tail + 1) % IOVA_FQ_SIZE) == fq->head);
+	return (((fq->tail + 1) & fq->mod_mask) == fq->head);
 }
 
 static inline unsigned int fq_ring_add(struct iova_fq *fq)
@@ -176,7 +171,7 @@ static inline unsigned int fq_ring_add(struct iova_fq *fq)
 
 	assert_spin_locked(&fq->lock);
 
-	fq->tail = (idx + 1) % IOVA_FQ_SIZE;
+	fq->tail = (idx + 1) & fq->mod_mask;
 
 	return idx;
 }
@@ -285,6 +280,58 @@ static int __iommu_map_pages(struct iommu_domain *domain, unsigned long iova,
 	}
 
 	return ret;
+}
+
+static void queue_iova(struct iommu_dma_cookie *cookie,
+		unsigned long pfn, unsigned long pages,
+		struct list_head *freelist)
+{
+	struct iova_fq *fq;
+	unsigned long flags;
+	unsigned int idx;
+
+	/*
+	 * Order against the IOMMU driver's pagetable update from unmapping
+	 * @pte, to guarantee that fq_flush_iotlb() observes that if called
+	 * from a different CPU before we release the lock below. Full barrier
+	 * so it also pairs with iommu_dma_init_fq() to avoid seeing partially
+	 * written fq state here.
+	 */
+	smp_mb();
+
+	if (cookie->options.qt == IOMMU_DMA_OPTS_SINGLE_QUEUE)
+		fq = cookie->single_fq;
+	else
+		fq = raw_cpu_ptr(cookie->percpu_fq);
+
+	spin_lock_irqsave(&fq->lock, flags);
+
+	/*
+	 * First remove all entries from the flush queue that have already been
+	 * flushed out on another CPU. This makes the fq_full() check below less
+	 * likely to be true.
+	 */
+	fq_ring_free_locked(cookie, fq);
+
+	if (fq_full(fq)) {
+		fq_flush_iotlb(cookie);
+		fq_ring_free_locked(cookie, fq);
+	}
+
+	idx = fq_ring_add(fq);
+
+	fq->entries[idx].iova_pfn = pfn;
+	fq->entries[idx].pages    = pages;
+	fq->entries[idx].counter  = atomic64_read(&cookie->fq_flush_start_cnt);
+	list_splice(freelist, &fq->entries[idx].freelist);
+
+	spin_unlock_irqrestore(&fq->lock, flags);
+
+	/* Avoid false sharing as much as possible. */
+	if (!atomic_read(&cookie->fq_timer_on) &&
+	    !atomic_xchg(&cookie->fq_timer_on, 1))
+		mod_timer(&cookie->fq_timer,
+			  jiffies + msecs_to_jiffies(cookie->options.fq_timeout));
 }
 
 static int __iommu_map(struct iommu_domain *domain, unsigned long iova,
@@ -459,58 +506,6 @@ static int dma_info_to_prot(enum dma_data_direction dir, bool coherent,
 	default:
 		return 0;
 	}
-}
-
-static void queue_iova(struct iommu_dma_cookie *cookie,
-		unsigned long pfn, unsigned long pages,
-		struct list_head *freelist)
-{
-	struct iova_fq *fq;
-	unsigned long flags;
-	unsigned int idx;
-
-	/*
-	 * Order against the IOMMU driver's pagetable update from unmapping
-	 * @pte, to guarantee that fq_flush_iotlb() observes that if called
-	 * from a different CPU before we release the lock below. Full barrier
-	 * so it also pairs with iommu_dma_init_fq() to avoid seeing partially
-	 * written fq state here.
-	 */
-	smp_mb();
-
-	if (cookie->options.qt == IOMMU_DMA_OPTS_SINGLE_QUEUE)
-		fq = cookie->single_fq;
-	else
-		fq = raw_cpu_ptr(cookie->percpu_fq);
-
-	spin_lock_irqsave(&fq->lock, flags);
-
-	/*
-	 * First remove all entries from the flush queue that have already been
-	 * flushed out on another CPU. This makes the fq_full() check below less
-	 * likely to be true.
-	 */
-	fq_ring_free_locked(cookie, fq);
-
-	if (fq_full(fq)) {
-		fq_flush_iotlb(cookie);
-		fq_ring_free_locked(cookie, fq);
-	}
-
-	idx = fq_ring_add(fq);
-
-	fq->entries[idx].iova_pfn = pfn;
-	fq->entries[idx].pages    = pages;
-	fq->entries[idx].counter  = atomic64_read(&cookie->fq_flush_start_cnt);
-	list_splice(freelist, &fq->entries[idx].freelist);
-
-	spin_unlock_irqrestore(&fq->lock, flags);
-
-	/* Avoid false sharing as much as possible. */
-	if (!atomic_read(&cookie->fq_timer_on) &&
-	    !atomic_xchg(&cookie->fq_timer_on, 1))
-		mod_timer(&cookie->fq_timer,
-			  jiffies + msecs_to_jiffies(IOVA_FQ_TIMEOUT));
 }
 
 static dma_addr_t iommu_dma_alloc_iova(struct iommu_domain *domain,
@@ -1026,8 +1021,6 @@ static int iommu_dma_map_sg_pswiotlb_pagesize(struct device *dev, struct scatter
 	struct scatterlist *s;
 	int i;
 
-	sg_dma_mark_swiotlb(sg);
-
 	for_each_sg(sg, s, nents, i) {
 		sg_dma_address(s) = pswiotlb_iommu_dma_map_page(dev, sg_page(s),
 				s->offset, s->length, dir, attrs);
@@ -1181,7 +1174,7 @@ void pswiotlb_iommu_dma_unmap_sg(struct device *dev, struct scatterlist *sg,
 	dma_addr_t start, end = 0, start_orig;
 	struct scatterlist *tmp, *s;
 	struct scatterlist *sg_orig = sg;
-	int i;
+	int i, j;
 	struct iommu_domain *domain = iommu_get_dma_domain(dev);
 	struct iommu_dma_cookie *cookie = domain->iova_cookie;
 	struct iova_domain *iovad = &cookie->iovad;
@@ -1216,10 +1209,10 @@ void pswiotlb_iommu_dma_unmap_sg(struct device *dev, struct scatterlist *sg,
 		/* check whether dma addr is in local node */
 		start_orig = start;
 		if (dir != DMA_TO_DEVICE) {
-			for_each_sg(sg_orig, s, nents, i) {
+			for_each_sg(sg_orig, s, nents, j) {
 				unsigned int s_iova_off = iova_offset(iovad, s->offset);
 
-				if (i > 0)
+				if (j > 0)
 					start_orig += s_iova_off;
 				iommu_dma_unmap_page_sg(dev, start_orig,
 						s_iova_off, s->length,

--- a/kernel/dma/phytium/pswiotlb-mapping.c
+++ b/kernel/dma/phytium/pswiotlb-mapping.c
@@ -417,7 +417,7 @@ void pswiotlb_setup_dma_ops(struct device *dev)
 	struct pci_dev *pdev;
 
 	if (dev && dev_is_pci(dev) && (pswiotlb_force_disable != true) &&
-			is_phytium_ps_socs()) {
+			is_phytium_ps_socs() && is_pswiotlb_active(dev)) {
 		pdev = to_pci_dev(dev);
 		if (pdev->dev.local_node == NUMA_NO_NODE) {
 			pdev->dev.can_use_pswiotlb = false;

--- a/kernel/dma/phytium/pswiotlb-mapping.c
+++ b/kernel/dma/phytium/pswiotlb-mapping.c
@@ -419,6 +419,13 @@ void pswiotlb_setup_dma_ops(struct device *dev)
 	if (dev && dev_is_pci(dev) && (pswiotlb_force_disable != true) &&
 			is_phytium_ps_socs()) {
 		pdev = to_pci_dev(dev);
+		if (pdev->dev.local_node == NUMA_NO_NODE) {
+			pdev->dev.can_use_pswiotlb = false;
+			dev_info(&pdev->dev, "The device %s use pswiotlb because it does NOT belong to a valid NUMA node\n",
+						pdev->dev.can_use_pswiotlb ? "would" : "would NOT");
+			return;
+		}
+
 		pdev->dev.can_use_pswiotlb = pswiotlb_is_dev_in_passthroughlist(pdev);
 		dev_info(&pdev->dev, "The device %s use pswiotlb because vendor 0x%04x %s in pswiotlb passthroughlist\n",
 					pdev->dev.can_use_pswiotlb ? "would" : "would NOT",

--- a/kernel/dma/phytium/pswiotlb.c
+++ b/kernel/dma/phytium/pswiotlb.c
@@ -1123,10 +1123,10 @@ static int pswiotlb_pool_find_slots(struct device *dev, int nid, struct p_io_tlb
 		index = pswiotlb_area_find_slots(dev, nid, pool, i, orig_addr,
 						alloc_size, alloc_align_mask);
 		if (index >= 0) {
-			if ((pool != &p_io_tlb_default_mem[nid].defpool) &&
-						!pool->transient) {
-				bitmap_set(pool->busy_record, i, 1);
-			}
+			if ((pool != &p_io_tlb_default_mem[nid].defpool)
+						&& !pool->transient
+						&& !test_bit(i, pool->busy_record))
+				set_bit(i, pool->busy_record);
 			return index;
 		}
 		if (++i >= pool->nareas)
@@ -1428,8 +1428,9 @@ static void pswiotlb_release_slots(struct device *dev, int nid, phys_addr_t tlb_
 	     i--)
 		mem->slots[i].list = ++count;
 	area->used -= nslots;
-	if ((mem != &p_io_tlb_default_mem[nid].defpool) && (area->used == 0))
-		bitmap_clear(mem->busy_record, aindex, 1);
+	if ((mem != &p_io_tlb_default_mem[nid].defpool) && (area->used == 0)
+				&& test_bit(aindex, mem->busy_record))
+		clear_bit(aindex, mem->busy_record);
 	clear_bit(PG_pswiotlb, &page->flags);
 	spin_unlock_irqrestore(&area->lock, flags);
 }

--- a/kernel/dma/phytium/pswiotlb.c
+++ b/kernel/dma/phytium/pswiotlb.c
@@ -870,6 +870,9 @@ void pswiotlb_store_local_node(struct pci_dev *dev, struct pci_bus *bus)
 	struct p_io_tlb_pool *defpool;
 	struct p_io_tlb_mem *mem;
 
+	if (!pswiotlb_node_num)
+		return;
+
 	dev->dev.local_node = pcibus_to_node(bus);
 	if (dev->dev.local_node == NUMA_NO_NODE)
 		return;
@@ -882,6 +885,8 @@ void pswiotlb_store_local_node(struct pci_dev *dev, struct pci_bus *bus)
 	pci_info(dev, "numa node: %d, pswiotlb defpool range: [%#018Lx-%#018Lx]\n"
 				"local node range: [%#018Lx-%#018Lx]\n", nid,
 		defpool->start, defpool->end, mem->node_min_addr, mem->node_max_addr);
+
+	dma_set_seg_boundary(&dev->dev, 0xffffffffffff);
 }
 /*
  * Return the offset into a pswiotlb slot required to keep the device happy.
@@ -1723,6 +1728,9 @@ static void pswiotlb_create_pswiotlb_debugfs_files(const char *dirname)
 static int __init pswiotlb_create_default_debugfs(void)
 {
 	char name[20] = "";
+
+	if (!pswiotlb_node_num)
+		return 0;
 
 	if (!pswiotlb_mtimer_alive && !pswiotlb_force_disable
 				&& is_phytium_ps_socs()) {

--- a/kernel/dma/phytium/pswiotlb.c
+++ b/kernel/dma/phytium/pswiotlb.c
@@ -871,6 +871,9 @@ void pswiotlb_store_local_node(struct pci_dev *dev, struct pci_bus *bus)
 	struct p_io_tlb_mem *mem;
 
 	dev->dev.local_node = pcibus_to_node(bus);
+	if (dev->dev.local_node == NUMA_NO_NODE)
+		return;
+
 	/* register pswiotlb resources */
 	dev->dev.dma_p_io_tlb_mem = p_io_tlb_default_mem;
 	nid = dev->dev.local_node;


### PR DESCRIPTION
This patches updates the support for phytium XXX controller driver.
1.Bypass pswiotlb when the device NUMA node is invalid
2.Adapt to the IOMMU DMA API upgraded by IOMMUFD
3.Pswiotlb unmapsg use independent sglist index
4.Atomic operations are used when recording busy areas
5.Disable pswiotlb in the kdump kernel