### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] arm64: Remove cpus_have_const_cap() part2

### DIFF
--- a/arch/arm64/include/asm/cpufeature.h
+++ b/arch/arm64/include/asm/cpufeature.h
@@ -466,19 +466,6 @@ static __always_inline bool cpus_have_cap(unsigned int num)
 /*
  * Test for a capability without a runtime check.
  *
- * Before capabilities are finalized, this returns false.
- * After capabilities are finalized, this is patched to avoid a runtime check.
- *
- * @num must be a compile-time constant.
- */
-static __always_inline bool __cpus_have_const_cap(int num)
-{
-	return alternative_has_cap_unlikely(num);
-}
-
-/*
- * Test for a capability without a runtime check.
- *
  * Before boot capabilities are finalized, this will BUG().
  * After boot capabilities are finalized, this is patched to avoid a runtime
  * check.
@@ -488,7 +475,7 @@ static __always_inline bool __cpus_have_const_cap(int num)
 static __always_inline bool cpus_have_final_boot_cap(int num)
 {
 	if (boot_capabilities_finalized())
-		return __cpus_have_const_cap(num);
+		return alternative_has_cap_unlikely(num);
 	else
 		BUG();
 }
@@ -505,30 +492,9 @@ static __always_inline bool cpus_have_final_boot_cap(int num)
 static __always_inline bool cpus_have_final_cap(int num)
 {
 	if (system_capabilities_finalized())
-		return __cpus_have_const_cap(num);
+		return alternative_has_cap_unlikely(num);
 	else
 		BUG();
-}
-
-/*
- * Test for a capability, possibly with a runtime check for non-hyp code.
- *
- * For hyp code, this behaves the same as cpus_have_final_cap().
- *
- * For non-hyp code:
- * Before capabilities are finalized, this behaves as cpus_have_cap().
- * After capabilities are finalized, this is patched to avoid a runtime check.
- *
- * @num must be a compile-time constant.
- */
-static __always_inline bool cpus_have_const_cap(int num)
-{
-	if (is_hyp_code())
-		return cpus_have_final_cap(num);
-	else if (system_capabilities_finalized())
-		return __cpus_have_const_cap(num);
-	else
-		return cpus_have_cap(num);
 }
 
 static inline int __attribute_const__

--- a/arch/arm64/include/asm/cpufeature.h
+++ b/arch/arm64/include/asm/cpufeature.h
@@ -828,7 +828,7 @@ static __always_inline bool system_uses_irq_prio_masking(void)
 static __always_inline bool system_uses_nmi(void)
 {
 	return IS_ENABLED(CONFIG_ARM64_NMI) &&
-		cpus_have_const_cap(ARM64_USES_NMI);
+		alternative_has_cap_likely(ARM64_USES_NMI);
 }
 
 static inline bool system_supports_mte(void)

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -3559,7 +3559,6 @@ EXPORT_SYMBOL_GPL(this_cpu_has_cap);
  * This helper function is used in a narrow window when,
  * - The system wide safe registers are set with all the SMP CPUs and,
  * - The SYSTEM_FEATURE system_cpucaps may not have been set.
- * In all other cases cpus_have_{const_}cap() should be used.
  */
 static bool __maybe_unused __system_matches_cap(unsigned int n)
 {


### PR DESCRIPTION
#1822

## Summary by Sourcery

Remove the cpus_have_const_cap() helper and update remaining callers to use alternative_has_cap_*() directly for finalized CPU capability checks on arm64.

Enhancements:
- Simplify arm64 CPU capability checks by inlining alternative_has_cap_*() in finalized capability helpers and NMI usage detection.
- Clean up stale documentation/comments related to deprecated cpus_have_const_cap() usage.