### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] mm: more ptep_get() conversion

### DIFF
--- a/mm/filemap.c
+++ b/mm/filemap.c
@@ -3525,7 +3525,7 @@ static vm_fault_t filemap_map_folio_range(struct vm_fault *vmf,
 		 * handled in the specific fault path, and it'll prohibit the
 		 * fault-around logic.
 		 */
-		if (!pte_none(vmf->pte[count]))
+		if (!pte_none(ptep_get(&vmf->pte[count])))
 			goto skip;
 
 		count++;

--- a/mm/ksm.c
+++ b/mm/ksm.c
@@ -455,7 +455,7 @@ static int break_ksm_pmd_entry(pmd_t *pmd, unsigned long addr, unsigned long nex
 			page = pfn_swap_entry_to_page(entry);
 	}
 	/* return 1 if the page is an normal ksm page or KSM-placed zero page */
-	ret = (page && PageKsm(page)) || is_ksm_zero_pte(*pte);
+	ret = (page && PageKsm(page)) || is_ksm_zero_pte(ptent);
 	pte_unmap_unlock(pte, ptl);
 	return ret;
 }

--- a/mm/userfaultfd.c
+++ b/mm/userfaultfd.c
@@ -347,7 +347,7 @@ static int mfill_atomic_pte_poison(pmd_t *dst_pmd,
 
 	ret = -EEXIST;
 	/* Refuse to overwrite any PTE, even a PTE marker (e.g. UFFD WP). */
-	if (!pte_none(*dst_pte))
+	if (!pte_none(ptep_get(dst_pte)))
 		goto out_unlock;
 
 	set_pte_at(dst_mm, dst_addr, dst_pte, _dst_pte);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc2
category: bugfix

Commit c33c794828f2 ("mm: ptep_get() conversion") converted all (non-arch) call sites to use ptep_get() instead of doing a direct dereference of the pte.  Full rationale can be found in that commit's log.

Since then, three new call sites have snuck in, which directly dereference the pte, so let's fix those up.

Unfortunately there is no reliable automated mechanism to catch these; I'm relying on a combination of Coccinelle (which throws up a lot of false positives) and some compiler magic to force a compiler error on dereference (While this approach finds dereferences, it also yields a non-booting kernel so can't be committed).

Link: https://lkml.kernel.org/r/20231114154945.490401-1-ryan.roberts@arm.com

Cc: Matthew Wilcox (Oracle) <willy@infradead.org>

(cherry picked from commit afccb0804fc74ac2f6737af6a139632606cb461d)

## Summary by Sourcery

Bug Fixes:
- Prevent unsafe or inconsistent direct PTE dereferences in filemap, KSM, and userfaultfd paths by switching to ptep_get()-based checks and existing ptent variables.