### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y]  [Upstream] mm/memory_hotplug: drop memblock_phys_free() call in try_remove_memory()

### DIFF
--- a/mm/memory_hotplug.c
+++ b/mm/memory_hotplug.c
@@ -2215,10 +2215,8 @@ static int __ref try_remove_memory(u64 start, u64 size)
 		kfree(altmap);
 	}
 
-	if (IS_ENABLED(CONFIG_ARCH_KEEP_MEMBLOCK)) {
-		memblock_phys_free(start, size);
+	if (IS_ENABLED(CONFIG_ARCH_KEEP_MEMBLOCK))
 		memblock_remove(start, size);
-	}
 
 	release_mem_region_adjustable(start, size);
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.11-rc1
category: phytium

The call for memblock_phys_free() in try_remove_memory() does not balance any call to memblock_alloc() (or memblock_reserve() for that matter).

There are no memblock_reserve() calls in mm/memory_hotplug.c, no memblock allocations possible after mm_core_init(), and even if memblock_add_node() called from add_memory_resource() would need to allocate memory, that memory would ba allocated from slab.

The patch f9126ab9241f ("memory-hotplug: fix wrong edge when hot add a new node") that introduced that call to memblock_free() does not provide adequate description why that was required and tinkering with memblock in the context of memory hotplug on x86 seems bogus because x86 never kept memblock after boot anyway.

Drop memblock_phys_free() call in try_remove_memory().

[rppt@kernel.org: rewrite the commit message]
Link: https://lkml.kernel.org/r/20240605082049.973242-1-rppt@kernel.org


Acked-by: David Hildenbrand <david@redhat.com>
Acked-by: Oscar Salvador <osalvador@suse.de>

(cherry picked from commit 7b09fa7ea4ee91ec2ad8ea6e9560f63901f2b76a)

## Summary by Sourcery

Bug Fixes:
- Prevent potential inconsistencies in memory hotplug handling by removing an unnecessary memblock_phys_free() call that was not paired with a corresponding memblock allocation.