### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] [Backport] wifi: mt76: mt7921: fix potential deadlock in mt7921_roc_abort_sync

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -336,12 +336,15 @@ void mt7921_roc_abort_sync(struct mt792x_dev *dev)
 {
 	struct mt792x_phy *phy = &dev->phy;
 
+	if (!test_and_clear_bit(MT76_STATE_ROC, &phy->mt76->state))
+		return;
+
 	del_timer_sync(&phy->roc_timer);
-	cancel_work_sync(&phy->roc_work);
-	if (test_and_clear_bit(MT76_STATE_ROC, &phy->mt76->state))
-		ieee80211_iterate_active_interfaces(mt76_hw(dev),
-						    IEEE80211_IFACE_ITER_RESUME_ALL,
-						    mt7921_roc_iter, (void *)phy);
+	cancel_work(&phy->roc_work);
+
+	ieee80211_iterate_interfaces(mt76_hw(dev),
+				     IEEE80211_IFACE_ITER_RESUME_ALL,
+				     mt7921_roc_iter, (void *)phy);
 }
 EXPORT_SYMBOL_GPL(mt7921_roc_abort_sync);
 


### PR DESCRIPTION
stable inclusion
from stable-v6.18.33
category: bugfix

[ Upstream commit d5059e52fd8bc624ec4255c9fa01a266513d126b ]

roc_abort_sync() can deadlock with roc_work(). roc_work() holds dev->mt76.mutex, while cancel_work_sync() waits for roc_work() to finish. If the caller already owns the same mutex, both sides block and no progress is possible.

This deadlock can occur during station removal when mt76_sta_state() -> mt76_sta_remove() -> mt7921_mac_sta_remove() -> mt7921_roc_abort_sync() invokes cancel_work_sync() while roc_work() is still running and holding dev->mt76.mutex.

This avoids the mutex deadlock and preserves exactly-once work ownership.

Fixes: 352d966126e6 ("wifi: mt76: mt7921: fix a potential association failure upon resuming")
Co-developed-by: Quan Zhou <quan.zhou@mediatek.com>


Link: https://patch.msgid.link/20260126180013.8167-1-sean.wang@kernel.org


[rename timer_delete_sync to del_timer_sync for v6.6 kernel KAPI] Conflicts:
	drivers/net/wireless/mediatek/mt76/mt7921/main.c
(cherry picked from commit 35180c772f5e11e2fa4d80d3dfd50906cb6d9646)

## Summary by Sourcery

Bug Fixes:
- Prevent deadlock between roc_abort_sync and roc_work by avoiding cancel_work_sync while holding the mt76 mutex.