### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] wifi: mt76: mt7925: fix off by one in mt7925_load_clc()

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7925/mcu.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7925/mcu.c
@@ -613,7 +613,7 @@ static int mt7925_load_clc(struct mt792x_dev *dev, const char *fw_name)
 	for (offset = 0; offset < len; offset += le32_to_cpu(clc->len)) {
 		clc = (const struct mt7925_clc *)(clc_base + offset);
 
-		if (clc->idx > ARRAY_SIZE(phy->clc))
+		if (clc->idx >= ARRAY_SIZE(phy->clc))
 			break;
 
 		/* do not init buf again if chip reset triggered */


### PR DESCRIPTION
mainline inclusion
from mainline-v6.14-rc1
category: bugfix

This comparison should be >= instead of > to prevent an out of bounds read and write.

Fixes: 9679ca7326e5 ("wifi: mt76: mt7925: fix a potential array-index-out-of-bounds issue for clc")

Link: https://patch.msgid.link/84bf5dd2-2fe3-4410-a7af-ae841e41082a@stanley.mountain

(cherry picked from commit 08fa656c91fd5fdf47ba393795b9c0d1e97539ed)

## Summary by Sourcery

Bug Fixes:
- Correct the CLC index comparison in mt7925 firmware loading to avoid potential out-of-bounds reads and writes.