### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] big header dependency cleanup targeting sched.h

### DIFF
--- a/arch/arm64/include/asm/spectre.h
+++ b/arch/arm64/include/asm/spectre.h
@@ -13,8 +13,8 @@
 #define __BP_HARDEN_HYP_VECS_SZ	((BP_HARDEN_EL2_SLOTS - 1) * SZ_2K)
 
 #ifndef __ASSEMBLY__
-
-#include <linux/percpu.h>
+#include <linux/smp.h>
+#include <asm/percpu.h>
 
 #include <asm/cpufeature.h>
 #include <asm/virt.h>

--- a/arch/m68k/include/asm/processor.h
+++ b/arch/m68k/include/asm/processor.h
@@ -8,6 +8,7 @@
 #ifndef __ASM_M68K_PROCESSOR_H
 #define __ASM_M68K_PROCESSOR_H
 
+#include <linux/preempt.h>
 #include <linux/thread_info.h>
 #include <asm/fpu.h>
 #include <asm/ptrace.h>

--- a/arch/microblaze/include/asm/pgtable.h
+++ b/arch/microblaze/include/asm/pgtable.h
@@ -336,6 +336,7 @@ static inline void set_pte(pte_t *ptep, pte_t pte)
 }
 
 #define __HAVE_ARCH_PTEP_TEST_AND_CLEAR_YOUNG
+struct vm_area_struct;
 static inline int ptep_test_and_clear_young(struct vm_area_struct *vma,
 		unsigned long address, pte_t *ptep)
 {

--- a/arch/x86/include/asm/debugreg.h
+++ b/arch/x86/include/asm/debugreg.h
@@ -5,6 +5,7 @@
 #include <linux/bug.h>
 #include <linux/percpu.h>
 #include <uapi/asm/debugreg.h>
+#include <asm/cpufeature.h>
 
 DECLARE_PER_CPU(unsigned long, cpu_dr7);
 

--- a/arch/x86/include/asm/paravirt.h
+++ b/arch/x86/include/asm/paravirt.h
@@ -6,6 +6,10 @@
 
 #include <asm/paravirt_types.h>
 
+#ifndef __ASSEMBLY__
+struct mm_struct;
+#endif
+
 #ifdef CONFIG_PARAVIRT
 #include <asm/pgtable_types.h>
 #include <asm/asm.h>

--- a/arch/x86/include/asm/paravirt_types.h
+++ b/arch/x86/include/asm/paravirt_types.h
@@ -3,6 +3,8 @@
 #define _ASM_X86_PARAVIRT_TYPES_H
 
 #ifndef __ASSEMBLY__
+#include <linux/types.h>
+
 /* These all sit in the .parainstructions section to tell us what to patch. */
 struct paravirt_patch_site {
 	u8 *instr;		/* original instructions */

--- a/arch/x86/kernel/fpu/bugs.c
+++ b/arch/x86/kernel/fpu/bugs.c
@@ -2,6 +2,7 @@
 /*
  * x86 FPU bug checks:
  */
+#include <asm/cpufeature.h>
 #include <asm/fpu/api.h>
 
 /*

--- a/arch/x86/lib/cache-smp.c
+++ b/arch/x86/lib/cache-smp.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#include <asm/paravirt.h>
 #include <linux/smp.h>
 #include <linux/export.h>
 

--- a/drivers/base/power/runtime.c
+++ b/drivers/base/power/runtime.c
@@ -11,6 +11,7 @@
 #include <linux/export.h>
 #include <linux/pm_runtime.h>
 #include <linux/pm_wakeirq.h>
+#include <linux/rculist.h>
 #include <trace/events/rpm.h>
 
 #include "../base.h"

--- a/drivers/gpu/drm/i915/i915_memcpy.c
+++ b/drivers/gpu/drm/i915/i915_memcpy.c
@@ -23,6 +23,8 @@
  */
 
 #include <linux/kernel.h>
+#include <linux/string.h>
+#include <linux/cpufeature.h>
 #include <asm/fpu/api.h>
 
 #include "i915_memcpy.h"

--- a/drivers/media/test-drivers/vidtv/vidtv_pes.c
+++ b/drivers/media/test-drivers/vidtv/vidtv_pes.c
@@ -14,6 +14,7 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ":%s, %d: " fmt, __func__, __LINE__
 
 #include <linux/types.h>
+#include <linux/math64.h>
 #include <linux/printk.h>
 #include <linux/ratelimit.h>
 

--- a/include/linux/hrtimer.h
+++ b/include/linux/hrtimer.h
@@ -16,7 +16,7 @@
 #include <linux/rbtree.h>
 #include <linux/init.h>
 #include <linux/list.h>
-#include <linux/percpu.h>
+#include <linux/percpu-defs.h>
 #include <linux/seqlock.h>
 #include <linux/timer.h>
 #include <linux/timerqueue.h>

--- a/include/linux/kmsan_types.h
+++ b/include/linux/kmsan_types.h
@@ -9,6 +9,8 @@
 #ifndef _LINUX_KMSAN_TYPES_H
 #define _LINUX_KMSAN_TYPES_H
 
+#include <linux/types.h>
+
 /* These constants are defined in the MSan LLVM instrumentation pass. */
 #define KMSAN_RETVAL_SIZE 800
 #define KMSAN_PARAM_SIZE 800

--- a/include/linux/ktime.h
+++ b/include/linux/ktime.h
@@ -21,12 +21,10 @@
 #ifndef _LINUX_KTIME_H
 #define _LINUX_KTIME_H
 
-#include <linux/time.h>
-#include <linux/jiffies.h>
 #include <asm/bug.h>
-
-/* Nanosecond scalar representation for kernel time values */
-typedef s64	ktime_t;
+#include <linux/jiffies.h>
+#include <linux/time.h>
+#include <linux/types.h>
 
 /**
  * ktime_set - Set a ktime_t variable from a seconds/nanoseconds value

--- a/include/linux/nodemask.h
+++ b/include/linux/nodemask.h
@@ -93,10 +93,10 @@
 #include <linux/threads.h>
 #include <linux/bitmap.h>
 #include <linux/minmax.h>
+#include <linux/nodemask_types.h>
 #include <linux/numa.h>
 #include <linux/random.h>
 
-typedef struct { DECLARE_BITMAP(bits, MAX_NUMNODES); } nodemask_t;
 extern nodemask_t _unused_nodemask_arg_;
 
 /**

--- a/include/linux/nodemask_types.h
+++ b/include/linux/nodemask_types.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __LINUX_NODEMASK_TYPES_H
+#define __LINUX_NODEMASK_TYPES_H
+
+#include <linux/bitops.h>
+#include <linux/numa.h>
+
+typedef struct { DECLARE_BITMAP(bits, MAX_NUMNODES); } nodemask_t;
+
+#endif /* __LINUX_NODEMASK_TYPES_H */

--- a/include/linux/nsproxy.h
+++ b/include/linux/nsproxy.h
@@ -2,6 +2,7 @@
 #ifndef _LINUX_NSPROXY_H
 #define _LINUX_NSPROXY_H
 
+#include <linux/refcount.h>
 #include <linux/spinlock.h>
 #include <linux/sched.h>
 #include <linux/deepin_kabi.h>

--- a/include/linux/prandom.h
+++ b/include/linux/prandom.h
@@ -10,7 +10,6 @@
 
 #include <linux/types.h>
 #include <linux/once.h>
-#include <linux/percpu.h>
 #include <linux/random.h>
 
 struct rnd_state {

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -20,7 +20,7 @@
 #include <linux/hrtimer.h>
 #include <linux/irqflags.h>
 #include <linux/seccomp.h>
-#include <linux/nodemask.h>
+#include <linux/nodemask_types.h>
 #include <linux/rcupdate.h>
 #include <linux/refcount.h>
 #include <linux/resource.h>

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -2293,37 +2293,6 @@ static inline bool preempt_model_preemptible(void)
 	return preempt_model_full() || preempt_model_rt();
 }
 
-/*
- * Does a critical section need to be broken due to another
- * task waiting?: (technically does not depend on CONFIG_PREEMPTION,
- * but a general need for low latency)
- */
-static inline int spin_needbreak(spinlock_t *lock)
-{
-#ifdef CONFIG_PREEMPTION
-	return spin_is_contended(lock);
-#else
-	return 0;
-#endif
-}
-
-/*
- * Check if a rwlock is contended.
- * Returns non-zero if there is another task waiting on the rwlock.
- * Returns zero if the lock is not contended or the system / underlying
- * rwlock implementation does not support contention detection.
- * Technically does not depend on CONFIG_PREEMPTION, but a general need
- * for low latency.
- */
-static inline int rwlock_needbreak(rwlock_t *lock)
-{
-#ifdef CONFIG_PREEMPTION
-	return rwlock_is_contended(lock);
-#else
-	return 0;
-#endif
-}
-
 static __always_inline bool need_resched(void)
 {
 	return unlikely(tif_need_resched());

--- a/include/linux/sched/task_stack.h
+++ b/include/linux/sched/task_stack.h
@@ -9,6 +9,7 @@
 #include <linux/sched.h>
 #include <linux/magic.h>
 #include <linux/kasan.h>
+#include <linux/refcount.h>
 
 #ifdef CONFIG_THREAD_INFO_IN_TASK
 

--- a/include/linux/spinlock.h
+++ b/include/linux/spinlock.h
@@ -449,6 +449,37 @@ static __always_inline int spin_is_contended(spinlock_t *lock)
 	return raw_spin_is_contended(&lock->rlock);
 }
 
+/*
+ * Does a critical section need to be broken due to another
+ * task waiting?: (technically does not depend on CONFIG_PREEMPTION,
+ * but a general need for low latency)
+ */
+static inline int spin_needbreak(spinlock_t *lock)
+{
+#ifdef CONFIG_PREEMPTION
+	return spin_is_contended(lock);
+#else
+	return 0;
+#endif
+}
+
+/*
+ * Check if a rwlock is contended.
+ * Returns non-zero if there is another task waiting on the rwlock.
+ * Returns zero if the lock is not contended or the system / underlying
+ * rwlock implementation does not support contention detection.
+ * Technically does not depend on CONFIG_PREEMPTION, but a general need
+ * for low latency.
+ */
+static inline int rwlock_needbreak(rwlock_t *lock)
+{
+#ifdef CONFIG_PREEMPTION
+	return rwlock_is_contended(lock);
+#else
+	return 0;
+#endif
+}
+
 #define assert_spin_locked(lock)	assert_raw_spin_locked(&(lock)->rlock)
 
 #else  /* !CONFIG_PREEMPT_RT */

--- a/include/linux/time_namespace.h
+++ b/include/linux/time_namespace.h
@@ -7,6 +7,7 @@
 #include <linux/nsproxy.h>
 #include <linux/ns_common.h>
 #include <linux/err.h>
+#include <linux/time64.h>
 
 struct user_namespace;
 extern struct user_namespace init_user_ns;

--- a/include/linux/time_namespace.h
+++ b/include/linux/time_namespace.h
@@ -12,6 +12,8 @@
 struct user_namespace;
 extern struct user_namespace init_user_ns;
 
+struct vm_area_struct;
+
 struct timens_offsets {
 	struct timespec64 monotonic;
 	struct timespec64 boottime;

--- a/include/linux/torture.h
+++ b/include/linux/torture.h
@@ -21,6 +21,7 @@
 #include <linux/debugobjects.h>
 #include <linux/bug.h>
 #include <linux/compiler.h>
+#include <linux/hrtimer.h>
 
 /* Definitions for a non-string torture-test module parameter. */
 #define torture_param(type, name, init, msg) \

--- a/include/linux/types.h
+++ b/include/linux/types.h
@@ -121,6 +121,9 @@ typedef s64			int64_t;
 #define aligned_be64		__aligned_be64
 #define aligned_le64		__aligned_le64
 
+/* Nanosecond scalar representation for kernel time values */
+typedef s64	ktime_t;
+
 /**
  * The type used for indexing onto a disc or disc partition.
  *

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -53,6 +53,7 @@
 #include <linux/seccomp.h>
 #include <linux/swap.h>
 #include <linux/syscalls.h>
+#include <linux/syscall_user_dispatch.h>
 #include <linux/jiffies.h>
 #include <linux/futex.h>
 #include <linux/compat.h>


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20231216024834.3510073-1-kent.overstreet@linux.dev/
 the issue being targeted here is that sched.h is entirely too much of an
everything header, and a nexus of recursive header dependencies.

the main strategy is to try to only pull type definitions into sched.h,
by splitting out *_types.h versions of sched.h dependencies, and
secondarily moving code out of sched.h into more appropriate locations.

this patchset does not go quite as far as I would have liked;
arch/x86/include/asm/processor.h also pulls in way too much, and I would
like to also split out a _types.h version for that, but that would
entail changing every arch's version of that header and I'm not going to
tackle that yet.

if we do get that done, the number of headers pulled in by sched.h will
be cut approximately in half (from well over 300 to 170-180) on an
allyesconfig.

build tested on x86, still needs build testing on other archs

https://evilpiepirate.org/git/bcachefs.git/log/?h=header_cleanup

Kent Overstreet (49):
  drivers/gpu/drm/i915/i915_memcpy.c: fix missing includes
  x86/kernel/fpu/bugs.c: fix missing include
  x86/lib/cache-smp.c: fix missing include
  x86/include/asm/debugreg.h: fix missing include
  x86/include/asm/paravirt_types.h: fix missing include
  task_stack.h: add missing include
  nsproxy.h: add missing include
  kernel/fork.c: add missing include
  kmsan: add missing types.h dependency
  time_namespace.h: fix missing include
  nodemask: Split out include/linux/nodemask_types.h
  prandom: Remove unused include
  timekeeping: Kill percpu.h dependency
  arm64: Fix circular header dependency
  kernel/numa.c: Move logging out of numa.h
  sched.h: Move (spin|rwlock)_needbreak() to spinlock.h
  ktime.h: move ktime_t to types.h
  hrtimers: Split out hrtimer_types.h
  locking/mutex: split out mutex_types.h
  posix-cpu-timers: Split out posix-timers_types.h
  locking/seqlock: Split out seqlock_types.h
  pid: Split out pid_types.h
  sched.h: move pid helpers to pid.h
  plist: Split out plist_types.h
  rslib: kill bogus dependency on list.h
  timerqueue: Split out timerqueue_types.h
  signal: Kill bogus dependency on list.h
  timers: Split out timer_types.h
  workqueue: Split out workqueue_types.h
  shm: Slim down dependencies
  ipc: Kill bogus dependency on spinlock.h
  Split out irqflags_types.h
  mm_types_task.h: Trim dependencies
  cpumask: Split out cpumask_types.h
  syscall_user_dispatch.h: split out *_types.h
  x86/signal: kill dependency on time.h
  uapi/linux/resource.h: fix include
  refcount: Split out refcount_types.h
  seccomp: Split out seccomp_types.h
  uidgid: Split out uidgid_types.h
  sem: Split out sem_types.h
  lockdep: move held_lock to lockdep_types.h
  restart_block: Trim includes
  rseq: Split out rseq.h from sched.h
  preempt.h: Kill dependency on list.h
  thread_info, uaccess.h: Move HARDENED_USERCOPY to better location
  Kill unnecessary kernel.h include
  kill unnecessary thread_info.h include
  Kill sched.h dependency on rcupdate.h

Matthew Wilcox (Oracle) (1):
  wait: Remove uapi header file from main header file

 arch/arm64/include/asm/spectre.h            |   4 +-
 arch/x86/include/asm/current.h              |   1 +
 arch/x86/include/asm/debugreg.h             |   1 +
 arch/x86/include/asm/fpu/types.h            |   2 +
 arch/x86/include/asm/paravirt_types.h       |   2 +
 arch/x86/include/asm/percpu.h               |   2 +-
 arch/x86/include/asm/preempt.h              |   1 -
 arch/x86/include/asm/tlbbatch.h             |   2 +-
 arch/x86/include/uapi/asm/signal.h          |   1 -
 arch/x86/kernel/fpu/bugs.c                  |   1 +
 arch/x86/kernel/signal.c                    |   1 +
 arch/x86/lib/cache-smp.c                    |   1 +
 drivers/gpu/drm/i915/i915_memcpy.c          |   2 +
 drivers/target/target_core_xcopy.c          |   1 +
 fs/exec.c                                   |   1 +
 include/linux/audit.h                       |   1 +
 include/linux/cpumask.h                     |   4 +-
 include/linux/cpumask_types.h               |  12 +
 include/linux/dma-fence.h                   |   1 +
 include/linux/hrtimer.h                     |  46 +--
 include/linux/hrtimer_types.h               |  50 +++
 include/linux/ipc.h                         |   2 +-
 include/linux/irqflags.h                    |  14 +-
 include/linux/irqflags_types.h              |  22 ++
 include/linux/kmsan_types.h                 |   2 +
 include/linux/ktime.h                       |   8 +-
 include/linux/lockdep.h                     |  57 ----
 include/linux/lockdep_types.h               |  57 ++++
 include/linux/mm_types_task.h               |   7 +-
 include/linux/mutex.h                       |  52 +---
 include/linux/mutex_types.h                 |  71 +++++
 include/linux/nodemask.h                    |   2 +-
 include/linux/nodemask_types.h              |  10 +
 include/linux/nsproxy.h                     |   1 +
 include/linux/numa.h                        |  18 +-
 include/linux/pid.h                         | 140 ++++++++-
 include/linux/pid_types.h                   |  16 +
 include/linux/plist.h                       |  12 +-
 include/linux/plist_types.h                 |  17 ++
 include/linux/posix-timers.h                |  68 +----
 include/linux/posix-timers_types.h          |  72 +++++
 include/linux/prandom.h                     |   1 -
 include/linux/preempt.h                     |   6 +-
 include/linux/rcupdate.h                    |  11 +
 include/linux/refcount.h                    |  13 +-
 include/linux/refcount_types.h              |  19 ++
 include/linux/restart_block.h               |   2 +-
 include/linux/resume_user_mode.h            |   1 +
 include/linux/rhashtable-types.h            |   2 +-
 include/linux/rseq.h                        | 131 ++++++++
 include/linux/rslib.h                       |   1 -
 include/linux/sched.h                       | 320 ++------------------
 include/linux/sched/signal.h                |   1 +
 include/linux/sched/task_stack.h            |   1 +
 include/linux/seccomp.h                     |  22 +-
 include/linux/seccomp_types.h               |  26 ++
 include/linux/sem.h                         |  10 +-
 include/linux/sem_types.h                   |  13 +
 include/linux/seqlock.h                     |  79 +----
 include/linux/seqlock_types.h               |  93 ++++++
 include/linux/shm.h                         |   4 +-
 include/linux/signal.h                      |   1 +
 include/linux/signal_types.h                |   2 +-
 include/linux/spinlock.h                    |  31 ++
 include/linux/syscall_user_dispatch.h       |   9 +-
 include/linux/syscall_user_dispatch_types.h |  22 ++
 include/linux/thread_info.h                 |  49 ---
 include/linux/time_namespace.h              |   3 +
 include/linux/timekeeping.h                 |   1 +
 include/linux/timer.h                       |  16 +-
 include/linux/timer_types.h                 |  23 ++
 include/linux/timerqueue.h                  |  13 +-
 include/linux/timerqueue_types.h            |  17 ++
 include/linux/types.h                       |   3 +
 include/linux/uaccess.h                     |  49 +++
 include/linux/uidgid.h                      |  11 +-
 include/linux/uidgid_types.h                |  15 +
 include/linux/uio.h                         |   2 +-
 include/linux/wait.h                        |   1 -
 include/linux/workqueue.h                   |  16 +-
 include/linux/workqueue_types.h             |  25 ++
 include/uapi/linux/resource.h               |   2 +-
 init/init_task.c                            |   1 +
 ipc/shm.c                                   |   1 +
 kernel/Makefile                             |   1 +
 kernel/exit.c                               |   4 +-
 kernel/fork.c                               |   2 +
 kernel/futex/core.c                         |   1 +
 kernel/futex/requeue.c                      |   1 +
 kernel/futex/waitwake.c                     |   1 +
 kernel/numa.c                               |  24 ++
 kernel/pid_namespace.c                      |   1 +
 kernel/sched/core.c                         |   1 +
 mm/swapfile.c                               |   1 +
 security/selinux/hooks.c                    |   1 +
 security/smack/smack_lsm.c                  |   1 +
 96 files changed, 1068 insertions(+), 825 deletions(-)
 create mode 100644 include/linux/cpumask_types.h
 create mode 100644 include/linux/hrtimer_types.h
 create mode 100644 include/linux/irqflags_types.h
 create mode 100644 include/linux/mutex_types.h
 create mode 100644 include/linux/nodemask_types.h
 create mode 100644 include/linux/pid_types.h
 create mode 100644 include/linux/plist_types.h
 create mode 100644 include/linux/posix-timers_types.h
 create mode 100644 include/linux/refcount_types.h
 create mode 100644 include/linux/rseq.h
 create mode 100644 include/linux/seccomp_types.h
 create mode 100644 include/linux/sem_types.h
 create mode 100644 include/linux/seqlock_types.h
 create mode 100644 include/linux/syscall_user_dispatch_types.h
 create mode 100644 include/linux/timer_types.h
 create mode 100644 include/linux/timerqueue_types.h
 create mode 100644 include/linux/uidgid_types.h
 create mode 100644 include/linux/workqueue_types.h
 create mode 100644 kernel/numa.c

-- 
2.43.0