### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] powerpc/32s: Implement local_flush_tlb_page_psize()

### DIFF
--- a/arch/powerpc/include/asm/book3s/32/tlbflush.h
+++ b/arch/powerpc/include/asm/book3s/32/tlbflush.h
@@ -83,7 +83,7 @@ static inline void local_flush_tlb_page(struct vm_area_struct *vma,
 static inline void local_flush_tlb_page_psize(struct mm_struct *mm,
 					      unsigned long vmaddr, int psize)
 {
-	BUILD_BUG();
+	flush_range(mm, vmaddr, vmaddr);
 }
 
 static inline void local_flush_tlb_mm(struct mm_struct *mm)


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
category: performance

There's a single call to local_flush_tlb_page_psize() in the code patching code. That call is never executed on 32-bit Book3S, because it's guarded by mm_patch_enabled() which is essentially a radix_enabled() check, which is always false on 32s.

However depending on how the optimiser sees things it may still trip over the BUILD_BUG() in the 32s stub of local_flush_tlb_page_psize().

To avoid that, implement it in terms of flush_range() so that if it ever becomes called it should function, even if not optimally.

Note that flush_range() deals with page aligning the address and so on, and that 32s doesn't support huge pages so there should be no issue with non-standard page sizes needing to be flushed.


Link: https://msgid.link/20231023092319.1507325-1-mpe@ellerman.id.au

(cherry picked from commit aad26d3b6af13c055b1d05dd253d2484551bde55)

## Summary by Sourcery

Bug Fixes:
- Prevent build-time failures on 32-bit Book3S by replacing the local_flush_tlb_page_psize() BUILD_BUG stub with a working implementation based on flush_range().