### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] nvme-tcp: fix the memleak while create new ctrl failed

### DIFF
--- a/drivers/nvme/host/tcp.c
+++ b/drivers/nvme/host/tcp.c
@@ -2149,7 +2149,7 @@ destroy_io:
 	}
 destroy_admin:
 	nvme_stop_keep_alive(ctrl);
-	nvme_tcp_teardown_admin_queue(ctrl, false);
+	nvme_tcp_teardown_admin_queue(ctrl, new);
 	return ret;
 }
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.13-rc2
category: bugfix

Now while we create new ctrl failed, we have not free the tagset occupied by admin_q, here try to fix it.

Fixes: fd1418de10b9 ("nvme-tcp: avoid open-coding nvme_tcp_teardown_admin_queue()")

Reviewed-by: Christoph Hellwig <hch@lst.de>
Reviewed-by: Hannes Reinecke <hare@suse.de>

(cherry picked from commit fec55c29e54d3ca6fe9d7d7d9266098b4514fd34)

## Summary by Sourcery

Bug Fixes:
- Ensure admin queue resources are fully released when nvme-tcp controller creation fails to prevent a memory leak.