### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] deepin: LoongArch: legacyboot: BPI: fix uninitialised field

### DIFF
--- a/arch/loongarch/kernel/legacy_boot.c
+++ b/arch/loongarch/kernel/legacy_boot.c
@@ -750,15 +750,16 @@ static int __init add_legacy_isa_io(struct fwnode_handle *fwnode, unsigned long 
 #define ISA_PHY_IOBASE  LOONGSON_LIO_BASE
 static int __init acpi_register_legacy_isa_io(void)
 {
-	struct fwnode_handle *fwnode;
+	struct fwnode_handle *fwnode = NULL;
 	u64 cpu_addr;
 	if (!acpi_disabled) {
-			cpu_addr = ISA_PHY_IOBASE;
-			fwnode = kzalloc(sizeof(*fwnode), GFP_ATOMIC);
+		cpu_addr = ISA_PHY_IOBASE;
+		fwnode = kzalloc(sizeof(*fwnode), GFP_ATOMIC);
 	}
 
 	if (fwnode)
-			add_legacy_isa_io(fwnode, cpu_addr);
+		add_legacy_isa_io(fwnode, cpu_addr);
+
 	return 0;
 }
 arch_initcall(acpi_register_legacy_isa_io);


### PR DESCRIPTION
deepin inclusion
category: bugfix

Fixes: 66c9a2ae14e1e ("deepin: LoongArch: legacyboot: BPI: workaround old firmware with ISA")

## Summary by Sourcery

Bug Fixes:
- Initialize the ACPI legacy ISA I/O firmware node handle to avoid using an uninitialized pointer during legacy boot on LoongArch.