### PR TITLE
[RFC] [Deepin-Kernel-SIG] [linux 6.6.y] [DEEPIN] deepin: OWNERS: update approvers

### DIFF
--- a/deepin/OWNERS
+++ b/deepin/OWNERS
@@ -2,6 +2,8 @@
 
 approvers:
 - Avenger-285714
+- dongert
+- lanlanxiyiji
 - opsiff
 emeritus_approvers:
 - deepin-community/deepin-sysdev-team


### PR DESCRIPTION
Update approvers list so deepin-ci-robot can request reviews more intelligently.

## Summary by Sourcery

Chores:
- Adjust Deepin OWNERS file to reflect the current set of approvers for deepin-ci-robot.