### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] USB: core: Fix root_hub's remote wakeup for wakeup sources on loongso…

### DIFF
--- a/drivers/usb/core/hub.c
+++ b/drivers/usb/core/hub.c
@@ -3486,7 +3486,9 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)
 			if (PMSG_IS_AUTO(msg))
 				goto err_wakeup;
 		}
+#if defined(CONFIG_MACH_LOONGSON64)
 		usb_enable_remote_wakeup(udev->bus->root_hub);
+#endif
 	}
 
 	/* disable USB2 hardware LPM */
@@ -3552,7 +3554,9 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)
 
 		if (udev->do_remote_wakeup) {
 			(void) usb_disable_remote_wakeup(udev);
+#if defined(CONFIG_MACH_LOONGSON64)
 			(void) usb_disable_remote_wakeup(udev->bus->root_hub);
+#endif
 		}
  err_wakeup:
 


### PR DESCRIPTION
…n platform

it make S3 resume auto in x86 and arm


Fixes: 06c01ac90583 ("USB: core: Enable root_hub's remote wakeup for wakeup sources")

## Summary by Sourcery

Bug Fixes:
- Prevent unintended automatic S3 resume on x86 and ARM by limiting root hub remote wakeup enable/disable to CONFIG_MACH_LOONGSON64 builds.