### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] mm: hugetlb_vmemmap: allow alloc vmemmap pages fallback to other nodes

### DIFF
--- a/mm/hugetlb_vmemmap.c
+++ b/mm/hugetlb_vmemmap.c
@@ -320,8 +320,7 @@ static int vmemmap_remap_free(unsigned long start, unsigned long end,
 		.vmemmap_pages	= &vmemmap_pages,
 	};
 	int nid = page_to_nid((struct page *)reuse);
-	gfp_t gfp_mask = GFP_KERNEL | __GFP_THISNODE | __GFP_NORETRY |
-			__GFP_NOWARN;
+	gfp_t gfp_mask = GFP_KERNEL | __GFP_NORETRY | __GFP_NOWARN;
 
 	/*
 	 * Allocate a new head vmemmap page to avoid breaking a contiguous


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
category: bugfix

In vmemmap_remap_free(), a new head vmemmap page is allocated to avoid breaking a contiguous block of struct page memory, however, the allocation can always fail when the given node is movable node.  Remove the __GFP_THISNODE to help avoid fragmentation.

Link: https://lkml.kernel.org/r/20230906093157.9737-1-yuancan@huawei.com

Suggested-by: Mike Kravetz <mike.kravetz@oracle.com>
Reviewed-by: Mike Kravetz <mike.kravetz@oracle.com>
Suggested-by: Muchun Song <songmuchun@bytedance.com>
Reviewed-by: Muchun Song <songmuchun@bytedance.com>

Conflicts:
	mm/hugetlb_vmemmap.c
(cherry picked from commit 6a898c2757af1ac852bb917a0866d2724f303076)

## Summary by Sourcery

Bug Fixes:
- Allow vmemmap head page allocation for hugetlb pages to fall back to other NUMA nodes instead of failing on movable nodes.