### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Two minor cleanups to break_down_buddy_pages

### DIFF
--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -6773,20 +6773,18 @@ static void break_down_buddy_pages(struct zone *zone, struct page *page,
 				   int migratetype)
 {
 	unsigned long size = 1 << high;
-	struct page *current_buddy, *next_page;
+	struct page *current_buddy;
 
 	while (high > low) {
 		high--;
 		size >>= 1;
 
 		if (target >= &page[size]) {
-			next_page = page + size;
 			current_buddy = page;
+			page = page + size;
 		} else {
-			next_page = page;
 			current_buddy = page + size;
 		}
-		page = next_page;
 
 		if (set_page_guard(zone, current_buddy, high, migratetype))
 			continue;

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -6791,10 +6791,8 @@ static void break_down_buddy_pages(struct zone *zone, struct page *page,
 		if (set_page_guard(zone, current_buddy, high, migratetype))
 			continue;
 
-		if (current_buddy != target) {
-			add_to_free_list(current_buddy, zone, high, migratetype);
-			set_buddy_order(current_buddy, high);
-		}
+		add_to_free_list(current_buddy, zone, high, migratetype);
+		set_buddy_order(current_buddy, high);
 	}
 }
 


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20230927103514.98281-3-shikemeng@huaweicloud.com/T/#u

This series contains two cleanups patches from original series [1] and
patches in this series do minor cleanup to break_down_buddy_pages.
Note: this series is on top of patch [2] which is the first patch in
original series [1].
Details of cleanups can be found in respective patches. Thanks!

[1]
https://lore.kernel.org/all/20230826154745.4019371-1-shikemeng@huaweicloud.com/T/#mef1b12a1a145e9422d586ec4950d81a409ea4e94
[2]
https://lore.kernel.org/all/20230927094401.68205-1-shikemeng@huaweicloud.com/T/#u

Kemeng Shi (2):
  mm/page_alloc: remove unnecessary check in break_down_buddy_pages
  mm/page_alloc: remove unnecessary next_page in break_down_buddy_pages

 mm/page_alloc.c | 12 ++++--------
 1 file changed, 4 insertions(+), 8 deletions(-)

-- 
2.30.0

## Summary by Sourcery

Simplify the memory allocator’s break_down_buddy_pages helper with minor cleanups to its buddy selection logic.

Enhancements:
- Remove the redundant next_page variable by directly updating the page pointer when splitting buddies.
- Eliminate an unnecessary check comparing current_buddy to target in break_down_buddy_pages, as the condition is always true.