### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] dm: shortcut the calls to linear_map and stripe_map

### DIFF
--- a/drivers/md/dm-linear.c
+++ b/drivers/md/dm-linear.c
@@ -85,7 +85,7 @@ static sector_t linear_map_sector(struct dm_target *ti, sector_t bi_sector)
 	return lc->start + dm_target_offset(ti, bi_sector);
 }
 
-static int linear_map(struct dm_target *ti, struct bio *bio)
+int linear_map(struct dm_target *ti, struct bio *bio)
 {
 	struct linear_c *lc = ti->private;
 

--- a/drivers/md/dm-stripe.c
+++ b/drivers/md/dm-stripe.c
@@ -268,7 +268,7 @@ static int stripe_map_range(struct stripe_c *sc, struct bio *bio,
 	return DM_MAPIO_SUBMITTED;
 }
 
-static int stripe_map(struct dm_target *ti, struct bio *bio)
+int stripe_map(struct dm_target *ti, struct bio *bio)
 {
 	struct stripe_c *sc = ti->private;
 	uint32_t stripe;

--- a/drivers/md/dm.c
+++ b/drivers/md/dm.c
@@ -1426,9 +1426,16 @@ static void __map_bio(struct bio *clone)
 		if (unlikely(dm_emulate_zone_append(md)))
 			r = dm_zone_map_bio(tio);
 		else
+			goto do_map;
+	} else {
+do_map:
+		if (likely(ti->type->map == linear_map))
+			r = linear_map(ti, clone);
+		else if (ti->type->map == stripe_map)
+			r = stripe_map(ti, clone);
+		else
 			r = ti->type->map(ti, clone);
-	} else
-		r = ti->type->map(ti, clone);
+	}
 
 	switch (r) {
 	case DM_MAPIO_SUBMITTED:

--- a/drivers/md/dm.h
+++ b/drivers/md/dm.h
@@ -188,9 +188,11 @@ void dm_kobject_release(struct kobject *kobj);
 /*
  * Targets for linear and striped mappings
  */
+int linear_map(struct dm_target *ti, struct bio *bio);
 int dm_linear_init(void);
 void dm_linear_exit(void);
 
+int stripe_map(struct dm_target *ti, struct bio *bio);
 int dm_stripe_init(void);
 void dm_stripe_exit(void);
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
category: performance

Shortcut the calls to linear_map and stripe_map, so that they don't suffer the overhead of retpolines used for indirect calls.



(cherry picked from commit f1445032173d4a49eb8b4a0808db499966897d9a)

## Summary by Sourcery

Optimize device-mapper bio mapping paths to reduce indirect call overhead for common linear and stripe targets.

Enhancements:
- Directly invoke linear and stripe mapping functions in the core dm bio mapping path to avoid retpoline overhead for these common targets.
- Expose linear_map and stripe_map in the dm header to allow their use from the core mapping logic.