### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] mm: huge_memory: use more folio api in __split_huge_page_tail()

### DIFF
--- a/mm/huge_memory.c
+++ b/mm/huge_memory.c
@@ -2478,13 +2478,13 @@ static void __split_huge_page_tail(struct folio *folio, int tail,
 	clear_compound_head(page_tail);
 
 	/* Finally unfreeze refcount. Additional reference from page cache. */
-	page_ref_unfreeze(page_tail, 1 + (!PageAnon(head) ||
-					  PageSwapCache(head)));
+	page_ref_unfreeze(page_tail, 1 + (!folio_test_anon(folio) ||
+					  folio_test_swapcache(folio)));
 
-	if (page_is_young(head))
-		set_page_young(page_tail);
-	if (page_is_idle(head))
-		set_page_idle(page_tail);
+	if (folio_test_young(folio))
+		folio_set_young(new_folio);
+	if (folio_test_idle(folio))
+		folio_set_idle(new_folio);
 
 	folio_xchg_last_cpupid(new_folio, folio_last_cpupid(folio));
 


### PR DESCRIPTION
mainline inclusion
from mainline-v6.8-rc1
category: performance

Use more folio APIs to save six compound_head() calls in __split_huge_page_tail().

Link: https://lkml.kernel.org/r/20231110033324.2455523-5-wangkefeng.wang@huawei.com

Reviewed-by: Matthew Wilcox (Oracle) <willy@infradead.org>

(cherry picked from commit b75427691f4a1fd3625d1f4c016832b8c75c2326)

## Summary by Sourcery

Enhancements:
- Replace page-based anon, swapcache, young, and idle checks and updates with folio-based helpers in __split_huge_page_tail() to reduce compound_head() usage and improve clarity.