### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] mm: remove PageAnonExclusive assertions in unuse_pte()

### DIFF
--- a/mm/swapfile.c
+++ b/mm/swapfile.c
@@ -1797,10 +1797,6 @@ static int unuse_pte(struct vm_area_struct *vma, pmd_t *pmd,
 	 */
 	arch_swap_restore(entry, page_folio(page));
 
-	/* See do_swap_page() */
-	BUG_ON(!PageAnon(page) && PageMappedToDisk(page));
-	BUG_ON(PageAnon(page) && PageAnonExclusive(page));
-
 	dec_mm_counter(vma->vm_mm, MM_SWAPENTS);
 	inc_mm_counter(vma->vm_mm, MM_ANONPAGES);
 	get_page(page);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.8-rc1
category: performance

The page in question is either freshly allocated or known to be in the swap cache; these assertions are not particularly useful.

Link: https://lkml.kernel.org/r/20231212164813.2540119-1-willy@infradead.org

Reviewed-by: David Hildenbrand <david@redhat.com>

(cherry picked from commit 8d294a8c6393afbde59cf14a0e8413df4b206698)

## Summary by Sourcery

Enhancements:
- Simplify unuse_pte() by dropping unnecessary BUG_ON checks for PageAnon and PageAnonExclusive conditions.