### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Convert aops->error_remove_page to ->error_remove_folio

### DIFF
--- a/mm/memory-failure.c
+++ b/mm/memory-failure.c
@@ -925,26 +925,26 @@ static const char * const action_page_types[] = {
  * The page count will stop it from being freed by unpoison.
  * Stress tests should be aware of this memory leak problem.
  */
-static int delete_from_lru_cache(struct page *p)
+static int delete_from_lru_cache(struct folio *folio)
 {
-	if (isolate_lru_page(p)) {
+	if (folio_isolate_lru(folio)) {
 		/*
 		 * Clear sensible page flags, so that the buddy system won't
-		 * complain when the page is unpoison-and-freed.
+		 * complain when the folio is unpoison-and-freed.
 		 */
-		ClearPageActive(p);
-		ClearPageUnevictable(p);
+		folio_clear_active(folio);
+		folio_clear_unevictable(folio);
 
 		/*
 		 * Poisoned page might never drop its ref count to 0 so we have
 		 * to uncharge it manually from its memcg.
 		 */
-		mem_cgroup_uncharge(page_folio(p));
+		mem_cgroup_uncharge(folio);
 
 		/*
-		 * drop the page count elevated by isolate_lru_page()
+		 * drop the refcount elevated by folio_isolate_lru()
 		 */
-		put_page(p);
+		folio_put(folio);
 		return 0;
 	}
 	return -EIO;
@@ -1042,7 +1042,7 @@ static int me_pagecache_clean(struct page_state *ps, struct page *p)
 	struct address_space *mapping;
 	bool extra_pins;
 
-	delete_from_lru_cache(p);
+	delete_from_lru_cache(folio);
 
 	/*
 	 * For anonymous folios the only reference left
@@ -1169,7 +1169,7 @@ static int me_swapcache_dirty(struct page_state *ps, struct page *p)
 	/* Trigger EIO in shmem: */
 	folio_clear_uptodate(folio);
 
-	ret = delete_from_lru_cache(p) ? MF_FAILED : MF_DELAYED;
+	ret = delete_from_lru_cache(folio) ? MF_FAILED : MF_DELAYED;
 	folio_unlock(folio);
 
 	if (ret == MF_DELAYED)
@@ -1188,7 +1188,7 @@ static int me_swapcache_clean(struct page_state *ps, struct page *p)
 
 	delete_from_swap_cache(folio);
 
-	ret = delete_from_lru_cache(p) ? MF_FAILED : MF_RECOVERED;
+	ret = delete_from_lru_cache(folio) ? MF_FAILED : MF_RECOVERED;
 	folio_unlock(folio);
 
 	if (has_extra_refcount(ps, p, false))

--- a/mm/memory-failure.c
+++ b/mm/memory-failure.c
@@ -1161,15 +1161,16 @@ static int me_pagecache_dirty(struct page_state *ps, struct page *p)
  */
 static int me_swapcache_dirty(struct page_state *ps, struct page *p)
 {
+	struct folio *folio = page_folio(p);
 	int ret;
 	bool extra_pins = false;
 
-	ClearPageDirty(p);
+	folio_clear_dirty(folio);
 	/* Trigger EIO in shmem: */
-	ClearPageUptodate(p);
+	folio_clear_uptodate(folio);
 
 	ret = delete_from_lru_cache(p) ? MF_FAILED : MF_DELAYED;
-	unlock_page(p);
+	folio_unlock(folio);
 
 	if (ret == MF_DELAYED)
 		extra_pins = true;

--- a/mm/memory-failure.c
+++ b/mm/memory-failure.c
@@ -950,14 +950,13 @@ static int delete_from_lru_cache(struct folio *folio)
 	return -EIO;
 }
 
-static int truncate_error_page(struct page *p, unsigned long pfn,
+static int truncate_error_page(struct folio *folio, unsigned long pfn,
 				struct address_space *mapping)
 {
-	struct folio *folio = page_folio(p);
 	int ret = MF_FAILED;
 
 	if (mapping->a_ops->error_remove_page) {
-		int err = mapping->a_ops->error_remove_page(mapping, p);
+		int err = mapping->a_ops->error_remove_page(mapping, &folio->page);
 
 		if (err != 0)
 			pr_info("%#lx: Failed to punch page: %d\n", pfn, err);
@@ -1078,7 +1077,7 @@ static int me_pagecache_clean(struct page_state *ps, struct page *p)
 	 *
 	 * Open: to take i_rwsem or not for this? Right now we don't.
 	 */
-	ret = truncate_error_page(p, page_to_pfn(p), mapping);
+	ret = truncate_error_page(folio, page_to_pfn(p), mapping);
 	if (has_extra_refcount(ps, p, extra_pins))
 		ret = MF_FAILED;
 
@@ -1212,7 +1211,7 @@ static int me_huge_page(struct page_state *ps, struct page *p)
 
 	mapping = folio_mapping(folio);
 	if (mapping) {
-		res = truncate_error_page(&folio->page, page_to_pfn(p), mapping);
+		res = truncate_error_page(folio, page_to_pfn(p), mapping);
 		/* The page is kept in page cache. */
 		extra_pins = true;
 		folio_unlock(folio);


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20231117161447.2461643-7-willy@infradead.org/T/#m1d49abe5684219800905b555d31aaab2f4e3bbf8

NOTE: 1 and 4 are merged , and 6 be skipped.

While this affects every filesystem, it's generally in a trivial way,
so I haven't cc'd the maintainers as it won't affect them.  Really,
this is a memory-failure patch series which converts a lot of uses of
page APIs into folio APIs with the usual benefits.

It is only compile tested.  Nothing here should change any user-visible
behaviour.

Matthew Wilcox (Oracle) (6):
  memory-failure: Use a folio in me_pagecache_clean()
  memory-failure: Use a folio in me_pagecache_dirty()
  memory-failure: Convert delete_from_lru_cache() to take a folio
  memory-failure: Use a folio in me_huge_page()
  memory-failure: Convert truncate_error_page to truncate_error_folio
  fs: Convert error_remove_page to error_remove_folio

 Documentation/filesystems/locking.rst |  4 +-
 Documentation/filesystems/vfs.rst     |  6 +--
 block/fops.c                          |  2 +-
 fs/afs/write.c                        |  2 +-
 fs/bcachefs/fs.c                      |  2 +-
 fs/btrfs/inode.c                      |  2 +-
 fs/ceph/addr.c                        |  4 +-
 fs/ext2/inode.c                       |  2 +-
 fs/ext4/inode.c                       |  6 +--
 fs/f2fs/compress.c                    |  2 +-
 fs/f2fs/inode.c                       |  2 +-
 fs/gfs2/aops.c                        |  4 +-
 fs/hugetlbfs/inode.c                  |  6 +--
 fs/nfs/file.c                         |  2 +-
 fs/ntfs/aops.c                        |  6 +--
 fs/ocfs2/aops.c                       |  2 +-
 fs/xfs/xfs_aops.c                     |  2 +-
 fs/zonefs/file.c                      |  2 +-
 include/linux/fs.h                    |  2 +-
 include/linux/mm.h                    |  3 +-
 mm/memory-failure.c                   | 63 +++++++++++++--------------
 mm/shmem.c                            |  6 +--
 mm/truncate.c                         |  9 ++--
 virt/kvm/guest_memfd.c                |  9 ++--
 24 files changed, 75 insertions(+), 75 deletions(-)

-- 
2.42.0

## Summary by Sourcery

Convert memory failure handling paths to operate on folios instead of pages, including LRU cache deletion and error truncation logic, as part of the broader error_remove_folio transition.

Enhancements:
- Update delete_from_lru_cache and related pagecache/swapcache handlers to accept and manipulate folios instead of struct page.
- Adjust truncate_error_page to work with folios in conjunction with filesystem address space operations, aligning with the error_remove_folio conversion.