### PR TITLE
scsi: leapraid: update driver to v2.00.01.05

### DIFF
--- a/drivers/scsi/leapraid/leapraid.h
+++ b/drivers/scsi/leapraid/leapraid.h
@@ -27,8 +27,6 @@
 /* Maximum number of retries waiting for doorbell to become operational. */
 #define LEAPRAID_DB_WAIT_OP_SHORT   10
 #define LEAPRAID_DB_WAIT_OP_LONG   200
-/* Sleep interval (in seconds) between doorbell polls. */
-#define LEAPRAID_DB_POLL_INTERVAL_S    1
 
 /* Maximum number of retries waiting for host to end recovery. */
 #define LEAPRAID_WAIT_SHOST_RECOVERY   400
@@ -180,7 +178,6 @@
 #define LEAPRAID_CFG_PAGE_NUM_DEV0      0x0
 
 /* SAS device page 0 flags. */
-#define LEAPRAID_SAS_DEV_P0_FLG_FP_CAP          0x2000
 #define LEAPRAID_SAS_DEV_P0_FLG_SATA_SMART      0x0040
 #define LEAPRAID_SAS_DEV_P0_FLG_ENC_LEVEL_VALID 0x0002
 #define LEAPRAID_SAS_DEV_P0_FLG_DEV_PRESENT     0x0001
@@ -207,15 +204,9 @@
 /* Physical disk page number. */
 #define LEAPRAID_CFG_PAGE_NUM_PD0       0x0
 
-/* Adapter page number. */
-#define LEAPRAID_CFG_PAGE_NUM_ADAPTER1  0x1
-
 #define LEAPRAID_CFG_UNIT_SIZE  4
 
 /* Raid volume type and state. */
-#define LEAPRAID_VOL_STATE_MISSING      0x00
-#define LEAPRAID_VOL_STATE_FAILED       0x01
-#define LEAPRAID_VOL_STATE_INITIALIZING 0x02
 #define LEAPRAID_VOL_STATE_ONLINE       0x03
 #define LEAPRAID_VOL_STATE_DEGRADED     0x04
 #define LEAPRAID_VOL_STATE_OPTIMAL      0x05
@@ -230,10 +221,6 @@
 #define LEAPRAID_RAIDCFG_P0_EFLG_VOL_PHYS_DISK_ELEMENT  0x0001
 #define LEAPRAID_RAIDCFG_P0_EFLG_HOT_SPARE_ELEMENT      0x0002
 #define LEAPRAID_RAIDCFG_P0_EFLG_OCE_ELEMENT            0x0003
-
-/* Raid action. */
-#define LEAPRAID_RAID_ACT_SYSTEM_SHUTDOWN_INITIATED     0x20
-#define LEAPRAID_RAID_ACT_PHYSDISK_HIDDEN               0x24
 
 /* SAS negotiated link rates. */
 #define LEAPRAID_SAS_NEG_LINK_RATE_MASK_PHYSICAL        0x0F
@@ -290,8 +277,6 @@
 
 #define LEAPRAID_TM_MSGFLAGS_LINK_RESET         0x00
 #define LEAPRAID_TM_RSP_INVALID_FRAME           0x02
-#define LEAPRAID_TM_RSP_TM_SUCCEEDED            0x08
-#define LEAPRAID_TM_RSP_IO_QUEUED_ON_ADAPTER    0x80
 
 /* SCSI enclosure processor request defines. */
 #define LEAPRAID_SEP_REQ_ACT_WRITE_STATUS               0x00
@@ -301,8 +286,6 @@
 
 /* The capabilities of the adapter. */
 #define LEAPRAID_ADAPTER_FEATURES_CAP_ATOMIC_REQ                0x00080000
-#define LEAPRAID_ADAPTER_FEATURES_CAP_RDPQ_ARRAY_CAPABLE        0x00040000
-#define LEAPRAID_ADAPTER_FEATURES_CAP_EVENT_REPLAY              0x00002000
 #define LEAPRAID_ADAPTER_FEATURES_CAP_INTEGRATED_RAID           0x00001000
 
 /* Event code definitions for the firmware. */
@@ -337,10 +320,6 @@
 #define LEAPRAID_EVT_SAS_TOPO_RC_MASK                   0x0F
 #define LEAPRAID_EVT_SAS_TOPO_RC_TARG_ADDED             0x01
 #define LEAPRAID_EVT_SAS_TOPO_RC_TARG_NOT_RESPONDING    0x02
-
-/* SAS discovery event defines. */
-#define LEAPRAID_EVT_SAS_DISC_RC_STARTED        0x01
-#define LEAPRAID_EVT_SAS_DISC_RC_COMPLETED      0x02
 
 /* Enclosure device status change event. */
 #define LEAPRAID_EVT_SAS_ENCL_RC_ADDED          0x01

--- a/drivers/scsi/leapraid/leapraid_app.c
+++ b/drivers/scsi/leapraid/leapraid_app.c
@@ -388,6 +388,7 @@ static int leapraid_ctl_do_command(struct leapraid_adapter *adapter,
 		dev_err(&adapter->pdev->dev,
 			"%s: ctl_cmd timeout, status=0x%x\n",
 			__func__, adapter->driver_cmds.ctl_cmd.status);
+		leapraid_log_req_context(adapter, taskid, ctl_sp_mpi_req);
 	}
 
 	if ((leap_mpi_req->func == LEAPRAID_FUNC_SMP_PASSTHROUGH ||
@@ -590,7 +591,7 @@ static int leapraid_ctl_ioctl_main(struct file *file, unsigned int cmd,
 			break;
 		}
 
-		if (karg.hdr.adapter_id  != ioctl_header.adapter_id) {
+		if (karg.hdr.adapter_id != ioctl_header.adapter_id) {
 			rc = -EINVAL;
 			break;
 		}
@@ -619,11 +620,6 @@ static int leapraid_ctl_ioctl_main(struct file *file, unsigned int cmd,
 unlock:
 	mutex_unlock(&adapter->access_ctrl.pci_access_lock);
 	return rc;
-}
-
-static long bad_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
-{
-	return -ENOTTY;
 }
 
 static long leapraid_ctl_ioctl(struct file *file, unsigned int cmd,
@@ -679,7 +675,6 @@ static const struct file_operations leapraid_ctl_fops = {
 	.owner = THIS_MODULE,
 	.unlocked_ioctl = leapraid_ctl_ioctl,
 	.mmap = leapraid_fw_mmap,
-	.compat_ioctl = bad_ioctl,
 };
 
 static struct miscdevice leapraid_ctl_dev = {

--- a/drivers/scsi/leapraid/leapraid_func.c
+++ b/drivers/scsi/leapraid/leapraid_func.c
@@ -47,6 +47,17 @@ static bool leapraid_should_skip_poll_work(struct leapraid_adapter *adapter);
 static int leapraid_make_adapter_ready(struct leapraid_adapter *adapter,
 				       enum reset_type type);
 
+static noinline bool leapraid_shost_in_recovery(struct Scsi_Host *shost)
+{
+	enum scsi_host_state state;
+
+	state = READ_ONCE(shost->shost_state);
+	return state == SHOST_RECOVERY ||
+	       state == SHOST_CANCEL_RECOVERY ||
+	       state == SHOST_DEL_RECOVERY ||
+	       shost->tmf_in_progress;
+}
+
 static void leapraid_debug_log_info(struct leapraid_adapter *adapter)
 {
 	struct leapraid_reg_base __iomem *iomem_base = adapter->iomem_base;
@@ -81,6 +92,7 @@ static void leapraid_debug_log_info(struct leapraid_adapter *adapter)
 			 debug_log[i + 2],
 			 debug_log[i + 3]);
 }
+
 static inline bool leapraid_is_end_dev(u32 dev_type)
 {
 	return (dev_type & LEAPRAID_DEVTYP_END_DEV) &&
@@ -171,7 +183,6 @@ static void leapraid_overheat_suspend(struct leapraid_adapter *adapter)
 
 	pdev = adapter->pdev;
 	shost = pci_get_drvdata(pdev);
-
 	if (!shost) {
 		dev_warn(&pdev->dev,
 			 "Overheat suspend failed, invalid host or adapter\n");
@@ -1948,7 +1959,7 @@ static const char *leapraid_tm_type_name(u8 task_type)
 	}
 }
 
-void leapraid_log_req_context(struct leapraid_adapter *adapter,
+void leapraid_log_req_context(struct leapraid_adapter *adapter, u16 smid,
 			      const void *req_data)
 {
 	const struct leapraid_req *req = req_data;
@@ -1961,8 +1972,8 @@ void leapraid_log_req_context(struct leapraid_adapter *adapter,
 		const struct leapraid_cfg_req *cfg_req = req_data;
 
 		dev_err(&adapter->pdev->dev,
-			"cfg-req: func=0x%02x(%s) act=0x%02x(%s)\n",
-			req->func, leapraid_func_name(req->func),
+			"cfg-req: smid=%u func=0x%02x(%s) action=0x%02x(%s)\n",
+			smid, req->func, leapraid_func_name(req->func),
 			cfg_req->action,
 			leapraid_cfg_action_name(cfg_req->action));
 		dev_err(&adapter->pdev->dev,
@@ -1984,12 +1995,12 @@ void leapraid_log_req_context(struct leapraid_adapter *adapter,
 		const struct leapraid_scsi_tm_req *tm_req = req_data;
 
 		dev_err(&adapter->pdev->dev,
-			"scsi_tm: func=0x%02x(%s) task=0x%02x(%s)\n",
-			req->func, leapraid_func_name(req->func),
+			"scsi_tm:: smid=%u func=0x%02x(%s) task=0x%02x(%s)\n",
+			smid, req->func, leapraid_func_name(req->func),
 			tm_req->task_type,
 			leapraid_tm_type_name(tm_req->task_type));
 		dev_err(&adapter->pdev->dev,
-			"scsi_tm: dev_hdl=0x%04x task_mid=%u\n",
+			"scsi_tm:: dev_hdl=0x%04x task_mid=%u\n",
 			le16_to_cpu(tm_req->dev_hdl),
 			le16_to_cpu(tm_req->task_mid));
 		break;
@@ -1998,8 +2009,8 @@ void leapraid_log_req_context(struct leapraid_adapter *adapter,
 		const struct leapraid_sep_req *sep_req = req_data;
 
 		dev_err(&adapter->pdev->dev,
-			"sep: func=0x%02x(%s) act=0x%02x(%s)\n",
-			req->func, leapraid_func_name(req->func),
+			"sep: smid=%u func=0x%02x(%s) action=0x%02x(%s)\n",
+			smid, req->func, leapraid_func_name(req->func),
 			sep_req->act,
 			leapraid_sep_action_name(sep_req->act));
 		dev_err(&adapter->pdev->dev,
@@ -2013,11 +2024,11 @@ void leapraid_log_req_context(struct leapraid_adapter *adapter,
 		const struct leapraid_io_unit_ctrl_req *io_req = req_data;
 
 		dev_err(&adapter->pdev->dev,
-			"timestamp sync: func=0x%02x(%s) op=0x%02x(%s)\n",
-			req->func, leapraid_func_name(req->func),
+			"ctl_cmd: smid=%u func=0x%02x(%s) action=0x%02x(%s)\n",
+			smid, req->func, leapraid_func_name(req->func),
 			io_req->op, leapraid_sas_op_name(io_req->op));
 		dev_err(&adapter->pdev->dev,
-			"timestamp sync: dev_hdl=0x%04x param=0x%02x(%s)\n",
+			"ctl_cmd: dev_hdl=0x%04x param=0x%02x(%s)\n",
 			le16_to_cpu(io_req->dev_hdl),
 			io_req->adapter_para,
 			leapraid_io_param_name(io_req->adapter_para));
@@ -2027,18 +2038,21 @@ void leapraid_log_req_context(struct leapraid_adapter *adapter,
 		const struct leapraid_smp_passthrough_req *smp_req = req_data;
 
 		dev_err(&adapter->pdev->dev,
-			"transport: func=0x%02x(%s) port=%u req_len=%u\n",
-			req->func, leapraid_func_name(req->func),
+			"smp_cmd: smid=%u func=0x%02x(%s) action=0x%02x\n",
+			smid, req->func, leapraid_func_name(req->func),
+			smp_req->passthrough_flg);
+		dev_err(&adapter->pdev->dev,
+			"smp_cmd: port=%u req_len=%u\n",
 			smp_req->physical_port,
 			le16_to_cpu(smp_req->req_data_len));
-		dev_err(&adapter->pdev->dev, "transport: sas_addr=0x%016llx\n",
+		dev_err(&adapter->pdev->dev, "smp_cmd: sas_addr=0x%016llx\n",
 			(unsigned long long)le64_to_cpu(smp_req->sas_address));
 		break;
 	}
 	default:
 		dev_err(&adapter->pdev->dev,
-			"%s: func=0x%02x(%s)\n",
-			__func__, req->func, leapraid_func_name(req->func));
+			"cmd: smid=%u func=0x%02x(%s)\n",
+			smid, req->func, leapraid_func_name(req->func));
 		break;
 	}
 }
@@ -2049,19 +2063,18 @@ static void leapraid_build_and_fire_cfg_req(
 		struct leapraid_cfg_rep *leap_mpi_cfgp_rep)
 {
 	struct leapraid_cfg_req *local_leap_cfg_req;
+	u16 smid;
 
 	memset(leap_mpi_cfgp_rep, 0, sizeof(struct leapraid_cfg_rep));
 	memset(&adapter->driver_cmds.cfg_op_cmd.reply, 0,
 	       sizeof(struct leapraid_cfg_rep));
 	adapter->driver_cmds.cfg_op_cmd.status = LEAPRAID_CMD_PENDING;
-	local_leap_cfg_req = leapraid_get_task_desc(
-				adapter,
-				adapter->driver_cmds.cfg_op_cmd.inter_taskid);
+	smid = adapter->driver_cmds.cfg_op_cmd.inter_taskid;
+	local_leap_cfg_req = leapraid_get_task_desc(adapter, smid);
 	memcpy(local_leap_cfg_req, leap_mpi_cfgp_req,
 	       sizeof(struct leapraid_cfg_req));
 	init_completion(&adapter->driver_cmds.cfg_op_cmd.done);
-	leapraid_fire_task(adapter,
-			   adapter->driver_cmds.cfg_op_cmd.inter_taskid);
+	leapraid_fire_task(adapter, smid);
 	wait_for_completion_timeout(&adapter->driver_cmds.cfg_op_cmd.done,
 				    LEAPRAID_CFG_OP_TIMEOUT * HZ);
 }
@@ -2074,11 +2087,13 @@ static int leapraid_req_cfg_func(struct leapraid_adapter *adapter,
 {
 	u32 adapter_status = UINT_MAX;
 	bool issue_reset = false;
+	u16 smid;
 	u8 retry_cnt;
 	int rc;
 
 	retry_cnt = 0;
 	mutex_lock(&adapter->driver_cmds.cfg_op_cmd.mutex);
+	smid = adapter->driver_cmds.cfg_op_cmd.inter_taskid;
 retry:
 	if (retry_cnt) {
 		if (retry_cnt > LEAPRAID_CFG_REQ_RETRY_TIMES) {
@@ -2115,14 +2130,16 @@ retry:
 				adapter->access_ctrl.shost_recovering ?
 				"shost recovery" : "pcie recovery",
 				adapter->driver_cmds.cfg_op_cmd.status);
-			leapraid_log_req_context(adapter, leap_mpi_cfgp_req);
+			leapraid_log_req_context(adapter, smid,
+						 leap_mpi_cfgp_req);
 			issue_reset = false;
 			rc = -EFAULT;
 		} else {
 			dev_err(&adapter->pdev->dev,
 				"cfg-req: timeout, status=0x%x, reset\n",
 				adapter->driver_cmds.cfg_op_cmd.status);
-			leapraid_log_req_context(adapter, leap_mpi_cfgp_req);
+			leapraid_log_req_context(adapter, smid,
+						 leap_mpi_cfgp_req);
 			issue_reset = true;
 		}
 
@@ -2162,7 +2179,7 @@ out_cleanup:
 	mutex_unlock(&adapter->driver_cmds.cfg_op_cmd.mutex);
 	if (issue_reset) {
 		if (adapter->scan_dev_desc.first_scan_dev_fired) {
-			dev_info(&adapter->pdev->dev,
+			dev_warn(&adapter->pdev->dev,
 				 "%s:%d cfg-req: Failure, issuing reset\n",
 				 __func__, __LINE__);
 			leapraid_hard_reset_handler(adapter, FULL_RESET);
@@ -2433,14 +2450,12 @@ static int leapraid_cfg_find_vol_in_page(
 			u16 phys_hdl;
 
 			phys_hdl = le16_to_cpu(elem->phys_disk_dev_hdl);
-
 			if (phys_hdl == pd_hdl) {
 				*vol_hdl = le16_to_cpu(elem->vol_dev_hdl);
 				return 0;
 			}
 			break;
 		}
-
 		case LEAPRAID_RAIDCFG_P0_EFLG_HOT_SPARE_ELEMENT:
 			*vol_hdl = 0;
 			return 0;
@@ -2607,7 +2622,6 @@ static int leapraid_cfg_get_number_pds(struct leapraid_adapter *adapter,
 	cfgp2.handle = hdl;
 	rc = leapraid_op_config_page(adapter, &raidvol_p0, cfgp1,
 				     cfgp2, GET_RAID_VOLUME_PG0);
-
 	if (!rc)
 		*num_pds = raidvol_p0.num_phys_disks;
 
@@ -2827,13 +2841,12 @@ static void leapraid_timestamp_sync(struct leapraid_adapter *adapter)
 	ktime_t current_time;
 	bool issue_reset = false;
 	u64 time_stamp;
+	u16 smid;
 
 	mutex_lock(&adapter->driver_cmds.timestamp_sync_cmd.mutex);
 	adapter->driver_cmds.timestamp_sync_cmd.status = LEAPRAID_CMD_PENDING;
-	io_unit_ctrl_req =
-		leapraid_get_task_desc(
-			adapter,
-			adapter->driver_cmds.timestamp_sync_cmd.inter_taskid);
+	smid = adapter->driver_cmds.timestamp_sync_cmd.inter_taskid;
+	io_unit_ctrl_req = leapraid_get_task_desc(adapter, smid);
 	memset(io_unit_ctrl_req, 0, sizeof(struct leapraid_io_unit_ctrl_req));
 	io_unit_ctrl_req->func = LEAPRAID_FUNC_SAS_IO_UNIT_CTRL;
 	io_unit_ctrl_req->op = LEAPRAID_SAS_OP_SET_PARAMETER;
@@ -2847,9 +2860,7 @@ static void leapraid_timestamp_sync(struct leapraid_adapter *adapter)
 	io_unit_ctrl_req->adapter_para_value2 =
 		cpu_to_le32(time_stamp >> 32);
 	init_completion(&adapter->driver_cmds.timestamp_sync_cmd.done);
-	leapraid_fire_task(
-		adapter,
-		adapter->driver_cmds.timestamp_sync_cmd.inter_taskid);
+	leapraid_fire_task(adapter, smid);
 	leapraid_debug_log_info(adapter);
 	wait_for_completion_timeout(&adapter->driver_cmds
 					.timestamp_sync_cmd.done,
@@ -2860,7 +2871,7 @@ static void leapraid_timestamp_sync(struct leapraid_adapter *adapter)
 			"%s: timestamp sync timeout, status=0x%x\n",
 			__func__,
 			adapter->driver_cmds.timestamp_sync_cmd.status);
-		leapraid_log_req_context(adapter, io_unit_ctrl_req);
+		leapraid_log_req_context(adapter, smid, io_unit_ctrl_req);
 		issue_reset =
 			leapraid_check_reset(
 				adapter->driver_cmds.timestamp_sync_cmd.status);
@@ -2891,15 +2902,16 @@ static void leapraid_check_scheduled_fault_work(struct work_struct *work)
 
 	adapter_state = leapraid_get_adapter_state(adapter);
 	if (adapter_state != LEAPRAID_DB_OPERATIONAL) {
-		dev_info(&adapter->pdev->dev, "%s:%d: call hard_reset\n",
-			 __func__, __LINE__);
+		dev_info(&adapter->pdev->dev, "%s:%d: call hard_reset 0x%x\n",
+			 __func__, __LINE__, adapter_state);
 		rc = leapraid_hard_reset_handler(adapter, FULL_RESET);
-		dev_warn(&adapter->pdev->dev, "%s: Hard reset %s\n",
-			 __func__, rc == 0 ? "success" : "failed");
-
 		adapter_state = leapraid_get_adapter_state(adapter);
-		if (rc && adapter_state != LEAPRAID_DB_OPERATIONAL)
+		if (rc && adapter_state != LEAPRAID_DB_OPERATIONAL) {
+			dev_err(&adapter->pdev->dev,
+				"%s: Hard reset failed, state=0x%x rc=%d\n",
+				__func__, adapter_state, rc);
 			return;
+		}
 	}
 
 	if (++adapter->timestamp_sync_cnt >=
@@ -3262,7 +3274,6 @@ void leapraid_smart_polling_stop(struct leapraid_adapter *adapter)
 
 	wq = desc->smart_poll_wq;
 	desc->smart_poll_wq = NULL;
-
 	if (wq) {
 		if (!cancel_delayed_work_sync(&desc->smart_poll_work))
 			flush_workqueue(wq);
@@ -3304,7 +3315,6 @@ static void leapraid_overheat_work(struct work_struct *work)
 	adapter->scan_dev_desc.scan_start = 0;
 	adapter->scan_dev_desc.wait_scan_dev_done = 0;
 	adapter->scan_dev_desc.driver_loading = 0;
-	wake_up(&adapter->access_ctrl.recovery_waitq);
 	wake_up(&adapter->access_ctrl.shost_recover_wq);
 	wake_up(&adapter->scan_dev_desc.wait_driver_loading);
 
@@ -3393,10 +3403,10 @@ static struct leapraid_fw_evt_work *leapraid_alloc_fw_evt_work(void)
 {
 	struct leapraid_fw_evt_work *fw_evt =
 		kzalloc(sizeof(*fw_evt), GFP_ATOMIC);
-	if (!fw_evt)
-		return NULL;
 
-	kref_init(&fw_evt->refcnt);
+	if (fw_evt)
+		kref_init(&fw_evt->refcnt);
+
 	return fw_evt;
 }
 
@@ -3467,7 +3477,6 @@ void leapraid_clean_active_fw_evt(struct leapraid_adapter *adapter)
 		return;
 
 	adapter->fw_evt_s.fw_evt_cleanup = 1;
-	wake_up(&adapter->access_ctrl.recovery_waitq);
 	if (adapter->access_ctrl.shost_recovering &&
 	    adapter->fw_evt_s.cur_evt)
 		adapter->fw_evt_s.cur_evt->ignore = 1;
@@ -4382,7 +4391,7 @@ void leapraid_exp_rm(struct leapraid_adapter *adapter, u64 sas_addr,
 		leapraid_exp_node_rm(adapter, topo_node_exp);
 }
 
-static int leapraid_internal_sas_topo_chg_evt(
+static void leapraid_internal_sas_topo_chg_evt(
 		struct leapraid_adapter *adapter,
 		struct leapraid_card_port *card_port,
 		struct leapraid_topo_node *topo_node_exp,
@@ -4399,11 +4408,11 @@ static int leapraid_internal_sas_topo_chg_evt(
 	evt_data = fw_evt->evt_data;
 	for (i = 0; i < evt_data->entry_num; i++) {
 		if (fw_evt->ignore)
-			return 0;
+			return;
 
 		if (adapter->access_ctrl.host_removing ||
 		    adapter->access_ctrl.pcie_recovering)
-			return 0;
+			return;
 
 		phy_number = evt_data->start_phy_num + i;
 		if (phy_number >= max_phys)
@@ -4441,12 +4450,10 @@ static int leapraid_internal_sas_topo_chg_evt(
 	if (evt_data->exp_status == LEAPRAID_EVT_SAS_TOPO_ES_NOT_RESPONDING &&
 	    topo_node_exp)
 		leapraid_exp_rm(adapter, sas_addr, card_port);
-
-	return 0;
 }
 
-static int leapraid_sas_topo_chg_evt(struct leapraid_adapter *adapter,
-				     struct leapraid_fw_evt_work *fw_evt)
+static void leapraid_sas_topo_chg_evt(struct leapraid_adapter *adapter,
+				      struct leapraid_fw_evt_work *fw_evt)
 {
 	struct leapraid_topo_node *topo_node_exp;
 	struct leapraid_card_port *card_port;
@@ -4459,13 +4466,13 @@ static int leapraid_sas_topo_chg_evt(struct leapraid_adapter *adapter,
 	if (adapter->access_ctrl.shost_recovering ||
 	    adapter->access_ctrl.host_removing ||
 	    adapter->access_ctrl.pcie_recovering)
-		return 0;
+		return;
 
 	evt_data = fw_evt->evt_data;
 	leapraid_sas_host_add(adapter, adapter->dev_topo.card.phys_num > 0);
 
 	if (fw_evt->ignore)
-		return 0;
+		return;
 
 	phdl = le16_to_cpu(evt_data->exp_dev_hdl);
 	card_port = leapraid_get_port_by_id(adapter,
@@ -4473,7 +4480,7 @@ static int leapraid_sas_topo_chg_evt(struct leapraid_adapter *adapter,
 					    false);
 	if (evt_data->exp_status == LEAPRAID_EVT_SAS_TOPO_ES_ADDED &&
 	    leapraid_exp_add(adapter, phdl) != 0)
-		return 0;
+		return;
 
 	spin_lock_irqsave(&adapter->dev_topo.topo_node_lock, flags);
 	topo_node_exp = leapraid_exp_find_by_hdl(adapter, phdl);
@@ -4487,13 +4494,13 @@ static int leapraid_sas_topo_chg_evt(struct leapraid_adapter *adapter,
 	} else {
 		spin_unlock_irqrestore(&adapter->dev_topo.topo_node_lock,
 				       flags);
-		return 0;
+		return;
 	}
 	spin_unlock_irqrestore(&adapter->dev_topo.topo_node_lock, flags);
 
-	return leapraid_internal_sas_topo_chg_evt(adapter, card_port,
-						  topo_node_exp, fw_evt,
-						  sas_addr, max_phys);
+	leapraid_internal_sas_topo_chg_evt(adapter, card_port,
+					   topo_node_exp, fw_evt,
+					   sas_addr, max_phys);
 }
 
 static void leapraid_reprobe_lun(struct scsi_device *sdev, void *no_uld_attach)
@@ -4603,7 +4610,6 @@ static void leapraid_sas_pd_hide(
 	}
 	spin_unlock_irqrestore(&adapter->dev_topo.sas_dev_lock, flags);
 	if (starget) {
-		dev_info(&adapter->pdev->dev, "hide sas_dev, hdl=0x%x\n", hdl);
 		starget_for_each_device(starget,
 					(void *)LEAPRAID_NO_ULD_ATTACH_FLAG,
 					leapraid_reprobe_lun);
@@ -4623,7 +4629,6 @@ static void leapraid_sas_pd_expose(
 	u16 hdl;
 
 	hdl = le16_to_cpu(evt_data->phys_disk_dev_hdl);
-
 	if (!hdl || hdl > adapter->adapter_attr.features.max_dev_handle) {
 		dev_warn(&adapter->pdev->dev,
 			 "%s: Invalid device handle\n", __func__);
@@ -4652,8 +4657,6 @@ static void leapraid_sas_pd_expose(
 	spin_unlock_irqrestore(&adapter->dev_topo.sas_dev_lock, flags);
 
 	if (starget) {
-		dev_info(&adapter->pdev->dev,
-			 "expose sas_dev, hdl=0x%x\n", hdl);
 		starget_for_each_device(starget,
 					LEAPRAID_ULD_ATTACH_FLAG,
 					leapraid_reprobe_lun);
@@ -4986,7 +4989,7 @@ static void leapraid_remove_unresp_sas_end_dev(
 		leapraid_sdev_put(sas_dev);
 	}
 
-	dev_info(&adapter->pdev->dev,
+	dev_warn(&adapter->pdev->dev,
 		 "Unresponsive SAS end devices removed\n");
 }
 
@@ -5011,7 +5014,7 @@ static void leapraid_remove_unresp_raid_volumes(
 		leapraid_sas_volume_delete_by_ptr(adapter, raid_volume);
 	}
 
-	dev_info(&adapter->pdev->dev,
+	dev_warn(&adapter->pdev->dev,
 		 "Unresponsive RAID volumes removed\n");
 }
 
@@ -5035,7 +5038,7 @@ static void leapraid_remove_unresp_sas_exp(struct leapraid_adapter *adapter)
 				 &head, list)
 		leapraid_exp_node_rm(adapter, topo_node_exp);
 
-	dev_info(&adapter->pdev->dev,
+	dev_warn(&adapter->pdev->dev,
 		 "Unresponsive SAS expanders removed\n");
 }
 
@@ -5153,8 +5156,6 @@ static void leapraid_scan_exp_after_reset(struct leapraid_adapter *adapter)
 	u16 hdl;
 	u8 port_id;
 
-	dev_info(&adapter->pdev->dev, "Begin scanning expanders\n");
-
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (hdl = 0xFFFF, cfgp2.handle = hdl;
 	     !leapraid_op_config_page(adapter, &exp_p0, cfgp1, cfgp2,
@@ -5185,8 +5186,6 @@ static void leapraid_scan_exp_after_reset(struct leapraid_adapter *adapter)
 					exp_p0.sas_address));
 		}
 	}
-
-	dev_info(&adapter->pdev->dev, "Expanders scan complete\n");
 }
 
 static void leapraid_scan_phy_disks_after_reset(
@@ -5202,8 +5201,6 @@ static void leapraid_scan_phy_disks_after_reset(
 	u8 phys_disk_num, port_id;
 	u16 hdl, parent_hdl;
 	u64 sas_addr;
-
-	dev_info(&adapter->pdev->dev, "Begin scanning phys disk\n");
 
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (phys_disk_num = 0xFF, cfgp2.form_specific = phys_disk_num;
@@ -5253,8 +5250,6 @@ static void leapraid_scan_phy_disks_after_reset(
 			}
 		}
 	}
-
-	dev_info(&adapter->pdev->dev, "PHYs disk scan complete\n");
 }
 
 static void leapraid_scan_vol_after_reset(struct leapraid_adapter *adapter)
@@ -5279,7 +5274,6 @@ static void leapraid_scan_vol_after_reset(struct leapraid_adapter *adapter)
 		return;
 	}
 
-	dev_info(&adapter->pdev->dev, "Begin scanning volumes\n");
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (hdl = 0xFFFF, cfgp2.handle = hdl;
 	     !leapraid_op_config_page(adapter, vol_p1, cfgp1,
@@ -5316,8 +5310,6 @@ static void leapraid_scan_vol_after_reset(struct leapraid_adapter *adapter)
 
 	kfree(vol_p0);
 	kfree(vol_p1);
-
-	dev_info(&adapter->pdev->dev, "Volumes scan complete\n");
 }
 
 static void leapraid_scan_sas_dev_after_reset(struct leapraid_adapter *adapter)
@@ -5329,9 +5321,6 @@ static void leapraid_scan_sas_dev_after_reset(struct leapraid_adapter *adapter)
 	u16 hdl, parent_hdl;
 	u64 sas_address;
 	u8 port_id;
-
-	dev_info(&adapter->pdev->dev,
-		 "Begin scanning SAS end devices\n");
 
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (hdl = 0xFFFF, cfgp2.handle = hdl;
@@ -5382,14 +5371,10 @@ static void leapraid_scan_sas_dev_after_reset(struct leapraid_adapter *adapter)
 					sas_dev_p0.sas_address));
 		}
 	}
-
-	dev_info(&adapter->pdev->dev, "SAS end devices scan complete\n");
 }
 
 static void leapraid_scan_all_dev_after_reset(struct leapraid_adapter *adapter)
 {
-	dev_info(&adapter->pdev->dev, "Begin scanning devices\n");
-
 	leapraid_sas_host_add(adapter, adapter->dev_topo.card.phys_num > 0);
 	leapraid_scan_exp_after_reset(adapter);
 	if (adapter->adapter_attr.raid_support) {
@@ -5397,8 +5382,6 @@ static void leapraid_scan_all_dev_after_reset(struct leapraid_adapter *adapter)
 		leapraid_scan_vol_after_reset(adapter);
 	}
 	leapraid_scan_sas_dev_after_reset(adapter);
-
-	dev_info(&adapter->pdev->dev, "Devices scan complete\n");
 }
 
 static void leapraid_hardreset_async_logic(struct leapraid_adapter *adapter)
@@ -5426,6 +5409,7 @@ static int leapraid_send_enc_cmd(struct leapraid_adapter *adapter,
 	void *req;
 	bool reset_flg = false;
 	int rc;
+	u16 smid;
 
 	mutex_lock(&adapter->driver_cmds.enc_cmd.mutex);
 	rc = leapraid_check_adapter_is_op(adapter, LEAPRAID_DB_WAIT_OP_SHORT,
@@ -5434,21 +5418,19 @@ static int leapraid_send_enc_cmd(struct leapraid_adapter *adapter,
 		goto unlock;
 
 	adapter->driver_cmds.enc_cmd.status = LEAPRAID_CMD_PENDING;
-	req = leapraid_get_task_desc(
-			adapter,
-			adapter->driver_cmds.enc_cmd.inter_taskid);
+	smid = adapter->driver_cmds.enc_cmd.inter_taskid;
+	req = leapraid_get_task_desc(adapter, smid);
 	memset(req, 0, LEAPRAID_REQUEST_SIZE);
 	memcpy(req, sep_req, sizeof(struct leapraid_sep_req));
 	init_completion(&adapter->driver_cmds.enc_cmd.done);
-	leapraid_fire_task(adapter,
-			   adapter->driver_cmds.enc_cmd.inter_taskid);
+	leapraid_fire_task(adapter, smid);
 	wait_for_completion_timeout(&adapter->driver_cmds.enc_cmd.done,
 				    LEAPRAID_ENC_CMD_TIMEOUT * HZ);
 	if (!(adapter->driver_cmds.enc_cmd.status & LEAPRAID_CMD_DONE)) {
 		dev_err(&adapter->pdev->dev,
 			"%s: SEP command timeout, status=0x%x\n",
 			__func__, adapter->driver_cmds.enc_cmd.status);
-		leapraid_log_req_context(adapter, sep_req);
+		leapraid_log_req_context(adapter, smid, sep_req);
 		reset_flg =
 			leapraid_check_reset(
 				adapter->driver_cmds.enc_cmd.status);
@@ -5512,10 +5494,10 @@ static int leapraid_wait_adapter_recovery(struct leapraid_adapter *adapter)
 {
 	unsigned long flags;
 
-	while (scsi_host_in_recovery(adapter->shost) ||
-	       adapter->access_ctrl.shost_recovering) {
-		if (adapter->access_ctrl.host_removing ||
-		    adapter->fw_evt_s.fw_evt_cleanup) {
+	while (leapraid_shost_in_recovery(adapter->shost) ||
+	       READ_ONCE(adapter->access_ctrl.shost_recovering)) {
+		if (READ_ONCE(adapter->access_ctrl.host_removing) ||
+		    READ_ONCE(adapter->fw_evt_s.fw_evt_cleanup)) {
 			spin_lock_irqsave(
 				&adapter->reset_desc.adapter_reset_lock,
 				flags);
@@ -5535,12 +5517,13 @@ static int leapraid_wait_adapter_recovery(struct leapraid_adapter *adapter)
 			return -EFAULT;
 		}
 
-		wait_event_timeout(adapter->access_ctrl.recovery_waitq,
-				   !adapter->access_ctrl.shost_recovering ||
-				   adapter->access_ctrl.host_removing ||
-				   adapter->fw_evt_s.fw_evt_cleanup,
-				   msecs_to_jiffies(1000));
+		wait_event_timeout(
+			adapter->access_ctrl.recovery_waitq,
+			(!leapraid_shost_in_recovery(adapter->shost) &&
+			 !READ_ONCE(adapter->access_ctrl.shost_recovering)),
+			msecs_to_jiffies(1000));
 	}
+
 	return 0;
 }
 
@@ -5625,7 +5608,6 @@ static void leapraid_sas_dev_stat_chg_evt(
 			leapraid_get_port_by_id(adapter,
 						event_data->physical_port,
 						false));
-
 	if (!sas_dev || !sas_dev->starget)
 		goto out_unlock;
 
@@ -5895,9 +5877,9 @@ static void leapraid_scan_dev_complete(struct leapraid_adapter *adapter)
 	leapraid_fw_evt_put(fw_evt);
 }
 
-static u8 leapraid_handle_scan_cb(struct leapraid_adapter *adapter,
-				  struct leapraid_driver_cmd *cmd,
-				  struct leapraid_rep *rep)
+static void leapraid_handle_scan_cb(struct leapraid_adapter *adapter,
+				    struct leapraid_driver_cmd *cmd,
+				    struct leapraid_rep *rep)
 {
 	u16 status;
 
@@ -5905,21 +5887,18 @@ static u8 leapraid_handle_scan_cb(struct leapraid_adapter *adapter,
 
 	status = le16_to_cpu(rep->adapter_status) &
 		 LEAPRAID_ADAPTER_STATUS_MASK;
-
 	if (status != LEAPRAID_ADAPTER_STATUS_SUCCESS)
 		adapter->scan_dev_desc.scan_dev_failed = 1;
 
 	if (!cmd->async_scan_dev) {
 		complete(&cmd->done);
-		return 1;
+		return;
 	}
 
 	if (status == LEAPRAID_ADAPTER_STATUS_SUCCESS)
 		leapraid_scan_dev_complete(adapter);
 	else
 		adapter->scan_dev_desc.scan_start_failed = status;
-
-	return 1;
 }
 
 static void leapraid_handle_ctl_cb(struct leapraid_adapter *adapter,
@@ -5933,7 +5912,6 @@ static void leapraid_handle_ctl_cb(struct leapraid_adapter *adapter,
 		return;
 
 	scsiio_reply = (struct leapraid_scsiio_rep *)rep;
-
 	if (!(scsiio_reply->scsi_state &
 	      LEAPRAID_SCSI_STATE_AUTOSENSE_VALID))
 		return;
@@ -5976,10 +5954,11 @@ static bool leapraid_driver_cmds_done(struct leapraid_adapter *adapter,
 		memcpy(&_sp_cmd->reply, leap_mpi_rep, reply_len);
 		_sp_cmd->status |= LEAPRAID_CMD_REPLY_VALID;
 
-		if (_sp_cmd->cb_idx == LEAPRAID_SCAN_DEV_CB_IDX)
-			return leapraid_handle_scan_cb(adapter,
-						       _sp_cmd,
-						       leap_mpi_rep);
+		if (_sp_cmd->cb_idx == LEAPRAID_SCAN_DEV_CB_IDX) {
+			leapraid_handle_scan_cb(adapter, _sp_cmd,
+						leap_mpi_rep);
+			return true;
+		}
 
 		if (_sp_cmd->cb_idx == LEAPRAID_CTL_CB_IDX)
 			leapraid_handle_ctl_cb(adapter, leap_mpi_rep, taskid);
@@ -6245,7 +6224,6 @@ static int leapraid_host_diag_reset(struct leapraid_adapter *adapter)
 {
 	u32 host_diag;
 
-	dev_info(&adapter->pdev->dev, "Entering host diag reset!\n");
 	pci_cfg_access_lock(adapter->pdev);
 
 	mutex_lock(&adapter->reset_desc.host_diag_mutex);
@@ -6269,14 +6247,13 @@ static int leapraid_host_diag_reset(struct leapraid_adapter *adapter)
 		goto out_failed;
 
 	pci_cfg_access_unlock(adapter->pdev);
-	dev_info(&adapter->pdev->dev, "Host diag success!\n");
 	return 0;
 
 out_cleanup:
 	mutex_unlock(&adapter->reset_desc.host_diag_mutex);
 out_failed:
 	pci_cfg_access_unlock(adapter->pdev);
-	dev_info(&adapter->pdev->dev, "Host diag failed!\n");
+	dev_err(&adapter->pdev->dev, "Host diag failed\n");
 	return -EFAULT;
 }
 
@@ -6791,11 +6768,8 @@ static void leapraid_search_resp_sas_dev(struct leapraid_adapter *adapter)
 	struct leapraid_sas_dev_p0 sas_dev_p0;
 	u32 device_info;
 
-	dev_info(&adapter->pdev->dev,
-		 "Begin searching for SAS end devices\n");
-
 	if (list_empty(&adapter->dev_topo.sas_dev_list))
-		goto exit_search;
+		return;
 
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (cfgp2.handle = 0xFFFF;
@@ -6808,9 +6782,6 @@ static void leapraid_search_resp_sas_dev(struct leapraid_adapter *adapter)
 
 		leapraid_mark_resp_sas_dev(adapter, &sas_dev_p0);
 	}
-exit_search:
-	dev_info(&adapter->pdev->dev,
-		 "SAS end devices searching complete\n");
 }
 
 static void leapraid_mark_resp_raid_volume(struct leapraid_adapter *adapter,
@@ -6879,14 +6850,11 @@ static void leapraid_search_resp_raid_volume(struct leapraid_adapter *adapter)
 	if (!adapter->adapter_attr.raid_support)
 		return;
 
-	dev_info(&adapter->pdev->dev,
-		 "Begin searching for RAID volumes\n");
-
 	spin_lock_irqsave(&adapter->dev_topo.raid_volume_lock, flags);
 	is_empty = list_empty(&adapter->dev_topo.raid_volume_list);
 	spin_unlock_irqrestore(&adapter->dev_topo.raid_volume_lock, flags);
 	if (is_empty)
-		goto exit_search;
+		return;
 
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (hdl = 0xFFFF, cfgp2.handle = hdl;
@@ -6924,9 +6892,6 @@ static void leapraid_search_resp_raid_volume(struct leapraid_adapter *adapter)
 		else
 			set_bit(hdl, adapter->dev_topo.pd_hdls);
 	}
-exit_search:
-	dev_info(&adapter->pdev->dev,
-		 "RAID volumes searching complete\n");
 }
 
 static void leapraid_mark_resp_exp(struct leapraid_adapter *adapter,
@@ -6987,10 +6952,8 @@ static void leapraid_search_resp_exp(struct leapraid_adapter *adapter)
 	u16 hdl;
 	u8 port;
 
-	dev_dbg(&adapter->pdev->dev,
-		"Begin searching for expanders\n");
 	if (list_empty(&adapter->dev_topo.exp_list))
-		goto exit_search;
+		return;
 
 	cfgp1.form = LEAPRAID_SAS_CFG_PGAD_GET_NEXT_LOOP;
 	for (hdl = 0xFFFF, cfgp2.handle = hdl;
@@ -7008,9 +6971,6 @@ static void leapraid_search_resp_exp(struct leapraid_adapter *adapter)
 				LEAPRAID_DISABLE_MP_PORT_ID);
 		leapraid_mark_resp_exp(adapter, &exp_p0);
 	}
-exit_search:
-	dev_dbg(&adapter->pdev->dev,
-		"Expander searching complete\n");
 }
 
 void leapraid_wait_cmds_done(struct leapraid_adapter *adapter)
@@ -7099,7 +7059,6 @@ int leapraid_hard_reset_handler(struct leapraid_adapter *adapter,
 		dev_err(&adapter->pdev->dev,
 			"Previous device scan failed or driver loading\n");
 		adapter->access_ctrl.host_removing = 1;
-		wake_up(&adapter->access_ctrl.recovery_waitq);
 		rc = -EFAULT;
 		goto out_cleanup;
 	}
@@ -7120,8 +7079,8 @@ int leapraid_hard_reset_handler(struct leapraid_adapter *adapter,
 		leapraid_hardreset_barrier(adapter);
 	}
 out_cleanup:
-	dev_info(&adapter->pdev->dev, "Hard reset %s\n",
-		 rc == 0 ? "SUCCESS" : "FAILED");
+	if (rc)
+		dev_err(&adapter->pdev->dev, "Hard reset failed\n");
 
 	spin_lock_irqsave(&adapter->reset_desc.adapter_reset_lock, flags);
 	adapter->reset_desc.adapter_reset_results = rc;
@@ -7358,8 +7317,8 @@ static void leapraid_map_msix_to_cpu(struct leapraid_adapter *adapter)
 {
 	struct leapraid_int_rq *int_rq;
 	const cpumask_t *affinity_mask;
+	int cpu;
 	u32 i;
-	u16 cpu;
 
 	if (!adapter->adapter_attr.rq_cnt)
 		return;
@@ -7383,6 +7342,7 @@ static void leapraid_map_msix_to_cpu(struct leapraid_adapter *adapter)
 				int_rq->rq.msix_idx;
 		}
 	}
+	return;
 out_apply_irq_affinity:
 	leapraid_cpus_on_irq(adapter);
 }
@@ -7445,7 +7405,6 @@ static int leapraid_setup_irqs(struct leapraid_adapter *adapter)
 			adapter->notification_desc.iopoll_qdex,
 			adapter->notification_desc.iopoll_qdex,
 			PCI_IRQ_MSIX | PCI_IRQ_AFFINITY, NULL);
-
 		if (rc < 0) {
 			dev_err(&adapter->pdev->dev,
 				"%d MSI/MSIX vectors allocated failed!\n",
@@ -7478,7 +7437,6 @@ static int leapraid_setup_irqs(struct leapraid_adapter *adapter)
 				 IRQF_SHARED,
 				 adapter->notification_desc.int_rqs[i].rq.name,
 				 &adapter->notification_desc.int_rqs[i].rq);
-
 		if (rc) {
 			dev_err(&adapter->pdev->dev,
 				"MSI/MSIx: request_irq %s failed!\n",
@@ -7536,8 +7494,6 @@ static int leapraid_setup_legacy_int(struct leapraid_adapter *adapter)
 
 static int leapraid_set_legacy_int(struct leapraid_adapter *adapter)
 {
-	int rc;
-
 	adapter->notification_desc.msix_cpu_map_sz = num_online_cpus();
 	adapter->notification_desc.msix_cpu_map =
 		kzalloc(adapter->notification_desc.msix_cpu_map_sz,
@@ -7560,9 +7516,7 @@ static int leapraid_set_legacy_int(struct leapraid_adapter *adapter)
 	if (!adapter->notification_desc.int_rqs)
 		return -ENOMEM;
 
-	rc = leapraid_setup_legacy_int(adapter);
-
-	return rc;
+	return leapraid_setup_legacy_int(adapter);
 }
 
 static int leapraid_set_msix(struct leapraid_adapter *adapter)
@@ -7670,9 +7624,7 @@ static int leapraid_set_msix(struct leapraid_adapter *adapter)
 	return 0;
 
 apply_legacy_int:
-	rc = leapraid_set_legacy_int(adapter);
-
-	return rc;
+	return leapraid_set_legacy_int(adapter);
 }
 
 static int leapraid_set_msi(struct leapraid_adapter *adapter)
@@ -7801,9 +7753,7 @@ static int leapraid_set_msi(struct leapraid_adapter *adapter)
 	return 0;
 
 apply_legacy_int:
-	rc = leapraid_set_legacy_int(adapter);
-
-	return rc;
+	return leapraid_set_legacy_int(adapter);
 }
 
 static int leapraid_set_notification(struct leapraid_adapter *adapter)
@@ -7886,18 +7836,16 @@ static int leapraid_adapter_unit_reset(struct leapraid_adapter *adapter)
 {
 	int rc = 0;
 
-	dev_info(&adapter->pdev->dev, "fire unit reset\n");
 	writel(LEAPRAID_FUNC_ADAPTER_UNIT_RESET << LEAPRAID_DB_FUNC_SHIFT,
 	       &adapter->iomem_base->db);
 	if (leapraid_db_wait_ack_and_clear_int(adapter))
 		rc = -EFAULT;
 
 	if (!leapraid_wait_adapter_ready(adapter)) {
-		dev_info(&adapter->pdev->dev, "unit reset: FAILED\n");
+		dev_err(&adapter->pdev->dev, "unit reset failed\n");
 		return -EFAULT;
 	}
 
-	dev_info(&adapter->pdev->dev, "unit reset: SUCCESS\n");
 	return rc;
 }
 
@@ -7905,7 +7853,6 @@ static int leapraid_make_adapter_ready(struct leapraid_adapter *adapter,
 				       enum reset_type type)
 {
 	u32 db;
-	int rc;
 	int count;
 
 	if (!leapraid_pci_active(adapter))
@@ -7944,8 +7891,7 @@ static int leapraid_make_adapter_ready(struct leapraid_adapter *adapter,
 		return 0;
 
 full_reset:
-	rc = leapraid_host_diag_reset(adapter);
-	return rc;
+	return leapraid_host_diag_reset(adapter);
 }
 
 static void leapraid_fw_log_exit(struct leapraid_adapter *adapter)
@@ -8116,15 +8062,13 @@ int leapraid_internal_init_cmd_priv(struct leapraid_adapter *adapter,
 	return 0;
 }
 
-int leapraid_internal_exit_cmd_priv(struct leapraid_adapter *adapter,
-				    struct leapraid_io_req_tracker *io_tracker)
+void leapraid_internal_exit_cmd_priv(struct leapraid_adapter *adapter,
+				     struct leapraid_io_req_tracker *io_tracker)
 {
 	if (io_tracker && io_tracker->chain)
 		dma_pool_free(adapter->mem_desc.sg_chain_pool,
 			      io_tracker->chain,
 			      io_tracker->chain_dma);
-
-	return 0;
 }
 
 static int leapraid_request_host_memory(struct leapraid_adapter *adapter)
@@ -8405,9 +8349,10 @@ static int leapraid_alloc_dev_topo_bitmaps(struct leapraid_adapter *adapter)
 {
 	u16 pd_hdls_sz;
 
-	pd_hdls_sz = adapter->adapter_attr.features.max_dev_handle /
-		     LEAPRAID_BITS_PER_BYTE;
-	pd_hdls_sz++;
+	pd_hdls_sz =
+		BITS_TO_LONGS(
+			adapter->adapter_attr.features.max_dev_handle + 1) *
+		sizeof(unsigned long);
 
 	adapter->dev_topo.pd_hdls_sz = pd_hdls_sz;
 	adapter->dev_topo.pd_hdls =
@@ -8643,48 +8588,52 @@ static int leapraid_cfg_pages(struct leapraid_adapter *adapter)
 {
 	union cfg_param_1 cfgp1 = {0};
 	union cfg_param_2 cfgp2 = {0};
-	struct leapraid_manufacturing_p0 manufacturing_page0;
-	struct leapraid_bios_page3 bios_page3;
-	struct leapraid_bios_page2 bios_page2;
+	union {
+		struct leapraid_manufacturing_p0 manufacturing_page0;
+		struct leapraid_bios_page3 bios_page3;
+		struct leapraid_bios_page2 bios_page2;
+	} cfg_page;
 	int rc;
 
-	rc = leapraid_op_config_page(adapter, &bios_page3, cfgp1,
+	rc = leapraid_op_config_page(adapter, &cfg_page.bios_page3, cfgp1,
 				     cfgp2, GET_BIOS_PG3);
 	if (rc)
 		return rc;
 
-	rc = leapraid_op_config_page(adapter, &bios_page2, cfgp1,
+	adapter->adapter_attr.bios_version =
+		le32_to_cpu(cfg_page.bios_page3.bios_version);
+
+	rc = leapraid_op_config_page(adapter, &cfg_page.bios_page2, cfgp1,
 				     cfgp2, GET_BIOS_PG2);
 	if (rc)
 		return rc;
 
-	rc = leapraid_op_config_page(adapter, &manufacturing_page0, cfgp1,
-				     cfgp2, GET_MANUFACTURING_PG0);
+	adapter->boot_devs.requested_boot_dev.form =
+		cfg_page.bios_page2.requested_boot_dev_form;
+	memcpy(adapter->boot_devs.requested_boot_dev.pg_dev,
+	       &cfg_page.bios_page2.requested_boot_dev,
+	       LEAPRAID_BOOT_DEV_SIZE);
+	adapter->boot_devs.requested_alt_boot_dev.form =
+		cfg_page.bios_page2.requested_alt_boot_dev_form;
+	memcpy(adapter->boot_devs.requested_alt_boot_dev.pg_dev,
+	       &cfg_page.bios_page2.requested_alt_boot_dev,
+	       LEAPRAID_BOOT_DEV_SIZE);
+	adapter->boot_devs.current_boot_dev.form =
+		cfg_page.bios_page2.current_boot_dev_form;
+	memcpy(adapter->boot_devs.current_boot_dev.pg_dev,
+	       &cfg_page.bios_page2.current_boot_dev,
+	       LEAPRAID_BOOT_DEV_SIZE);
+
+	rc = leapraid_op_config_page(adapter, &cfg_page.manufacturing_page0,
+				     cfgp1, cfgp2, GET_MANUFACTURING_PG0);
 	if (rc)
 		return rc;
 
-	adapter->adapter_attr.bios_version =
-		le32_to_cpu(bios_page3.bios_version);
 	snprintf(adapter->adapter_attr.board_name,
 		 sizeof(adapter->adapter_attr.board_name),
 		 "%.*s",
-		 (int)sizeof(manufacturing_page0.board_name),
-		 manufacturing_page0.board_name);
-	adapter->boot_devs.requested_boot_dev.form =
-		bios_page2.requested_boot_dev_form;
-	memcpy(adapter->boot_devs.requested_boot_dev.pg_dev,
-	       &bios_page2.requested_boot_dev,
-	       LEAPRAID_BOOT_DEV_SIZE);
-	adapter->boot_devs.requested_alt_boot_dev.form =
-		bios_page2.requested_alt_boot_dev_form;
-	memcpy(adapter->boot_devs.requested_alt_boot_dev.pg_dev,
-	       &bios_page2.requested_alt_boot_dev,
-	       LEAPRAID_BOOT_DEV_SIZE);
-	adapter->boot_devs.current_boot_dev.form =
-		bios_page2.current_boot_dev_form;
-	memcpy(adapter->boot_devs.current_boot_dev.pg_dev,
-	       &bios_page2.current_boot_dev,
-	       LEAPRAID_BOOT_DEV_SIZE);
+		 (int)sizeof(cfg_page.manufacturing_page0.board_name),
+		 cfg_page.manufacturing_page0.board_name);
 	return rc;
 }
 
@@ -8793,8 +8742,6 @@ int leapraid_scan_dev(struct leapraid_adapter *adapter, bool async_scan_dev)
 
 out_cleanup:
 	adapter->driver_cmds.scan_dev_cmd.status = LEAPRAID_CMD_NOT_USED;
-	dev_info(&adapter->pdev->dev,
-		 "Device scan %s\n", rc == 0 ? "SUCCESS" : "FAILED");
 	return rc;
 }
 
@@ -8936,11 +8883,7 @@ static int leapraid_make_adapter_available(struct leapraid_adapter *adapter)
 		return 0;
 	}
 
-	rc = leapraid_scan_dev(adapter, false);
-	if (rc)
-		return rc;
-
-	return rc;
+	return leapraid_scan_dev(adapter, false);
 }
 
 int leapraid_ctrl_init(struct leapraid_adapter *adapter)
@@ -9006,7 +8949,6 @@ int leapraid_ctrl_init(struct leapraid_adapter *adapter)
 
 out_free:
 	adapter->access_ctrl.host_removing = 1;
-	wake_up(&adapter->access_ctrl.recovery_waitq);
 	leapraid_fw_log_exit(adapter);
 	leapraid_free_internal_scsi_cmd(adapter);
 	leapraid_disable_controller(adapter);

--- a/drivers/scsi/leapraid/leapraid_func.h
+++ b/drivers/scsi/leapraid/leapraid_func.h
@@ -51,11 +51,11 @@
 #define LEAPRAID_BOARD_NAME_LENGTH      17
 #define LEAPRAID_AUTHOR                 "LeapIO Inc."
 #define LEAPRAID_DESCRIPTION            "LeapRAID Driver"
-#define LEAPRAID_DRIVER_VERSION         "2.00.01.02"
+#define LEAPRAID_DRIVER_VERSION         "2.00.01.05"
 #define LEAPRAID_MAJOR_VERSION          2
 #define LEAPRAID_MINOR_VERSION          00
 #define LEAPRAID_BUILD_VERSION          01
-#define LEAPRAID_RELEASE_VERSION        02
+#define LEAPRAID_RELEASE_VERSION        05
 #define LEAPRAID_MSG_VERSION            0x1021
 #define LEAPRAID_HEADER_VERSION         0x0000
 
@@ -127,7 +127,6 @@
 
 /* SMP (Serial Management Protocol). */
 #define LEAPRAID_SMP_PT_FLAG_SGL_PTR            0x80
-#define LEAPRAID_SMP_FN_REPORT_PHY_ERR_LOG      0x91
 #define LEAPRAID_SMP_FRAME_HEADER_SIZE          4
 #define LEAPRAID_SCSI_HOST_SHIFT                16
 #define LEAPRAID_SCSI_DRIVER_SHIFT              24
@@ -171,13 +170,9 @@
 
 /* Basic constants and limits.   */
 #define LEAPRAID_BUSY_LIMIT             1
-#define LEAPRAID_INDEX_FIRST            0
-#define LEAPRAID_BITS_PER_BYTE          8
 #define LEAPRAID_INVALID_HOST_DIAG_VAL  0xFFFFFFFF
 
 /* Retry/Sleep configuration. */
-#define LEAPRAID_WRITE_SEQUENCE_OFFSET  0x4
-#define LEAPRAID_WRSEQ_KEY_VALUE_MASK   0xF
 #define LEAPRAID_WRSEQ_FLUSH_KEY_VALUE  0x0
 #define LEAPRAID_WRSEQ_1ST_KEY_VALUE    0xF
 #define LEAPRAID_WRSEQ_2ND_KEY_VALUE    0x4
@@ -187,7 +182,6 @@
 #define LEAPRAID_WRSEQ_6TH_KEY_VALUE    0xD
 #define LEAPRAID_UNLOCK_RETRY_LIMIT     20
 #define LEAPRAID_UNLOCK_SLEEP_MS        100
-#define LEAPRAID_MSLEEP_SHORT_MS        50
 #define LEAPRAID_MSLEEP_NORMAL_MS       100
 #define LEAPRAID_MSLEEP_EXTRA_LONG_MS   500
 #define LEAPRAID_IO_POLL_DELAY_US       500
@@ -198,7 +192,6 @@
 #define LEAPRAID_INVALID_DEV_HANDLE     0xFFFF
 
 /* Commands queue depth. */
-#define LEAPRAID_COALESCING_DEPTH_MAX   256
 #define LEAPRAID_DEFAULT_CMD_QD_OFFSET  64
 #define LEAPRAID_REPLY_QD_ALIGNMENT     16
 /* Task ID offset. */
@@ -224,7 +217,6 @@
 #define LEAPRAID_CTL_CMD_TIMEOUT               LEAPRAID_UNIFIED_TIMEOUT
 #define LEAPRAID_SCAN_DEV_CMD_TIMEOUT          300
 #define LEAPRAID_TIMESTAMP_SYNC_CMD_TIMEOUT    LEAPRAID_UNIFIED_TIMEOUT
-#define LEAPRAID_RAID_ACTION_CMD_TIMEOUT       LEAPRAID_UNIFIED_TIMEOUT
 #define LEAPRAID_ENC_CMD_TIMEOUT               LEAPRAID_UNIFIED_TIMEOUT
 #define LEAPRAID_IO_CMD_TIMEOUT                LEAPRAID_UNIFIED_TIMEOUT
 #define LEAPRAID_NOTIFY_EVENT_CMD_TIMEOUT      LEAPRAID_UNIFIED_TIMEOUT
@@ -599,6 +591,7 @@ struct leapraid_fw_evt_work {
  * @leapraid_evt_masks: Array of event masks for filtering firmware events.
  */
 struct leapraid_fw_evt_struct {
+	u32 leapraid_evt_masks[4];
 	char fw_evt_name[48];
 	struct workqueue_struct *fw_evt_thread;
 	spinlock_t fw_evt_lock; /* protects firmware event */
@@ -606,7 +599,6 @@ struct leapraid_fw_evt_struct {
 	struct leapraid_fw_evt_work *cur_evt;
 	struct task_struct *cur_evt_task;
 	u8 fw_evt_cleanup;
-	u32 leapraid_evt_masks[4];
 };
 
 /**
@@ -1446,7 +1438,7 @@ int leapraid_get_volume_cap(struct leapraid_adapter *adapter,
 int leapraid_internal_init_cmd_priv(
 		struct leapraid_adapter *adapter,
 		struct leapraid_io_req_tracker *io_tracker);
-int leapraid_internal_exit_cmd_priv(
+void leapraid_internal_exit_cmd_priv(
 		struct leapraid_adapter *adapter,
 		struct leapraid_io_req_tracker *io_tracker);
 void leapraid_clean_active_fw_evt(struct leapraid_adapter *adapter);
@@ -1517,7 +1509,7 @@ int leapraid_op_config_page(struct leapraid_adapter *adapter,
 			    void *cfgp, union cfg_param_1 cfgp1,
 			    union cfg_param_2 cfgp2,
 			    enum config_page_action cfg_op);
-void leapraid_log_req_context(struct leapraid_adapter *adapter,
+void leapraid_log_req_context(struct leapraid_adapter *adapter, u16 smid,
 			      const void *req_data);
 
 int leapraid_change_queue_depth(struct scsi_device *sdev, int qdepth);

--- a/drivers/scsi/leapraid/leapraid_os.c
+++ b/drivers/scsi/leapraid/leapraid_os.c
@@ -157,9 +157,8 @@ static int leapraid_tm_post_processing(struct leapraid_adapter *adapter,
 	leapraid_sync_irqs(adapter, true);
 	leapraid_unmask_int(adapter);
 
-	rc = leapraid_tm_cmd_map_status(adapter, channel, id, lun, type,
-					taskid_task);
-	return rc;
+	return leapraid_tm_cmd_map_status(adapter, channel, id, lun, type,
+					  taskid_task);
 }
 
 static void leapraid_build_tm_req(struct leapraid_scsi_tm_req *scsi_tm_req,
@@ -185,6 +184,7 @@ int leapraid_issue_tm(struct leapraid_adapter *adapter, u16 hdl, uint channel,
 	struct leapraid_scsiio_req *scsiio_req;
 	struct leapraid_io_req_tracker *io_req_tracker = NULL;
 	u16 msix_task;
+	u16 taskid;
 	bool issue_reset = false;
 	u32 db;
 	int rc;
@@ -239,16 +239,15 @@ int leapraid_issue_tm(struct leapraid_adapter *adapter, u16 hdl, uint channel,
 		msix_task = io_req_tracker->msix_io;
 	else
 		msix_task = 0;
-	leapraid_fire_hpr_task(adapter,
-			       adapter->driver_cmds.tm_cmd.hp_taskid,
-			       msix_task);
+	taskid = adapter->driver_cmds.tm_cmd.hp_taskid;
+	leapraid_fire_hpr_task(adapter, taskid, msix_task);
 	wait_for_completion_timeout(&adapter->driver_cmds.tm_cmd.done,
 				    LEAPRAID_TM_CMD_TIMEOUT * HZ);
 	if (!(adapter->driver_cmds.tm_cmd.status & LEAPRAID_CMD_DONE)) {
 		dev_err(&adapter->pdev->dev,
 			"%s: TM cmd timeout, status=0x%x\n",
 			__func__, adapter->driver_cmds.tm_cmd.status);
-		leapraid_log_req_context(adapter, scsi_tm_req);
+		leapraid_log_req_context(adapter, taskid, scsi_tm_req);
 		issue_reset =
 			leapraid_check_reset(
 				adapter->driver_cmds.tm_cmd.status);
@@ -644,7 +643,6 @@ static void leapraid_probe_sas(struct leapraid_adapter *adapter)
 						    sas_dev->hdl,
 						    sas_dev->parent_sas_addr,
 						    sas_dev->card_port);
-
 		if (!added)
 			goto remove_dev;
 
@@ -805,10 +803,7 @@ static inline bool leapraid_is_scmd_permitted(struct leapraid_adapter *adapter,
 			return false;
 
 		opcode = scmd->cmnd[0];
-		if (opcode == SYNCHRONIZE_CACHE || opcode == START_STOP)
-			return true;
-
-		return false;
+		return opcode == SYNCHRONIZE_CACHE || opcode == START_STOP;
 	}
 	return true;
 }
@@ -1101,13 +1096,15 @@ static int leapraid_error_handler(struct scsi_cmnd *scmd,
 
 out_eh_done:
 	if (type == LEAPRAID_TM_TASKTYPE_ABORT_TASK) {
-		dev_info(&adapter->pdev->dev,
-			 "EH ABORT result: %s, scmd=0x%p\n",
-			 rc == SUCCESS ? "success" : "failed", scmd);
+		if (rc)
+			dev_err(&adapter->pdev->dev,
+				"EH ABORT result: failed, scmd=0x%p\n",
+				scmd);
 	} else {
-		dev_info(&adapter->pdev->dev,
-			 "EH %s result: %s, scmd=0x%p\n",
-			 str, rc == SUCCESS ? "success" : "failed", scmd);
+		if (rc)
+			dev_err(&adapter->pdev->dev,
+				"EH %s result: failed, scmd=0x%p\n",
+				str, scmd);
 		if (sas_dev)
 			leapraid_sdev_put(sas_dev);
 	}
@@ -1161,8 +1158,10 @@ static int leapraid_eh_host_reset_handler(struct scsi_cmnd *scmd)
 		rc = SUCCESS;
 
 out_host_reset_done:
-	dev_info(&adapter->pdev->dev, "EH HOST RESET result: %s, scmd=0x%p\n",
-		 rc == SUCCESS ? "success" : "failed", scmd);
+	if (rc)
+		dev_err(&adapter->pdev->dev,
+			"EH HOST RESET result: failed, scmd=0x%p\n",
+			scmd);
 	return rc;
 }
 
@@ -1227,8 +1226,8 @@ static int leapraid_slave_alloc(struct scsi_device *sdev)
 	return 0;
 }
 
-static int leapraid_slave_cfg_volume(struct scsi_device *sdev,
-				     struct queue_limits *lim)
+static bool leapraid_slave_cfg_volume(struct scsi_device *sdev,
+				      struct queue_limits *lim)
 {
 	struct Scsi_Host *shost = sdev->host;
 	struct leapraid_adapter *adapter = shost_priv(shost);
@@ -1276,10 +1275,10 @@ static int leapraid_slave_cfg_volume(struct scsi_device *sdev,
 	return 0;
 }
 
-static int leapraid_slave_configure_extra(struct scsi_device *sdev,
-					  struct leapraid_sas_dev **psas_dev,
-					  u16 vol_hdl, u64 volume_wwid,
-					  bool *is_target_ssp, int *qd)
+static bool leapraid_slave_configure_extra(struct scsi_device *sdev,
+					   struct leapraid_sas_dev **psas_dev,
+					   u16 vol_hdl, u64 volume_wwid,
+					   bool *is_target_ssp, int *qd)
 {
 	struct leapraid_sas_dev *sas_dev;
 	struct leapraid_sdev_priv *sdev_priv;
@@ -1587,11 +1586,9 @@ static bool leapraid_scan_check_status(struct leapraid_adapter *adapter,
 		wake_up(&adapter->scan_dev_desc.wait_driver_loading);
 		adapter->scan_dev_desc.wait_scan_dev_done = 0;
 		adapter->access_ctrl.host_removing = 1;
-		wake_up(&adapter->access_ctrl.recovery_waitq);
 		return true;
 	}
 
-	dev_info(&adapter->pdev->dev, "Device scan: SUCCESS\n");
 	adapter->driver_cmds.scan_dev_cmd.status = LEAPRAID_CMD_NOT_USED;
 	leapraid_scan_dev_done(adapter);
 	return true;
@@ -2207,7 +2204,6 @@ static void leapraid_remove(struct pci_dev *pdev)
 		   !atomic_read(&adapter->overheat_desc.thermal_alert));
 
 	adapter->access_ctrl.host_removing = 1;
-	wake_up(&adapter->access_ctrl.recovery_waitq);
 
 	leapraid_wait_cmds_done(adapter);
 
@@ -2248,7 +2244,6 @@ static void leapraid_shutdown(struct pci_dev *pdev)
 	}
 
 	adapter->access_ctrl.host_removing = 1;
-	wake_up(&adapter->access_ctrl.recovery_waitq);
 	leapraid_wait_cmds_done(adapter);
 	leapraid_clean_active_fw_evt(adapter);
 	leapraid_overheat_cleanup(adapter);
@@ -2335,7 +2330,6 @@ static pci_ers_result_t leapraid_pci_slot_reset(struct pci_dev *pdev)
 	dev_err(&pdev->dev, "%s PCI error slot reset\n",
 		adapter->adapter_attr.name);
 
-	adapter->access_ctrl.pcie_recovering = 0;
 	adapter->pdev = pdev;
 	pci_restore_state(pdev);
 	if (leapraid_set_pcie_and_notification(adapter)) {
@@ -2345,13 +2339,15 @@ static pci_ers_result_t leapraid_pci_slot_reset(struct pci_dev *pdev)
 		return PCI_ERS_RESULT_DISCONNECT;
 	}
 
+	adapter->access_ctrl.pcie_recovering = 0;
 	dev_info(&pdev->dev, "%s: Hard reset triggered by PCI slot reset\n",
 		 adapter->adapter_attr.name);
 	dev_info(&adapter->pdev->dev, "%s: %d: call hard_reset\n",
 		 __func__, __LINE__);
 	rc = leapraid_hard_reset_handler(adapter, FULL_RESET);
-	dev_info(&pdev->dev, "%s hard reset: %s\n",
-		 adapter->adapter_attr.name, rc == 0 ? "success" : "failed");
+	if (rc)
+		dev_err(&pdev->dev, "%s hard reset: failed\n",
+			adapter->adapter_attr.name);
 
 	return rc == 0 ? PCI_ERS_RESULT_RECOVERED :
 		 PCI_ERS_RESULT_DISCONNECT;
@@ -2368,6 +2364,7 @@ static void leapraid_pci_resume(struct pci_dev *pdev)
 	}
 
 	dev_err(&pdev->dev, "PCI error resume!\n");
+
 	pci_aer_clear_nonfatal_status(pdev);
 	leapraid_check_scheduled_fault_start(adapter);
 	leapraid_fw_log_start(adapter);

--- a/drivers/scsi/leapraid/leapraid_transport.c
+++ b/drivers/scsi/leapraid/leapraid_transport.c
@@ -298,6 +298,7 @@ static int leapraid_transport_exp_report_manu(struct leapraid_adapter *adapter,
 	dma_addr_t c2h_dma_addr;
 	bool issue_reset = false;
 	void *data_out = NULL;
+	u16 inter_taskid;
 	size_t c2h_size;
 	size_t h2c_size;
 	void *psge;
@@ -338,10 +339,8 @@ static int leapraid_transport_exp_report_manu(struct leapraid_adapter *adapter,
 	rep_manu_request->allocated_response_length = 0;
 	rep_manu_request->request_length = 0;
 
-	smp_passthrough_req =
-		leapraid_get_task_desc(
-			adapter,
-			adapter->driver_cmds.transport_cmd.inter_taskid);
+	inter_taskid = adapter->driver_cmds.transport_cmd.inter_taskid;
+	smp_passthrough_req = leapraid_get_task_desc(adapter, inter_taskid);
 	memset(smp_passthrough_req, 0,
 	       sizeof(struct leapraid_smp_passthrough_req));
 	smp_passthrough_req->func = LEAPRAID_FUNC_SMP_PASSTHROUGH;
@@ -354,8 +353,7 @@ static int leapraid_transport_exp_report_manu(struct leapraid_adapter *adapter,
 			       c2h_dma_addr, c2h_size);
 
 	init_completion(&adapter->driver_cmds.transport_cmd.done);
-	leapraid_fire_task(adapter,
-			   adapter->driver_cmds.transport_cmd.inter_taskid);
+	leapraid_fire_task(adapter, inter_taskid);
 	wait_for_completion_timeout(&adapter->driver_cmds.transport_cmd.done,
 				    LEAPRAID_TRANSPORT_CMD_TIMEOUT * HZ);
 	if (!(adapter->driver_cmds.transport_cmd.status & LEAPRAID_CMD_DONE)) {
@@ -363,7 +361,8 @@ static int leapraid_transport_exp_report_manu(struct leapraid_adapter *adapter,
 		dev_err(&adapter->pdev->dev,
 			"%s: SMP passthrough timeout, st=0x%x\n",
 			__func__, adapter->driver_cmds.transport_cmd.status);
-		leapraid_log_req_context(adapter, smp_passthrough_req);
+		leapraid_log_req_context(adapter, inter_taskid,
+					 smp_passthrough_req);
 		if (!(adapter->driver_cmds.transport_cmd.status &
 		      LEAPRAID_CMD_RESET))
 			issue_reset = true;
@@ -1249,20 +1248,21 @@ static void leapraid_build_smp_task(struct leapraid_adapter *adapter,
 static int leapraid_send_smp_req(struct leapraid_adapter *adapter)
 {
 	const struct leapraid_smp_passthrough_req *smp_passthrough_req;
+	u16 inter_taskid;
 
 	dev_dbg(&adapter->pdev->dev,
 		"%s: Sending smp request\n", __func__);
-	smp_passthrough_req = leapraid_get_task_desc(
-		adapter, adapter->driver_cmds.transport_cmd.inter_taskid);
+	inter_taskid = adapter->driver_cmds.transport_cmd.inter_taskid;
+	smp_passthrough_req = leapraid_get_task_desc(adapter, inter_taskid);
 	init_completion(&adapter->driver_cmds.transport_cmd.done);
-	leapraid_fire_task(adapter,
-			   adapter->driver_cmds.transport_cmd.inter_taskid);
+	leapraid_fire_task(adapter, inter_taskid);
 	wait_for_completion_timeout(&adapter->driver_cmds.transport_cmd.done,
 				    LEAPRAID_TRANSPORT_CMD_TIMEOUT * HZ);
 	if (!(adapter->driver_cmds.transport_cmd.status & LEAPRAID_CMD_DONE)) {
 		dev_err(&adapter->pdev->dev, "%s: timeout, st=0x%x\n",
 			__func__, adapter->driver_cmds.transport_cmd.status);
-		leapraid_log_req_context(adapter, smp_passthrough_req);
+		leapraid_log_req_context(adapter, inter_taskid,
+					 smp_passthrough_req);
 		if (!(adapter->driver_cmds.transport_cmd.status &
 		      LEAPRAID_CMD_RESET)) {
 			dev_dbg(&adapter->pdev->dev,


### PR DESCRIPTION
leapraid driver changes from v2.00.01.02 to v2.00.01.05.

This update includes:
- recovery wait and hard reset flow stabilization
- improved timeout diagnostics with per-command context logging
- MSI-X/IRQ CPU affinity fixes
- SAS topology and event bitmap alignment fixes
- transport and task-management error-path cleanup
- config-page stack usage reduction and adapter info cleanup
- ioctl compatibility cleanup
- resource cleanup and failure-path hardening