### PR TITLE
CPU type: phytium: update phytium CPU type support

### DIFF
--- a/arch/arm64/include/asm/phytium_cputype.h
+++ b/arch/arm64/include/asm/phytium_cputype.h
@@ -28,7 +28,7 @@
 #define SMCCC_FAILURE		(-1)
 #define FUNC_ID_GET_CPU_VERSION 0xc2000002
 
-enum phyt_cpu_type {
+enum phyt_soc_type {
 	PE1702 = 1,
 	PS17064,
 	PD1904,
@@ -44,7 +44,9 @@ enum phyt_cpu_type {
 	UNKNOWN_SOC
 };
 
-static enum phyt_cpu_type do_smccc_res(struct arm_smccc_res res)
+extern enum phyt_soc_type phyt_soc_type_t;
+
+static enum phyt_soc_type do_smccc_res(struct arm_smccc_res res)
 {
 	unsigned long smc_cpu_ver = res.a1;
 
@@ -77,7 +79,7 @@ static enum phyt_cpu_type do_smccc_res(struct arm_smccc_res res)
 	}
 }
 
-static enum phyt_cpu_type do_read_sysreg(void)
+static enum phyt_soc_type do_read_sysreg(void)
 {
 	u32 aidr_reg_val = read_sysreg(aidr_el1);
 
@@ -91,7 +93,7 @@ static enum phyt_cpu_type do_read_sysreg(void)
 	}
 }
 
-static enum phyt_cpu_type do_read_mpidr(void)
+static enum phyt_soc_type do_read_mpidr(void)
 {
 	u32 part_id = read_cpuid_part_number();
 
@@ -120,9 +122,9 @@ static inline bool is_phytium_soc(void)
 	return false;
 }
 
-static inline enum phyt_cpu_type phyt_read_cpu_type(void)
+static inline enum phyt_soc_type phyt_read_soc_type(void)
 {
-	enum phyt_cpu_type ctype;
+	enum phyt_soc_type ctype;
 	struct arm_smccc_res res;
 
 	if (!is_phytium_soc())
@@ -147,49 +149,90 @@ static inline enum phyt_cpu_type phyt_read_cpu_type(void)
 	return ctype;
 }
 
+static inline void phyt_soc_type_init(void)
+{
+	enum phyt_soc_type ctype = phyt_read_soc_type();
+
+	switch (ctype) {
+	case PE1702:
+		phyt_soc_type_t = PE1702;
+		break;
+	case PS17064:
+		phyt_soc_type_t = PS17064;
+		break;
+	case PD1904:
+		phyt_soc_type_t = PD1904;
+		break;
+	case PS20064:
+		phyt_soc_type_t = PS20064;
+		break;
+	case PD2008:
+		phyt_soc_type_t = PD2008;
+		break;
+	case PS21064:
+		phyt_soc_type_t = PS21064;
+		break;
+	case PE220X:
+		phyt_soc_type_t = PE220X;
+		break;
+	case PS23064:
+		phyt_soc_type_t = PS23064;
+		break;
+	case PD2308:
+		phyt_soc_type_t = PD2308;
+		break;
+	case PS24080:
+		phyt_soc_type_t = PS24080;
+		break;
+	case PD2408:
+		phyt_soc_type_t = PD2408;
+		break;
+	case PS15016:
+		phyt_soc_type_t = PS15016;
+		break;
+	default:
+		phyt_soc_type_t = UNKNOWN_SOC;
+		break;
+	}
+}
+
 static inline bool is_pd2408(void)
 {
-	enum phyt_cpu_type ctype = phyt_read_cpu_type();
 
-	if (ctype == PD2408)
+	if (phyt_soc_type_t == PD2408)
 		return true;
 	return false;
 }
 
 static inline bool is_ps23064(void)
 {
-	enum phyt_cpu_type ctype = phyt_read_cpu_type();
 
-	if (ctype == PS23064)
+	if (phyt_soc_type_t == PS23064)
 		return true;
 	return false;
 }
 
 static inline bool is_ps24080(void)
 {
-	enum phyt_cpu_type ctype = phyt_read_cpu_type();
 
-	if (ctype == PS24080)
+	if (phyt_soc_type_t == PS24080)
 		return true;
 	return false;
 }
 
 static inline bool is_pd2308(void)
 {
-	enum phyt_cpu_type ctype = phyt_read_cpu_type();
 
-	if (ctype == PD2308)
+	if (phyt_soc_type_t == PD2308)
 		return true;
 	return false;
 }
 
 static inline bool is_pe220x(void)
 {
-	enum phyt_cpu_type ctype = phyt_read_cpu_type();
 
-	if (ctype == PE220X)
+	if (phyt_soc_type_t == PE220X)
 		return true;
-
 	return false;
 }
 

--- a/arch/arm64/include/asm/phytium_cputype.h
+++ b/arch/arm64/include/asm/phytium_cputype.h
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2025,Phytium Technology Co.,Ltd.
+ */
+#ifndef __ASM_PHYTIUM_CPUTYPE_H
+#define __ASM_PHYTIUM_CPUTYPE_H
+
+#include <linux/arm-smccc.h>
+#include <asm/cputype.h>
+
+#define SOC_ID_PE1702	0x1
+#define SOC_ID_PS17064	0x2
+#define SOC_ID_PD1904	0x3
+#define SOC_ID_PS20064	0x4
+
+#define SOC_ID_PD2008	0x5
+#define SOC_ID_PS21064	0x6
+#define SOC_ID_PE220X	0x7
+#define SOC_ID_PS23064	0x8
+#define SOC_ID_PD2308	0x9
+#define SOC_ID_PS2480	0xa
+#define SOC_ID_PD2408	0xb
+
+#define SYS_REG_VAL_PS24080	0x6
+#define SYS_REG_VAL_PS23064	0x8
+
+#define SMCCC_SUCCESS		0
+#define SMCCC_FAILURE		(-1)
+#define FUNC_ID_GET_CPU_VERSION 0xc2000002
+
+enum phyt_cpu_type {
+	PE1702 = 1,
+	PS17064,
+	PD1904,
+	PS20064,
+	PD2008,
+	PS21064,
+	PE220X,
+	PS23064,
+	PD2308,
+	PS24080,
+	PD2408,
+	PS15016,
+	UNKNOWN_SOC
+};
+
+static enum phyt_cpu_type do_smccc_res(struct arm_smccc_res res)
+{
+	unsigned long smc_cpu_ver = res.a1;
+
+	smc_cpu_ver = (smc_cpu_ver >> 8);
+	switch (smc_cpu_ver) {
+	case SOC_ID_PE1702:
+		return PE1702;
+	case SOC_ID_PS17064:
+		return PS17064;
+	case SOC_ID_PD1904:
+		return PD1904;
+	case SOC_ID_PS20064:
+		return PS20064;
+	case SOC_ID_PD2008:
+		return PD2008;
+	case SOC_ID_PS21064:
+		return PS21064;
+	case SOC_ID_PE220X:
+		return PE220X;
+	case SOC_ID_PS23064:
+		return PS23064;
+	case SOC_ID_PD2308:
+		return PD2308;
+	case SOC_ID_PS2480:
+		return PS24080;
+	case SOC_ID_PD2408:
+		return PD2408;
+	default:
+		return UNKNOWN_SOC;
+	}
+}
+
+static enum phyt_cpu_type do_read_sysreg(void)
+{
+	u32 aidr_reg_val = read_sysreg(aidr_el1);
+
+	switch (aidr_reg_val) {
+	case SYS_REG_VAL_PS24080:
+		return PS24080;
+	case SYS_REG_VAL_PS23064:
+		return PS23064;
+	default:
+		return UNKNOWN_SOC;
+	}
+}
+
+static enum phyt_cpu_type do_read_mpidr(void)
+{
+	u32 part_id = read_cpuid_part_number();
+
+	switch (part_id) {
+	case PHYTIUM_CPU_PART_FTC303:
+		return PE220X;
+	case PHYTIUM_CPU_PART_FTC660:
+		return PS15016;
+	case PHYTIUM_CPU_PART_FTC661:
+		return PE1702;
+	case PHYTIUM_CPU_PART_FTC662:
+		return PS17064;
+	case PHYTIUM_CPU_PART_FTC663:
+		return PD1904;
+	case PHYTIUM_CPU_PART_FTC862:
+		return PD2408;
+	default:
+		return UNKNOWN_SOC;
+	}
+}
+
+static inline bool is_phytium_soc(void)
+{
+	if (read_cpuid_implementor() == ARM_CPU_IMP_PHYTIUM)
+		return true;
+	return false;
+}
+
+static inline enum phyt_cpu_type phyt_read_cpu_type(void)
+{
+	enum phyt_cpu_type ctype;
+	struct arm_smccc_res res;
+
+	if (!is_phytium_soc())
+		return UNKNOWN_SOC;
+
+	arm_smccc_smc(FUNC_ID_GET_CPU_VERSION, 0, 0, 0, 0, 0, 0, 0, &res);
+	switch (res.a0) {
+	case SMCCC_SUCCESS:
+		ctype = do_smccc_res(res);
+		if (ctype != UNKNOWN_SOC)
+			break;
+		fallthrough;
+	case SMCCC_FAILURE:
+		ctype = do_read_sysreg();
+		if (ctype != UNKNOWN_SOC)
+			break;
+		fallthrough;
+	default:
+		ctype = do_read_mpidr();
+		break;
+	}
+	return ctype;
+}
+
+static inline bool is_pd2408(void)
+{
+	enum phyt_cpu_type ctype = phyt_read_cpu_type();
+
+	if (ctype == PD2408)
+		return true;
+	return false;
+}
+
+static inline bool is_ps23064(void)
+{
+	enum phyt_cpu_type ctype = phyt_read_cpu_type();
+
+	if (ctype == PS23064)
+		return true;
+	return false;
+}
+
+static inline bool is_ps24080(void)
+{
+	enum phyt_cpu_type ctype = phyt_read_cpu_type();
+
+	if (ctype == PS24080)
+		return true;
+	return false;
+}
+
+static inline bool is_pd2308(void)
+{
+	enum phyt_cpu_type ctype = phyt_read_cpu_type();
+
+	if (ctype == PD2308)
+		return true;
+	return false;
+}
+
+static inline bool is_pe220x(void)
+{
+	enum phyt_cpu_type ctype = phyt_read_cpu_type();
+
+	if (ctype == PE220X)
+		return true;
+
+	return false;
+}
+
+#endif
+
+

--- a/arch/arm64/kernel/setup.c
+++ b/arch/arm64/kernel/setup.c
@@ -57,6 +57,12 @@
 #include <asm/haoc/iee-si.h>
 #endif
 
+#ifdef CONFIG_ARCH_PHYTIUM
+#include <asm/phytium_cputype.h>
+enum phyt_soc_type phyt_soc_type_t;
+EXPORT_SYMBOL(phyt_soc_type_t);
+#endif
+
 static int num_standard_resources;
 static struct resource *standard_resources;
 
@@ -349,6 +355,9 @@ void __init __no_sanitize_address setup_arch(char **cmdline_p)
 			   FW_BUG "Booted with MMU enabled!");
 	}
 
+#ifdef CONFIG_ARCH_PHYTIUM
+	phyt_soc_type_init();
+#endif
 	arm64_memblock_init();
 
 	paging_init();


### PR DESCRIPTION
These patches updates the support for phytium CPU type.

1.arm64: phytium: Add support of reading cpu type for Phytium Socs
2.arm64: phytium: Update the method to obtain CPU type for Phytium SoCs

## Summary by Sourcery

Add centralized detection and initialization of Phytium SoC CPU types on arm64 at boot.

New Features:
- Introduce a Phytium-specific CPU/SoC type enumeration and detection helpers for arm64.
- Expose a global Phytium SoC type variable for use by other subsystems.
- Initialize Phytium SoC type early in arm64 boot when building for CONFIG_ARCH_PHYTIUM.