### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] platform/x86: think-lmi: fixed the "Call Trace" error warning in think-lmi

### DIFF
--- a/drivers/platform/x86/think-lmi.h
+++ b/drivers/platform/x86/think-lmi.h
@@ -7,7 +7,7 @@
 
 #define TLMI_SETTINGS_COUNT  256
 #define TLMI_SETTINGS_MAXLEN 512
-#define TLMI_PWD_BUFSIZE     129
+#define TLMI_PWD_BUFSIZE     256
 #define TLMI_LANG_MAXLEN       4
 #define TLMI_INDEX_MAX        32
 


### PR DESCRIPTION
The maximum BIOS password length returned by the Lenovo platform BIOS/WMI exceeded the size assumed by the `think_lmi` driver's internal static buffer, causing the driver to trigger a `WARN_ON()` during self-checks.

To resolve this, `TLMI_PWD_BUFSIZE` has been increased to 256 to completely eliminate recurring Call Trace warnings.

https://pms.uniontech.com/bug-view-360877.html
https://pms.uniontech.com/bug-view-325259.html

error:
kernel: ------------[ cut here ]------------
kernel: WARNING: CPU: 4 PID: 665 at drivers/platform/x86/think-lmi.c:326 tlmi_get_pwd_settings.constprop.0+0xe6/0x130 [think_lmi] kernel: Modules linked in: kvm(+) videobuf2_v4l2 snd_intel_dspcfg snd_intel_sdw_acpi videodev irqbypass snd_hda_codec videobuf2_common think_lmi(+) mc rapl firmware_attributes_class wmi_bmof bfq snd_hda_core rfkill(+) pcspkr(+) snd_hwdep libarc4 acpi_cpufreq sp5100_tco k10temp sg input_leds(+) ac hid_multitouch(+) mac_hid serio_raw uos_touchpad_expand parport_pc ppdev lp efi_pstore parport fuse loop nfnetlink dmi_sysfs ip_tables x_tables autofs4 uas usb_storage fantgpu(OE) crct10dif_pclmul i2c_algo_bit crc32_pclmul polyval_clmulni drm_display_helper polyval_generic cec hid_generic ghash_clmulni_intel drm_kms_helper sha512_ssse3 i2c_hid_acpi sha256_ssse3 i2c_hid snd_pcm sha1_ssse3 hid snd_timer aesni_intel xhci_pci crypto_simd xhci_pci_renesas snd r8169 drm cryptd xhci_hcd i2c_piix4 video soundcore realtek battery wmi agpgart button
kernel: CPU: 4 PID: 665 Comm: (udev-worker) Tainted: G           OE      6.6.0-amd64-desktop #25.00.2501.018
kernel: Hardware name: KaiTian /LXKT-HG4M-X7, BIOS W0WKT1FA 11/18/2025
kernel: RIP: 0010:tlmi_get_pwd_settings.constprop.0+0xe6/0x130 [think_lmi]
kernel: Code: 61 a3 e2 81 3d cb 63 0c 00 80 00 00 00 77 1b 31 c0 48 8b 55 f0 65 48 2b 14 25 28 00 00 00 75 4b 48 8b 5d f8 c9 c3 cc cc cc cc <0f> 0b c7 05 a2 63 0c 00 80 00 00 00 eb d7 b8 a1 ff ff ff eb d2 48
kernel: RSP: 0018:ffffc90000e879b8 EFLAGS: 00010202
kernel: RAX: ffff888129b89c60 RBX: ffff888129b89840 RCX: 00000000045bc004
kernel: RDX: 00000000045ba004 RSI: ffff888129b89870 RDI: 000000000005a0c0
kernel: RBP: ffffc90000e879d8 R08: 0000000000000000 R09: 000000ff000000ff
kernel: R10: ffffffffa50fa040 R11: 000000ff000000ff R12: 00000000000000ff
kernel: R13: ffffffffc0e2a180 R14: 00000000000000ff R15: ffffffffc0d66310
kernel: FS:  00007f85713398c0(0000) GS:ffff888467a00000(0000) knlGS:0000000000000000
kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
kernel: CR2: 0000556b8785d4f8 CR3: 0000000116bc6000 CR4: 0000000000350ee0
kernel: Call Trace:
kernel:  <TASK>
kernel:  tlmi_analyze+0x31c/0x640 [think_lmi]
kernel:  ? __uuid_parse+0x50/0x90
kernel:  ? __pfx_tlmi_probe+0x10/0x10 [think_lmi]
kernel:  tlmi_probe+0xe/0x30 [think_lmi]
kernel:  wmi_dev_probe+0x102/0x2c0 [wmi]
kernel:  really_probe+0x1b8/0x420
kernel:  __driver_probe_device+0x80/0x170
kernel:  driver_probe_device+0x24/0x80
kernel:  __driver_attach+0xdf/0x1e0
kernel:  ? __pfx___driver_attach+0x10/0x10
kernel:  bus_for_each_dev+0x8a/0xe0
kernel:  driver_attach+0x1e/0x30
kernel:  bus_add_driver+0x117/0x240
kernel:  driver_register+0x5e/0x120
kernel:  ? __pfx_tlmi_driver_init+0x10/0x10 [think_lmi]
kernel:  __wmi_driver_register+0x1a/0x20 [wmi]
kernel:  tlmi_driver_init+0x1c/0xff0 [think_lmi]
kernel:  do_one_initcall+0x5b/0x330
kernel:  do_init_module+0x68/0x250
kernel:  load_module+0x979/0xa80
kernel:  ? security_kernel_post_read_file+0x6d/0x80
kernel:  init_module_from_file+0x97/0xd0
kernel:  ? init_module_from_file+0x97/0xd0
kernel:  idempotent_init_module+0x11c/0x300
kernel:  __x64_sys_finit_module+0x60/0xc0
kernel:  x64_sys_call+0xe9f/0x1b60
kernel:  do_syscall_64+0x4e/0x150
kernel:  entry_SYSCALL_64_after_hwframe+0x78/0xe2
kernel: RIP: 0033:0x7f8571b4fea9
kernel: Code: ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 44 00 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 47 cf 0c 00 f7 d8 64 89 01 48
kernel: RSP: 002b:00007ffc3d734a28 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
kernel: RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007f8571b4fea9
kernel: RDX: 0000000000000000 RSI: 00007f8571c7e4f5 RDI: 0000000000000028
kernel: RBP: 0000556b87869010 R08: 0000000000000040 R09: 0000556b8773cc80
kernel: R10: 0000000000000038 R11: 0000000000000246 R12: 00007f8571c7e4f5
kernel: R13: 0000000000020000 R14: 0000556b878687b0 R15: 0000000000000000
kernel:  </TASK>
kernel: ---[ end trace 0000000000000000 ]---


Change-Id: Iae0de57988a78d46b109ffca1b0bd79bc9ff5724

## Summary by Sourcery

Enhancements:
- Expand TLMI_PWD_BUFSIZE from 129 to 256 to accommodate larger BIOS-reported password lengths without triggering internal warnings.