### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Add folio_zero_tail() and folio_fill_tail()

### DIFF
--- a/fs/ext4/inline.c
+++ b/fs/ext4/inline.c
@@ -528,9 +528,8 @@ static int ext4_read_inline_folio(struct inode *inode, struct folio *folio)
 
 	kaddr = kmap_local_folio(folio, 0);
 	ret = ext4_read_inline_data(inode, kaddr, len, &iloc);
-	flush_dcache_folio(folio);
+	kaddr = folio_zero_tail(folio, len, kaddr + len);
 	kunmap_local(kaddr);
-	folio_zero_segment(folio, len, folio_size(folio));
 	folio_mark_uptodate(folio);
 	brelse(iloc.bh);
 

--- a/fs/iomap/buffered-io.c
+++ b/fs/iomap/buffered-io.c
@@ -369,28 +369,18 @@ static int iomap_read_inline_data(const struct iomap_iter *iter,
 {
 	const struct iomap *iomap = iomap_iter_srcmap(iter);
 	size_t size = i_size_read(iter->inode) - iomap->offset;
-	size_t poff = offset_in_page(iomap->offset);
 	size_t offset = offset_in_folio(folio, iomap->offset);
-	void *addr;
 
 	if (folio_test_uptodate(folio))
 		return 0;
 
-	if (WARN_ON_ONCE(size > PAGE_SIZE - poff))
-		return -EIO;
-	if (WARN_ON_ONCE(size > PAGE_SIZE -
-			 offset_in_page(iomap->inline_data)))
-		return -EIO;
 	if (WARN_ON_ONCE(size > iomap->length))
 		return -EIO;
 	if (offset > 0)
 		ifs_alloc(iter->inode, folio, iter->flags);
 
-	addr = kmap_local_folio(folio, offset);
-	memcpy(addr, iomap->inline_data, size);
-	memset(addr + size, 0, PAGE_SIZE - poff - size);
-	kunmap_local(addr);
-	iomap_set_range_uptodate(folio, offset, PAGE_SIZE - poff);
+	folio_fill_tail(folio, offset, iomap->inline_data, size);
+	iomap_set_range_uptodate(folio, offset, folio_size(folio) - offset);
 	return 0;
 }
 


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20231107212643.3490372-1-willy@infradead.org/T/#u

I'm trying to make it easier for filesystems with tailpacking /
stuffing / inline data to use folios.  The primary function here is
folio_fill_tail().  You give it a pointer to memory where the data
currently is, and it takes care of copying it into the folio at that
offset.  That works for gfs2 & iomap.  Then There's Ext4.  Rather than
gin up some kind of specialist "Here's a two pointers to two blocks
of memory" routine, just let it do its current thing, and let it call
folio_zero_tail(), which is also called by folio_fill_tail().

Other filesystems can be converted later; these ones seemed like good
examples as they're already partly or completely converted to folios.

Matthew Wilcox (Oracle) (3):
  mm: Add folio_zero_tail() and use it in ext4
  mm: Add folio_fill_tail() and use it in iomap
  gfs2: Convert stuffed_readpage() to stuffed_read_folio()

 fs/ext4/inline.c        |  3 +-
 fs/gfs2/aops.c          | 37 +++++++++-----------
 fs/iomap/buffered-io.c  | 14 ++------
 include/linux/highmem.h | 76 +++++++++++++++++++++++++++++++++++++++++
 4 files changed, 96 insertions(+), 34 deletions(-)

-- 
2.42.0

## Summary by Sourcery

Introduce folio helper APIs for zeroing and filling folio tails and adopt them in inline-data read paths for ext4 and iomap, improving folio-based filesystem handling of inline data.

New Features:
- Add folio_zero_tail() helper to zero and flush the unused tail region of a folio.
- Add folio_fill_tail() helper to copy inline data into a folio and pad the remaining tail with zeroes, including support for highmem and large folios.

Enhancements:
- Refactor ext4 inline folio read to use folio_zero_tail() instead of manual dcache flush and tail zeroing.
- Refactor iomap inline data read to use folio_fill_tail() and mark the entire folio range uptodate based on folio size, preparing for larger folios.