### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Code simplification and clean-up for hugetlb vmemmap

### DIFF
--- a/mm/gup.c
+++ b/mm/gup.c
@@ -622,6 +622,7 @@ static struct page *follow_pmd_mask(struct vm_area_struct *vma,
 		spin_unlock(ptl);
 		if (page)
 			return page;
+		return no_page_table(vma, flags);
 	}
 	if (likely(!pmd_trans_huge(pmdval)))
 		return follow_page_pte(vma, address, pmd, flags, &ctx->pgmap);
@@ -670,6 +671,7 @@ static struct page *follow_pud_mask(struct vm_area_struct *vma,
 		spin_unlock(ptl);
 		if (page)
 			return page;
+		return no_page_table(vma, flags);
 	}
 	if (unlikely(pud_bad(*pud)))
 		return no_page_table(vma, flags);

--- a/mm/pagewalk.c
+++ b/mm/pagewalk.c
@@ -540,6 +540,11 @@ EXPORT_SYMBOL_GPL(walk_page_range);
  * not backed by VMAs. Because 'unusual' entries may be walked this function
  * will also not lock the PTEs for the pte_entry() callback. This is useful for
  * walking the kernel pages tables or page tables for firmware.
+ *
+ * Note: Be careful to walk the kernel pages tables, the caller may be need to
+ * take other effective approache (mmap lock may be insufficient) to prevent
+ * the intermediate kernel page tables belonging to the specified address range
+ * from being freed (e.g. memory hot-remove).
  */
 int walk_page_range_novma(struct mm_struct *mm, unsigned long start,
 			  unsigned long end, const struct mm_walk_ops *ops,
@@ -557,7 +562,29 @@ int walk_page_range_novma(struct mm_struct *mm, unsigned long start,
 	if (start >= end || !walk.mm)
 		return -EINVAL;
 
-	mmap_assert_write_locked(walk.mm);
+	/*
+	 * 1) For walking the user virtual address space:
+	 *
+	 * The mmap lock protects the page walker from changes to the page
+	 * tables during the walk.  However a read lock is insufficient to
+	 * protect those areas which don't have a VMA as munmap() detaches
+	 * the VMAs before downgrading to a read lock and actually tearing
+	 * down PTEs/page tables. In which case, the mmap write lock should
+	 * be hold.
+	 *
+	 * 2) For walking the kernel virtual address space:
+	 *
+	 * The kernel intermediate page tables usually do not be freed, so
+	 * the mmap map read lock is sufficient. But there are some exceptions.
+	 * E.g. memory hot-remove. In which case, the mmap lock is insufficient
+	 * to prevent the intermediate kernel pages tables belonging to the
+	 * specified address range from being freed. The caller should take
+	 * other actions to prevent this race.
+	 */
+	if (mm == &init_mm)
+		mmap_assert_locked(walk.mm);
+	else
+		mmap_assert_write_locked(walk.mm);
 
 	return walk_pgd_range(start, end, &walk);
 }


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20231127084645.27017-1-songmuchun@bytedance.com/T/#u

This series aims to simplify and clean the code of hugetlb vmemmap, please
look at the commit message of each individual patch for more details.

Thanks.

Muchun Song (4):
  mm: pagewalk: assert write mmap lock only for walking the user page
    tables
  mm: hugetlb_vmemmap: use walk_page_range_novma() to simplify the code
  mm: hugetlb_vmemmap: move PageVmemmapSelfHosted() check to
    split_vmemmap_huge_pmd()
  mm: hugetlb_vmemmap: convert page to folio

 mm/hugetlb_vmemmap.c | 259 ++++++++++++++-----------------------------
 mm/pagewalk.c        |  29 ++++-
 2 files changed, 111 insertions(+), 177 deletions(-)

-- 
2.20.1

## Summary by Sourcery

Simplify and clean up hugetlb vmemmap handling while tightening page table walking semantics and fixing get_user_pages fallback behavior.

Bug Fixes:
- Ensure follow_pmd_mask() and follow_pud_mask() correctly fall back to no_page_table() when no page is returned for a locked huge page mapping.

Enhancements:
- Refactor hugetlb vmemmap page table walking to use walk_page_range_novma() with dedicated mm_walk_ops instead of custom traversal code.
- Move the vmemmap self-hosting check into the PMD split path and base vmemmap optimization decisions on folios rather than pages.
- Clarify and relax mmap locking assertions in walk_page_range_novma() to distinguish between user and kernel address space walks and document constraints around kernel page table freeing.