### PR TITLE
UART:phytium:update UART V2 driver support to 6.6.0.4

### DIFF
--- a/drivers/tty/serial/Kconfig
+++ b/drivers/tty/serial/Kconfig
@@ -107,15 +107,6 @@ config SERIAL_PHYTIUM_UART_V2
 
           If unsure, say N.
 
-config SERIAL_PHYTIUM_V2_DEBUG
-        bool "Phytium UART V2 debug/heartbeat function support"
-        depends on SERIAL_PHYTIUM_UART_V2
-        help
-          This driver supports the Phytium UART V2 controller Debug on platform adapters.
-          If you want to enable debug, say Y here.
-
-          If unsure, say N.
-
 config SERIAL_EARLYCON_RISCV_SBI
 	bool "Early console using RISC-V SBI"
 	depends on RISCV_SBI_V01

--- a/drivers/tty/serial/phytium-uart-v2.c
+++ b/drivers/tty/serial/phytium-uart-v2.c
@@ -1073,7 +1073,6 @@ static int phytium_register_port(struct phytium_uart_port *pup)
 	return rc;
 }
 
-#if defined(CONFIG_SERIAL_PHYTIUM_V2_DEBUG)
 static int phytium_uart_enable_debug(struct phytium_uart_port *pup,
 		bool enable)
 {
@@ -1085,9 +1084,9 @@ static int phytium_uart_enable_debug(struct phytium_uart_port *pup,
 	}
 	pup->debug_enable = enable;
 	dbg_regval = phytium_uart_read(pup, PHYUART_DBG_REG);
-	if (!enable && (dbg_regval & PHYUART_DBG_ENABLE_MASK))
+	if (!enable)
 		dbg_regval &= ~PHYUART_DBG_ENABLE_MASK;
-	else if (enable && !(dbg_regval & PHYUART_DBG_ENABLE_MASK))
+	else
 		dbg_regval |= PHYUART_DBG_ENABLE_MASK;
 
 	phytium_uart_write(dbg_regval, pup, PHYUART_DBG_REG);
@@ -1105,11 +1104,11 @@ static int phytium_uart_enable_heartbeat(struct phytium_uart_port *pup,
 	}
 	pup->heartbeat_enable = enable;
 	dbg_regval = phytium_uart_read(pup, PHYUART_DBG_REG);
-	if (!enable && (dbg_regval & PHYUART_DBG_HEARTBEAT_MASK)) {
-		dbg_regval &= ~PHYUART_DBG_HEARTBEAT_MASK;
+	if (!enable) {
+		dbg_regval &= ~PHYUART_DBG_HEARTBEAT_ENABLE_MASK;
 		phytium_uart_write(dbg_regval, pup, PHYUART_DBG_REG);
 		del_timer(&pup->alive_timer);
-	} else if (enable && !(dbg_regval & PHYUART_DBG_HEARTBEAT_MASK)) {
+	} else {
 		dbg_regval |= PHYUART_DBG_HEARTBEAT_MASK
 			| PHYUART_DBG_HEARTBEAT_ENABLE_MASK;
 		phytium_uart_write(dbg_regval, pup, PHYUART_DBG_REG);
@@ -1185,7 +1184,6 @@ static ssize_t heartbeat_enable_store(struct device *dev,
 }
 static DEVICE_ATTR_RW(debug_enable);
 static DEVICE_ATTR_RW(heartbeat_enable);
-#endif
 static int phytium_uart_probe(struct platform_device *pdev)
 {
 	struct phytium_uart_port *pup;
@@ -1262,16 +1260,12 @@ static int phytium_uart_probe(struct platform_device *pdev)
 	pup->old_cr = 0;
 	pup->m_buf_empty = true;
 	snprintf(pup->type, sizeof(pup->type), "phytium,uart-v2");
-#if defined(CONFIG_SERIAL_PHYTIUM_V2_DEBUG)
 	pup->debug_enable = false;
 	pup->heartbeat_enable = false;
 
-	phytium_uart_enable_heartbeat(pup, true);
-	phytium_uart_enable_debug(pup, true);
-
 	pup->alive_timer.expires = jiffies + msecs_to_jiffies(5000);
 	timer_setup(&pup->alive_timer, alive_timer_routine, 0);
-	add_timer(&pup->alive_timer);
+	phytium_uart_enable_heartbeat(pup, true);
 	ret = device_create_file(&pdev->dev,
 				&dev_attr_debug_enable);
 	if (ret < 0) {
@@ -1284,18 +1278,15 @@ static int phytium_uart_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "PHYUART: device_create_heartbeat file error.\n");
 		goto heartbeat_enable_free;
 	}
-#endif
 	platform_set_drvdata(pdev, pup);
 	return phytium_register_port(pup);
 
-#if defined(CONFIG_SERIAL_PHYTIUM_V2_DEBUG)
 heartbeat_enable_free:
 	device_remove_file(pup->dev, &dev_attr_heartbeat_enable);
 debug_enable_free:
 	device_remove_file(pup->dev, &dev_attr_debug_enable);
-#endif
+	del_timer(&pup->alive_timer);
 free:
-	kfree(pup);
 	return -1;
 }
 
@@ -1306,7 +1297,9 @@ static int phytium_uart_remove(struct platform_device *pdev)
 	uart_remove_one_port(&phytium_uart, &pup->port);
 
 	phytium_unregister_port(pup);
-
+	device_remove_file(pup->dev, &dev_attr_heartbeat_enable);
+	device_remove_file(pup->dev, &dev_attr_debug_enable);
+	del_timer(&pup->alive_timer);
 	return 0;
 }
 


### PR DESCRIPTION
This patches updates the support for phytium UART controller driver
1.Fix some issues for uart-v2 driver

## Summary by Sourcery

Update the Phytium UART v2 driver’s debug and heartbeat handling to be always available and to clean up resources correctly on probe failure and device removal.

Bug Fixes:
- Fix heartbeat and debug register programming so enable/disable always updates the appropriate debug control bits.
- Ensure the heartbeat timer is started and stopped via the heartbeat enable path rather than manually adding it.
- Clean up sysfs attributes and the heartbeat timer on probe failure and driver removal to avoid leaks and dangling resources.

Enhancements:
- Remove the build-time CONFIG_SERIAL_PHYTIUM_V2_DEBUG guard so debug and heartbeat controls are always compiled in.