### PR TITLE
CODEC: phytium: update CODEC controller driver support to 6.6.0.4

### DIFF
--- a/sound/soc/codecs/phytium-codec-v2.c
+++ b/sound/soc/codecs/phytium-codec-v2.c
@@ -328,6 +328,9 @@ error:
 static int phyt_probe(struct snd_soc_component *component)
 {
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	return phyt_set_cmd(priv, PHYTCODEC_MSG_CMD_SET_PROBE);
 }
@@ -335,6 +338,9 @@ static int phyt_probe(struct snd_soc_component *component)
 static void phyt_remove(struct snd_soc_component *component)
 {
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	phyt_set_cmd(priv, PHYTCODEC_MSG_CMD_SET_REMOVE);
 }
@@ -342,6 +348,9 @@ static void phyt_remove(struct snd_soc_component *component)
 static int phyt_suspend(struct snd_soc_component *component)
 {
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	return phyt_pm_cmd(priv, PHYTCODEC_MSG_CMD_SET_SUSPEND);
 }
@@ -349,6 +358,9 @@ static int phyt_suspend(struct snd_soc_component *component)
 static int phyt_resume(struct snd_soc_component *component)
 {
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	return phyt_pm_cmd(priv, PHYTCODEC_MSG_CMD_SET_RESUME);
 }
@@ -428,6 +440,9 @@ static int phyt_startup(struct snd_pcm_substream *substream,
 	int ret;
 	struct snd_soc_component *component = dai->component;
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
 		ret = phyt_set_cmd(priv, PHYTCODEC_MSG_CMD_SET_STARTUP);
@@ -443,6 +458,9 @@ static void phyt_shutdown(struct snd_pcm_substream *substream,
 	int ret;
 	struct snd_soc_component *component = dai->component;
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
 		ret = phyt_set_cmd(priv, PHYTCODEC_MSG_CMD_SET_SHUTDOWN);
@@ -495,6 +513,9 @@ static int phyt_set_dai_fmt(struct snd_soc_dai *codec_dai,
 	int ret;
 	struct snd_soc_component *component = codec_dai->component;
 	struct phytium_codec *priv = snd_soc_component_get_drvdata(component);
+	struct phytcodec_cmd *msg = priv->sharemem_base;
+
+	memset(msg, 0, sizeof(struct phytcodec_cmd));
 
 	if ((fmt & SND_SOC_DAIFMT_MASTER_MASK) != SND_SOC_DAIFMT_CBS_CFS)
 		return -EINVAL;
@@ -745,6 +766,7 @@ static ssize_t debug_store(struct device *dev, struct device_attribute *da,
 			dev_err(dev, "dump command requires one argument\n");
 			goto error;
 		}
+		memset(priv->sharemem_base, 0, sizeof(struct phytcodec_cmd));
 		phyt_get_cmd(priv, PHYTCODEC_MSG_CMD_GET_ALL_REGS);
 	} else if (strcmp(cmd, "help") == 0) {
 		dev_info(dev, "Available commands:\n"
@@ -804,8 +826,9 @@ static void phyt_codec_init(struct phytium_codec *priv)
 	if (sysfs_create_group(&priv->dev->kobj, &phyt_codec_device_group))
 		dev_warn(priv->dev, "failed to create sysfs\n");
 
-	phyt_dai.playback.channels_max = phyt_get_channels(priv);
-	phyt_dai.capture.channels_max = phyt_dai.playback.channels_max;
+	priv->channels = phyt_get_channels(priv);
+	phyt_dai.playback.channels_max = priv->channels;
+	phyt_dai.capture.channels_max = priv->channels;
 
 	phyt_writel_reg(priv->regfile_base, PHYTIUM_CODEC_INT_MASK, 0x0);
 	phyt_writel_reg(priv->regfile_base, PHYTIUM_CODEC_INT_ENABLE, 0x1);

--- a/sound/soc/codecs/phytium-codec-v2.c
+++ b/sound/soc/codecs/phytium-codec-v2.c
@@ -101,17 +101,20 @@ static const struct snd_soc_dapm_route phyt_dapm_routes[] = {
 static void phyt_codec_show_status(uint8_t status)
 {
 	switch (status) {
-	case 0:
+	case ERR_CODEC_SUCCESS:
 		pr_err("success\n");
 		break;
-	case 2:
+	case ERR_CODEC_DEV_BUSY:
 		pr_err("device busy\n");
 		break;
-	case 3:
+	case ERR_CODEC_RW_ERROR:
 		pr_err("read/write error\n");
 		break;
-	case 4:
-		pr_err("no device\n");
+	case ERR_CODEC_NODEV:
+		pr_err("no hw device\n");
+		break;
+	case ERR_CODEC_NO_INIT:
+		pr_err("no init\n");
 		break;
 	default:
 		pr_err("unknown error: %d\n", status);

--- a/sound/soc/codecs/phytium-codec-v2.h
+++ b/sound/soc/codecs/phytium-codec-v2.h
@@ -95,6 +95,15 @@ enum phytcodec_complete {
 	PHYTCODEC_COMPLETE_INVALID_PARAMETERS,
 };
 
+enum phytcodec_status {
+	ERR_CODEC_SUCCESS = 0,
+	ERR_CODEC_BUS_BUSY,
+	ERR_CODEC_DEV_BUSY,
+	ERR_CODEC_RW_ERROR,
+	ERR_CODEC_NODEV,	//HW
+	ERR_CODEC_NO_INIT,	//SW
+};
+
 struct phytcodec_rw_data {
 	uint8_t addr;
 	uint8_t reg;


### PR DESCRIPTION
This patches updates the support for phytium CODEC controller driver.
1.Add controller status code;
2. initialize share memory and channels.

## Summary by Sourcery

Update the Phytium CODEC v2 driver to use explicit status codes and properly initialize shared memory and channel configuration across lifecycle operations.

Enhancements:
- Introduce a dedicated phytcodec_status enum and use symbolic status codes in status reporting.
- Ensure shared memory command structures are zero-initialized in probe, remove, power-management, DAI startup/shutdown, and debug paths.
- Store the detected channel count in the driver state and use it consistently for playback and capture channel configuration.