### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] sync bugfixes for mm/rmap: interface overhaul 

### DIFF
--- a/include/linux/rmap.h
+++ b/include/linux/rmap.h
@@ -194,8 +194,15 @@ static inline void __folio_rmap_sanity_checks(struct folio *folio,
 {
 	/* hugetlb folios are handled separately. */
 	VM_WARN_ON_FOLIO(folio_test_hugetlb(folio), folio);
-	VM_WARN_ON_FOLIO(folio_test_large(folio) &&
-			 !folio_test_large_rmappable(folio), folio);
+
+	/*
+	 * TODO: we get driver-allocated folios that have nothing to do with
+	 * the rmap using vm_insert_page(); therefore, we cannot assume that
+	 * folio_test_large_rmappable() holds for large folios. We should
+	 * handle any desired mapcount+stats accounting for these folios in
+	 * VM_MIXEDMAP VMAs separately, and then sanity-check here that
+	 * we really only get rmappable folios.
+	 */
 
 	VM_WARN_ON_ONCE(nr_pages <= 0);
 	VM_WARN_ON_FOLIO(page_folio(page) != folio, folio);

--- a/mm/huge_memory.c
+++ b/mm/huge_memory.c
@@ -2305,7 +2305,7 @@ static void __split_huge_pmd_locked(struct vm_area_struct *vma, pmd_t *pmd,
 			page = pmd_page(old_pmd);
 			folio = page_folio(page);
 			if (!folio_test_dirty(folio) && pmd_dirty(old_pmd))
-				folio_set_dirty(folio);
+				folio_mark_dirty(folio);
 			if (!folio_test_referenced(folio) && pmd_young(old_pmd))
 				folio_set_referenced(folio);
 			folio_remove_rmap_pmd(folio, page, vma);
@@ -3452,7 +3452,7 @@ int set_pmd_migration_entry(struct page_vma_mapped_walk *pvmw,
 	}
 
 	if (pmd_dirty(pmdval))
-		folio_set_dirty(folio);
+		folio_mark_dirty(folio);
 	if (pmd_write(pmdval))
 		entry = make_writable_migration_entry(page_to_pfn(page));
 	else if (anon_exclusive)

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -1467,7 +1467,7 @@ static unsigned long zap_pte_range(struct mmu_gather *tlb,
 			delay_rmap = 0;
 			if (!folio_test_anon(folio)) {
 				if (pte_dirty(ptent)) {
-					folio_set_dirty(folio);
+					folio_mark_dirty(folio);
 					if (tlb_delay_rmap(tlb)) {
 						delay_rmap = 1;
 						force_flush = 1;

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -4477,8 +4477,9 @@ vm_fault_t do_set_pmd(struct vm_fault *vmf, struct page *page)
 	if (!thp_vma_suitable_order(vma, haddr, PMD_ORDER))
 		return ret;
 
-	if (page != &folio->page || folio_order(folio) != HPAGE_PMD_ORDER)
+	if (folio_order(folio) != HPAGE_PMD_ORDER)
 		return ret;
+	page = &folio->page;
 
 	/*
 	 * Just backoff if any subpage of a THP is corrupted otherwise


### PR DESCRIPTION
https://github.com/deepin-community/kernel/pull/1969

## Summary by Sourcery

Align rmap and hugepage handling with upstream fixes to improve correctness of THP and folio dirty accounting.

Bug Fixes:
- Relax rmap sanity checks for large folios to account for driver-allocated folios in mixed VMAs.
- Ensure do_set_pmd uses the folio order consistently and correctly derives the page from the folio when installing PMD-sized THPs.
- Fix THP and migration entry paths to correctly mark backing folios dirty based on pmd state.

Enhancements:
- Replace legacy folio_set_dirty uses with folio_mark_dirty to match the updated folio dirty-tracking interface.