### PR TITLE
[6.6] HYGON: Add new PSP device id for Hygon CPU

### DIFF
--- a/drivers/crypto/ccp/sp-pci.c
+++ b/drivers/crypto/ccp/sp-pci.c
@@ -603,6 +603,7 @@ static const struct pci_device_id sp_pci_table[] = {
 	{ PCI_VDEVICE(HYGON, 0x14a6), (kernel_ulong_t)&hygon_dev_vdata[2] },
 	{ PCI_VDEVICE(HYGON, 0x14d8), (kernel_ulong_t)&hygon_dev_vdata[1] },
 	{ PCI_VDEVICE(HYGON, 0x14c6), (kernel_ulong_t)&hygon_dev_vdata[2] },
+	{ PCI_VDEVICE(HYGON, 0x2006), (kernel_ulong_t)&hygon_dev_vdata[2] },
 	/* Last entry must be zero */
 	{ 0, }
 };


### PR DESCRIPTION
add new psp device id for Hygon CPU

## Summary by Sourcery

New Features:
- Support the Hygon PSP device with PCI ID 0x2006 in the CCP SP PCI driver