### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Sync two fixes from v7.2-rc

### DIFF
--- a/drivers/usb/storage/usb.c
+++ b/drivers/usb/storage/usb.c
@@ -488,7 +488,7 @@ void usb_stor_adjust_quirks(struct usb_device *udev, unsigned long *fflags)
 			US_FL_INITIAL_READ10 | US_FL_WRITE_CACHE |
 			US_FL_NO_ATA_1X | US_FL_NO_REPORT_OPCODES |
 			US_FL_MAX_SECTORS_240 | US_FL_NO_REPORT_LUNS |
-			US_FL_ALWAYS_SYNC);
+			US_FL_ALWAYS_SYNC | US_FL_NO_SAME);
 
 	p = quirks;
 	while (*p) {

--- a/virt/kvm/guest_memfd.c
+++ b/virt/kvm/guest_memfd.c
@@ -434,6 +434,7 @@ int kvm_gmem_bind(struct kvm *kvm, struct kvm_memory_slot *slot,
 
 	if (!xa_empty(&gmem->bindings) &&
 	    xa_find(&gmem->bindings, &start, end - 1, XA_PRESENT)) {
+		r = -EEXIST;
 		filemap_invalidate_unlock(inode->i_mapping);
 		goto err;
 	}


### PR DESCRIPTION
## Summary by Sourcery

Optimize and harden page table entry copying and batch handling in memory management, while syncing related architecture, VM scanning, USB storage, and KVM guest memory fixes.

New Features:
- Support batched copying of consecutive present PTEs that map the same folio during fork to reduce overhead.
- Introduce architecture-agnostic helpers for iterating consecutive PFNs in PTEs and write-protecting batches of PTEs.

Bug Fixes:
- Fix PTE PFN increment logic in various architecture set_ptes implementations by using a common pte_next_pfn helper and PFN_PTE_SHIFT definitions.
- Correct handling of preallocated folios and return codes in copy_pte_range when copying present PTEs, avoiding misinterpretation of success vs error.
- Ensure USB storage devices with generic quirks also apply US_FL_NO_SAME to avoid problematic SCSI SAME usage.
- Prevent duplicate guest_memfd bindings in KVM slots by returning -EEXIST when an overlapping binding already exists.

Enhancements:
- Improve folio-aware PTE batching logic to better handle large folios, soft-dirty and dirty bits, and writable mappings during fork.
- Refine vmscan logic by using boolean file flags instead of ints for file vs anonymous LRUs, slightly clarifying scan behavior.