### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] Sync two fixes from v7.2-rc

### DIFF
--- a/drivers/usb/storage/usb.c
+++ b/drivers/usb/storage/usb.c
@@ -488,7 +488,7 @@ void usb_stor_adjust_quirks(struct usb_device *udev, unsigned long *fflags)
 			US_FL_INITIAL_READ10 | US_FL_WRITE_CACHE |
 			US_FL_NO_ATA_1X | US_FL_NO_REPORT_OPCODES |
 			US_FL_MAX_SECTORS_240 | US_FL_NO_REPORT_LUNS |
-			US_FL_ALWAYS_SYNC);
+			US_FL_ALWAYS_SYNC | US_FL_NO_SAME);
 
 	p = quirks;
 	while (*p) {

--- a/virt/kvm/guest_memfd.c
+++ b/virt/kvm/guest_memfd.c
@@ -434,6 +434,7 @@ int kvm_gmem_bind(struct kvm *kvm, struct kvm_memory_slot *slot,
 
 	if (!xa_empty(&gmem->bindings) &&
 	    xa_find(&gmem->bindings, &start, end - 1, XA_PRESENT)) {
+		r = -EEXIST;
 		filemap_invalidate_unlock(inode->i_mapping);
 		goto err;
 	}


### PR DESCRIPTION
## Summary by Sourcery

Sync upstream USB storage and KVM guest_memfd fixes into the 6.6.y kernel tree.

Bug Fixes:
- Prevent use of the SCSI SAME command for affected USB storage devices by adding the NO_SAME quirk to the default flags set.
- Ensure kvm_gmem_bind fails with EEXIST when attempting to bind guest_memfd memory that already has conflicting bindings.