### PR TITLE
LoongArch: gpio: Initializing 'ngpios' instead of using dirty data

### DIFF
--- a/drivers/gpio/gpio-loongson-64bit.c
+++ b/drivers/gpio/gpio-loongson-64bit.c
@@ -191,7 +191,7 @@ static int loongson_gpio_to_irq(struct gpio_chip *chip, unsigned int offset)
 static int loongson_gpio_init(struct device *dev, struct loongson_gpio_chip *lgpio,
 			      void __iomem *reg_base)
 {
-	u32 ngpios;
+	u32 ngpios = 0;
 	u32 gpio_base;
 	int rval;
 
@@ -202,7 +202,9 @@ static int loongson_gpio_init(struct device *dev, struct loongson_gpio_chip *lgp
 	lgpio->chip.direction_output = loongson_gpio_direction_output;
 	lgpio->chip.set = loongson_gpio_set;
 	lgpio->chip.parent = dev;
-	device_property_read_u32(dev, "gpio_base", &gpio_base);
+	rval = device_property_read_u32(dev, "gpio_base", &gpio_base);
+	if (rval)
+		gpio_base = -1;
 	if (!gpio_base)
 		gpio_base = -1;
 	lgpio->chip.base = gpio_base;


### PR DESCRIPTION
The kernel failed to boot on 3A6000 with the
'Loongson-UDK2018-V4.0.05878.1-stable202411' bison. The error is: '''
  gpio gpiochip0: Static allocation of GPIO base is deprecated, use dynamic all.
  gpio gpiochip1: Static allocation of GPIO base is deprecated, use dynamic all.
  gpio gpiochip2: line cnt 39952 is greater than fast path cnt 512
  rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:
  watchdog: BUG: soft lockup - CPU#3 stuck for 26s! [(udev-worker):194]
  watchdog: Watchdog detected hard LOCKUP on cpu 0
  ....
  rcu:     0-...!: (0 ticks this GP) idle=7324/1/0x4000000000000000 softirq=7010
'''
The logs above show that 'ngpios' is a very large value exceeding the
limit of '512'. When the the "ngpios" atribute is missing in the ACPI
DSDT, 'device_property_read_u32' failed but the error is ignored, and
the 'ngpios' retains its garbage value on the stack.

Function call chain is:
 loongson_gpio_init()
   devm_gpiochip_add_data()
     devm_gpiochip_add_data_with_key()
       gpiochip_add_data_with_key()

The soft lockup is caused by a 'for' loop based on 'ngpios' within the gpiochip_add_data_with_key().

So, initializing `ngpios` to 0 to solve it.

## Summary by Sourcery

Prevent LoongArch GPIO initialization from using uninitialized configuration values derived from ACPI properties.

Bug Fixes:
- Initialize the LoongArch GPIO chip's ngpios field to a safe default to avoid excessive loop counts and soft lockups when the ACPI ngpios property is missing or invalid.
- Handle failures when reading the gpio_base device property by falling back to an invalid base value rather than using stale or zero data.