### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] Fix kabi for recently update

### DIFF
--- a/include/linux/bpf_verifier.h
+++ b/include/linux/bpf_verifier.h
@@ -364,7 +364,7 @@ struct bpf_jmp_history_entry {
 	/* additional registers that need precision tracking when this
 	 * jump is backtracked, vector of six 10-bit records
 	 */
-	u64 linked_regs;
+	DEEPIN_KABI_EXTEND(u64 linked_regs)
 };
 
 /* Maximum number of register states that can exist at once */

--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -418,9 +418,8 @@ struct iommu_ops {
 	unsigned long pgsize_bitmap;
 	struct module *owner;
 	struct iommu_domain *identity_domain;
-	struct iommu_domain *default_domain;
 
-	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_USE(1, struct iommu_domain *default_domain)
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)


### PR DESCRIPTION
## Summary by Sourcery

Maintain Deepin kernel ABI compatibility for iommu and BPF verifier structures after recent updates.

Bug Fixes:
- Restore the iommu_ops default_domain field through DEEPIN KABI mechanisms to preserve ABI stability.
- Wrap the bpf_jmp_history_entry linked_regs field with DEEPIN KABI extensions to keep BPF verifier structure layout compatible.