### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18-y] [Openeuler] cgroup: disable kernel memory accounting for all memory cgroups by de…

### DIFF
--- a/Documentation/admin-guide/cgroup-v1/memory.rst
+++ b/Documentation/admin-guide/cgroup-v1/memory.rst
@@ -329,9 +329,9 @@ the amount of kernel memory used by the system. Kernel memory is fundamentally
 different than user memory, since it can't be swapped out, which makes it
 possible to DoS the system by consuming too much of this precious resource.
 
-Kernel memory accounting is enabled for all memory cgroups by default. But
-it can be disabled system-wide by passing cgroup.memory=nokmem to the kernel
-at boot time. In this case, kernel memory will not be accounted at all.
+Kernel memory accounting is disabled for all memory cgroups by default. But
+it can be enabled system-wide by passing cgroup.memory=kmem to the kernel
+at boot time. In this case, kernel memory will all be accounted.
 
 Kernel memory limits are not imposed for the root cgroup. Usage for the root
 cgroup may or may not be accounted. The memory used is accumulated into

--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -667,6 +667,7 @@
 			Format: <string>
 			nosocket -- Disable socket memory accounting.
 			nokmem -- Disable kernel memory accounting.
+			kmem -- Enable kernel memory accounting.
 			nobpf -- Disable BPF memory accounting.
 
 	checkreqprot=	[SELINUX] Set initial checkreqprot flag value.

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -90,7 +90,7 @@ EXPORT_PER_CPU_SYMBOL_GPL(int_active_memcg);
 static bool cgroup_memory_nosocket __ro_after_init;
 
 /* Kernel memory accounting disabled? */
-static bool cgroup_memory_nokmem __ro_after_init;
+static bool cgroup_memory_nokmem __ro_after_init = true;
 
 /* BPF memory accounting disabled? */
 static bool cgroup_memory_nobpf __ro_after_init;
@@ -5105,6 +5105,8 @@ static int __init cgroup_memory(char *s)
 			cgroup_memory_nosocket = true;
 		if (!strcmp(token, "nokmem"))
 			cgroup_memory_nokmem = true;
+		else if (!strcmp(token, "kmem"))
+			cgroup_memory_nokmem = false;
 		if (!strcmp(token, "nobpf"))
 			cgroup_memory_nobpf = true;
 	}


### PR DESCRIPTION
…fault

hulk inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I8QLND CVE: NA

----------------------------------------

The kernel memory accounting for all memory cgroups is not stable, and it will cause a 100% regression in hackbench compared with kernel-4.19, so disable it by default. We can use the following command line to enable or disable it:
cgroup.memory=kmem or cgroup.memory=nokmem.





(cherry picked from commit 53fbd8c46be1f3d71fe2d0d0bb7858c1257aa4de)

## Summary by Sourcery

Disable kernel memory accounting for memory cgroups by default and add a kernel parameter option to re-enable it.

Bug Fixes:
- Avoid performance regressions caused by unstable kernel memory accounting in memory cgroups by turning it off by default.

Documentation:
- Document the ability to toggle kernel memory accounting for memory cgroups via kernel parameters.