### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6-y] [Deepin] iommu: Fix kabi in iommu_ops by using KABI_USE

### DIFF
--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -417,10 +417,9 @@ struct iommu_ops {
 	const struct iommu_domain_ops *default_domain_ops;
 	unsigned long pgsize_bitmap;
 	struct module *owner;
-	struct iommu_domain *identity_domain;
 
-	DEEPIN_KABI_USE(1, struct iommu_domain *default_domain)
-	DEEPIN_KABI_RESERVE(2)
+	DEEPIN_KABI_USE(1, struct iommu_domain *identity_domain)
+	DEEPIN_KABI_USE(2, struct iommu_domain *default_domain)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)
 	DEEPIN_KABI_RESERVE(5)


### PR DESCRIPTION
deepin inclusion
category: kabi

When DEEPIN_KABI_RESERVE=y, struct iommu_ops is kabi whitelist, commit df31b298477e6 ("iommu: Add iommu_ops->identity_domain") upstream introduce identity_domain in iommu_ops.

We can use DEEPIN_KABI_USE to fix it.

Fixes: c16b2be275f56 ("iommu: Add iommu_ops->identity_domain")

## Summary by Sourcery

Bug Fixes:
- Fix KABI breakage in struct iommu_ops by mapping identity_domain and default_domain through DEEPIN_KABI_USE slots instead of direct fields.