### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] mm/thp: add CONFIG_TRANSPARENT_HUGEPAGE_NEVER option

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -871,6 +871,12 @@ choice
 	  madvise(MADV_HUGEPAGE) but it won't risk to increase the
 	  memory footprint of applications without a guaranteed
 	  benefit.
+
+	config TRANSPARENT_HUGEPAGE_NEVER
+		bool "never"
+	help
+	  Disable Transparent Hugepage by default. It can still be
+	  enabled at runtime via sysfs.
 endchoice
 
 config THP_SWAP


### PR DESCRIPTION
mainline inclusion
from mainline-v6.8-rc1
category: performance

Currently enabling THP support (CONFIG_TRANSPARENT_HUGEPAGE) requires enabling either CONFIG_TRANSPARENT_HUGEPAGE_ALWAYS or CONFIG_TRANSPARENT_HUGEPAGE_MADVISE, which both cause khugepaged starting by default at kernel bootup.  Add the third choice CONFIG_TRANSPARENT_HUGEPAGE_NEVER, in line with the existing kernel command line setting transparent_hugepage=never, to disable THP by default (in particular, to prevent starting khugepaged by default) but still allow enabling it at runtime via sysfs.

Rationale: khugepaged has its own non-negligible memory cost even if it is not used by any applications, since it bumps up vm.min_free_kbytes to its own required minimum in set_recommended_min_free_kbytes().  For example, on a machine with 4GB RAM, with 3 mm zones and pageblock_order == MAX_ORDER, starting khugepaged causes vm.min_free_kbytes increase from 8MB to 132MB.

So if we use THP on machines with e.g.  >=8GB of memory for better performance, but avoid using it on lower-memory machines to avoid its memory overhead, then for the same reason we also want to avoid even starting khugepaged on those <8GB machines.  So with CONFIG_TRANSPARENT_HUGEPAGE_NEVER we can use the same kernel image on both
>=8GB and <8GB machines, with THP support enabled but khugepaged not
started by default.  The userspace can then decide to enable THP via sysfs if needed, based on the total amount of memory.

This could also be achieved with the existing transparent_hugepage=never setting in the kernel command line instead.  But it seems cleaner to avoid tweaking the command line for such a basic setting.

P.S. I see that CONFIG_TRANSPARENT_HUGEPAGE_NEVER was already proposed in the past [1] but without an explanation of the purpose.

[1] https://lore.kernel.org/all/202211301651462590168@zte.com.cn/

Link: https://lkml.kernel.org/r/20231205170244.2746210-1-dmaluka@chromium.org
Link: https://lore.kernel.org/all/20231204163254.2636289-1-dmaluka@chromium.org/


(cherry picked from commit 683ec99f12f4c386c23bed7f6a8ef44db5a4999a)

## Summary by Sourcery

Introduce a Kconfig option to support disabling transparent huge pages by default while keeping runtime enablement via sysfs.

New Features:
- Add CONFIG_TRANSPARENT_HUGEPAGE_NEVER to allow kernels to include THP support without starting khugepaged by default on boot.

Enhancements:
- Align THP configuration behavior with the existing transparent_hugepage=never kernel command-line option to simplify deployment across machines with differing memory sizes.