### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] zswap/list_lru: restore list_lru_add/list_lru_del for KAPI

### DIFF
--- a/include/linux/list_lru.h
+++ b/include/linux/list_lru.h
@@ -82,7 +82,7 @@ int memcg_list_lru_alloc(struct mem_cgroup *memcg, struct list_lru *lru,
 void memcg_reparent_list_lrus(struct mem_cgroup *memcg, struct mem_cgroup *parent);
 
 /**
- * list_lru_add: add an element to the lru list's tail
+ * __list_lru_add: add an element to the lru list's tail
  * @lru: the lru pointer
  * @item: the item to be added.
  * @nid: the node id of the sublist to add the item to.
@@ -99,8 +99,9 @@ void memcg_reparent_list_lrus(struct mem_cgroup *memcg, struct mem_cgroup *paren
  *
  * Return: true if the list was updated, false otherwise
  */
-bool list_lru_add(struct list_lru *lru, struct list_head *item, int nid,
+bool __list_lru_add(struct list_lru *lru, struct list_head *item, int nid,
 		    struct mem_cgroup *memcg);
+bool list_lru_add(struct list_lru *lru, struct list_head *item);
 
 /**
  * list_lru_add_obj: add an element to the lru list's tail
@@ -116,7 +117,7 @@ bool list_lru_add(struct list_lru *lru, struct list_head *item, int nid,
 bool list_lru_add_obj(struct list_lru *lru, struct list_head *item);
 
 /**
- * list_lru_del: delete an element from the lru list
+ * __list_lru_del: delete an element from the lru list
  * @lru: the lru pointer
  * @item: the item to be deleted.
  * @nid: the node id of the sublist to delete the item from.
@@ -128,8 +129,9 @@ bool list_lru_add_obj(struct list_lru *lru, struct list_head *item);
  *
  * Return: true if the list was updated, false otherwise
  */
-bool list_lru_del(struct list_lru *lru, struct list_head *item, int nid,
+bool __list_lru_del(struct list_lru *lru, struct list_head *item, int nid,
 		    struct mem_cgroup *memcg);
+bool list_lru_del(struct list_lru *lru, struct list_head *item);
 
 /**
  * list_lru_del_obj: delete an element from the lru list

--- a/mm/list_lru.c
+++ b/mm/list_lru.c
@@ -106,7 +106,7 @@ list_lru_from_memcg(struct list_lru *lru, int nid, struct mem_cgroup *memcg)
 #endif /* CONFIG_MEMCG_KMEM */
 
 /* The caller must ensure the memcg lifetime. */
-bool list_lru_add(struct list_lru *lru, struct list_head *item, int nid,
+bool __list_lru_add(struct list_lru *lru, struct list_head *item, int nid,
 		    struct mem_cgroup *memcg)
 {
 	struct list_lru_node *nlru = &lru->node[nid];
@@ -134,18 +134,25 @@ bool list_lru_add_obj(struct list_lru *lru, struct list_head *item)
 
 	if (list_lru_memcg_aware(lru)) {
 		rcu_read_lock();
-		ret = list_lru_add(lru, item, nid, mem_cgroup_from_slab_obj(item));
+		ret = __list_lru_add(lru, item, nid, mem_cgroup_from_slab_obj(item));
 		rcu_read_unlock();
 	} else {
-		ret = list_lru_add(lru, item, nid, NULL);
+		ret = __list_lru_add(lru, item, nid, NULL);
 	}
 
 	return ret;
 }
 EXPORT_SYMBOL_GPL(list_lru_add_obj);
 
+/* Legacy two-argument KAPI for out-of-tree modules. */
+bool list_lru_add(struct list_lru *lru, struct list_head *item)
+{
+	return list_lru_add_obj(lru, item);
+}
+EXPORT_SYMBOL_GPL(list_lru_add);
+
 /* The caller must ensure the memcg lifetime. */
-bool list_lru_del(struct list_lru *lru, struct list_head *item, int nid,
+bool __list_lru_del(struct list_lru *lru, struct list_head *item, int nid,
 		    struct mem_cgroup *memcg)
 {
 	struct list_lru_node *nlru = &lru->node[nid];
@@ -163,7 +170,6 @@ bool list_lru_del(struct list_lru *lru, struct list_head *item, int nid,
 	spin_unlock(&nlru->lock);
 	return false;
 }
-EXPORT_SYMBOL_GPL(list_lru_del);
 
 bool list_lru_del_obj(struct list_lru *lru, struct list_head *item)
 {
@@ -172,15 +178,22 @@ bool list_lru_del_obj(struct list_lru *lru, struct list_head *item)
 
 	if (list_lru_memcg_aware(lru)) {
 		rcu_read_lock();
-		ret = list_lru_del(lru, item, nid, mem_cgroup_from_slab_obj(item));
+		ret = __list_lru_del(lru, item, nid, mem_cgroup_from_slab_obj(item));
 		rcu_read_unlock();
 	} else {
-		ret = list_lru_del(lru, item, nid, NULL);
+		ret = __list_lru_del(lru, item, nid, NULL);
 	}
 
 	return ret;
 }
 EXPORT_SYMBOL_GPL(list_lru_del_obj);
+
+/* Legacy two-argument KAPI for out-of-tree modules. */
+bool list_lru_del(struct list_lru *lru, struct list_head *item)
+{
+	return list_lru_del_obj(lru, item);
+}
+EXPORT_SYMBOL_GPL(list_lru_del);
 
 void list_lru_isolate(struct list_lru_one *list, struct list_head *item)
 {

--- a/mm/list_lru.c
+++ b/mm/list_lru.c
@@ -213,8 +213,7 @@ EXPORT_SYMBOL_GPL(list_lru_isolate_move);
 void list_lru_putback(struct list_lru *lru, struct list_head *item, int nid,
 		      struct mem_cgroup *memcg)
 {
-	struct list_lru_one *list =
-		list_lru_from_memcg_idx(lru, nid, memcg_kmem_id(memcg));
+	struct list_lru_one *list = list_lru_from_memcg(lru, nid, memcg);
 
 	if (list_empty(item)) {
 		list_add_tail(item, &list->list);

--- a/mm/zswap.c
+++ b/mm/zswap.c
@@ -364,7 +364,7 @@ static void zswap_lru_add(struct list_lru *list_lru, struct zswap_entry *entry)
 	rcu_read_lock();
 	memcg = mem_cgroup_from_entry(entry);
 	/* will always succeed */
-	list_lru_add(list_lru, &entry->lru, nid, memcg);
+	__list_lru_add(list_lru, &entry->lru, nid, memcg);
 	rcu_read_unlock();
 }
 
@@ -376,7 +376,7 @@ static void zswap_lru_del(struct list_lru *list_lru, struct zswap_entry *entry)
 	rcu_read_lock();
 	memcg = mem_cgroup_from_entry(entry);
 	/* will always succeed */
-	list_lru_del(list_lru, &entry->lru, nid, memcg);
+	__list_lru_del(list_lru, &entry->lru, nid, memcg);
 	rcu_read_unlock();
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Restore legacy list_lru_add/list_lru_del kernel API while introducing internal memcg-aware helpers and updating zswap to use the new interfaces.

New Features:
- Reintroduce two-argument list_lru_add and list_lru_del symbols for out-of-tree modules relying on the legacy KAPI.

Enhancements:
- Introduce internal __list_lru_add/__list_lru_del helpers that take nid and memcg parameters for in-tree callers like zswap.
- Simplify list_lru_putback to use list_lru_from_memcg instead of memcg_kmem_id-based lookup.