### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [zhaoxin] x86/microcode/zhaoxin: Fix NULL check for the P4D page allocation x86/mce/zhaoxin: Fix bus number shift in ZDI error reporting

### DIFF
--- a/arch/x86/kernel/cpu/mce/apei.c
+++ b/arch/x86/kernel/cpu/mce/apei.c
@@ -176,7 +176,7 @@ void zx_apei_mce_report_zdi_error(struct cper_sec_proc_generic *zdi_err)
 	mce_setup(&m);
 	m.misc = 0;
 	m.misc |= (zdi_err->requestor_id & 0xff) << 19;
-	m.misc |= ((zdi_err->requestor_id & 0xff00) >> 8) >> 24;
+	m.misc |= ((zdi_err->requestor_id & 0xff00) >> 8) << 24;
 	m.bank = 5;
 	switch (zdi_err->responder_id) {
 	case 2:

--- a/arch/x86/kernel/cpu/microcode/zhaoxin.c
+++ b/arch/x86/kernel/cpu/microcode/zhaoxin.c
@@ -396,7 +396,7 @@ static __init void init_microcode_pages(void)
 
 	if (pgtable_l5_enabled()) {
 		microcode_p4d_page = (p4d_t *)__get_free_page(GFP_KERNEL_ACCOUNT);
-		if (!microcode_pud_page) {
+		if (!microcode_p4d_page) {
 			pr_err("Failed to allocate P4D page\n");
 			goto fail_pud;
 		}


### PR DESCRIPTION
[x86/mce/zhaoxin: Fix bus number shift in ZDI error reporting](https://github.com/deepin-community/kernel/commit/644aa3b67414d4a83e9e99be116c414b4fe8f79f)
[x86/microcode/zhaoxin: Fix NULL check for the P4D page allocation](https://github.com/deepin-community/kernel/commit/53d2e433991d2d0e582019afbf6a003a612d6f48)

## Summary by Sourcery

Fix Zhaoxin-specific x86 error handling and microcode page allocation issues.

Bug Fixes:
- Correct the bit shift used when encoding the bus number in ZDI machine check error reporting.
- Fix the NULL pointer check after allocating the P4D microcode page when 5-level paging is enabled.