### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] net: wangxun: ngbe: Guard ngbe_netpoll with CONFIG_NET_POLL_CONTROLLER

### DIFF
--- a/drivers/net/ethernet/wangxun/ngbe/ngbe_main.c
+++ b/drivers/net/ethernet/wangxun/ngbe/ngbe_main.c
@@ -6904,6 +6904,7 @@ static int ngbe_ioctl(struct net_device *netdev, struct ifreq *ifr, int cmd)
 	}
 }
 
+#ifdef CONFIG_NET_POLL_CONTROLLER
 /* Polling 'interrupt' - used by things like netconsole to send skbs
  * without having to re-enable interrupts. It's not called while
  * the interrupt routine is executing.
@@ -6928,6 +6929,7 @@ static void ngbe_netpoll(struct net_device *netdev)
 		ngbe_intr(0, adapter);
 	}
 }
+#endif
 
 /**
  * ngbe_setup_tc - routine to configure net_device for multiple traffic


### PR DESCRIPTION
When CONFIG_NET_POLL_CONTROLLER is disabled, ngbe_netpoll() is compiled in but never referenced, as the ndo_netpoll assignment is already guarded by the same config. This triggers an unused-function warning (-Wunused-function).

Wrap the function definition in #ifdef CONFIG_NET_POLL_CONTROLLER to match its usage.

Fixes: 4d604082eb0c ("deepin: net: wangxun: ngbe: add support for wangxun 1G")
Reported-by: WangYuli <wangyl5933@chinaunicom.cn>

## Summary by Sourcery

Bug Fixes:
- Prevent an unused-function warning by only compiling ngbe_netpoll when CONFIG_NET_POLL_CONTROLLER is enabled.