### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Radxa] ufs: core: add PA_TACTIVATE quirk for Kioxia THGJFGT1E45BAILB

### DIFF
--- a/drivers/ufs/core/ufshcd.c
+++ b/drivers/ufs/core/ufshcd.c
@@ -276,6 +276,9 @@ static const struct ufs_dev_quirk ufs_fixups[] = {
 	  .model = "THGLF2G9D8KBADG",
 	  .quirk = UFS_DEVICE_QUIRK_PA_TACTIVATE },
 	{ .wmanufacturerid = UFS_VENDOR_TOSHIBA,
+	  .model = "THGJFGT1E45BAILB",
+	  .quirk = UFS_DEVICE_QUIRK_PA_TACTIVATE },
+	{ .wmanufacturerid = UFS_VENDOR_TOSHIBA,
 	  .model = "THGJFJT1E45BATP",
 	  .quirk = UFS_DEVICE_QUIRK_NO_TIMESTAMP_SUPPORT },
 	{}


### PR DESCRIPTION
The Kioxia THGJFGT1E45BAILB UFS 3.1 device fails to resume from suspend with OCS invalid and PHY adapter errors when transitioning power modes via START STOP UNIT:

  ufshcd-qcom: OCS invalid from controller for tag 28
  ufshcd-qcom: pa_err[0] = 0x80000001 at 315293661 us
  ufshcd-qcom: dl_err[0] = 0x80004000 at 315293662 us
  ufshcd-qcom: __ufshcd_issue_tm_cmd: task management cmd 0x08 timed-out
  ufshcd-qcom: ufshcd_eh_device_reset_handler: failed with err -110

Add UFS_DEVICE_QUIRK_PA_TACTIVATE to set PA_TACTIVATE to 1ms, giving the M-PHY adequate stabilization time during power mode transitions.

Tested on Radxa Dragon Q6A.

[WangYuli: Move this quirk from ufs_qcom_dev_fixups to ufs_fixups.]

Link: https://forum.radxa.com/t/ufs-random-reboots/30630
Link: https://github.com/radxa/kernel/pull/551

## Summary by Sourcery

Bug Fixes:
- Ensure reliable suspend/resume and power mode transitions for the Kioxia THGJFGT1E45BAILB UFS device by applying the PA_TACTIVATE quirk.