### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [deepin] PCI: Keep pci_resize_resource() 3-arg API for DKMS compatibility

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
@@ -1168,9 +1168,9 @@ int amdgpu_device_resize_fb_bar(struct amdgpu_device *adev)
 
 	pci_release_resource(adev->pdev, 0);
 
-	r = pci_resize_resource(adev->pdev, 0, rbar_size,
-				(adev->asic_type >= CHIP_BONAIRE) ? 1 << 5
-								  : 1 << 2);
+	r = __pci_resize_resource(adev->pdev, 0, rbar_size,
+				  (adev->asic_type >= CHIP_BONAIRE) ? 1 << 5
+								    : 1 << 2);
 	if (r == -ENOSPC)
 		DRM_INFO("Not enough PCI address space for a large BAR.");
 	else if (r && r != -ENOTSUPP)

--- a/drivers/gpu/drm/i915/gt/intel_region_lmem.c
+++ b/drivers/gpu/drm/i915/gt/intel_region_lmem.c
@@ -37,7 +37,7 @@ _resize_bar(struct drm_i915_private *i915, int resno, resource_size_t size)
 
 	_release_bars(pdev);
 
-	ret = pci_resize_resource(pdev, resno, bar_size, 0);
+	ret = pci_resize_resource(pdev, resno, bar_size);
 	if (ret) {
 		drm_info(&i915->drm, "Failed to resize BAR%d to %dM (%pe)\n",
 			 resno, 1 << bar_size, ERR_PTR(ret));

--- a/drivers/pci/pci-sysfs.c
+++ b/drivers/pci/pci-sysfs.c
@@ -1487,7 +1487,7 @@ static ssize_t resource##n##_resize_store(struct device *dev,		\
 									\
 	pci_remove_resource_files(pdev);				\
 									\
-	ret = pci_resize_resource(pdev, n, size, 0);			\
+	ret = pci_resize_resource(pdev, n, size);			\
 									\
 	pci_assign_unassigned_bus_resources(pdev->bus);			\
 									\

--- a/drivers/pci/rebar.c
+++ b/drivers/pci/rebar.c
@@ -154,7 +154,7 @@ void pci_restore_rebar_state(struct pci_dev *pdev)
 }
 
 /**
- * pci_resize_resource - reconfigure a Resizable BAR and resources
+ * __pci_resize_resource - reconfigure a Resizable BAR and resources
  * @dev: the PCI device
  * @resno: index of the BAR to be resized
  * @size: new size as defined in the spec (0=1MB, 31=128TB)
@@ -173,8 +173,8 @@ void pci_restore_rebar_state(struct pci_dev *pdev)
  * Return: 0 on success, or negative on error. In case of an error, the
  *         resources are restored to their original places.
  */
-int pci_resize_resource(struct pci_dev *dev, int resno, int size,
-			int exclude_bars)
+int __pci_resize_resource(struct pci_dev *dev, int resno, int size,
+			  int exclude_bars)
 {
 	struct pci_host_bridge *host;
 	int old, ret;
@@ -214,5 +214,24 @@ int pci_resize_resource(struct pci_dev *dev, int resno, int size,
 error_resize:
 	pci_rebar_set_size(dev, resno, old);
 	return ret;
+}
+EXPORT_SYMBOL(__pci_resize_resource);
+
+/**
+ * pci_resize_resource - reconfigure a Resizable BAR and resources
+ * @dev: the PCI device
+ * @resno: index of the BAR to be resized
+ * @size: new size as defined in the spec (0=1MB, 31=128TB)
+ *
+ * Reconfigure @resno to @size and re-run resource assignment algorithm
+ * with the new size.  All device resources that share a bridge window
+ * with @resno are released prior to the resize.
+ *
+ * Return: 0 on success, or negative on error. In case of an error, the
+ *         resources are restored to their original places.
+ */
+int pci_resize_resource(struct pci_dev *dev, int resno, int size)
+{
+	return __pci_resize_resource(dev, resno, size, 0);
 }
 EXPORT_SYMBOL(pci_resize_resource);

--- a/include/linux/pci.h
+++ b/include/linux/pci.h
@@ -1419,8 +1419,9 @@ static inline int pci_rebar_bytes_to_size(u64 bytes)
 }
 
 u32 pci_rebar_get_possible_sizes(struct pci_dev *pdev, int bar);
-int __must_check pci_resize_resource(struct pci_dev *dev, int i, int size,
-				     int exclude_bars);
+int __must_check pci_resize_resource(struct pci_dev *dev, int i, int size);
+int __must_check __pci_resize_resource(struct pci_dev *dev, int i, int size,
+				       int exclude_bars);
 int pci_select_bars(struct pci_dev *dev, unsigned long flags);
 bool pci_device_is_present(struct pci_dev *pdev);
 void pci_ignore_hotplug(struct pci_dev *dev);


### PR DESCRIPTION
deepin inclusion
category: kapi

Commit 916bfc605c84 ("PCI: Fix restoring BARs on BAR resize rollback path") added an exclude_bars parameter to pci_resize_resource(), which broke the exported kernel API: out-of-tree DKMS modules calling it with the original 3-argument prototype fail to compile with "too few arguments to function 'pci_resize_resource'".

Restore API compatibility by splitting the interface:

- Rename the implementation to __pci_resize_resource() taking the new exclude_bars parameter, and export it.
- Provide pci_resize_resource() with the original 3-argument prototype as a wrapper passing exclude_bars=0, keeping the exported symbol and behavior unchanged for existing callers.
- Make amdgpu call __pci_resize_resource() since it needs to exclude its register BAR; sysfs and i915 go back to the 3-argument call.

Assisted-by: kimi:K3-256k

## Summary by Sourcery

Restore PCI Resizable BAR API compatibility while keeping the newer extended interface available.

New Features:
- Introduce __pci_resize_resource() helper that supports excluding specific BARs during PCI Resizable BAR operations.

Enhancements:
- Reintroduce the original 3-argument pci_resize_resource() wrapper to preserve KAPI compatibility for out-of-tree modules.
- Update amdgpu to call __pci_resize_resource() directly while simplifying i915 and sysfs callers back to the 3-argument pci_resize_resource() API.