### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [deepin] pinctrl: zhaoxin: Fix pinctrl_gpio_direction_*() calls after API change

### DIFF
--- a/drivers/pinctrl/zhaoxin/pinctrl-zhaoxin.c
+++ b/drivers/pinctrl/zhaoxin/pinctrl-zhaoxin.c
@@ -284,12 +284,12 @@ static void zhaoxin_gpio_set(struct gpio_chip *chip, unsigned int offset, int va
 
 static int zhaoxin_gpio_direction_input(struct gpio_chip *chip, unsigned int offset)
 {
-	return pinctrl_gpio_direction_input(chip->base + offset);
+	return pinctrl_gpio_direction_input(chip, offset);
 }
 
 static int zhaoxin_gpio_direction_output(struct gpio_chip *chip, unsigned int offset, int value)
 {
-	return pinctrl_gpio_direction_output(chip->base + offset);
+	return pinctrl_gpio_direction_output(chip, offset);
 }
 
 static int zhaoxin_gpio_request(struct gpio_chip *gc, unsigned int offset)


### PR DESCRIPTION
Commit 25cf951e14cc8 ("pinctrl: remove pinctrl_gpio_direction_output()") [upstream commit 45d2055b0067739253883dc541f37c86aad45c92] changed pinctrl_gpio_direction_input() and pinctrl_gpio_direction_output() to take a struct gpio_chip pointer and a hardware offset instead of the global GPIO number, and converted all in-tree callers. The zhaoxin driver was missed, breaking its build:

  error: too few arguments to function 'pinctrl_gpio_direction_output'
  error: passing argument 1 ... from incompatible pointer type

Pass the gpio_chip and offset directly, matching the new prototype. The pinctrl core translates them back to the global GPIO number via gc->base + offset, so the behavior is unchanged.

This fixes x86 build failed after cherry-pick v6.6.147..v6.6.148. Fixes: 25cf951e14cc8 ("pinctrl: remove pinctrl_gpio_direction_output()")

## Summary by Sourcery

Bug Fixes:
- Fix build failure in the zhaoxin pinctrl driver by adapting pinctrl_gpio_direction_input/output() calls to the updated function signatures.