### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [deepin] bonding: kabi fix prevent potential infinite loop in bond_header_parse()

### DIFF
--- a/drivers/firewire/net.c
+++ b/drivers/firewire/net.c
@@ -269,7 +269,7 @@ static const struct header_ops fwnet_header_ops = {
 	.create         = fwnet_header_create,
 	.cache		= fwnet_header_cache,
 	.cache_update	= fwnet_header_cache_update,
-	.parse          = fwnet_header_parse,
+	.parse_v2          = fwnet_header_parse,
 };
 
 /* FIXME: is this correct for all cases? */

--- a/drivers/media/dvb-core/dvb_net.c
+++ b/drivers/media/dvb-core/dvb_net.c
@@ -1304,7 +1304,7 @@ static int dvb_net_stop(struct net_device *dev)
 
 static const struct header_ops dvb_header_ops = {
 	.create		= eth_header,
-	.parse		= eth_header_parse,
+	.parse_v2		= eth_header_parse,
 };
 
 

--- a/drivers/net/bonding/bond_main.c
+++ b/drivers/net/bonding/bond_main.c
@@ -1502,8 +1502,10 @@ static int bond_header_parse(const struct sk_buff *skb,
 	slave = rcu_dereference(bond->curr_active_slave);
 	if (slave) {
 		slave_ops = READ_ONCE(slave->dev->header_ops);
-		if (slave_ops && slave_ops->parse)
-			ret = slave_ops->parse(skb, slave->dev, haddr);
+		if (slave_ops && slave_ops->parse_v2)
+			ret = slave_ops->parse_v2(skb, slave->dev, haddr);
+		else if (slave_ops && slave_ops->parse)
+ 			ret = slave_ops->parse(skb, haddr);
 	}
 	rcu_read_unlock();
 	return ret;
@@ -1511,7 +1513,7 @@ static int bond_header_parse(const struct sk_buff *skb,
 
 static const struct header_ops bond_header_ops = {
 	.create	= bond_header_create,
-	.parse	= bond_header_parse,
+	.parse_v2	= bond_header_parse,
 };
 
 static void bond_setup_by_slave(struct net_device *bond_dev,

--- a/drivers/net/ipvlan/ipvlan_main.c
+++ b/drivers/net/ipvlan/ipvlan_main.c
@@ -386,7 +386,7 @@ static int ipvlan_hard_header(struct sk_buff *skb, struct net_device *dev,
 
 static const struct header_ops ipvlan_header_ops = {
 	.create  	= ipvlan_hard_header,
-	.parse		= eth_header_parse,
+	.parse_v2		= eth_header_parse,
 	.cache		= eth_header_cache,
 	.cache_update	= eth_header_cache_update,
 };

--- a/drivers/net/macvlan.c
+++ b/drivers/net/macvlan.c
@@ -613,7 +613,7 @@ static int macvlan_hard_header(struct sk_buff *skb, struct net_device *dev,
 
 static const struct header_ops macvlan_hard_header_ops = {
 	.create  	= macvlan_hard_header,
-	.parse		= eth_header_parse,
+	.parse_v2		= eth_header_parse,
 	.cache		= eth_header_cache,
 	.cache_update	= eth_header_cache_update,
 };

--- a/drivers/net/team/team_core.c
+++ b/drivers/net/team/team_core.c
@@ -2178,8 +2178,10 @@ static int team_header_parse(const struct sk_buff *skb,
 	port = team_header_port_get_rcu(team, false);
 	if (port) {
 		port_ops = READ_ONCE(port->dev->header_ops);
-		if (port_ops && port_ops->parse)
-			ret = port_ops->parse(skb, port->dev, haddr);
+		if (port_ops && port_ops->parse_v2)
+			ret = port_ops->parse_v2(skb, port->dev, haddr);
+		else if (port_ops && port_ops->parse)
+			ret = port_ops->parse(skb, haddr);
 	}
 	rcu_read_unlock();
 	return ret;
@@ -2187,7 +2189,7 @@ static int team_header_parse(const struct sk_buff *skb,
 
 static const struct header_ops team_header_ops = {
 	.create		= team_header_create,
-	.parse		= team_header_parse,
+	.parse_v2		= team_header_parse,
 };
 
 static void team_setup_by_port(struct net_device *dev,

--- a/drivers/net/wireless/cisco/airo.c
+++ b/drivers/net/wireless/cisco/airo.c
@@ -2657,7 +2657,7 @@ static int mpi_map_card(struct airo_info *ai, struct pci_dev *pci)
 }
 
 static const struct header_ops airo_header_ops = {
-	.parse = wll_header_parse,
+	.parse_v2 = wll_header_parse,
 };
 
 static const struct net_device_ops airo11_netdev_ops = {

--- a/drivers/net/wireless/intersil/hostap/hostap_main.c
+++ b/drivers/net/wireless/intersil/hostap/hostap_main.c
@@ -787,7 +787,7 @@ const struct header_ops hostap_80211_ops = {
 	.create		= eth_header,
 	.cache		= eth_header_cache,
 	.cache_update	= eth_header_cache_update,
-	.parse		= hostap_80211_header_parse,
+	.parse_v2		= hostap_80211_header_parse,
 };
 EXPORT_SYMBOL(hostap_80211_ops);
 

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -313,9 +313,7 @@ struct header_ops {
 	int	(*create) (struct sk_buff *skb, struct net_device *dev,
 			   unsigned short type, const void *daddr,
 			   const void *saddr, unsigned int len);
-	int	(*parse)(const struct sk_buff *skb,
-			 const struct net_device *dev,
-			 unsigned char *haddr);
+	int	(*parse)(const struct sk_buff *skb, unsigned char *haddr);
 	int	(*cache)(const struct neighbour *neigh, struct hh_cache *hh, __be16 type);
 	void	(*cache_update)(struct hh_cache *hh,
 				const struct net_device *dev,
@@ -323,7 +321,9 @@ struct header_ops {
 	bool	(*validate)(const char *ll_header, unsigned int len);
 	__be16	(*parse_protocol)(const struct sk_buff *skb);
 
-	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_USE(1, int	(*parse_v2)(const struct sk_buff *skb,
+			 const struct net_device *dev,
+			 unsigned char *haddr))
 	DEEPIN_KABI_RESERVE(2)
 };
 
@@ -3229,9 +3229,11 @@ static inline int dev_parse_header(const struct sk_buff *skb,
 {
 	const struct net_device *dev = skb->dev;
 
-	if (!dev->header_ops || !dev->header_ops->parse)
+	if (!dev->header_ops || (!dev->header_ops->parse && !dev->header_ops->parse_v2))
 		return 0;
-	return dev->header_ops->parse(skb, dev, haddr);
+	if (dev->header_ops->parse_v2)
+		return dev->header_ops->parse_v2(skb, dev, haddr);
+	return  dev->header_ops->parse(skb, haddr);
 }
 
 static inline __be16 dev_parse_header_protocol(const struct sk_buff *skb)

--- a/net/8021q/vlan_dev.c
+++ b/net/8021q/vlan_dev.c
@@ -512,7 +512,7 @@ static __be16 vlan_parse_protocol(const struct sk_buff *skb)
 
 static const struct header_ops vlan_header_ops = {
 	.create	 = vlan_dev_hard_header,
-	.parse	 = eth_header_parse,
+	.parse_v2	 = eth_header_parse,
 	.parse_protocol = vlan_parse_protocol,
 };
 
@@ -532,7 +532,7 @@ static int vlan_passthru_hard_header(struct sk_buff *skb, struct net_device *dev
 
 static const struct header_ops vlan_passthru_header_ops = {
 	.create	 = vlan_passthru_hard_header,
-	.parse	 = eth_header_parse,
+	.parse_v2	 = eth_header_parse,
 	.parse_protocol = vlan_parse_protocol,
 };
 

--- a/net/ethernet/eth.c
+++ b/net/ethernet/eth.c
@@ -329,7 +329,7 @@ EXPORT_SYMBOL(eth_validate_addr);
 
 const struct header_ops eth_header_ops ____cacheline_aligned = {
 	.create		= eth_header,
-	.parse		= eth_header_parse,
+	.parse_v2		= eth_header_parse,
 	.cache		= eth_header_cache,
 	.cache_update	= eth_header_cache_update,
 	.parse_protocol	= eth_header_parse_protocol,

--- a/net/hsr/hsr_device.c
+++ b/net/hsr/hsr_device.c
@@ -248,7 +248,7 @@ static netdev_tx_t hsr_dev_xmit(struct sk_buff *skb, struct net_device *dev)
 
 static const struct header_ops hsr_header_ops = {
 	.create	 = eth_header,
-	.parse	 = eth_header_parse,
+	.parse_v2	 = eth_header_parse,
 };
 
 static struct sk_buff *hsr_init_skb(struct hsr_port *master)

--- a/net/ipv4/ip_gre.c
+++ b/net/ipv4/ip_gre.c
@@ -898,7 +898,7 @@ static int ipgre_header_parse(const struct sk_buff *skb, const struct net_device
 
 static const struct header_ops ipgre_header_ops = {
 	.create	= ipgre_header,
-	.parse	= ipgre_header_parse,
+	.parse_v2	= ipgre_header_parse,
 };
 
 #ifdef CONFIG_NET_IPGRE_BROADCAST

--- a/net/mac802154/iface.c
+++ b/net/mac802154/iface.c
@@ -490,7 +490,7 @@ mac802154_header_parse(const struct sk_buff *skb,
 
 static const struct header_ops mac802154_header_ops = {
 	.create         = mac802154_header_create,
-	.parse          = mac802154_header_parse,
+	.parse_v2          = mac802154_header_parse,
 };
 
 static const struct net_device_ops mac802154_wpan_ops = {

--- a/net/phonet/af_phonet.c
+++ b/net/phonet/af_phonet.c
@@ -141,7 +141,7 @@ static int pn_header_parse(const struct sk_buff *skb,
 
 const struct header_ops phonet_header_ops = {
 	.create = pn_header_create,
-	.parse = pn_header_parse,
+	.parse_v2 = pn_header_parse,
 };
 EXPORT_SYMBOL(phonet_header_ops);
 


### PR DESCRIPTION
deepin inclusion
category: kabi
CVE: CVE-2026-23451

--------------------------------

use .parse_v2 for new kapi and .parse for old.

Fixes: b7405dcf7385 ("bonding: prevent potential infinite loop in bond_header_parse()")

## Summary by Sourcery

Introduce a new header_ops parse_v2 callback while preserving KABI, and update networking drivers to use it for safer header parsing.

Bug Fixes:
- Fix potential infinite loop and incorrect device usage in bonding and team header parsing by routing through the new parse_v2 callback and correct device pointers.

Enhancements:
- Add a KABI-safe parse_v2 entry to struct header_ops and adjust core dev_parse_header logic to prefer parse_v2 while keeping legacy parse for older consumers.
- Update multiple networking subsystems (Ethernet, VLAN, IPvlan, Macvlan, wireless, FireWire, HSR, GRE, 802.15.4, and Phonet) to register their header_ops using parse_v2 instead of the legacy parse callback.