### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [KAPI] PCI: Keep pci_resize_resource() 3-arg API for DKMS compatibility

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
@@ -1736,9 +1736,9 @@ int amdgpu_device_resize_fb_bar(struct amdgpu_device *adev)
 
 	pci_release_resource(adev->pdev, 0);
 
-	r = pci_resize_resource(adev->pdev, 0, rbar_size,
-				(adev->asic_type >= CHIP_BONAIRE) ? 1 << 5
-								  : 1 << 2);
+	r = __pci_resize_resource(adev->pdev, 0, rbar_size,
+				  (adev->asic_type >= CHIP_BONAIRE) ? 1 << 5
+								    : 1 << 2);
 	if (r == -ENOSPC)
 		dev_info(adev->dev,
 			 "Not enough PCI address space for a large BAR.");

--- a/drivers/gpu/drm/i915/gt/intel_region_lmem.c
+++ b/drivers/gpu/drm/i915/gt/intel_region_lmem.c
@@ -37,7 +37,7 @@ _resize_bar(struct drm_i915_private *i915, int resno, resource_size_t size)
 
 	_release_bars(pdev);
 
-	ret = pci_resize_resource(pdev, resno, bar_size, 0);
+	ret = pci_resize_resource(pdev, resno, bar_size);
 	if (ret) {
 		drm_info(&i915->drm, "Failed to resize BAR%d to %dM (%pe)\n",
 			 resno, 1 << bar_size, ERR_PTR(ret));

--- a/drivers/gpu/drm/xe/xe_vram.c
+++ b/drivers/gpu/drm/xe/xe_vram.c
@@ -56,7 +56,7 @@ static void resize_bar(struct xe_device *xe, int resno, resource_size_t size)
 
 	release_bars(pdev);
 
-	ret = pci_resize_resource(pdev, resno, bar_size, 0);
+	ret = pci_resize_resource(pdev, resno, bar_size);
 	if (ret) {
 		drm_info(&xe->drm, "Failed to resize BAR%d to %dM (%pe). Consider enabling 'Resizable BAR' support in your BIOS\n",
 			 resno, 1 << bar_size, ERR_PTR(ret));

--- a/drivers/pci/pci-sysfs.c
+++ b/drivers/pci/pci-sysfs.c
@@ -1599,7 +1599,7 @@ static ssize_t __resource_resize_store(struct device *dev, int n,
 
 	pci_remove_resource_files(pdev);
 
-	ret = pci_resize_resource(pdev, n, size, 0);
+	ret = pci_resize_resource(pdev, n, size);
 
 	pci_assign_unassigned_bus_resources(bus);
 

--- a/drivers/pci/rebar.c
+++ b/drivers/pci/rebar.c
@@ -192,7 +192,7 @@ void pci_resize_resource_set_size(struct pci_dev *dev, int resno, int size)
 }
 
 /**
- * pci_resize_resource - reconfigure a Resizable BAR and resources
+ * __pci_resize_resource - reconfigure a Resizable BAR and resources
  * @dev: the PCI device
  * @resno: index of the BAR to be resized
  * @size: new size as defined in the spec (0=1MB, 31=128TB)
@@ -211,8 +211,8 @@ void pci_resize_resource_set_size(struct pci_dev *dev, int resno, int size)
  * Return: 0 on success, or negative on error. In case of an error, the
  *         resources are restored to their original places.
  */
-int pci_resize_resource(struct pci_dev *dev, int resno, int size,
-			int exclude_bars)
+int __pci_resize_resource(struct pci_dev *dev, int resno, int size,
+			  int exclude_bars)
 {
 	struct pci_host_bridge *host;
 	u32 sizes;
@@ -233,5 +233,26 @@ int pci_resize_resource(struct pci_dev *dev, int resno, int size,
 		return -EINVAL;
 
 	return pci_do_resource_release_and_resize(dev, resno, size, exclude_bars);
+}
+EXPORT_SYMBOL(__pci_resize_resource);
+
+/**
+ * pci_resize_resource - reconfigure a Resizable BAR and resources
+ * @dev: the PCI device
+ * @resno: index of the BAR to be resized
+ * @size: new size as defined in the spec (0=1MB, 31=128TB)
+ *
+ * Reconfigure @resno to @size and re-run resource assignment algorithm
+ * with the new size.
+ *
+ * Prior to resize, release @dev resources that share a bridge window with
+ * @resno.  This unpins the bridge window resource to allow changing it.
+ *
+ * Return: 0 on success, or negative on error. In case of an error, the
+ *         resources are restored to their original places.
+ */
+int pci_resize_resource(struct pci_dev *dev, int resno, int size)
+{
+	return __pci_resize_resource(dev, resno, size, 0);
 }
 EXPORT_SYMBOL(pci_resize_resource);

--- a/include/linux/pci.h
+++ b/include/linux/pci.h
@@ -1433,8 +1433,9 @@ static inline int pci_rebar_bytes_to_size(u64 bytes)
 }
 
 u32 pci_rebar_get_possible_sizes(struct pci_dev *pdev, int bar);
-int __must_check pci_resize_resource(struct pci_dev *dev, int i, int size,
-				     int exclude_bars);
+int __must_check pci_resize_resource(struct pci_dev *dev, int i, int size);
+int __must_check __pci_resize_resource(struct pci_dev *dev, int i, int size,
+				       int exclude_bars);
 int pci_select_bars(struct pci_dev *dev, unsigned long flags);
 bool pci_device_is_present(struct pci_dev *pdev);
 void pci_ignore_hotplug(struct pci_dev *dev);


### PR DESCRIPTION
deepin inclusion
category: kapi

Commit 916bfc605c84 ("PCI: Fix restoring BARs on BAR resize rollback path") added an exclude_bars parameter to pci_resize_resource(), which broke the exported kernel API: out-of-tree DKMS modules calling it with the original 3-argument prototype fail to compile with "too few arguments to function 'pci_resize_resource'".

Restore API compatibility by splitting the interface:

- Rename the implementation to __pci_resize_resource() taking the new exclude_bars parameter, and export it.
- Provide pci_resize_resource() with the original 3-argument prototype as a wrapper passing exclude_bars=0, keeping the exported symbol and behavior unchanged for existing callers.
- Make amdgpu call __pci_resize_resource() since it needs to exclude its register BAR; sysfs, i915 and xe go back to the 3-argument call.

Assisted-by: kimi:K3-256k
Fixes for loonggpu-kernel-dkms

## Summary by Sourcery

Preserve PCI BAR resize kernel API compatibility while retaining the newer exclude_bars behavior.

Bug Fixes:
- Restore the original 3-argument pci_resize_resource() interface to prevent DKMS and other out-of-tree callers from failing to build after the API change.

Enhancements:
- Introduce __pci_resize_resource() as the 4-argument implementation, exporting it for in-tree callers that need fine-grained exclude_bars control.
- Update amdgpu to use __pci_resize_resource() with exclude_bars while i915, xe, and PCI sysfs interfaces use the restored 3-argument pci_resize_resource() wrapper.