### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [KABI] writeback: kabi fix in struct bdi_writeback

### DIFF
--- a/include/linux/backing-dev-defs.h
+++ b/include/linux/backing-dev-defs.h
@@ -155,10 +155,6 @@ struct bdi_writeback {
 	struct list_head blkcg_node;	/* anchored at blkcg->cgwb_list */
 	struct list_head b_attached;	/* attached inodes, protected by list_lock */
 	struct list_head offline_node;	/* anchored at offline_cgwbs */
-	struct work_struct switch_work;	/* work used to perform inode switching
-					 * to this wb */
-	struct llist_head switch_wbs_ctxs;	/* queued contexts for
-						 * writeback switching */
 
 	union {
 		struct work_struct release_work;
@@ -166,12 +162,19 @@ struct bdi_writeback {
 	};
 #endif
 
+#ifdef CONFIG_CGROUP_WRITEBACK
+	DEEPIN_KABI_USE(1, struct llist_head switch_wbs_ctxs)/* queued contexts for
+						 * writeback switching */
+	DEEPIN_KABI_USE(2, 3, 4, 5, 6, struct work_struct switch_work)	/* work used to perform inode switching
+					 * to this wb */
+#else
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)
 	DEEPIN_KABI_RESERVE(5)
 	DEEPIN_KABI_RESERVE(6)
+#endif
 };
 
 struct backing_dev_info {


### PR DESCRIPTION
deepin inclusion
category: kabi

Fixes: ed5400f4b6ce ("writeback: Avoid contention on wb->list_lock when switching inodes")

## Summary by Sourcery

Preserve kernel ABI compatibility for struct bdi_writeback while reintroducing writeback switching fields under controlled macros.

Bug Fixes:
- Restore the switch_work and switch_wbs_ctxs fields in struct bdi_writeback in a KABI-safe manner for cgroup writeback configurations.

Enhancements:
- Use DEEPIN_KABI_USE and DEEPIN_KABI_RESERVE macros to manage KABI slots in struct bdi_writeback depending on CONFIG_CGROUP_WRITEBACK.