### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [clearlinux] readdir: add unlikely hint on len check

### DIFF
--- a/fs/readdir.c
+++ b/fs/readdir.c
@@ -147,7 +147,7 @@ EXPORT_SYMBOL(iterate_dir);
  */
 static int verify_dirent_name(const char *name, int len)
 {
-	if (len <= 0 || len >= PATH_MAX)
+	if (unlikely(len <= 0 || len >= PATH_MAX))
 		return -EIO;
 	if (memchr(name, '/', len))
 		return -EIO;


### PR DESCRIPTION
Currently the out of bounds check for the length is very unlikely to be false for valid name strings. Analysis with gcov coverage show this to be so.

Add an unlikely hint on the error return path check. This improves performance when testing with single instance stress-ng dentry and dirent stressors. Tested with a 6.15 kernel, built with gcc 14.2.0 on a Debian Ultra 9 285K system with turbo disabled to reduce test jitter on tmpfs. Each test case was run 25 times and the % standard deviation was less than 0.4%. Geometric mean of 25 results show the following stress-ng bogo-ops performance improvments:

getdent: 1.1%
dentry:  0.9%

## Summary by Sourcery

Enhancements:
- Mark the directory entry name length bounds check as unlikely to fail to improve iterate_dir performance in typical workloads.