### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [deepin] efi/loongarch: Disable EFI KASLR when hibernation is supported

### DIFF
--- a/drivers/firmware/efi/libstub/loongarch.c
+++ b/drivers/firmware/efi/libstub/loongarch.c
@@ -23,7 +23,12 @@ unsigned long efi_get_kimg_kaslr_address(void)
 	unsigned int random_offset = 0;
 
 #ifdef CONFIG_RANDOMIZE_BASE
-	if (!efi_nokaslr) {
+	/*
+	 * Hibernation requires a fixed kernel load address. Keep the EFI load
+	 * address unchanged; relocate.c handles the nohibernate/noresume
+	 * exceptions by applying relocation-time KASLR instead.
+	 */
+	if (!efi_nokaslr && !IS_ENABLED(CONFIG_HIBERNATION)) {
 		efi_get_random_bytes(sizeof(random_offset), (u8 *)&random_offset);
 		random_offset ^= (random_get_entropy() << 16);
 		random_offset &= (CONFIG_RANDOMIZE_BASE_MAX_OFFSET - 1);


### PR DESCRIPTION
deepin inclusion
category: bugfix

Hibernation requires a fixed kernel load address. EFI preferred-address randomization runs before relocate.c's hibernation checks, and the relocation-time KASLR is skipped once kaslr_offset() is nonzero.

Keep the EFI load address fixed when CONFIG_HIBERNATION is enabled. relocate.c still handles the nohibernate/noresume exceptions by applying relocation-time KASLR when hibernation is disabled from the command line.

Fixes: 659095adf4ec3 ("efi/loongarch: Randomize kernel preferred address for KASLR")

## Summary by Sourcery

Bug Fixes:
- Ensure hibernation works correctly on LoongArch EFI systems by preventing early KASLR randomization from changing the kernel load address when CONFIG_HIBERNATION is enabled.