### PR TITLE
KVM: x86: Add support for CPUID leaf 0x8C860000

### DIFF
--- a/arch/x86/kvm/cpuid.c
+++ b/arch/x86/kvm/cpuid.c
@@ -820,6 +820,9 @@ void kvm_set_cpu_caps(void)
 		kvm_cpu_cap_set(X86_FEATURE_NULL_SEL_CLR_BASE);
 	kvm_cpu_cap_set(X86_FEATURE_NO_SMM_CTL_MSR);
 
+	kvm_cpu_cap_mask(CPUID_8C86_0000_EDX,
+			 0 | F(HYGON_SM3) | F(HYGON_SM4));
+
 	kvm_cpu_cap_mask(CPUID_C000_0001_EDX,
 		F(XSTORE) | F(XSTORE_EN) | F(XCRYPT) | F(XCRYPT_EN) |
 		F(ACE2) | F(ACE2_EN) | F(PHE) | F(PHE_EN) |
@@ -1386,6 +1389,10 @@ static inline int __do_cpuid_func(struct kvm_cpuid_array *array, u32 function)
 		entry->ebx = ebx.full;
 		break;
 	}
+	case 0x8C860000:
+		entry->eax = 0x8C860000;
+		cpuid_entry_override(entry, CPUID_8C86_0000_EDX);
+		break;
 	/*Add support for Centaur's CPUID instruction*/
 	case 0xC0000000:
 		/* Extended to 0xC0000006 */
@@ -1443,6 +1450,15 @@ static int get_cpuid_func(struct kvm_cpuid_array *array, u32 func,
 		return r;
 
 	limit = array->entries[array->nent - 1].eax;
+
+	if ((func == 0x80000000) &&
+	    (boot_cpu_has(X86_FEATURE_HYGON_SM3) ||
+	     boot_cpu_has(X86_FEATURE_HYGON_SM4))) {
+		r = do_cpuid_func(array, 0x8C860000, type);
+		if (r)
+			return r;
+	}
+
 	for (func = func + 1; func <= limit; ++func) {
 		r = do_cpuid_func(array, func, type);
 		if (r)

--- a/arch/x86/kvm/reverse_cpuid.h
+++ b/arch/x86/kvm/reverse_cpuid.h
@@ -86,6 +86,7 @@ static const struct cpuid_reg reverse_cpuid[] = {
 	[CPUID_8086_0001_EDX] = {0x80860001, 0, CPUID_EDX},
 	[CPUID_1_ECX]         = {         1, 0, CPUID_ECX},
 	[CPUID_C000_0001_EDX] = {0xc0000001, 0, CPUID_EDX},
+	[CPUID_8C86_0000_EDX] = {0x8c860000, 0, CPUID_EDX},
 	[CPUID_C000_0006_EAX] = {0xc0000006, 0, CPUID_EAX},
 	[CPUID_8000_0001_ECX] = {0x80000001, 0, CPUID_ECX},
 	[CPUID_7_0_EBX]       = {         7, 0, CPUID_EBX},


### PR DESCRIPTION
CPUID leaf 0x8C860000 on Hygon processors advertises support for SM3 and SM4 cryptographic algorithms. Expose this leaf to KVM guests so that guest OSes can detect these features and enable hardware-accelerated SM3/SM4 operations.

Port Hygon CPUID leaf support from Anolis kernel and adapt it to the current deepin kernel KVM reverse CPUID layout.

## Summary by Sourcery

Expose Hygon-specific cryptographic CPUID leaf 0x8C860000 to KVM guests when SM3/SM4 features are present.

New Features:
- Advertise Hygon SM3 and SM4 cryptographic capabilities to KVM guests via CPUID leaf 0x8C860000 when supported by the host.

Enhancements:
- Extend reverse CPUID mappings and CPUID emulation logic to include Hygon-specific leaf 0x8C860000.