### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [deepin] [KAPI] drm/fb-helper: Restore drm_fb_helper_*_fbi() names for out-of-tree mo…

### DIFF
--- a/include/drm/drm_fb_helper.h
+++ b/include/drm/drm_fb_helper.h
@@ -403,4 +403,21 @@ static inline void drm_fb_helper_lastclose(struct drm_device *dev)
 }
 #endif
 
+/*
+ * Compatibility helpers for the pre-v6.19 DRM fbdev helper API, so that
+ * out-of-tree modules written against the old interface keep building
+ * after fb_info allocation was moved into the fbdev helpers.
+ *
+ * The fb_info instance is now allocated by drm_fb_helper_initial_config()
+ * before the driver's fbdev_probe callback runs, hence
+ * drm_fb_helper_alloc_fbi() only has to return the already allocated
+ * instance.
+ */
+static inline struct fb_info *drm_fb_helper_alloc_fbi(struct drm_fb_helper *fb_helper)
+{
+	return fb_helper->info;
+}
+
+#define drm_fb_helper_unregister_fbi drm_fb_helper_unregister_info
+
 #endif


### PR DESCRIPTION
…dules

Commit 0ea1144e99950 ("drm/fb-helper: Allocate and release fb_info in single place", backported from v6.19) moved the drm_fb_helper_alloc_info() call out of drivers into the fbdev helpers and made the function itself private, so neither drm_fb_helper_alloc_info() nor its old name drm_fb_helper_alloc_fbi() (removed in v6.1) is available to modules anymore.

Out-of-tree drivers that still follow the old fbdev setup flow, such as the loonggpu DKMS driver, fail to build with implicit declarations of drm_fb_helper_alloc_fbi() and drm_fb_helper_unregister_fbi(). Note that in the new flow drm_fb_helper_initial_config() allocates the fb_info instance before invoking the driver's fbdev_probe callback, so the old alloc helper only has to return the instance stored in drm_fb_helper.info.

Add drm_fb_helper_alloc_fbi() back as an inline wrapper returning fb_helper->info, and alias drm_fb_helper_unregister_fbi() to drm_fb_helper_unregister_info(). No functional change for in-tree code.

Assisted-by: kimi:Kimi-K3

## Summary by Sourcery

Restore compatibility fbdev helper interfaces for out-of-tree DRM modules by reintroducing alloc/unregister helpers as wrappers around the current API.

Enhancements:
- Add inline drm_fb_helper_alloc_fbi() wrapper returning the helper’s existing fb_info instance.
- Alias drm_fb_helper_unregister_fbi() to drm_fb_helper_unregister_info() to preserve the legacy unregister interface for external drivers.