### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Phytium] some phytium driver fixes found by GitHub Copilot

### DIFF
--- a/drivers/mtd/maps/phytium_lbc.c
+++ b/drivers/mtd/maps/phytium_lbc.c
@@ -434,6 +434,8 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 		}
 	} else if (has_acpi_companion(dev)) {
 		res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+		if (!res)
+			return -ENODEV;
 		fwnode_property_read_string_array(dev->fwnode, "reg-names", reg_names_array, 2);
 		res->name = reg_names_array[0];
 		lbc->io_base = devm_ioremap_resource(dev, res);
@@ -443,6 +445,8 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 		}
 
 		res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
+		if (!res)
+			return -ENODEV;
 		res->name = reg_names_array[1];
 		lbc->mm_base = devm_ioremap_resource(dev, res);
 		if (IS_ERR(lbc->mm_base)) {

--- a/drivers/mtd/maps/phytium_lbc.c
+++ b/drivers/mtd/maps/phytium_lbc.c
@@ -455,6 +455,9 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 			kfree(lbc);
 			return ret;
 		}
+	} else {
+		dev_err(dev, "no device tree node or ACPI companion found.\n");
+		return -ENODEV;
 	}
 
 	lbc->mm_size = resource_size(res);

--- a/drivers/mtd/maps/phytium_lbc.c
+++ b/drivers/mtd/maps/phytium_lbc.c
@@ -416,7 +416,6 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 
 	if (!lbc->dev_num || lbc->dev_num > PHYTIUM_MAX_SRAM_BLOCK) {
 		dev_err(dev, "no device deceted, or device number is too large\n");
-		kfree(lbc);
 		return -ENODEV;
 	}
 	dev_num = 0;
@@ -426,14 +425,12 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 		lbc->io_base = devm_ioremap_resource(dev, res);
 		if (IS_ERR(lbc->io_base)) {
 			ret = PTR_ERR(lbc->io_base);
-			kfree(lbc);
 			return ret;
 		}
 		res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "lbc_mm");
 		lbc->mm_base = devm_ioremap_resource(dev, res);
 		if (IS_ERR(lbc->mm_base)) {
 			ret = PTR_ERR(lbc->mm_base);
-			kfree(lbc);
 			return ret;
 		}
 	} else if (has_acpi_companion(dev)) {
@@ -443,7 +440,6 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 		lbc->io_base = devm_ioremap_resource(dev, res);
 		if (IS_ERR(lbc->io_base)) {
 			ret = PTR_ERR(lbc->io_base);
-			kfree(lbc);
 			return ret;
 		}
 
@@ -452,7 +448,6 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 		lbc->mm_base = devm_ioremap_resource(dev, res);
 		if (IS_ERR(lbc->mm_base)) {
 			ret = PTR_ERR(lbc->mm_base);
-			kfree(lbc);
 			return ret;
 		}
 	} else {

--- a/drivers/mtd/maps/phytium_lbc.c
+++ b/drivers/mtd/maps/phytium_lbc.c
@@ -404,7 +404,7 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 	int ret;
 	int i;
 	struct resource *res;
-	const char **reg_names_array;
+	const char *reg_names_array[4] = {0};
 
 	lbc = devm_kzalloc(dev, sizeof(struct phytium_lbc), GFP_KERNEL);
 	if (!lbc)
@@ -419,7 +419,6 @@ static int phytium_lbc_probe(struct platform_device *pdev)
 		return -ENODEV;
 	}
 	dev_num = 0;
-	reg_names_array = kcalloc(4, sizeof(*reg_names_array), GFP_KERNEL);
 	if (dev->of_node) {
 		res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "localbus");
 		lbc->io_base = devm_ioremap_resource(dev, res);

--- a/drivers/spi/spi-phytium-qspi.c
+++ b/drivers/spi/spi-phytium-qspi.c
@@ -685,7 +685,7 @@ static int phytium_qspi_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct spi_controller *ctrl;
-	struct resource *res;
+	struct resource *res = NULL;
 	struct phytium_qspi *qspi;
 	int i, ret;
 	struct spi_mem *mem;


### PR DESCRIPTION
## Summary by Sourcery

Fix Phytium localbus and QSPI driver probing and resource handling.

Bug Fixes:
- Prevent double-free/mismatched free by removing kfree on devm-managed phytium_lbc allocations.
- Replace dynamically allocated reg-names array with a fixed-size stack array in phytium_lbc to avoid allocation and lifetime issues.
- Add checks for missing ACPI memory resources and fail probing with ENODEV when they are absent in phytium_lbc.
- Return ENODEV when neither a device tree node nor an ACPI companion is present for the Phytium localbus controller.
- Initialize the resource pointer in phytium_qspi_probe to avoid potential use of an uninitialized variable.