### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [CIX] clocksource/drivers/sky1-gpt: Fix section mismatch in probe path

### DIFF
--- a/drivers/clocksource/timer-sky1-gpt.c
+++ b/drivers/clocksource/timer-sky1-gpt.c
@@ -165,7 +165,7 @@ static struct clocksource clocksource_gpt = {
 	.flags	= CLOCK_SOURCE_IS_CONTINUOUS,
 };
 
-static int __init sky1_clocksource_init(struct sky1_timer *sky1tm)
+static int sky1_clocksource_init(struct sky1_timer *sky1tm)
 {
 	unsigned int c = clk_get_rate(sky1tm->tclk);
 	void __iomem *reg = sky1tm->base + FREE_CNT;
@@ -275,7 +275,7 @@ static irqreturn_t sky1_timer_interrupt(int irq, void *dev_id)
 	return IRQ_HANDLED;
 }
 
-static int __init sky1_clockevent_init(struct sky1_timer *sky1tm)
+static int sky1_clockevent_init(struct sky1_timer *sky1tm)
 {
 	struct clock_event_device *ced = &sky1tm->ced;
 


### PR DESCRIPTION
sky1_timer_probe() is registered as the platform driver's .probe callback and therefore lives in .text. It calls
sky1_clocksource_init() and sky1_clockevent_init(), which are marked __init and land in .init.text, triggering modpost section mismatch warnings:

  WARNING: modpost: drivers/clocksource/timer-sky1-gpt: section mismatch in reference:
  sky1_timer_probe+0x194 (section: .text) -> sky1_clocksource_init (section: .init.text)
  WARNING: modpost: drivers/clocksource/timer-sky1-gpt: section mismatch in reference:
  sky1_timer_probe+0x1a0 (section: .text) -> sky1_clockevent_init (section: .init.text)

.probe can run after init memory has been freed: the driver is tristate, so probe executes at module load time, and even built-in it may run late via deferred probe or unbind/rebind. Referencing freed .init.text from such a path is a potential use-after-free.

Drop the __init annotation from both helpers. Neither of them calls any other __init function, so this fully resolves the mismatch. An init-only registration model (e.g. builtin_platform_driver_probe()) is not applicable here since the driver is tristate and also supports ACPI-based platforms.

Fixes: 6a1b5aa1d1f7 ("clocksource: timer-sky1-gpt: add sky1 gpt timer support")
Assisted-by: Kimi Code:K3

## Summary by Sourcery

Bug Fixes:
- Prevent potential use-after-free by ensuring probe-time clocksource and clockevent initialization functions are retained beyond init memory.