### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Xlnid] net: xlnid: kcompat: Also probe for DEEPIN_KABI_CONST

### DIFF
--- a/drivers/net/ethernet/xel/xlnid/sdk/kcompat-generator.sh
+++ b/drivers/net/ethernet/xel/xlnid/sdk/kcompat-generator.sh
@@ -172,7 +172,7 @@ function gen-gnss() {
 	fh='include/linux/fs.h'
 
 	gen HAVE_CDEV_DEVICE if fun cdev_device_add in "$cdh"
-	gen HAVE_DEV_UEVENT_CONST if method dev_uevent of class matches '(const|RH_KABI_CONST) struct device' in "$clh" "$dh"
+	gen HAVE_DEV_UEVENT_CONST if method dev_uevent of class matches '(const|RH_KABI_CONST|DEEPIN_KABI_CONST) struct device' in "$clh" "$dh"
 	gen HAVE_STREAM_OPEN if fun stream_open in "$fh"
 	# There can be either macro class_create or a function
 	gen NEED_CLASS_CREATE_WITH_MODULE_PARAM if fun class_create matches 'owner' in "$clh" "$dh"


### PR DESCRIPTION
The kcompat generator probes the kernel tree for a const-qualified dev_uevent() method, accepting either a plain const or RHEL's RH_KABI_CONST annotation.  On deepin kernels the equivalent annotation is DEEPIN_KABI_CONST, which the probe does not recognize.

Extend the match expression with DEEPIN_KABI_CONST so the generator keeps producing correct results when it is re-run against a deepin kernel tree.  Keep the RH_KABI_CONST branch: this SDK is cross-distro compatibility code and may still be built on RHEL kernels.

The pre-generated kcompat_generated_defs.h does not need to be regenerated: upstream 6.6 dev_uevent() is already const-qualified, so the plain const branch already matches.

Fixes: a1accf332801d ("net: ethernet: xel: add XEL network driver support")
Assisted-by: Kimi Code:K3

## Summary by Sourcery

Enhancements:
- Broaden kcompat generator matching for dev_uevent() to include DEEPIN_KABI_CONST so SDK compatibility checks work correctly on Deepin kernels while retaining RHEL support.