### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [KABI] lsm: Fix kabi in lsm_blob_sizes by using KABI_USE

### DIFF
--- a/include/linux/lsm_hooks.h
+++ b/include/linux/lsm_hooks.h
@@ -62,13 +62,12 @@ struct lsm_blob_sizes {
 	int	lbs_file;
 	int lbs_backing_file;
 	int	lbs_inode;
-	int	lbs_sock;
 	int	lbs_superblock;
 	int	lbs_ipc;
 	int	lbs_msg_msg;
 	int	lbs_task;
 	int	lbs_xattr_count; /* number of xattr slots in new_xattrs array */
-	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_USE(1, int lbs_sock)
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)


### PR DESCRIPTION
deepin inclusion
category: kabi

When DEEPIN_KABI_RESERVE=y, struct lsm_blob_sizes is kabi whitelist, commit 8279513e592b ("lsm: infrastructure management of the sock security") upstream introduce lbs_sock in the middle of struct lsm_blob_sizes which "move management of the sock->sk_security blob out of the individual security modules and into the security infrastructure." and be backport to v6.6 stable version for it is Stable-dep-of commit 56acfeb10019 ("selinux: avoid sk_socket dereference in selinux_sctp_bind_connect()")

change struct lsm_blob_sizes { ... +int lbs_sock; ... } ->shift the offsets of lbs_superblock, lbs_ipc, lbs_msg_msg, lbs_task and lbs_xattr_count in our KABI whitelist.

The new field is an int which is smaller than the unsigned long KABI reserve in the struct, and lbs_sock fills the padding hole after lbs_xattr_count so that all the other fields keep their offsets. We can use DEEPIN_KABI_USE to fix it.

Fixes: 8279513e592b ("lsm: infrastructure management of the sock security")

## Summary by Sourcery

Bug Fixes:
- Fix potential KABI breakage caused by inserting lbs_sock into struct lsm_blob_sizes and shifting subsequent field offsets.