### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [KABI] fscrypt: kabi fix in struct fscrypt_operations

### DIFF
--- a/include/linux/fscrypt.h
+++ b/include/linux/fscrypt.h
@@ -175,9 +175,12 @@ struct fscrypt_operations {
 	 * external journal devices), and wants to support inline encryption,
 	 * then it must implement this function.  Otherwise it's not needed.
 	 */
+	DEEPIN_KABI_REPLACE(
+	struct block_device **(*get_devices)(struct super_block *sb,
+					     unsigned int *num_devs),
 	unsigned int (*get_devices)(
 		struct super_block *sb,
-		struct block_device *devs[FSCRYPT_MAX_DEVICES]);
+		struct block_device *devs[FSCRYPT_MAX_DEVICES]))
 
 	DEEPIN_KABI_RESERVE(1)
 	DEEPIN_KABI_RESERVE(2)


### PR DESCRIPTION
deepin inclusion
category: kabi

Commit f9616e117d85 ("fscrypt: Avoid dynamic allocation in fscrypt_get_devices()") changed the type of the get_devices member of struct fscrypt_operations, which is reachable from struct super_block and hence breaks kabi.

Wrap the member in DEEPIN_KABI_REPLACE so that genksyms keeps seeing the original type while the compiler sees the new one.  The only implementer of ->get_devices() is f2fs, which is updated in-tree by the same commit, so changing the callback signature is safe.

Fixes: f9616e117d85 ("fscrypt: Avoid dynamic allocation in fscrypt_get_devices()")

## Summary by Sourcery

Bug Fixes:
- Prevent KABI breakage caused by the get_devices member type change in struct fscrypt_operations.