### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] [stable] fbcon: Use correct type for vc_resize() return value

### DIFF
--- a/drivers/video/fbdev/core/fbcon.c
+++ b/drivers/video/fbdev/core/fbcon.c
@@ -1358,8 +1358,7 @@ static void fbcon_set_disp(struct fb_info *info, struct fb_var_screeninfo *var,
 	struct vc_data **default_mode, *vc;
 	struct vc_data *svc;
 	struct fbcon_ops *ops = info->fbcon_par;
-	int rows, cols;
-	unsigned long ret = 0;
+	int rows, cols, ret;
 
 	p = &fb_display[unit];
 


### PR DESCRIPTION
Link: https://github.com/deepin-community/kernel/pull/2040

[ Upstream commit 84202754fb1727dc3ee87f47104e4162ecc8ba3a ]

The return value of vc_resize() is int, but fbcon_set_disp() stores it in an unsigned long variable. While the !ret check happens to work correctly by coincidence (negative values become large positive values), the types should match. Use int instead.

Eliminates the following W=3 warning:

  drivers/video/fbdev/core/fbcon.c: In function 'fbcon_set_disp':
  drivers/video/fbdev/core/fbcon.c:1494:14: warning: implicit conversion from 'int' to 'unsigned long' [-Wconversion]

Fixes: af0db3c1f898 ("fbdev: Fix vmalloc out-of-bounds write in fast_imageblit")
Cc: stable@vger.kernel.org # v6.17+

Reviewed-by: Thomas Zimmermann <tzimmermann@suse.de>



(cherry picked from commit 03a0e49a2e38e6ac90310354b2a27979f54c61f1)

## Summary by Sourcery

Bug Fixes:
- Fix type mismatch in fbcon_set_disp() return value storage that could lead to incorrect handling of vc_resize() failures and resolves the associated W=3 -Wconversion warning.