### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [KABI] lsm: Fix kabi breakage for security.c by hide net/sock.h include

### DIFF
--- a/security/security.c
+++ b/security/security.c
@@ -30,7 +30,7 @@
 #include <linux/string.h>
 #include <linux/msg.h>
 #include <net/flow.h>
-#include <net/sock.h>
+#include DEEPIN_KABI_HIDE_INCLUDE(<net/sock.h>)
 #ifdef CONFIG_CREDP
 #include <asm/haoc/iee-cred.h>
 #endif


### PR DESCRIPTION
deepin inclusion
category: kabi

No functional change.

Commit 8279513e592b ("lsm: infrastructure management of the sock security") added #include <net/sock.h> to security/security.c for the new lsm_sock_alloc() helper. This makes struct sock fully visible to genksyms while it was opaque ({ UNKNOWN }) before, so the whole network type graph gets expanded into the checksums of the kabi whitelist symbols exported from security.c:

change security_inode_setattr 0x7db7bd97 0x70ae116a change security_d_instantiate 0x97e5e2f8 0x981f0a20

Use DEEPIN_KABI_HIDE_INCLUDE so that genksyms keeps seeing struct sock as opaque while the compiler still gets the real header.

Fixes: 8279513e592b ("lsm: infrastructure management of the sock security")

## Summary by Sourcery

Bug Fixes:
- Preserve existing KABI checksums for security symbols by keeping struct sock opaque to genksyms while retaining compiler access to its definition.