### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Phytium] net: macb: count Tx drops in macb_mac_link_down()

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -767,18 +767,31 @@ static void macb_mac_link_down(struct phylink_config *config, unsigned int mode,
 
 	/* Tx clean */
 	for (q = 0, queue = bp->queues; q < bp->num_queues; ++q, ++queue) {
+		unsigned int dropped = 0;
+
 		spin_lock(&queue->tx_ptr_lock);
 		for (i = 0; i < bp->tx_ring_size; i++) {
 			tx_skb = macb_tx_skb(queue, i);
 			/* free unsent skb buffers */
-			if (tx_skb)
+			if (tx_skb) {
+				if (tx_skb->skb)
+					dropped++;
 				macb_tx_unmap(bp, tx_skb, 0);
+			}
 
 			tx_desc = macb_tx_desc(queue, i);
 			macb_set_addr(bp, tx_desc, 0);
 			tx_desc->ctrl &= ~MACB_BIT(TX_USED);
 		}
 		spin_unlock(&queue->tx_ptr_lock);
+
+		/* Account for the in-flight packets dropped here:
+		 * macb_tx_unmap() clears each tx_skb->skb, so the
+		 * drop counting in macb_free_consistent() can no
+		 * longer observe them and will not count them twice.
+		 */
+		queue->stats.tx_dropped += dropped;
+		bp->dev->stats.tx_dropped += dropped;
 	}
 
 	netif_tx_stop_all_queues(ndev);


### PR DESCRIPTION
On this branch, macb_mac_link_down() walks the whole Tx ring and releases every in-flight SKB via macb_tx_unmap() without counting them. Since phylink_stop() synchronously invokes mac_link_down(), macb_close() always reaches macb_free_consistent() with all tx_skb->skb pointers already cleared, so the drop accounting added there by commit 48b1e61769cc7 ("net: macb: drop in-flight Tx SKBs on close") can never observe any packet and tx_dropped stays zero.

Move the accounting into the link-down cleanup where the packets are actually released. macb_free_consistent() keeps its own counting loop as a safety net; it cannot double count because macb_tx_unmap() NULLs each tx_skb->skb here.

Assisted-by: kimi:Kimi-K3:high
Fixes: 48b1e61769cc75 ("net: macb: drop in-flight Tx SKBs on close")

## Summary by Sourcery

Bug Fixes:
- Account for in-flight Tx packets dropped during MAC link-down cleanup in both per-queue and device transmit drop statistics.