### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] mm/mempolicy: fix mmap_read_lock leak in migrate_to_node() !vma path

### DIFF
--- a/mm/mempolicy.c
+++ b/mm/mempolicy.c
@@ -1032,6 +1032,7 @@ static long migrate_to_node(struct mm_struct *mm, int source, int dest,
 	mmap_read_lock(mm);
 	vma = find_vma(mm, 0);
 	if (unlikely(!vma)) {
+		mmap_read_unlock(mm);
 		return 0;
 	}
 


### PR DESCRIPTION
deepin inclusion
category: bugfix

This revert commit ae504fe1a079b897ea0bba3b551855b1d92888c2.

This tree carries the mainline mempolicy locking rework ("mempolicy: mmap_lock is not needed while migrating folios"), where migrate_to_node() acquires mmap_read_lock() itself and do_migrate_pages() does not hold it. The early !vma return path lost the matching mmap_read_unlock() when ae504fe1a079b ("FROMLIST: mm/mempolicy: fix unbalanced unlock in backported VMA check") removed it - that removal was only correct for the vanilla 6.6 caller-locks model.

Restore the unlock, matching mainline. This covers the intent of stable-6.6 commit d77401968c78 ("mm/mempolicy: fix wrong mmap_read_unlock() in migrate_to_node()"), which targets the vanilla 6.6 caller-locks model and is not applicable verbatim here.

This revert commit ae504fe1a079b897ea0bba3b551855b1d92888c2. stable upstream commit:
commit d77401968c789037b1ba962705ef998133715b1f
    mm/mempolicy: fix wrong mmap_read_unlock() in migrate_to_node()

    The backport of commit 091c1dd2d4df ("mm/mempolicy: fix migrate_to_node()
    assuming there is at least one VMA in a MM") contains an error:
    migrate_to_node() does not lock the mmap_lock itself, that is handled by
    the caller instead.

    So let's drop the wrong mmap_read_unlock(). Fortunately, this path is
    very hard to hit in practice.

## Summary by Sourcery

Bug Fixes:
- Fix a potential mmap read-lock leak when migrate_to_node() finds no VMA.