### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] sysctl: fix kabi breakage of ctl_table_header constification

### DIFF
--- a/include/linux/sysctl.h
+++ b/include/linux/sysctl.h
@@ -27,6 +27,7 @@
 #include <linux/wait.h>
 #include <linux/rbtree.h>
 #include <linux/uidgid.h>
+#include <linux/deepin_kabi.h>
 #include <uapi/linux/sysctl.h>
 
 /* For the /proc/sys support */
@@ -182,7 +183,7 @@ struct ctl_table_header {
 		struct rcu_head rcu;
 	};
 	struct completion *unregistering;
-	const struct ctl_table *ctl_table_arg;
+	DEEPIN_KABI_CONST struct ctl_table *ctl_table_arg;
 	struct ctl_table_root *root;
 	struct ctl_table_set *set;
 	struct ctl_dir *parent;


### PR DESCRIPTION
deepin inclusion
category: bugfix
bugzilla: https://atomgit.com/openeuler/kernel/issues/9792

--------------------------------

Commit b5d2a71f22986 ("sysctl: treewide: constify
ctl_table_header::ctl_table_arg"), backported from stable-v6.6.151, constified the ctl_table_arg member of struct ctl_table_header. Although it is claimed as no functional change, the added const qualifier changes the genksyms expansion of struct ctl_table_header, which is reachable from struct device via:

    struct device -> struct io_tlb_mem -> struct dentry ->
    struct super_block -> struct user_namespace ->
    struct ctl_table_header

and is also referenced directly by struct net, struct net_device and struct devlink.  As a result the checksums of nearly all device/netdev/devlink related exported symbols (device_add, dev_change_flags, _dev_err, devlink_register, ...) changed, breaking KABI against OLK-6.6.

Wrap the field with KABI_CONST so that genksyms still sees the original non-const declaration and the old checksums are preserved, while the real build keeps the const semantics.  The field is a pointer; adding const to the pointee does not change the struct layout, so binary compatibility with third party modules is retained.

Fixes: b5d2a71f2298 ("sysctl: treewide: constify ctl_table_header::ctl_table_arg")

## Summary by Sourcery

Bug Fixes:
- Preserve kernel ABI compatibility for sysctl table headers and dependent exported symbols while retaining const-correctness in builds.