### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [KABI] apply kabi fixes for 6.6.150-6.6.152

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -930,7 +930,6 @@ struct task_struct {
 
 	struct mm_struct		*mm;
 	struct mm_struct		*active_mm;
-	struct address_space		*faults_disabled_mapping;
 
 	int				exit_state;
 	int				exit_code;
@@ -1617,7 +1616,7 @@ struct task_struct {
 	 */
 	randomized_struct_fields_end
 
-	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_USE(1, struct address_space *faults_disabled_mapping)
 	DEEPIN_KABI_RESERVE(2)
 	DEEPIN_KABI_RESERVE(3)
 	DEEPIN_KABI_RESERVE(4)

--- a/include/net/netfilter/nf_conntrack_expect.h
+++ b/include/net/netfilter/nf_conntrack_expect.h
@@ -7,6 +7,7 @@
 #define _NF_CONNTRACK_EXPECT_H
 
 #include <linux/refcount.h>
+#include <linux/deepin_kabi.h>
 
 #include <net/netfilter/nf_conntrack.h>
 #include <net/netfilter/nf_conntrack_zones.h>
@@ -48,9 +49,6 @@ struct nf_conntrack_expect {
 	/* Helper that created this expectation */
 	struct nf_conntrack_helper __rcu *helper;
 
-	/* Helper to assign to new connection */
-	struct nf_conntrack_helper __rcu *assign_helper;
-
 	/* The conntrack of the master connection */
 	struct nf_conn *master;
 
@@ -67,6 +65,9 @@ struct nf_conntrack_expect {
 #endif
 
 	struct rcu_head rcu;
+
+	/* Helper to assign to new connection */
+	DEEPIN_KABI_EXTEND(struct nf_conntrack_helper __rcu *assign_helper)
 };
 
 static inline struct net *nf_ct_exp_net(struct nf_conntrack_expect *exp)

--- a/include/net/sch_generic.h
+++ b/include/net/sch_generic.h
@@ -101,7 +101,6 @@ struct Qdisc {
 	struct hlist_node       hash;
 	u32			handle;
 	u32			parent;
-	int			depth;
 
 	struct netdev_queue	*dev_queue;
 
@@ -131,7 +130,7 @@ struct Qdisc {
 	netdevice_tracker	dev_tracker;
 	struct lock_class_key	root_lock_key;
 
-	DEEPIN_KABI_RESERVE(1)
+	DEEPIN_KABI_USE(1, int depth)
 	DEEPIN_KABI_RESERVE(2)
 
 	/* private data */

--- a/include/net/sch_generic.h
+++ b/include/net/sch_generic.h
@@ -440,8 +440,9 @@ struct tcf_proto {
 	 */
 	spinlock_t		lock;
 	bool			deleting;
-	bool			counted;
-	bool			usesw;
+	/* counted/usesw fill the alignment hole after 'deleting' */
+	DEEPIN_KABI_FILL_HOLE(bool counted)
+	DEEPIN_KABI_FILL_HOLE(bool usesw)
 	refcount_t		refcnt;
 	struct rcu_head		rcu;
 	struct hlist_node	destroy_ht_node;
@@ -490,7 +491,6 @@ struct tcf_block {
 	struct flow_block flow_block;
 	struct list_head owner_list;
 	bool keep_dst;
-	atomic_t useswcnt;
 	atomic_t offloadcnt; /* Number of oddloaded filters */
 	unsigned int nooffloaddevcnt; /* Number of devs unable to do offload */
 	unsigned int lockeddevcnt; /* Number of devs that require rtnl lock. */
@@ -501,6 +501,11 @@ struct tcf_block {
 	struct rcu_head rcu;
 	DECLARE_HASHTABLE(proto_destroy_ht, 7);
 	struct mutex proto_destroy_lock; /* Lock for proto_destroy hashtable. */
+
+	/* tcf_block is only allocated by the kernel (cls_api) and is never
+	 * embedded in other structs, so extending it at the end is safe.
+	 */
+	DEEPIN_KABI_EXTEND(atomic_t useswcnt)
 };
 
 static inline bool lockdep_tcf_chain_is_locked(struct tcf_chain *chain)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Apply Deepin KABI compatibility updates for Linux 6.6.150–6.6.152 by reusing reserved fields, filling alignment holes, and safely extending kernel networking structures.