### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [Upstream] wifi: mt76: fix MAC address for non OF pcie cards

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/eeprom.c
+++ b/drivers/net/wireless/mediatek/mt76/eeprom.c
@@ -181,7 +181,7 @@ mt76_eeprom_override(struct mt76_phy *phy)
 	if (err == -EPROBE_DEFER)
 		return err;
 
-	if (err) {
+	if (!is_valid_ether_addr(phy->macaddr)) {
 		eth_random_addr(phy->macaddr);
 		dev_info(dev->dev,
 			 "Invalid MAC address, using random address %pM\n",


### PR DESCRIPTION
If seems the check for err is wrong as the proper macaddr gets written to from the EEPROM itself. Meaning checking err from of_get_mac_address is wrong as the proper macaddr has been written by this point.

Closes:
https://lore.kernel.org/linux-wireless/30a90714-02d8-45f2-a7f1-4cfe0627d50b@skade.local/

Reported-by: Klara Modin <klarasmodin@gmail.com>
Closes: https://lore.kernel.org/all/ajRmlyx_AEGybykL@soda.int.kasm.eu/
Reported-by: Tobias Klausmann <klausman@schwarzvogel.de>
Fixes: 31ee1582717e ("wifi: mt76: fix of_get_mac_address error handling")

Tested-by: Tobias Klausmann <klausman@schwarzvogel.de>
Tested-by: Klara Modin <klarasmodin@gmail.com>
Tested-by: John Rowley <lkml@johnrowley.me>
Link: https://patch.msgid.link/20260706232857.807044-1-rosenp@gmail.com

(cherry picked from commit 7fd35e8c0548e97258f64f47c98a891173b8e35e)

## Summary by Sourcery

Bug Fixes:
- Preserve valid MAC addresses read from EEPROM for non-device-tree PCIe cards instead of incorrectly replacing them with random addresses.