### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [Upstream] Update kernel base to 6.18.48

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 6
 PATCHLEVEL = 18
-SUBLEVEL = 47
+SUBLEVEL = 48
 EXTRAVERSION =
 NAME = Baby Opossum Posse
 

--- a/net/ipv4/inet_fragment.c
+++ b/net/ipv4/inet_fragment.c
@@ -437,6 +437,13 @@ int inet_frag_queue_insert(struct inet_frag_queue *q, struct sk_buff *skb,
 {
 	struct sk_buff *last = q->fragments_tail;
 
+	/* An IP fragment is never a GSO packet, but an untrusted source
+	 * (virtio_net_hdr) may have attached GSO metadata to it. Do not let
+	 * that reach the reassembled skb, whose head keeps the first
+	 * fragment's shinfo and whose frag_list is not GRO-shaped.
+	 */
+	skb_gso_reset(skb);
+
 	/* RFC5722, Section 4, amended by Errata ID : 3089
 	 *                          When reassembling an IPv6 datagram, if
 	 *   one or more its constituent fragments is determined to be an


### PR DESCRIPTION
Update kernel base to 6.18.48.

## Summary by Sourcery

Update the kernel base to 6.18.48 and harden IP fragment reassembly against invalid GSO metadata.

Bug Fixes:
- Prevent untrusted GSO metadata on IP fragments from propagating to reassembled packets.

Build:
- Update the kernel base version to 6.18.48.