### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [Upstream] LoongArch: KVM: Fix PC double advance in kernel MMIO read fast path

### DIFF
--- a/arch/loongarch/kvm/exit.c
+++ b/arch/loongarch/kvm/exit.c
@@ -483,7 +483,6 @@ int kvm_emu_mmio_read(struct kvm_vcpu *vcpu, larch_inst inst)
 		srcu_read_unlock(&vcpu->kvm->srcu, idx);
 		if (!ret) {
 			kvm_complete_mmio_read(vcpu, run);
-			update_pc(&vcpu->arch);
 			vcpu->mmio_needed = 0;
 			return EMULATE_DONE;
 		}


### PR DESCRIPTION
In the in-kernel MMIO read fast path of kvm_emu_mmio_read(), kvm_complete_mmio_read() already advances the guest PC via update_pc(). The explicit update_pc() call right after it advances the PC a second time, so PC moves forward by 8 bytes instead of 4, and the instruction following the MMIO read is silently skipped.

The user space MMIO read completion path in kvm_arch_vcpu_ioctl_run() calls kvm_complete_mmio_read() only once, and the MMIO write fast path advances the PC exactly once as well.

Here remove the redundant update_pc() so the kernel MMIO read fast path advances the PC by a single instruction.

Cc: stable@vger.kernel.org
Fixes: 80edf90831a2 ("LoongArch: KVM: Add sign extension with kernel MMIO read emulation")
Reviewed-by: Bibo Mao <maobibo@loongson.cn>
Reviewed-by: Tao Cui <cuitao@kylinos.cn>


(cherry picked from commit fd4021529faa931818186b6e83bd46f5de7517eb)

## Summary by Sourcery

Bug Fixes:
- Fix the LoongArch KVM kernel MMIO read fast path so guest PCs advance by one instruction instead of skipping the following instruction.