### PR TITLE
[linux-6.6.y]LoongArch: KVM: Remove redundant CSR clearing in kvm_set_one_reg

### DIFF
--- a/arch/loongarch/kvm/vcpu.c
+++ b/arch/loongarch/kvm/vcpu.c
@@ -963,12 +963,6 @@ static int kvm_set_one_reg(struct kvm_vcpu *vcpu,
 			}
 
 			kvm_loongarch_reset_ipi(vcpu);
-			/*
-			 * When the vcpu resets, clear the ESTAT and GINTC registers,
-			 * and clear other CSR registers through the _kvm_set_csr register.
-			 */
-			kvm_write_sw_gcsr(vcpu->arch.csr, LOONGARCH_CSR_GINTC, 0);
-			kvm_write_sw_gcsr(vcpu->arch.csr, LOONGARCH_CSR_ESTAT, 0);
 			memset(&vcpu->arch.irq_pending, 0, sizeof(vcpu->arch.irq_pending));
 			memset(&vcpu->arch.irq_clear, 0, sizeof(vcpu->arch.irq_clear));
 


### PR DESCRIPTION
The clearing of LOONGARCH_CSR_GINTC and LOONGARCH_CSR_ESTAT in kvm_set_one_reg is redundant, Both commit 97d5e7bbbde0 ("LoongArch: KVM: Repair the restart pressure test virtual machine hang dead problem") and commit 869523f0de29 ("LoongArch: KVM: Fully clear some CSRs when VM reboot") have addressed similar concerns. Remove them to align with the upstream codebase.

## Summary by Sourcery

Enhancements:
- Remove redundant clearing of the LoongArch GINTC and ESTAT CSRs during vCPU register reset handling.