### PR TITLE
[Deepin-Kernel-SIG] [linux 6.18.y] [FROMLIST] LoongArch: rethook: Do not save/restore percpu base register in tramp…

### DIFF
--- a/arch/loongarch/kernel/rethook_trampoline.S
+++ b/arch/loongarch/kernel/rethook_trampoline.S
@@ -24,7 +24,6 @@
 	cfi_st	t6, PT_R18
 	cfi_st	t7, PT_R19
 	cfi_st	t8, PT_R20
-	cfi_st	u0, PT_R21
 	cfi_st	fp, PT_R22
 	cfi_st	s0, PT_R23
 	cfi_st	s1, PT_R24
@@ -59,7 +58,6 @@
 	cfi_ld	t6, PT_R18
 	cfi_ld	t7, PT_R19
 	cfi_ld	t8, PT_R20
-	cfi_ld	u0, PT_R21
 	cfi_ld	fp, PT_R22
 	cfi_ld	s0, PT_R23
 	cfi_ld	s1, PT_R24


### PR DESCRIPTION
…oline

The rethook trampoline saves $r21 ($u0), the percpu base, into its frame at entry and restores it at exit. In between, rethook_trampoline_handler() may schedule via preempt_enable_notrace(); if the task migrates to another CPU, the frame's $r21 names the old CPU's percpu base, and restoring it poisons $r21 on the new CPU. Until the next user->kernel transition heals $r21, this_cpu_*() accesses (runqueues, RCU per-CPU data, timer tick programming, FPU ownership) hit the wrong CPU's percpu area.

Under kretprobe-heavy preemptible load this corrupts scheduler and timer state: scheduling-while-atomic splats, wrong-CPU RCU warnings, WARN_ON_ONCE(rq != this_rq()) in nohz_balance_exit_idle(), and CPUs parking in the idle loop with the constant timer never re-armed (hard lockup). Reproduces on a Loongson-3A6000 with kretprobes on VFS paths plus heavy file churn (OS install / unsquashfs).

By convention $r21 always holds the current CPU's percpu base in kernel mode: exception entries reload it only when coming from user mode, and RESTORE_SOME() restores it only when returning to user mode; the context-switch path never writes it. The live $r21 at trampoline exit is therefore already correct, and nothing in between can legitimately change it (kernel C code cannot write a global register variable). The same flaw existed in the pre-rethook kretprobe trampoline since v6.3; it was carried over when rethook replaced it. Drop both the save and the restore. Drop the restore to solve the issue, and drop the save to keep the code tidy and for a privileged reader, neither matters much, so no need to clear it.

Fixes: 3f5536860086d ("LoongArch: Add kretprobes support")
Cc: stable@vger.kernel.org # v6.5+
Assisted-by: Kimi:Kimi-K3 # debug and root-cause analysis

(cherry picked from commit 03cfc87c23484d4f72447bcae5fe1630add2cb5c)

## Summary by Sourcery

Fix LoongArch rethook trampoline handling of the per-CPU base register to keep per-CPU accesses valid across task migration.

Bug Fixes:
- Prevent LoongArch rethook trampolines from restoring a stale per-CPU base after task migration, avoiding corruption of scheduler, RCU, timer, and other per-CPU state.

Enhancements:
- Remove unnecessary per-CPU base register save and restore operations from the rethook trampoline.