### PR TITLE
[Deepin-Kernel-SIG] [linux 6.6.y] [FROMLIST] mei: vsc: Initialize mutexes before requesting the IRQ

### DIFF
--- a/drivers/misc/mei/vsc-tp.c
+++ b/drivers/misc/mei/vsc-tp.c
@@ -527,15 +527,15 @@ static int vsc_tp_probe(struct spi_device *spi)
 	init_waitqueue_head(&tp->xfer_wait);
 	tp->spi = spi;
 
+	mutex_init(&tp->mutex);
+	mutex_init(&tp->event_notify_mutex);
+
 	irq_set_status_flags(spi->irq, IRQ_DISABLE_UNLAZY);
 	ret = request_threaded_irq(spi->irq, vsc_tp_isr, vsc_tp_thread_isr,
 				   IRQF_TRIGGER_FALLING | IRQF_ONESHOT,
 				   dev_name(dev), tp);
 	if (ret)
-		return ret;
-
-	mutex_init(&tp->mutex);
-	mutex_init(&tp->event_notify_mutex);
+		goto err_destroy_mutex;
 
 	/* only one child acpi device */
 	ret = acpi_dev_for_each_child(ACPI_COMPANION(dev),
@@ -560,6 +560,7 @@ static int vsc_tp_probe(struct spi_device *spi)
 err_destroy_lock:
 	free_irq(spi->irq, tp);
 
+err_destroy_mutex:
 	mutex_destroy(&tp->event_notify_mutex);
 	mutex_destroy(&tp->mutex);
 

--- a/fs/ntfs3/super.c
+++ b/fs/ntfs3/super.c
@@ -1869,10 +1869,11 @@ static int __init init_ntfs_fs(void)
 		goto out1;
 	}
 
-	register_as_ntfs_legacy();
 	err = register_filesystem(&ntfs_fs_type);
 	if (err)
 		goto out;
+
+	register_as_ntfs_legacy();
 
 	return 0;
 out:


### PR DESCRIPTION
## Summary by Sourcery

Fix MEI VSC probe initialization ordering and make NTFS filesystem registration failure handling safer.

Bug Fixes:
- Initialize MEI VSC mutexes before requesting the IRQ and clean them up when IRQ registration fails, preventing interrupt handlers from accessing uninitialized synchronization primitives.
- Register the NTFS filesystem before enabling its legacy registration path, ensuring legacy setup only occurs after filesystem registration succeeds.