### PR TITLE
[Deepin-Kernel-SIG] [linux 7.2.y] [FROMLIST] iommu/arm-smmu-v3: Disable implementations during devm teardown

### DIFF
--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -4789,6 +4789,8 @@ static void arm_smmu_disable_action(void *data)
 {
 	struct arm_smmu_device *smmu = data;
 
+	if (smmu->impl_ops && smmu->impl_ops->device_disable)
+		smmu->impl_ops->device_disable(smmu);
 	arm_smmu_device_disable(smmu);
 }
 
@@ -5621,8 +5623,6 @@ static void arm_smmu_device_shutdown(struct platform_device *pdev)
 {
 	struct arm_smmu_device *smmu = platform_get_drvdata(pdev);
 
-	if (smmu->impl_ops && smmu->impl_ops->device_disable)
-		smmu->impl_ops->device_disable(smmu);
 	arm_smmu_device_disable(smmu);
 }
 


### PR DESCRIPTION
The Tegra241 CMDQV teardown fix moved VINTF hardware deinitialization into the implementation device_disable() callback. However, its stable backport preceded the conversion to devm teardown and could only invoke the callback from the shutdown path.

Now that arm_smmu_disable_action() manages normal teardown, invoke the implementation callback there while the command queue is still alive. This prevents the subsequent implementation remove action from releasing resources while the CMDQV hardware remains active.

After ("iommu/arm-smmu-v3: Manage teardown with devm") merged in stable, now keep the shutdown path consistent with mainline, where disabling the base SMMU is sufficient.

Fixes: 5994617e09ee ("iommu/tegra241-cmdqv: Fix CMD_SYNC use-after-free on teardown")

## Summary by Sourcery

Ensure implementation-specific ARM SMMU hardware is disabled before resources are released during managed teardown.

Bug Fixes:
- Invoke implementation-specific SMMU disable callbacks during normal devm teardown so CMDQV and related hardware are deinitialized before their resources are released.
- Remove the redundant implementation callback from the platform shutdown path to keep teardown behavior consistent with mainline.