### PR TITLE
[Deepin-Kernel-SIG] [linux 7.2.y] [stable] ksmbd: zero pipe read compound padding

### DIFF
--- a/fs/smb/server/smb2pdu.c
+++ b/fs/smb/server/smb2pdu.c
@@ -7226,13 +7226,18 @@ static noinline int smb2_read_pipe(struct ksmbd_work *work)
 		}
 
 		aux_payload_buf =
-			kvmalloc(rpc_resp->payload_sz, KSMBD_DEFAULT_GFP);
+			kvmalloc(ALIGN(rpc_resp->payload_sz, 8),
+				 KSMBD_DEFAULT_GFP);
 		if (!aux_payload_buf) {
 			err = -ENOMEM;
 			goto out;
 		}
 
 		memcpy(aux_payload_buf, rpc_resp->payload, rpc_resp->payload_sz);
+		if (rpc_resp->payload_sz & 7)
+			memset(aux_payload_buf + rpc_resp->payload_sz, 0,
+			       ALIGN(rpc_resp->payload_sz, 8) -
+			       rpc_resp->payload_sz);
 
 		nbytes = rpc_resp->payload_sz;
 		err = ksmbd_iov_pin_rsp_read(work, (void *)rsp,


### PR DESCRIPTION
Tracking to final 7.2.5 stable state after v7.2.5 released.

commit 73f860489e3be2245598d1819226304fc5b87291 upstream.

Compound response handling extends the last response iov to an eight-byte boundary.

smb2_read_pipe() allocates only the payload size, so the alignment padding can expose up to seven bytes of uninitialized kernel heap memory.

Allocate the aligned size and clear the unused tail before pinning the response buffer.

Fixes: e2b76ab8b5c9 ("ksmbd: add support for read compound")
Reported-by: Cheryl Babcock <cheryl@renat.io>


(cherry picked from commit be15b8da4a82cf1e1f9880b2661b90770606eec1)

## Summary by Sourcery

Bug Fixes:
- Prevent ksmbd compound pipe-read responses from exposing uninitialized kernel heap memory through alignment padding.